### PR TITLE
Move compatibility routines to pg_extension_base/pg_compat.h

### DIFF
--- a/pg_extension_base/include/pg_extension_base/pg_compat.h
+++ b/pg_extension_base/include/pg_extension_base/pg_compat.h
@@ -16,5 +16,30 @@
  */
 
 #pragma once
+#include "postgres.h"
 
-/* nothing currently */
+#if PG_VERSION_NUM < 170000
+
+#define foreach_ptr(type, var, lst) foreach_internal(type, *, var, lst, lfirst)
+#define foreach_int(var, lst)	foreach_internal(int, , var, lst, lfirst_int)
+#define foreach_oid(var, lst)	foreach_internal(Oid, , var, lst, lfirst_oid)
+#define foreach_xid(var, lst)	foreach_internal(TransactionId, , var, lst, lfirst_xid)
+
+/*
+ * The internal implementation of the above macros.  Do not use directly.
+ *
+ * This macro actually generates two loops in order to declare two variables of
+ * different types.  The outer loop only iterates once, so we expect optimizing
+ * compilers will unroll it, thereby optimizing it away.
+ */
+#define foreach_internal(type, pointer, var, lst, func) \
+	for (type pointer var = 0, pointer var##__outerloop = (type pointer) 1; \
+		 var##__outerloop; \
+		 var##__outerloop = 0) \
+		for (ForEachState var##__state = {(lst), 0}; \
+			 (var##__state.l != NIL && \
+			  var##__state.i < var##__state.l->length && \
+			 (var = func(&var##__state.l->elements[var##__state.i]), true)); \
+			 var##__state.i++)
+
+#endif

--- a/pg_lake_engine/include/pg_lake/pg_version_compat/pg_version_compat.h
+++ b/pg_lake_engine/include/pg_lake/pg_version_compat/pg_version_compat.h
@@ -15,30 +15,6 @@
  * limitations under the License.
  */
 
-#include "postgres.h"
+#pragma message("pg_lake/pg_version_compat/pg_version_compat.h is deprecated; use pg_extension_base/pg_compat.h instead")
 
-#if PG_VERSION_NUM < 170000
-
-#define foreach_ptr(type, var, lst) foreach_internal(type, *, var, lst, lfirst)
-#define foreach_int(var, lst)	foreach_internal(int, , var, lst, lfirst_int)
-#define foreach_oid(var, lst)	foreach_internal(Oid, , var, lst, lfirst_oid)
-#define foreach_xid(var, lst)	foreach_internal(TransactionId, , var, lst, lfirst_xid)
-
-/*
- * The internal implementation of the above macros.  Do not use directly.
- *
- * This macro actually generates two loops in order to declare two variables of
- * different types.  The outer loop only iterates once, so we expect optimizing
- * compilers will unroll it, thereby optimizing it away.
- */
-#define foreach_internal(type, pointer, var, lst, func) \
-	for (type pointer var = 0, pointer var##__outerloop = (type pointer) 1; \
-		 var##__outerloop; \
-		 var##__outerloop = 0) \
-		for (ForEachState var##__state = {(lst), 0}; \
-			 (var##__state.l != NIL && \
-			  var##__state.i < var##__state.l->length && \
-			 (var = func(&var##__state.l->elements[var##__state.i]), true)); \
-			 var##__state.i++)
-
-#endif
+#include "pg_extension_base/pg_compat.h"

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -49,7 +49,7 @@
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/transaction/transaction_hooks.h"
 #include "pg_lake/util/injection_points.h"
-#include "pg_lake/pg_version_compat/pg_version_compat.h"
+#include "pg_extension_base/pg_compat.h"
 #include "pg_lake/transaction/track_iceberg_metadata_changes.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"

--- a/pg_lake_table/src/duckdb/transform_query_to_duckdb.c
+++ b/pg_lake_table/src/duckdb/transform_query_to_duckdb.c
@@ -54,7 +54,7 @@
 #include "pg_lake/fdw/writable_table.h"
 #include "pg_lake/fdw/utils.h"
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"
-#include "pg_lake/pg_version_compat/pg_version_compat.h"
+#include "pg_extension_base/pg_compat.h"
 #include "pg_lake/pgduck/read_data.h"
 #include "pg_lake/pgduck/rewrite_query.h"
 #include "pg_lake/parsetree/options.h"

--- a/pg_lake_table/src/fdw/data_file_pruning.c
+++ b/pg_lake_table/src/fdw/data_file_pruning.c
@@ -57,7 +57,7 @@
 #include "pg_lake/iceberg/data_file_stats.h"
 #include "pg_lake/iceberg/partitioning/partition.h"
 #include "pg_lake/iceberg/temporal_utils.h"
-#include "pg_lake/pg_version_compat/pg_version_compat.h"
+#include "pg_extension_base/pg_compat.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
 #include "pg_lake/iceberg/hash_utils.h"
 #include "pg_lake/pgduck/map.h"

--- a/pg_lake_table/src/fdw/pg_lake_table.c
+++ b/pg_lake_table/src/fdw/pg_lake_table.c
@@ -90,7 +90,7 @@
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/permissions/roles.h"
-#include "pg_lake/pg_version_compat/pg_version_compat.h"
+#include "pg_extension_base/pg_compat.h"
 #include "pg_lake/pgduck/array_conversion.h"
 #include "pg_lake/pgduck/client.h"
 #include "pg_lake/pgduck/explain.h"

--- a/pg_lake_table/src/fdw/snapshot.c
+++ b/pg_lake_table/src/fdw/snapshot.c
@@ -35,7 +35,7 @@
 #include "pg_lake/fdw/writable_table.h"
 #include "pg_lake/pgduck/map.h"
 #include "pg_lake/parsetree/options.h"
-#include "pg_lake/pg_version_compat/pg_version_compat.h"
+#include "pg_extension_base/pg_compat.h"
 #include "pg_lake/pgduck/remote_storage.h"
 #include "pg_lake/planner/restriction_collector.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"

--- a/pg_lake_table/src/planner/query_pushdown.c
+++ b/pg_lake_table/src/planner/query_pushdown.c
@@ -42,7 +42,7 @@
 #include "pg_lake/planner/insert_select.h"
 #include "pg_lake/planner/query_pushdown.h"
 #include "pg_lake/planner/restriction_collector.h"
-#include "pg_lake/pg_version_compat/pg_version_compat.h"
+#include "pg_extension_base/pg_compat.h"
 #include "pg_lake/pgduck/array_conversion.h"
 #include "pg_lake/pgduck/client.h"
 #include "pg_lake/pgduck/explain.h"


### PR DESCRIPTION
We had two places for pg compatibility and only need one; choose the pg_extension_base, as that makes more sense.

Currently leaving the old file around with a deprecation warning, but maybe we just want to remove it entirely.
