### PR TITLE
Change iceberg table and catalog locations

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
@@ -28,6 +28,9 @@
 extern char *IcebergDefaultLocationPrefix;
 
 
+extern PGDLLEXPORT char *ExternalIcebergStoragePrefix;
+extern PGDLLEXPORT char *InternalIcebergStoragePrefix;
+
 /*
 * From the external view perspective, the pg_catalog.iceberg_tables
 * (and pg_lake_iceberg.tables) includes both the internal and

--- a/pg_lake_iceberg/include/pg_lake/object_store_catalog/object_store_catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/object_store_catalog/object_store_catalog.h
@@ -8,8 +8,6 @@
 extern PGDLLEXPORT bool EnableObjectStoreCatalog;
 
 extern PGDLLEXPORT char *ObjectStoreCatalogLocationPrefix;
-extern PGDLLEXPORT char *ExternalObjectStorePrefix;
-extern PGDLLEXPORT char *InternalObjectStorePrefix;
 
 extern PGDLLEXPORT void InitObjectStoreCatalog(void);
 extern PGDLLEXPORT void ExportIcebergCatalogIfChanged(void);

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -98,19 +98,19 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
-	DefineCustomStringVariable("pg_lake_iceberg.external_object_store_catalog_prefix",
+	DefineCustomStringVariable("pg_lake_iceberg.external_iceberg_storage_prefix",
 							   gettext_noop("Specifies the prefix used for the object store catalog files for external tables."),
 							   NULL,
-							   &ExternalObjectStorePrefix,
+							   &ExternalIcebergStoragePrefix,
 							   "fromsf",
 							   PGC_SIGHUP,
 							   GUC_NO_SHOW_ALL | GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE,
 							   NULL, NULL, NULL);
 
-	DefineCustomStringVariable("pg_lake_iceberg.internal_object_store_catalog_prefix",
+	DefineCustomStringVariable("pg_lake_iceberg.internal_iceberg_storage_prefix",
 							   gettext_noop("Specifies the prefix used for the object store catalog files for internal tables."),
 							   NULL,
-							   &InternalObjectStorePrefix,
+							   &InternalIcebergStoragePrefix,
 							   "frompg",
 							   PGC_SIGHUP,
 							   GUC_NO_SHOW_ALL | GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE,

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -22,8 +22,6 @@
 #include "pg_lake/storage/local_storage.h"
 
 char	   *ObjectStoreCatalogLocationPrefix = NULL;
-char	   *ExternalObjectStorePrefix = "fromsf";
-char	   *InternalObjectStorePrefix = "frompg";
 
 PG_FUNCTION_INFO_V1(list_object_store_tables);
 PG_FUNCTION_INFO_V1(trigger_object_store_catalog_generation);
@@ -496,16 +494,16 @@ GetExternalObjectStoreCatalogFilePath(const char *catalogName)
 				 errdetail("Set the GUC to use catalog=object_store.")));
 	}
 
-	if (ExternalObjectStorePrefix == NULL)
+	if (ExternalIcebergStoragePrefix == NULL)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("pg_lake_iceberg.external_object_store_prefix is not set"),
+				 errmsg("pg_lake_iceberg.external_iceberg_storage_prefix is not set"),
 				 errdetail("Set the GUC to use catalog=object_store.")));
 	}
 
-	return psprintf("%s/_catalog/%s/%s.json", defaultPrefix,
-					ExternalObjectStorePrefix, URLEncodePath(catalogName));
+	return psprintf("%s/%s/catalog/%s.json", defaultPrefix,
+					ExternalIcebergStoragePrefix, URLEncodePath(catalogName));
 }
 
 static char *
@@ -521,16 +519,16 @@ GetInternalObjectStoreCatalogFilePath(const char *catalogName)
 				 errdetail("Set the GUC to use catalog=object_store.")));
 	}
 
-	if (InternalObjectStorePrefix == NULL)
+	if (InternalIcebergStoragePrefix == NULL)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("pg_lake_iceberg.internal_object_store_prefix is not set"),
+				 errmsg("pg_lake_iceberg.internal_iceberg_storage_prefix is not set"),
 				 errdetail("Set the GUC to use catalog=object_store.")));
 	}
 
-	return psprintf("%s/_catalog/%s/%s.json", defaultPrefix,
-					InternalObjectStorePrefix, URLEncodePath(catalogName));
+	return psprintf("%s/%s/catalog/%s.json", defaultPrefix,
+					InternalIcebergStoragePrefix, URLEncodePath(catalogName));
 }
 
 /*

--- a/pg_lake_table/tests/pytests/test_create_table.py
+++ b/pg_lake_table/tests/pytests/test_create_table.py
@@ -219,7 +219,7 @@ def test_create_table_with_default_location(
     )[0][0]
 
     assert (
-        f"s3://{TEST_BUCKET}/{dbname}/public/test_create_table_with_default_location/{table_oid}"
+        f"s3://{TEST_BUCKET}/frompg/tables/{dbname}/public/test_create_table_with_default_location/{table_oid}"
         in first_table_metadata_location
     )
 
@@ -275,7 +275,7 @@ def test_create_table_with_default_location(
     )[0][0]
 
     assert (
-        f"s3://{TEST_BUCKET}/{dbname}/public/test_create_table_with_default_location/{table_oid}"
+        f"s3://{TEST_BUCKET}/frompg/tables/{dbname}/public/test_create_table_with_default_location/{table_oid}"
         in second_table_metadata_location
     )
 
@@ -333,7 +333,7 @@ def test_create_table_with_default_location_override(
         pg_conn,
     )
     assert (
-        f"s3://{TEST_BUCKET}/test_create_table_with_default_location_override/{dbname}/public/test_create_table_with_default_location"
+        f"s3://{TEST_BUCKET}/test_create_table_with_default_location_override/frompg/tables/{dbname}/public/test_create_table_with_default_location"
         in result[0][0]
     )
 

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -978,14 +978,14 @@ def adjust_object_store_settings(superuser_conn):
     # to be able to read the same tables that we write, use the same prefix
     run_command(
         f"""
-        ALTER SYSTEM SET pg_lake_iceberg.internal_object_store_catalog_prefix = 'tmp';
+        ALTER SYSTEM SET pg_lake_iceberg.internal_iceberg_storage_prefix = 'tmp';
         """,
         superuser_conn,
     )
 
     run_command(
         f"""
-		ALTER SYSTEM SET pg_lake_iceberg.external_object_store_catalog_prefix = 'tmp';
+		ALTER SYSTEM SET pg_lake_iceberg.external_iceberg_storage_prefix = 'tmp';
         """,
         superuser_conn,
     )
@@ -1009,13 +1009,13 @@ def adjust_object_store_settings(superuser_conn):
     )
     run_command(
         f"""
-        ALTER SYSTEM RESET pg_lake_iceberg.internal_object_store_catalog_prefix;
+        ALTER SYSTEM RESET pg_lake_iceberg.internal_iceberg_storage_prefix;
 	   """,
         superuser_conn,
     )
     run_command(
         f"""
-     	ALTER SYSTEM RESET pg_lake_iceberg.external_object_store_catalog_prefix;
+     	ALTER SYSTEM RESET pg_lake_iceberg.external_iceberg_storage_prefix;
         """,
         superuser_conn,
     )


### PR DESCRIPTION
This change does 2 things:

- When a table is created with `catalog=object_store`, the catalog file used to be in `defaultPrefix/_catalog/frompg/pg_db.json` after this commit: `defaultPrefix/frompg/catalog/pg_db.json`

- When any iceberg table is created, it used to be located in `defaultPrefix/dbname/schema/table_name/table_oid`. After this commit: `defaultPrefix/frompg/tables/dbname/schema/table_name/table_oid`

The goal is to be able to differentiate the tables written by Postgres, and other systems. The `frompg` allows this. Also, we can control the access of `/catalog` folder such that only privileged users can access that.

