### PR TITLE
Improve the DCO experience

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,26 +1,5 @@
 require:
   signoff: true
 
-message: |
-  Thank you for your contribution!
-  
-  This project uses the Developer Certificate of Origin (DCO).
-  DCO is a simple way for you to confirm that you wrote your code
-  and that you have the right to contribute it.
-  
-  You can read more here:
-  https://developercertificate.org/
-
-  Your commit is missing a "Signed-off-by" line.
-
-  Please fix it by running:
-
-      git commit --amend -s
-      git push --force
-
-  If your PR has multiple commits:
-
-      git rebase --signoff main
-      git push --force
-
-  After fixing, the DCO check will turn green and you can merge.
+require:
+  members: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Description
+Please explain what this PR changes and why.
+
+---
+
+## Checklist
+
+- [ ] I have tested my changes and added tests if necessary
+- [ ] I updated documentation if needed
+- [ ] **I confirm that all my commits are signed off (DCO)**
+
+---
+
+## DCO Reminder (important)
+
+This project uses the Developer Certificate of Origin (DCO).  
+DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.
+
+If the DCO check fails, please sign off your commits.
+
+### How to sign off
+
+For your last commit:
+    git commit --amend -s
+    git push --force
+
+For multiple commits:
+    git rebase --signoff main
+    git push --force
+
+More info: https://developercertificate.org/


### PR DESCRIPTION
It looks like the `message` field is not supported in DCO. Instead, let's add that to PR template. We wouldn't want DCO requirement to be implicit for external contributors.

For internal contributors, let's not require DCO.