### PR TITLE
Do not generate a new schema if already exists

### DIFF
--- a/pg_lake_engine/include/pg_lake/parquet/leaf_field.h
+++ b/pg_lake_engine/include/pg_lake/parquet/leaf_field.h
@@ -50,6 +50,7 @@ typedef struct LeafField
 }			LeafField;
 
 extern PGDLLEXPORT int LeafFieldCompare(const ListCell *a, const ListCell *b);
+extern PGDLLEXPORT bool SchemaFieldsEquivalent(DataFileSchemaField * fieldA, DataFileSchemaField * fieldB);
 #if PG_VERSION_NUM < 170000
 extern PGDLLEXPORT int pg_cmp_s32(int32 a, int32 b);
 #endif

--- a/pg_lake_engine/include/pg_lake/util/string_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/string_utils.h
@@ -33,7 +33,7 @@ extern PGDLLEXPORT char *EscapedStringLiteral(const char *val);
 extern PGDLLEXPORT char *ReverseStringSearch(const char *haystack, const char *needle);
 extern PGDLLEXPORT int32_t AdjustAnyCharTypmod(int32_t typmod, int32_t newLength);
 extern PGDLLEXPORT int32_t GetAnyCharLengthFrom(int32_t typmod);
-
+extern PGDLLEXPORT bool PgStrcasecmpNullable(const char *a, const char *b);
 
 #define RangeVarQuoteIdentifier(rv) \
 	(((rv)->schemaname != NULL) ?							  \

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -21,6 +21,7 @@
 
 #include "pg_lake/parquet/field.h"
 #include "pg_lake/parquet/leaf_field.h"
+#include "pg_lake/util/string_utils.h"
 
 static FieldStructElement * DeepCopyFieldStructElement(FieldStructElement * structElementField);
 static Field * DeepCopyField(const Field * field);
@@ -145,3 +146,40 @@ pg_cmp_s32(int32 a, int32 b)
 	return (a > b) - (a < b);
 }
 #endif
+
+
+
+/*
+* SchemaFieldsEquivalent compares two DataFileSchemaField structs for equivalence.
+* It returns true if they are equivalent, false otherwise.
+* Note that we do not compare the field->type here, as we do not allow changing
+* the type of any field in the schema, including nested types.
+*/
+bool
+SchemaFieldsEquivalent(DataFileSchemaField * fieldA, DataFileSchemaField * fieldB)
+{
+	if (fieldA->id != fieldB->id)
+		return false;
+
+	if (!PgStrcasecmpNullable(fieldA->name, fieldB->name))
+		return false;
+
+	if (fieldA->required != fieldB->required)
+		return false;
+
+	if (!PgStrcasecmpNullable(fieldA->doc, fieldB->doc))
+		return false;
+
+	if (!PgStrcasecmpNullable(fieldA->writeDefault, fieldB->writeDefault))
+		return false;
+
+	if (!PgStrcasecmpNullable(fieldA->initialDefault, fieldB->initialDefault))
+		return false;
+
+	/*
+	 * We don't allow changing any of the types of the fields in the schema,
+	 * including the fields of nested types. So we don't need to compare
+	 * anything about the field->type here.
+	 */
+	return true;
+}

--- a/pg_lake_engine/src/utils/string_utils.c
+++ b/pg_lake_engine/src/utils/string_utils.c
@@ -245,3 +245,19 @@ GetAnyCharLengthFrom(int32_t typmod)
 
 	return typmod - VARHDRSZ;
 }
+
+
+/*
+* PgStrcasecmpNullable compares two strings for equality, treating NULLs as equal.
+*/
+bool
+PgStrcasecmpNullable(const char *a, const char *b)
+{
+	if (a == NULL && b == NULL)
+		return true;
+
+	if (a == NULL || b == NULL)
+		return false;
+
+	return pg_strcasecmp(a, b) == 0;
+}


### PR DESCRIPTION
Similar to #79, but this time for `schema` field.

#68 is rebased on top of this 
