### PR TITLE
External catalog metadata stability

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
@@ -55,6 +55,7 @@ extern PGDLLEXPORT void DeleteInternalIcebergCatalogTable(Oid relationId);
 
 extern PGDLLEXPORT List *GetAllInternalIcebergRelationIds(void);
 extern PGDLLEXPORT char *GetIcebergMetadataLocation(Oid relationId, bool forUpdate);
+extern PGDLLEXPORT void ResetExternalCatalogMetadataPerTxHash(void);
 extern PGDLLEXPORT void LockIcebergPgLakeCatalogForUpdate(Oid relationId);
 extern PGDLLEXPORT char *GetIcebergCatalogMetadataLocation(Oid relationId, bool forUpdate);
 extern PGDLLEXPORT char *GetIcebergCatalogPreviousMetadataLocation(Oid relationId, bool forUpdate);

--- a/pg_lake_table/src/transaction/transaction_hooks.c
+++ b/pg_lake_table/src/transaction/transaction_hooks.c
@@ -22,6 +22,7 @@
 
 #include "pg_lake/transaction/track_iceberg_metadata_changes.h"
 #include "pg_lake/transaction/transaction_hooks.h"
+#include "pg_lake/iceberg/catalog.h"
 
 
 static void IcebergXactCallback(XactEvent event, void *arg);
@@ -65,6 +66,7 @@ IcebergXactCallback(XactEvent event, void *arg)
 			{
 				ResetTrackedIcebergMetadataOperation();
 				ResetRestCatalogRequests();
+				ResetExternalCatalogMetadataPerTxHash();
 				break;
 			}
 		case XACT_EVENT_PRE_PREPARE:
@@ -82,6 +84,7 @@ IcebergXactCallback(XactEvent event, void *arg)
 			{
 				PostAllRestCatalogRequests();
 				ResetRestCatalogRequests();
+				ResetExternalCatalogMetadataPerTxHash();
 				break;
 			}
 	}


### PR DESCRIPTION
(opening as draft, because there seems to be a concurrency issue with INSERT vs VACUUM, which I couldn't figure out clearly what's going on. Still useful to have this patch available for future iterations)

Before this commit, we fetched metadata from external catalogs, such as REST or object_store, multipe times even for a single command.

Let's align more with Postgres' transaction semantics:
- Always use the same metadata for a given command
- For the same tables accessed in a single tx, behave depending on the isolation-level:
	- For `REPEATABLE READ` and `SERIALIZABLE`, use the same metadata across multiple accesses to the same table within the transaction
	- For `READ-COMMITTED`, fetch the metadata per statement.
