### PR TITLE
Do not add a partition spec if it already exists

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/partition_transform.h
+++ b/pg_lake_table/include/pg_lake/fdw/partition_transform.h
@@ -28,6 +28,7 @@ extern void *ApplyBucketTransformToColumn(IcebergPartitionTransform * transform,
 										  Datum columnValue, bool isNull,
 										  size_t *bucketSize);
 extern List *CurrentPartitionTransformList(Oid relationId);
+extern IcebergPartitionSpec * GetPartitionSpecIfAlreadyExist(Oid relationId, List *partitionTransforms);
 extern List *AllPartitionTransformList(Oid relationId);
 extern List *GetPartitionTransformsFromSpecFields(Oid relationId, List *specFields);
 extern void *DeserializePartitionValueFromPGText(IcebergPartitionTransform * transform,

--- a/pg_lake_table/include/pg_lake/partitioning/partition_spec_catalog.h
+++ b/pg_lake_table/include/pg_lake/partitioning/partition_spec_catalog.h
@@ -43,6 +43,7 @@ typedef struct IcebergPartitionSpecHashEntry
 extern void UpdateDefaultPartitionSpecId(Oid relationId, int specId);
 extern void InsertPartitionSpecAndPartitionFields(Oid relationId, IcebergPartitionSpec * spec);
 extern int	GetLargestSpecId(Oid relationId);
+extern List *GetAllIcebergPartitionSpecIds(Oid relationId);
 extern PGDLLEXPORT int GetCurrentSpecId(Oid relationId);
 extern int	GetLargestPartitionFieldId(Oid relationId);
 extern IcebergPartitionSpecField * GetIcebergPartitionFieldFromCatalog(Oid relationId, int fieldId);

--- a/pg_lake_table/src/ddl/ddl_changes.c
+++ b/pg_lake_table/src/ddl/ddl_changes.c
@@ -212,6 +212,15 @@ ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 			List	   *parsedTransforms = ddlOperation->parsedTransforms;
 			List	   *analyzedTransforms = AnalyzeIcebergTablePartitionBy(relationId, parsedTransforms);
 
+			*partitionSpec = GetPartitionSpecIfAlreadyExist(relationId, analyzedTransforms);
+			if (*partitionSpec != NULL)
+			{
+				/* update lake_iceberg.internal_tables specId */
+				UpdateDefaultPartitionSpecId(relationId, (*partitionSpec)->spec_id);
+
+				return;
+			}
+
 			/*
 			 * creatint a new spec, get the largest spec and we'll increment
 			 * it if needed when assigning

--- a/pg_lake_table/tests/pytests/test_writable_table_vacuum.py
+++ b/pg_lake_table/tests/pytests/test_writable_table_vacuum.py
@@ -747,7 +747,7 @@ def test_vacuum_iceberg_identity_partitioned_table(
         expected_data_files_cnt=11,
     )
 
-    # add same partition_by and insert with a new spec (we could have used existing spec but we always create a new one)
+    # add same partition_by and insert with the existing spec
     run_command(
         f"""
         ALTER TABLE {table_name} OPTIONS (ADD partition_by 'id');
@@ -761,8 +761,8 @@ def test_vacuum_iceberg_identity_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=20,
-        expected_data_files_cnt=21,
+        expected_partition_values_cnt=10,
+        expected_data_files_cnt=11,
     )
 
     # set new partition_by and insert with a new spec
@@ -779,8 +779,8 @@ def test_vacuum_iceberg_identity_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=30,
-        expected_data_files_cnt=31,
+        expected_partition_values_cnt=20,
+        expected_data_files_cnt=21,
     )
 
     # sanity check on table
@@ -839,7 +839,7 @@ def test_vacuum_iceberg_truncate_partitioned_table(
         expected_data_files_cnt=10,
     )
 
-    # add same partition_by and insert with a new spec (we could have used existing spec but we always create a new one)
+    # add same partition_by and insert with a the old spec
     run_command(
         f"""
         ALTER TABLE {table_name} OPTIONS (ADD partition_by 'truncate(1,id)');
@@ -854,8 +854,8 @@ def test_vacuum_iceberg_truncate_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=18,
-        expected_data_files_cnt=19,
+        expected_partition_values_cnt=9,
+        expected_data_files_cnt=10,
     )
 
     # set new partition_by and insert with a new spec
@@ -873,8 +873,8 @@ def test_vacuum_iceberg_truncate_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=27,
-        expected_data_files_cnt=28,
+        expected_partition_values_cnt=18,
+        expected_data_files_cnt=19,
     )
 
     # sanity check on table
@@ -933,7 +933,7 @@ def test_vacuum_iceberg_bucket_partitioned_table(
         expected_data_files_cnt=9,
     )
 
-    # add same partition_by and insert with a new spec (we could have used existing spec but we always create a new one)
+    # add same partition_by and insert with a the existing spec
     run_command(
         f"""
         ALTER TABLE {table_name} OPTIONS (ADD partition_by 'bucket(100,id)');
@@ -947,8 +947,8 @@ def test_vacuum_iceberg_bucket_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=16,
-        expected_data_files_cnt=17,
+        expected_partition_values_cnt=8,
+        expected_data_files_cnt=9,
     )
 
     # set new partition_by and insert with a new spec
@@ -965,8 +965,8 @@ def test_vacuum_iceberg_bucket_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=24,
-        expected_data_files_cnt=25,
+        expected_partition_values_cnt=16,
+        expected_data_files_cnt=17,
     )
 
     # sanity check on table
@@ -1034,7 +1034,7 @@ def test_vacuum_iceberg_year_partitioned_table(
         expected_data_files_cnt=11,
     )
 
-    # add same partition_by and insert with a new spec (we could have used existing spec but we always create a new one)
+    # add same partition_by and insert with the old spec
     run_command(
         f"""
         ALTER TABLE {table_name} OPTIONS (ADD partition_by 'year(a)');
@@ -1053,8 +1053,8 @@ def test_vacuum_iceberg_year_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=20,
-        expected_data_files_cnt=21,
+        expected_partition_values_cnt=10,
+        expected_data_files_cnt=11,
     )
 
     # set new partition_by and insert with a new spec
@@ -1076,8 +1076,8 @@ def test_vacuum_iceberg_year_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=30,
-        expected_data_files_cnt=31,
+        expected_partition_values_cnt=20,
+        expected_data_files_cnt=21,
     )
 
     # sanity check on table
@@ -1136,7 +1136,7 @@ def test_vacuum_iceberg_multi_partitioned_table(
         expected_data_files_cnt=11,
     )
 
-    # add same partition_by and insert with a new spec (we could have used existing spec but we always create a new one)
+    # add same partition_by and insert with the same spec
     run_command(
         f"""
         ALTER TABLE {table_name} OPTIONS (ADD partition_by 'truncate(1,id), bucket(100,value)');
@@ -1151,8 +1151,8 @@ def test_vacuum_iceberg_multi_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=40,
-        expected_data_files_cnt=21,
+        expected_partition_values_cnt=20,
+        expected_data_files_cnt=11,
     )
 
     # set new partition_by and insert with a new spec
@@ -1170,8 +1170,8 @@ def test_vacuum_iceberg_multi_partitioned_table(
     assert_partition_values_and_data_files(
         pg_conn,
         table_name,
-        expected_partition_values_cnt=42,
-        expected_data_files_cnt=22,
+        expected_partition_values_cnt=22,
+        expected_data_files_cnt=12,
     )
 
     # sanity check on table


### PR DESCRIPTION
Both Spark and Polaris follows this. Before this commit, we blindly added partition specs, even if the same spec existed before. Now, we are switching to a more proper way: if the same spec exists in the table earlier, we simply use that instead of adding one more spec.

This is especially useful for #68, where Polaris throws an error if we try to send a partition spec that already exists. Here `the same spec` means a spec that has the exact same fields with an existing spec in the table.

To give an example, previously we created 3 specs for the following, now 2:
```sql
ALTER TABLE t OPTION (ADD partition_by='bucket(10,a)');
..
ALTER TABLE t OPTION (ADD partition_by='bucket(20,a)');
..
-- back to 10, this does not generate a new spec anymore
ALTER TABLE t OPTION (ADD partition_by='bucket(10,a)');
```

On Polaris, before this commit, we'd get the following, given Polaris thinks this spec already exists:
```
alter table t (set partition_by 'bucket(10,a)');
WARNING:  HTTP request failed (HTTP 400)
DETAIL:  Cannot set last added spec: no spec has been added
HINT:  The rest catalog returned error type: ValidationException
```



