### PR TITLE
Change the object store table/catalog layout

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
@@ -60,7 +60,7 @@ extern PGDLLEXPORT void UpdateExternalCatalogMetadataLocation(char *catalogName,
 															  const char *previousMetadataLocation);
 extern PGDLLEXPORT void UpdateInternalCatalogMetadataLocation(Oid relationId, const char *metadataLocation, const char *previousMetadataLocation);
 extern PGDLLEXPORT void UpdateAllInternalIcebergTablesToReadOnly(void);
-extern PGDLLEXPORT const char *GetIcebergDefaultLocationPrefix(void);
+extern PGDLLEXPORT char *GetIcebergDefaultLocationPrefix(void);
 extern PGDLLEXPORT bool IcebergTablesCatalogExists(void);
 extern PGDLLEXPORT void ErrorIfReadOnlyIcebergTable(Oid relationId);
 extern PGDLLEXPORT bool WarnIfReadOnlyIcebergTable(Oid relationId);

--- a/pg_lake_iceberg/src/iceberg/catalog.c
+++ b/pg_lake_iceberg/src/iceberg/catalog.c
@@ -740,7 +740,7 @@ UpdateAllInternalIcebergTablesToReadOnly(void)
  * GetIcebergDefaultLocationPrefix returns the default location prefix
  * for iceberg tables. Trailing slash is removed, if present.
  */
-const char *
+char *
 GetIcebergDefaultLocationPrefix(void)
 {
 	if (IcebergDefaultLocationPrefix == NULL)

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -504,7 +504,7 @@ GetExternalObjectStoreCatalogFilePath(const char *catalogName)
 				 errdetail("Set the GUC to use catalog=object_store.")));
 	}
 
-	return psprintf("%s/_catalog/%s/%s.json", defaultPrefix,
+	return psprintf("%s/%s/catalog/%s.json", defaultPrefix,
 					ExternalObjectStorePrefix, URLEncodePath(catalogName));
 }
 
@@ -529,7 +529,7 @@ GetInternalObjectStoreCatalogFilePath(const char *catalogName)
 				 errdetail("Set the GUC to use catalog=object_store.")));
 	}
 
-	return psprintf("%s/_catalog/%s/%s.json", defaultPrefix,
+	return psprintf("%s/%s/catalog/%s.json", defaultPrefix,
 					InternalObjectStorePrefix, URLEncodePath(catalogName));
 }
 


### PR DESCRIPTION
And alternative to #96

This change does 2 things:

- When a table is created with `catalog=obeject_store`, the catalog file used to be in `defaultPrefix/_catalog/frompg/pg_db.json` after this commit: `defaultPrefix/frompg/catalog/pg_db.json`

- When an `catalog=object_store` iceberg table is created, it used to be located in `defaultPrefix/dbname/schema/table_name/oid`. After this commit: `defaultPrefix/frompg/tables/dbname/schema/table_name/oid`

The goal is to be able to differentiate the tables written by Postgres, and other systems. The `frompg` allows this. Also, we can control the access of `/catalog` folder such that only priviledged users can access that.
