### PR TITLE
Fix rewriting trigonometric funcs with degrees arg

### DIFF
--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -162,6 +162,7 @@ static Node *RewriteFuncExprCardinality(Node *node, void *context);
 static Node *RewriteFuncExprArrayLength(Node *node, void *context);
 static Node *RewriteFuncExprPostgisBytea(Node *node, void *context);
 static Node *RewriteFuncExprTrigonometry(Node *node, void *context);
+static Node *RewriteFuncExprInverseTrigonometry(Node *node, void *context);
 static Node *RewriteFuncExprJsonbArrayLength(Node *node, void *context);
 static Node *RewriteFuncExprEncode(Node *node, void *context);
 static Node *RewriteFuncExprDecode(Node *node, void *context);
@@ -258,16 +259,16 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 
 	/* degree variants of trigonometry functions */
 	{
-		"pg_catalog", "acosd", RewriteFuncExprTrigonometry, 0
+		"pg_catalog", "acosd", RewriteFuncExprInverseTrigonometry, 0
 	},
 	{
-		"pg_catalog", "asind", RewriteFuncExprTrigonometry, 0
+		"pg_catalog", "asind", RewriteFuncExprInverseTrigonometry, 0
 	},
 	{
-		"pg_catalog", "atand", RewriteFuncExprTrigonometry, 0
+		"pg_catalog", "atand", RewriteFuncExprInverseTrigonometry, 0
 	},
 	{
-		"pg_catalog", "atan2d", RewriteFuncExprTrigonometry, 0
+		"pg_catalog", "atan2d", RewriteFuncExprInverseTrigonometry, 0
 	},
 	{
 		"pg_catalog", "cosd", RewriteFuncExprTrigonometry, 0
@@ -2089,10 +2090,57 @@ RewriteFuncExprCardinality(Node *node, void *context)
 
 /*
  * RewriteFuncExprTrigonometry rewrites several trigonometry
- * function calls by adding a degrees(..) call.
+ * function calls by adding a radians(..) call.
  */
 static Node *
 RewriteFuncExprTrigonometry(Node *node, void *context)
+{
+	FuncExpr   *funcExpr = castNode(FuncExpr, node);
+
+	/* find the no degrees variant */
+	switch (funcExpr->funcid)
+	{
+		case F_COSD:
+			funcExpr->funcid = F_COS;
+			break;
+
+		case F_COTD:
+			funcExpr->funcid = F_COT;
+			break;
+
+		case F_SIND:
+			funcExpr->funcid = F_SIN;
+			break;
+
+		case F_TAND:
+			funcExpr->funcid = F_TAN;
+			break;
+
+		default:
+			elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
+	}
+
+	FuncExpr   *radiansExpr = makeNode(FuncExpr);
+
+	radiansExpr->funcid = F_RADIANS;
+	radiansExpr->funcresulttype = funcExpr->funcresulttype;
+	radiansExpr->funcretset = false;
+	radiansExpr->funcvariadic = false;
+	radiansExpr->funcformat = COERCE_EXPLICIT_CALL;
+	radiansExpr->location = -1;
+	radiansExpr->args = funcExpr->args;
+
+	funcExpr->args = list_make1((Node *) radiansExpr);
+	return (Node *) funcExpr;
+}
+
+
+/*
+ * RewriteFuncExprInverseTrigonometry rewrites several inverse
+ * trigonometry function calls by adding a degrees(..) call.
+ */
+static Node *
+RewriteFuncExprInverseTrigonometry(Node *node, void *context)
 {
 	FuncExpr   *funcExpr = castNode(FuncExpr, node);
 
@@ -2115,22 +2163,6 @@ RewriteFuncExprTrigonometry(Node *node, void *context)
 			funcExpr->funcid = F_ATAN2;
 			break;
 
-		case F_COSD:
-			funcExpr->funcid = F_COS;
-			break;
-
-		case F_COTD:
-			funcExpr->funcid = F_COT;
-			break;
-
-		case F_SIND:
-			funcExpr->funcid = F_SIN;
-			break;
-
-		case F_TAND:
-			funcExpr->funcid = F_TAN;
-			break;
-
 		default:
 			elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
 	}
@@ -2147,7 +2179,6 @@ RewriteFuncExprTrigonometry(Node *node, void *context)
 
 	return (Node *) degreesExpr;
 }
