### PR TITLE
Restrict the reduction of secrets further

### DIFF
--- a/pg_lake_iceberg/src/http/http_client.c
+++ b/pg_lake_iceberg/src/http/http_client.c
@@ -584,7 +584,11 @@ RedactSensitiveJson(char *input)
 		"\"token\"",
 		"\"client_secret\"",
 		"\"authorization\"",
-		"\"Authorization\""
+		"\"Authorization\"",
+		"\"s3.access-key-id\"",
+		"\"s3.secret-access-key\"",
+		"\"s3.session-token\"",
+		"\"storage-credentials\""
 	};
 	const int	keyCount = sizeof(keys) / sizeof(keys[0]);
 


### PR DESCRIPTION
Extension of https://github.com/Snowflake-Labs/pg_lake/pull/71

As we use `vended-credentials`, Polaris returns the credentials for the storage location, let's hide all the possible secrets documented in Polaris docs:
```
INFO:  received response with status code 200, body: {"metadata":{"format-version":2,"table-uuid":"8e34719d-cbb6-4bb1-893d-a0982fbe9018","location":"s3://okalaci-eu-central/ondertest/part/t_time_col_part3","last-sequence-number":0,"last-updated-ms":1765868381748,"last-column-id":0,"current-schema-id":0,"schemas":[{"type":"struct","schema-id":0,"fields":[]}],"default-spec-id":0,"partition-specs":[{"spec-id":0,"fields":[]}],"last-partition-id":999,"default-sort-order-id":0,"sort-orders":[{"order-id":0,"fields":[]}],"properties":{"created-at":"2025-12-16T06:59:41.720604572Z","write.parquet.compression-codec":"zstd"},"current-snapshot-id":-1,"refs":{},"snapshots":[],"statistics":[],"partition-statistics":[],"snapshot-log":[],"metadata-log":[]},"config":{"s3.access-key-id":"********************","s3.secret-access-key":"****************************************","s3.session-token":"************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************","expiration-time":"1765871981000"},"storage-credentials":[{"prefix":"s3://okalaci-eu-central/ondertest/part/t_time_col_part3","config":{"s3.access-key-id":"********************","s3.secret-access-key":"****************************************","s3.session-token":"************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************","expiration-time":"1765871981000"}}]}

```
