### PR TITLE
Use GetTransactionSnapshot() over GetActiveSnapshot()

### DIFF
--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -511,7 +511,7 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	bool		newFilesOnly = false;
 	bool		forUpdate = false;
 	char	   *orderBy = NULL;
-	Snapshot	snapshot = GetActiveSnapshot();
+	Snapshot	snapshot = GetTransactionSnapshot();
 
 	HTAB	   *currentFilesMap = GetTableDataFilesByPathHashFromCatalog(opTracker->relationId, dataOnly, newFilesOnly,
 																		 forUpdate, orderBy, snapshot, allTransforms);


### PR DESCRIPTION
Fixes #85 

We already do serialization properly via `LockTableForUpdate` on
modify vs vacuum, that part is fine.

The problem is that when the waiting transaction is unblocked, it
cannot really see the catalog changes done by the others, unless
the snapshot is `GetLatestSnapshot()` or `GetTransactionSnapshot()`

And, in VACUUM & all other places, we already do that properly:

https://github.com/Snowflake-Labs/pg_lake/blob/bfa38cef35eea16aade99f2557fab7c923a9f9c9/pg_lake_table/src/fdw/writable_table.c#L692-L696

So, we should do that for table scan as well, and this PR is
about that.

Essentially, we get to Iceberg catalog operations follow a global order defined by
`LockTableForUpdate()` within that order, each 'catalog op' sees all committed
changes from earlier `catalog ops` by calling into `GetTransactionSnapshot()`.

One nice benefit of using `GetTransactionSnapshot()` over `GetLatestSnapshot()` is that
we also preserve the `REPEATABLE READ` and `SERIALIZABLE` transaction semantics.

We also use the same snapshot for all tables in a scan.