### PR TITLE
Fix a few warts with the duckdb module patching approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ delete_old_cluster.sh
 pg_lake_iceberg/logs/polaris.log
 .volume/
 Dockerfile.alpine
+/duckdb_pglake/.patches_applied

--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,10 @@ install-duckdb_pglake: duckdb_pglake
 		$(MAKE) -C duckdb_pglake install; \
 	fi
 
-pgduck_server: duckdb_pglake
+pgduck_server: install-duckdb_pglake
 	$(MAKE) -C pgduck_server
 
-install-pgduck_server: install-duckdb_pglake pgduck_server
+install-pgduck_server: pgduck_server
 	$(MAKE) -C pgduck_server install
 
 ## Overridden targets; basically the ones in CUSTOM_TARGETS above

--- a/duckdb_pglake/Makefile
+++ b/duckdb_pglake/Makefile
@@ -132,23 +132,23 @@ release: patch_duckdb
 
 #### Misc
 
-# patch exit code 1 means the patch is already applied, since we might run this multiple times, be robust
-patch_duckdb:
-	cd duckdb && \
-	find ../patches/duckdb -type f -name '*.patch' -print | xargs -0 printf '%s ' | \
-	while read -r patch; do \
-	patch -l -p1 -N < "$$patch" || [ $$? -eq 1 ]; \
+# we assume that any modified files in these subdirs indicate that we have
+# already been patched.  This does mean if you have updated updating the patches here you
+# will need to reset the repositories so the new patches will be picked up.
+
+.patches_applied: $(shell find patches -type f -name '*.patch')
+	for patchdir in duckdb duckdb-postgres duckdb-azure; do \
+		(cd $$patchdir && \
+		git checkout -f . && \
+		find ../patches/$$patchdir -type f -name '*.patch' -print | sort | xargs -0 printf '%s ' | \
+		while read -r patch; do \
+			echo "applying $$patch to $$patchdir" ; \
+			git apply --ignore-whitespace "$$patch"; \
+		done;) \
 	done
-	cd duckdb-postgres && \
-	find ../patches/duckdb-postgres -type f -name '*.patch' -print | xargs -0 printf '%s ' | \
-	while read -r patch; do \
-	patch -l -p1 -N < "$$patch" || [ $$? -eq 1 ]; \
-	done
-	cd duckdb-azure && \
-	find ../patches/duckdb-azure -type f -name '*.patch' -print | xargs -0 printf '%s ' | \
-	while read -r patch; do \
-	patch -l -p1 -N < "$$patch" || [ $$? -eq 1 ]; \
-	done
+	touch .patches_applied
+
+patch_duckdb: .patches_applied
 
 format:
 	find src/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i


### PR DESCRIPTION
## Description

This uses `git apply` to apply the changes directly, as well as is a bit smarter about ensuring that we don't re-apply patches multiple times, which can lead to compile errors.

Since the logic is the same, we also remove some of the duplication here.

## Checklist

- [X] I have tested my changes and added tests if necessary
- [X] I updated documentation if needed
- [X] **I confirm that all my commits are signed off (DCO)**
