### PR TITLE
Duckdb patch return_stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,8 @@ clean-avro:
 ifneq ("$(wildcard avro/lang/c/build)","")
 	$(MAKE) -C avro/lang/c/build clean
 	rm -r avro/lang/c/build
+	# clean patches 	
+	cd avro && git checkout -f .
 endif
 
 uninstall-avro:

--- a/duckdb_pglake/Makefile
+++ b/duckdb_pglake/Makefile
@@ -132,11 +132,7 @@ release: patch_duckdb
 
 #### Misc
 
-# we assume that any modified files in these subdirs indicate that we have
-# already been patched.  This does mean if you have updated updating the patches here you
-# will need to reset the repositories so the new patches will be picked up.
-
-.patches_applied: $(shell find patches -type f -name '*.patch')
+patch_duckdb: $(shell find patches -type f -name '*.patch')
 	for patchdir in duckdb duckdb-postgres duckdb-azure; do \
 		(cd $$patchdir && \
 		git checkout -f . && \
@@ -146,10 +142,12 @@ release: patch_duckdb
 			git apply --ignore-whitespace "$$patch"; \
 		done;) \
 	done
-	touch .patches_applied
 
-patch_duckdb: .patches_applied
-
+clean_patches:
+	for patchdir in duckdb duckdb-postgres duckdb-azure; do \
+		(cd $$patchdir && \
+		git checkout -f . ); \
+	done
 
 format:
 	find src/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
@@ -160,7 +158,7 @@ pull:
 	git submodule init
 	git submodule update --recursive --remote
 
-clean:
+clean: clean_patches
 	rm -rf build
 	rm -rf testext
 	rm -f libduckdb.so

--- a/duckdb_pglake/patches/duckdb/return_stats.patch
+++ b/duckdb_pglake/patches/duckdb/return_stats.patch
@@ -1,0 +1,53 @@
+diff --git a/extension/parquet/parquet_writer.cpp b/extension/parquet/parquet_writer.cpp
+index 3c6d11d9ad..d1a7b54ad5 100644
+--- a/extension/parquet/parquet_writer.cpp
++++ b/extension/parquet/parquet_writer.cpp
+@@ -3,6 +3,7 @@
+ #include "duckdb.hpp"
+ #include "mbedtls_wrapper.hpp"
+ #include "parquet_crypto.hpp"
++#include "parquet_decimal_utils.hpp"
+ #include "parquet_timestamp.hpp"
+ #include "resizable_buffer.hpp"
+ #include "duckdb/common/file_system.hpp"
+@@ -656,8 +657,20 @@ struct DecimalStatsUnifier : public NumericStatsUnifier<T> {
+ 		if (stats.empty()) {
+ 			return string();
+ 		}
+-		auto numeric_val = Load<T>(const_data_ptr_cast(stats.data()));
+-		return Value::DECIMAL(numeric_val, width, scale).ToString();
++
++		auto stats_data = const_data_ptr_cast(stats.data());
++
++		if (sizeof(T) == sizeof(hugeint_t))
++		{
++			auto _schema = ParquetColumnSchema();
++			auto numeric_val = ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(stats_data, stats.size(), _schema);
++			return Value::DECIMAL(numeric_val, width, scale).ToString();
++		}
++		else
++		{
++			auto numeric_val = Load<T>(stats_data);
++			return Value::DECIMAL(numeric_val, width, scale).ToString();
++		}
+ 	}
+ };
+ 
+@@ -781,7 +794,7 @@ struct NullStatsUnifier : public ColumnStatsUnifier {
+ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &type) {
+ 	switch (type.id()) {
+ 	case LogicalTypeId::BOOLEAN:
+-		return make_uniq<NullStatsUnifier>();
++		return make_uniq<NumericStatsUnifier<int8_t>>();
+ 	case LogicalTypeId::TINYINT:
+ 	case LogicalTypeId::SMALLINT:
+ 	case LogicalTypeId::INTEGER:
+@@ -826,6 +839,8 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
+ 			return make_uniq<DecimalStatsUnifier<int32_t>>(width, scale);
+ 		case PhysicalType::INT64:
+ 			return make_uniq<DecimalStatsUnifier<int64_t>>(width, scale);
++		case PhysicalType::INT128:
++			return make_uniq<DecimalStatsUnifier<hugeint_t>>(width, scale);
+ 		default:
+ 			return make_uniq<NullStatsUnifier>();
+ 		}


### PR DESCRIPTION
Patch duckdb to return stats for columns of boolean and numeric with precision > 18 and precision <= 38.
