### PR TITLE
Fix pg_lake cloning error when running `docker compose up`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -258,8 +258,7 @@ ENV VCPKG_TOOLCHAIN_PATH="/home/postgres/vcpkg/scripts/buildsystems/vcpkg.cmake"
 FROM dev_base AS base
 
 # Clone pg_lake project
-RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts && \
-    git clone git@github.com:snowflake-labs/pg_lake.git \
+RUN git clone https://github.com/snowflake-labs/pg_lake.git \
       --branch ${PG_LAKE_REF} --recurse-submodules /home/postgres/pg_lake
 
 ############## pg_lake_postgres ##############


### PR DESCRIPTION
`docker compose up` fails with an error when cloning pg_lake repo:

```
0.623 Cloning into '/home/postgres/pg_lake'...
0.916 git@github.com: Permission denied (publickey).
0.917 fatal: Could not read from remote repository.
0.917
0.917 Please make sure you have the correct access rights
0.917 and the repository exists.
------
Dockerfile:261
```

Fix by cloning using public HTTPS.