### PR TITLE
Fix issue that it can't access AWS credential

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,10 +43,13 @@ services:
         - BASE_IMAGE_OS=almalinux
         - BASE_IMAGE_TAG=9
     container_name: pgduck-server
+    environment:
+      AWS_SHARED_CREDENTIALS_FILE: /home/postgres/.aws/credentials
+      AWS_CONFIG_FILE: /home/postgres/.aws/config        
     volumes:
       - ./scripts/entrypoint-pgduck-server.sh:/entrypoint-pgduck-server.sh
       - ./scripts/init-pgduck-server.sql:/init-pgduck-server.sql
-      - ${USERPROFILE}${HOME}/.aws:/root/.aws:ro
+      - ${USERPROFILE}${HOME}/.aws:/home/postgres/.aws:ro
       - pgduck-unix-socket-volume:/home/postgres/pgduck_socket_dir
       - pg-18-tmp-dir-volume:/home/postgres/pgsql-18/data/base/pgsql_tmp
       - pg-17-tmp-dir-volume:/home/postgres/pgsql-17/data/base/pgsql_tmp


### PR DESCRIPTION
Hi pg_lake team,

I'm Sho, DevRel JP @ Snowflake.
I met aws credential error in docker-compose.

Currently, you were mounting the AWS credential to the pgduck-server in the root folder, but since the execution user for pgduck-server is the postgres user, so this PR enable it mount to the postgres user directory, not root.

This PR also make a fix because the credential environment variables were not being loaded correctly unless specified in docker-compose.

I'm not sure about the development policy in this repo, but if this PR is okay, I would appreciate it if you could merge it.