-
 
 
 /*

--- a/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
@@ -76,53 +76,73 @@ test_agg_cases = [
     ("trunc(double)", "WHERE trunc(col_double) = 1.0", "trunc(", True),
     ("trunc(numeric)", "WHERE trunc(col_numeric) = 1.0", "trunc(", True),
     # Trigonometry operators, input must be in the range [-1,1]
-    ("acos", "WHERE abs(col_double) < 1 and acos(col_double) > 0", "acos(", True),
+    (
+        "acos",
+        "WHERE abs(col_double)<1 and abs(acos(col_double) - 0.988432) < 0.001",
+        "acos(",
+        True,
+    ),
     (
         "acosd",
-        "WHERE abs(col_double) < 1 and acosd(col_double) > 0",
+        "WHERE abs(col_double)<1 and abs(acosd(col_double) - 56.63298) < 0.001",
         "degrees(acos(",
         True,
     ),
-    ("asin", "WHERE abs(col_double) < 1 and asin(col_double) < 0", "asin(", True),
+    (
+        "asin",
+        "WHERE abs(col_double)<1 and abs(asin(col_double) - 0.582364) < 0.001",
+        "asin(",
+        True,
+    ),
     (
         "asind",
-        "WHERE abs(col_double) < 1 and asind(col_double) < 0",
+        "WHERE abs(col_double)<1 and abs(asind(col_double) - 33.36701) < 0.001",
         "degrees(asin(",
         True,
     ),
-    ("atan", "WHERE abs(col_double) < 1 and atan(col_double) < 0", "atan(", True),
+    (
+        "atan",
+        "WHERE abs(atan(col_double) - 0.5028432) < 0.001",
+        "atan(",
+        True,
+    ),
     (
         "atand",
-        "WHERE abs(col_double) < 1 and atand(col_double) < 0",
+        "WHERE abs(atand(col_double) - 28.81079) < 0.001",
         "degrees(atan(",
         True,
     ),
-    ("atan2", "WHERE abs(col_double) < 1 and atan2(col_double, 1) < 0", "atan2(", True),
+    (
+        "atan2",
+        "WHERE abs(atan2(col_double, 1) - 0.5028432) < 0.001",
+        "atan2(",
+        True,
+    ),
     (
         "atan2d",
-        "WHERE abs(col_double) < 1 and atan2d(col_double, 1) < 0",
+        "WHERE abs(atan2d(col_double, 1) - 28.810793) < 0.001",
         "degrees(atan2(",
         True,
     ),
-    ("cos", "WHERE abs(col_double) < 1 and cos(col_double) > 0", "cos(", True),
+    ("cos", "WHERE abs(cos(col_double) - 0.8525245) < 0.001", "cos(", True),
     (
         "cosd",
-        "WHERE abs(col_double) < 1 and cosd(col_double) > 0",
-        "degrees(cos(",
+        "WHERE abs(cosd(col_double) - 0.999953) < 0.001",
+        "cos(radians(",
         True,
     ),
-    ("sin", "WHERE abs(col_double) < 1 and sin(col_double) < 0", "sin(", True),
+    ("sin", "WHERE abs(sin(col_double) - 0.522687) < 0.001", "sin(", True),
     (
         "sind",
-        "WHERE abs(col_double) < 1 and sind(col_double) < 0",
-        "degrees(sin(",
+        "WHERE abs(sind(col_double) - 0.00959) < 0.001",
+        "sin(radians(",
         True,
     ),
-    ("tan", "WHERE abs(col_double) < 1 and tan(col_double) < 0", "tan(", True),
+    ("tan", "WHERE abs(tan(col_double) - 0.61310) < 0.001", "tan(", True),
     (
         "tand",
-        "WHERE abs(col_double) < 1 and tand(col_double) < 0",
-        "degrees(tan(",
+        "WHERE abs(tand(col_double) - 0.00959) < 0.001",
+        "tan(radians(",
         True,
     ),
 ]
@@ -165,6 +185,8 @@ def create_math_pushdown_table(pg_conn, s3, extension):
 					SELECT 1, 1, 1, 1.1, 1.1,  1.1, 1.1, 1.1
 					 	UNION ALL
 					SELECT -1, -1, -100, -1.1, -0.1,  2.2, 2.2, 2.2
+						UNION ALL
+					SELECT -1, -1, -100, -1.1, 0.55,  2.2, 2.2, 2.2
 						UNION ALL
 					SELECT 1561, 223123, -100123, -111.111111, -12222.1222222, 21231.2123123, 4534652.2456456, 4.2
 				) TO '{url}' WITH (FORMAT 'parquet');


### PR DESCRIPTION
This PR uses `radians` function instead of `degrees`, as duckdb doesn't support trignonometric functions with degrees arguments. `radians` is to convert degrees to radians, and by also converting the trigonometric function to radians version of itself, the rewritten query will be able to be executed correctly.

Currently, an example query `select sind(a) from test_tbl;` gets rewritten as `select degrees(sin(a)) from test_tbl;` which is entirely incorrect. With this PR, it's going to be like `select sin(radians(a)) from test_tbl;` which gives the correct result.

fixes: #53 