### PR TITLE
Bump all extension versions to 3.1

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -353,3 +353,17 @@ We use the following for simplicity:
    CREATE TABLE t_iceberg(a int) USING iceberg;
    ```
 
+## Automatically Bumping Extension Versions
+
+To bump all PostgreSQL extensions in the repo to a new version:
+
+```bash
+python tools/bump_extension_versions.py 3.0
+```
+
+What it does:
+
+   - Finds all folders containing a `.control` file.
+   - Updates the `default_version` field in each control file.
+   - Creates a new SQL stub for version upgrade (e.g., `pg_lake_engine--2.4--3.0.sql`).
+

--- a/pg_extension_base/pg_extension_base--1.6--3.1.sql
+++ b/pg_extension_base/pg_extension_base--1.6--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_extension_base from 1.6 to 3.1
+

--- a/pg_extension_base/pg_extension_base.control
+++ b/pg_extension_base/pg_extension_base.control
@@ -1,5 +1,5 @@
 comment = 'Extension development kit by Snowflake'
-default_version = '1.6'
+default_version = '3.1'
 module_pathname = '$libdir/pg_extension_base'
 relocatable = false
 schema = pg_catalog

--- a/pg_extension_updater/pg_extension_updater--1.1--3.1.sql
+++ b/pg_extension_updater/pg_extension_updater--1.1--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_extension_updater from 1.1 to 3.1
+

--- a/pg_extension_updater/pg_extension_updater.control
+++ b/pg_extension_updater/pg_extension_updater.control
@@ -1,5 +1,5 @@
 comment = 'Automatic extension updater'
-default_version = '1.1'
+default_version = '3.1'
 module_pathname = '$libdir/pg_extension_updater'
 requires = 'pg_extension_base'
 relocatable = false

--- a/pg_lake/pg_lake--3.0--3.1.sql
+++ b/pg_lake/pg_lake--3.0--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_lake from 3.0 to 3.1
+

--- a/pg_lake/pg_lake.control
+++ b/pg_lake/pg_lake.control
@@ -1,6 +1,6 @@
 # pg_lake extension
 comment = 'Data lake extension by Snowflake'
-default_version = '3.0'
+default_version = '3.1'
 module_pathname = '$libdir/pg_lake'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_benchmark/pg_lake_benchmark--3.0--3.1.sql
+++ b/pg_lake_benchmark/pg_lake_benchmark--3.0--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_lake_benchmark from 3.0 to 3.1
+

--- a/pg_lake_benchmark/pg_lake_benchmark.control
+++ b/pg_lake_benchmark/pg_lake_benchmark.control
@@ -1,6 +1,6 @@
 # pg_lake_benchmark extension
 comment = 'Benchmark for PgLake and Iceberg tables'
-default_version = '3.0'
+default_version = '3.1'
 module_pathname = '$libdir/pg_lake_benchmark'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_copy/pg_lake_copy--3.0--3.1.sql
+++ b/pg_lake_copy/pg_lake_copy--3.0--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_lake_copy from 3.0 to 3.1
+

--- a/pg_lake_copy/pg_lake_copy.control
+++ b/pg_lake_copy/pg_lake_copy.control
@@ -1,5 +1,5 @@
 comment = 'Copy to/from data lake files'
-default_version = '3.0'
+default_version = '3.1'
 module_pathname = '$libdir/pg_lake_copy'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_engine/pg_lake_engine--3.0--3.1.sql
+++ b/pg_lake_engine/pg_lake_engine--3.0--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_lake_engine from 3.0 to 3.1
+

--- a/pg_lake_engine/pg_lake_engine.control
+++ b/pg_lake_engine/pg_lake_engine.control
@@ -1,5 +1,5 @@
 comment = 'Query engine for data lake queries'
-default_version = '3.0'
+default_version = '3.1'
 module_pathname = '$libdir/pg_lake_engine'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_spatial/pg_lake_spatial--3.0--3.1.sql
+++ b/pg_lake_spatial/pg_lake_spatial--3.0--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_lake_spatial from 3.0 to 3.1
+

--- a/pg_lake_spatial/pg_lake_spatial.control
+++ b/pg_lake_spatial/pg_lake_spatial.control
@@ -1,6 +1,6 @@
 # pg_lake_spatial extension
 comment = 'Geospatial file format support'
-default_version = '3.0'
+default_version = '3.1'
 module_pathname = '$libdir/pg_lake_spatial'
 relocatable = false
 schema = pg_catalog

--- a/pg_map/pg_map--1.2--3.1.sql
+++ b/pg_map/pg_map--1.2--3.1.sql
@@ -1,0 +1,2 @@
+-- Upgrade script for pg_map from 1.2 to 3.1
+

--- a/pg_map/pg_map.control
+++ b/pg_map/pg_map.control
@@ -1,4 +1,4 @@
-default_version = '1.2'
+default_version = '3.1'
 module_pathname = '$libdir/pg_map'
 relocatable = false
 schema = pg_catalog

--- a/tools/bump_extension_versions.py
+++ b/tools/bump_extension_versions.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Bump PostgreSQL extension versions across multiple subdirectories.
+
+This script:
+  1. Scans subfolders for .control files (marks them as PostgreSQL extensions)
+  2. Updates their 'default_version' line to a target version (if different)
+  3. Creates a version upgrade SQL file (e.g., pg_lake_engine--2.4--3.0.sql)
+
+Usage:
+  python bump_extension_versions.py 3.0
+"""
+
+import os
+import sys
+import re
+from pathlib import Path
+
+def find_extensions(base_dir):
+    """
+    Return a list of top-level directories that contain a .control file.
+    (No recursive search — avoids test subfolders, etc.)
+    """
+    extensions = []
+    for item in base_dir.iterdir():
+        if not item.is_dir():
+            continue
+        # Look only directly under this folder for .control files
+        control_files = list(item.glob("*.control"))
+        if control_files:
+            extensions.append(item)
+    return extensions
+
+def bump_control_file(control_path, new_version):
+    """
+    Update the default_version line in the .control file.
+    Returns (old_version, changed)
+    """
+    with open(control_path, "r") as f:
+        lines = f.readlines()
+
+    old_version = None
+    new_lines = []
+    changed = False
+
+    for line in lines:
+        if line.strip().startswith("default_version"):
+            match = re.search(r"['\"]([^'\"]+)['\"]", line)
+            if match:
+                old_version = match.group(1)
+                if old_version == new_version:
+                    # Version is already up to date, no changes needed
+                    return old_version, False
+                line = re.sub(r"['\"]([^'\"]+)['\"]", f"'{new_version}'", line)
+                changed = True
+        new_lines.append(line)
+
+    if changed:
+        with open(control_path, "w") as f:
+            f.writelines(new_lines)
+
+    return old_version, changed
+
+def create_upgrade_sql(ext_dir, ext_name, old_version, new_version):
+    """
+    Create a stub SQL upgrade file: extname--old--new.sql
+    """
+    if not old_version:
+        print(f"⚠️  No old version found for {ext_name}, skipping SQL file.")
+        return
+    sql_path = ext_dir / f"{ext_name}--{old_version}--{new_version}.sql"
+    if sql_path.exists():
+        print(f"✅ SQL upgrade file already exists: {sql_path}")
+        return
+    with open(sql_path, "w") as f:
+        f.write(f"-- Upgrade script for {ext_name} from {old_version} to {new_version}\n")
+    print(f"🆕 Created {sql_path}")
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python bump_extension_versions.py <new_version>")
+        sys.exit(1)
+
+    new_version = sys.argv[1]
+    repo_root = Path.cwd()
+
+    print(f"🔍 Scanning for PostgreSQL extensions in {repo_root}")
+    extensions = find_extensions(repo_root)
+    if not extensions:
+        print("No extensions found.")
+        sys.exit(0)
+
+    for ext_dir in extensions:
+        control_files = list(ext_dir.glob("*.control"))
+        for control_file in control_files:
+            ext_name = control_file.stem
+            print(f"\n📦 Updating {ext_name}")
+            old_version, changed = bump_control_file(control_file, new_version)
+
+            if not old_version:
+                print(f"⚠️ Could not find old version for {ext_name}, skipping SQL file.")
+                continue
+
+            if not changed:
+                print(f"⏩ {ext_name} already at version {new_version}, skipping.")
+                continue
+
+            create_upgrade_sql(ext_dir, ext_name, old_version, new_version)
+            print(f"✅ Bumped {ext_name} from {old_version} → {new_version}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We decided that we'll keep all the extension versions in sync. Let's get prepared for a release.

We already bumped few extensions to 3.1, and this PR does the rest:
```sql
\dx
                                List of installed extensions
         Name         | Version |   Schema   |                  Description
----------------------+---------+------------+-----------------------------------------------
 btree_gist           | 1.7     | public     | support for indexing common datatypes in GiST
 pg_extension_base    | 3.1     | pg_catalog | Extension development kit by Snowflake
 pg_extension_updater | 3.1     | pg_catalog | Automatic extension updater
 pg_lake              | 3.1     | pg_catalog | Data lake extension by Snowflake
 pg_lake_copy         | 3.1     | pg_catalog | Copy to/from data lake files
 pg_lake_engine       | 3.1     | pg_catalog | Query engine for data lake queries
 pg_lake_iceberg      | 3.1     | pg_catalog | Iceberg implementation in Postgres
 pg_lake_table        | 3.1     | pg_catalog | Data lake tables and Iceberg tables
 pg_map               | 3.1     | pg_catalog | Map type for Postgres
 pgaudit              | 17.0    | public     | provides auditing functionality
 plpgsql              | 1.0     | pg_catalog | PL/pgSQL procedural language
(11 rows)
```

In this commit, we also add a tiny python script that helps bootstrap new versions.