### PR TITLE
Increment HTTP Timeouts

### DIFF
--- a/pg_lake_iceberg/src/http/http_client.c
+++ b/pg_lake_iceberg/src/http/http_client.c
@@ -35,11 +35,11 @@
 #include <ctype.h>
 #include <curl/curl.h>
 
-/* 5 second */
-#define CONNECT_TIMEOUT_MS  5000
-
 /* 20 seconds */
-#define TOTAL_TIMEOUT_MS   20000
+#define CONNECT_TIMEOUT_MS  20000
+
+/* 180 seconds */
+#define TOTAL_TIMEOUT_MS   180000
 
 
 typedef enum


### PR DESCRIPTION
I have seen some Polaris REST servers to respond slowly when many tables updated. For example, below is an example of inserting 100 tables in a single TX:
```
WARNING:  Timeout was reached
WARNING:  Operation timed out after 20002 milliseconds with 0 bytes received
DEBUG:  cleaning up libcurl
WARNING:  HTTP request failed Operation timed out after 20002 milliseconds with 0 bytes received
COMMIT
```

So, let's bump the timeouts a bit more, especially the TOTAL_TIMEOUT_MS, which is the actual commit time for REST catalogs.

