### PR TITLE
Refactor make targets

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -15,6 +15,7 @@ runs:
       shell: bash
       run: |
         echo "PGDIR=/home/postgres/pgsql-${{ inputs.pg_version }}" >> $GITHUB_ENV
+        echo "PG_LIBDIR=/home/postgres/pgsql-${{ inputs.pg_version }}/lib" >> $GITHUB_ENV
         echo "PATH=/home/postgres/pgsql-${{ inputs.pg_version }}/bin:$PATH" >> $GITHUB_ENV
         echo "PG_REGRESS_DIR=/home/postgres/pgsql-${{ inputs.pg_version }}/regress" >> $GITHUB_ENV
 
@@ -45,7 +46,7 @@ runs:
       with:
         key: duckdb_pglake-${{ inputs.container_os }}-${{ hashFiles('duckdb_pglake/src/**', 'duckdb_pglake/Makefile', 'duckdb_pglake/patches/**', 'duckdb_pglake/extension_config.cmake', 'duckdb_pglake/CMakeLists.txt') }}
         path: |
-          duckdb_pglake/libduckdb.so
+          ${{ env.PG_LIBDIR }}/libduckdb.so
 
     - uses: actions/cache@v4
       id: cache_polaris
@@ -56,26 +57,26 @@ runs:
           /home/postgres/pgsql-${{ inputs.pg_version }}/bin/polaris-admin.jar
           /home/postgres/pgsql-${{ inputs.pg_version }}/bin/polaris-server.jar
 
-    - name: Compile and install without duckdb_pglake cache
-      if: steps.cache_libduckdb.outputs.cache-hit != 'true'
+    - name: Compile and install all extensions and pgduck_server
       shell: bash
       run: |
         export PGCOMPAT_BUILD_CONFIG=Release
 
-        # Build duckdb_pglake
-        make -j 16 && make install
+        if [ -f "${{ env.PG_LIBDIR }}/libduckdb.so" ]; then
+          echo "Using cached libduckdb.so"
+          export FORCE_DUCKDB_BUILD=0;
+        else
+          echo "Building libduckdb.so"
+          export FORCE_DUCKDB_BUILD=1;
+        fi
+
+        make install-pgduck_server && make install-pg_lake_spatial && make install-pg_lake_benchmark
 
     - name: Build Polaris if not already in the cache
       if: steps.cache_polaris.outputs.cache-hit != 'true'
       shell: bash
       run: |
         make -j16 install-rest_catalog
-
-    - name: Compile and install with duckdb_pglake cache
-      if: steps.cache_libduckdb.outputs.cache-hit == 'true'
-      shell: bash
-      run: |
-        make ci-cached -j 16 && make install-ci-cached
 
     - name: Install the test extensions
       shell: bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -266,16 +266,7 @@ FROM base AS pg_lake_postgres
 
 # Install pg_lake
 RUN cd pg_lake && \
-    make install-pg_extension_base && \
-    make install-pg_map && \
-    make install-pg_extension_updater && \
-    make install-pg_lake_engine && \
-    make install-avro && \
-    make install-pg_lake_iceberg && \
-    make install-pg_lake_table && \
     make install-pg_lake_spatial && \
-    make install-pg_lake_copy && \
-    make install-pg_lake && \
     make install-pg_lake_benchmark
 
 RUN initdb -D $PGBASEDIR/pgsql-$PG_MAJOR/data -U postgres --locale=C.UTF-8 --data-checksums
@@ -286,5 +277,4 @@ FROM base AS pgduck_server
 ARG PGCOMPAT_BUILD_CONFIG=Release
 
 # Install pgduck_server
-RUN cd pg_lake/duckdb_pglake && make && make install && rm -r build
-RUN cd pg_lake/pgduck_server && make && make install
+RUN make install-pgduck_server

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -136,9 +136,10 @@ export VCPKG_TOOLCHAIN_PATH="$(pwd)/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 # install pg_lake extensions
 git clone --recurse-submodules https://github.com/snowflake-labs/pg_lake.git && \
-cd pg_lake/duckdb_pglake && make && make install && \
-cd .. && make install-avro-local && make fast && make install-fast
+cd pg_lake && make install
 ```
+
+**NOTE:** Run `make install-fast` instead of `make install` to skip rebuilding DuckDB if you have already built it once. This will significantly speed up the installation process.
 
 For MacOS to work with `vcpkg`, you will need to install `cmake` via `brew`, however you cannot use the latest version of CMake, due to compatibility issues with other DuckDB plugins.  To install a known-working version of `cmake` using `brew`, run the following:
 
@@ -255,7 +256,7 @@ make -C src/test/isolation install
 export PATH=$HOME/pgsql/18/lib/pgxs/src/test/isolation:$PATH
 ```
 
-Build PostGIS (dependency of pg_lake_spatial):
+Build PostGIS (dependency of pg_lake_spatial (install postgis before `make install-pg_lake_spatial`)):
 
 ```bash
 git clone git@github.com:postgis/postgis.git

--- a/pg_lake_copy/Makefile
+++ b/pg_lake_copy/Makefile
@@ -7,7 +7,7 @@ SOURCES := $(wildcard src/*.c) $(wildcard src/*/*.c)
 OBJS := $(patsubst %.c,%.o,$(sort $(SOURCES)))
 
 SHLIB_LINK = $(libpq)
-PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -I../pg_lake_engine/include -I../avro/lang/c/src -I../pg_lake_iceberg/include -I../pg_lake_table/include -std=gnu99 -g -Wall -Wextra -Wno-unused-parameter -Werror
+PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -I../pg_lake_engine/include -I../pg_lake_iceberg/include -I../pg_lake_table/include -std=gnu99 -g -Wall -Wextra -Wno-unused-parameter -Werror
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)

--- a/pg_lake_iceberg/Makefile
+++ b/pg_lake_iceberg/Makefile
@@ -7,7 +7,7 @@ DATA = $(wildcard $(EXTENSION)--*--*.sql) $(EXTENSION)--3.0.sql
 LIB_AVRO_PATH = $(abspath ../avro/lang/c/build/avrolib/lib)
 LIB64_AVRO_PATH = $(abspath ../avro/lang/c/build/avrolib/lib64)
 
-PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -std=gnu99 -g -I../pg_lake_engine/include -I../avro/lang/c/src
+PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -std=gnu99 -g -I../pg_lake_engine/include
 SHLIB_LINK_INTERNAL = $(libpq)
 PG_LDFLAGS  = -L$(LIB_AVRO_PATH) -L$(LIB64_AVRO_PATH) -Wl,-rpath,$(LIB_AVRO_PATH) -Wl,-rpath,$(LIB64_AVRO_PATH) -lavro -lcurl
 

--- a/pg_lake_table/Makefile
+++ b/pg_lake_table/Makefile
@@ -12,7 +12,7 @@ DATA = $(wildcard $(EXTENSION)--*--*.sql) $(EXTENSION)--3.0.sql
 
 PGFILEDESC = "pg_lake_table - foreign data wrapper for data lakes"
 
-PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -I../pg_extension_base/include -I../pg_lake_engine/include -I../pg_lake_iceberg/include -I../avro/lang/c/src
+PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -I../pg_extension_base/include -I../pg_lake_engine/include -I../pg_lake_iceberg/include
 SHLIB_LINK_INTERNAL = $(libpq)
 
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
- [x] Remove fast and ci makefile targets. Instead, make the default build target smart to skip building duckdb, if already built before.
- [x] Fix broken avro build dependency on make targets.  