### PR TITLE
Add hyperbolic functions: sinh, cosh, tanh.

### DIFF
--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -79,6 +79,16 @@ inline void ThrowInternalError(DataChunk &args, ExpressionState &state, Vector &
 	throw InternalException(str);
 }
 
+inline void SinhPG(DataChunk &args, ExpressionState &state, Vector &result)
+{
+	auto &input_vector = args.data[0];
+
+	UnaryExecutor::Execute<double, double>(
+		input_vector, result, args.size(),
+		[&](double value) {
+			return std::sinh(value);
+		});
+}
 
 inline void AcoshPG(DataChunk &args, ExpressionState &state, Vector &result)
 {
@@ -94,6 +104,16 @@ inline void AcoshPG(DataChunk &args, ExpressionState &state, Vector &result)
 		});
 }
 
+inline void CoshPG(DataChunk &args, ExpressionState &state, Vector &result)
+{
+	auto &input_vector = args.data[0];
+
+	UnaryExecutor::Execute<double, double>(
+		input_vector, result, args.size(),
+		[&](double value) {
+			return std::cosh(value);
+		});
+}
 
 inline void AtanhPG(DataChunk &args, ExpressionState &state, Vector &result)
 {
@@ -108,6 +128,19 @@ inline void AtanhPG(DataChunk &args, ExpressionState &state, Vector &result)
 			return std::atanh(value);
 		});
 }
+
+inline void TanhPG(DataChunk &args, ExpressionState &state, Vector &result)
+{
+	auto &input_vector = args.data[0];
+
+	UnaryExecutor::Execute<double, double>(
+		input_vector, result, args.size(),
+		[&](double value) {
+			return std::tanh(value);
+		});
+}
+
+
 
 
 /*
@@ -287,11 +320,20 @@ static void LoadInternal(ExtensionLoader &loader) {
     auto to_date_function = ScalarFunction("to_date", {LogicalType::DOUBLE}, LogicalType::DATE, ToDateScalarFun);
     loader.RegisterFunction(to_date_function);
 
+	auto sinh_function = ScalarFunction("sinh_pg", {LogicalType::DOUBLE}, LogicalType::DOUBLE, SinhPG);
+    loader.RegisterFunction(sinh_function);
+
     auto acosh_function = ScalarFunction("acosh_pg", {LogicalType::DOUBLE}, LogicalType::DOUBLE, AcoshPG);
     loader.RegisterFunction(acosh_function);
 
+	auto cosh_function = ScalarFunction("cosh_pg", {LogicalType::DOUBLE}, LogicalType::DOUBLE, CoshPG);
+    loader.RegisterFunction(cosh_function);
+
 	auto atanh_function = ScalarFunction("atanh_pg", {LogicalType::DOUBLE}, LogicalType::DOUBLE, AtanhPG);
 	loader.RegisterFunction(atanh_function);
+
+	auto tanh_function = ScalarFunction("tanh_pg", {LogicalType::DOUBLE}, LogicalType::DOUBLE, TanhPG);
+    loader.RegisterFunction(tanh_function);
 
 	auto nullify_any_type = ScalarFunction("nullify_any_type", {LogicalType::ANY}, LogicalType::SQLNULL, NullifyAnyType);
 	loader.RegisterFunction(nullify_any_type);

--- a/pg_lake_engine/pg_lake_engine--3.0--3.1.sql
+++ b/pg_lake_engine/pg_lake_engine--3.0--3.1.sql
@@ -16,13 +16,31 @@ CREATE FUNCTION __lake__internal__nsp__.to_hex(bytea)
  IMMUTABLE PARALLEL SAFE STRICT
 AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
 
+CREATE FUNCTION __lake__internal__nsp__.sinh_pg(double precision)
+ RETURNS double precision
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
+
 CREATE FUNCTION __lake__internal__nsp__.acosh_pg(double precision)
  RETURNS double precision
  LANGUAGE C
  IMMUTABLE PARALLEL SAFE STRICT
 AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
 
+CREATE FUNCTION __lake__internal__nsp__.cosh_pg(double precision)
+ RETURNS double precision
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
+
 CREATE FUNCTION __lake__internal__nsp__.atanh_pg(double precision)
+ RETURNS double precision
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
+
+CREATE FUNCTION __lake__internal__nsp__.tanh_pg(double precision)
  RETURNS double precision
  LANGUAGE C
  IMMUTABLE PARALLEL SAFE STRICT

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -286,10 +286,19 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 
 	/* hyperbolic functions */
 	{
+		"pg_catalog", "sinh", RewriteFuncExprHyperbolic, 0
+	},
+	{
 		"pg_catalog", "acosh", RewriteFuncExprHyperbolic, 0
 	},
 	{
+		"pg_catalog", "cosh", RewriteFuncExprHyperbolic, 0
+	},
+	{
 		"pg_catalog", "atanh", RewriteFuncExprHyperbolic, 0
+	},
+	{
+		"pg_catalog", "tanh", RewriteFuncExprHyperbolic, 0
 	},
 
 	/* explicit calls to cast functions */
@@ -2208,12 +2217,24 @@ RewriteFuncExprHyperbolic(Node *node, void *context)
 
 	switch (funcExpr->funcid)
 	{
+		case F_SINH:
+			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP), makeString("sinh_pg"));
+			break;
+
 		case F_ACOSH:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP), makeString("acosh_pg"));
 			break;
 		
+	    case F_COSH:
+			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP), makeString("cosh_pg"));
+			break;
+		
 		case F_ATANH:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP), makeString("atanh_pg"));
+			break;
+
+		case F_TANH:
+			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP), makeString("tanh_pg"));
 			break;
 
 		default:

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -350,6 +350,10 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"asinh", 'f', 1, {"float8"}, NULL},
 	{"acosh", 'f', 1, {"float8"}, NULL},
 	{"atanh", 'f', 1, {"float8"}, NULL},
+	{"sinh", 'f', 1, {"float8"}, NULL},
+	{"cosh", 'f', 1, {"float8"}, NULL},
+	{"tanh", 'f', 1, {"float8"}, NULL},
+
 
 	/* array functions */
 	{"array_append", 'f', 2, {"anycompatiblearray", "anycompatible"}, NULL},

--- a/pg_lake_spatial/tests/pytests/test_internal_schema.py
+++ b/pg_lake_spatial/tests/pytests/test_internal_schema.py
@@ -21,6 +21,6 @@ def test_internal_schema(
     """,
         pg_conn,
     )[0][0]
-    assert result == 63
+    assert result == 66
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
@@ -146,15 +146,33 @@ test_agg_cases = [
         True,
     ),
     (
+        "sinh",
+        "WHERE abs(sinh(col_double) - 0.5781516) < 0.001",
+        "sinh_pg(",
+        True,
+    ),
+    (
         "asinh",
         "WHERE col_double > 1 and abs(asinh(col_double) - 0.9503469) < 0.001",
         "asinh(",
         True,
     ),
     (
+        "cosh",
+        "WHERE abs(cosh(col_double) - 1.1551014) < 0.001",
+        "cosh_pg(",
+        True,
+    ),
+    (
         "acosh",
         "WHERE col_double > 1 and abs(acosh(col_double) - 0.4435682) < 0.001",
         "acosh_pg(",
+        True,
+    ),
+    (
+        "tanh",
+        "WHERE abs(tanh(col_double) - 0.5005202) < 0.001",
+        "tanh_pg(",
         True,
     ),
     (


### PR DESCRIPTION
# Add Hyperbolic Functions: sinh, cosh, tanh

## Description
This PR adds support for the following hyperbolic functions:

- sinh
- cosh
- tanh

The following changes are included:

- Implemented C++ scalar functions for sinh, cosh and tanh.
- Registered the functions in the function loader.
- Added SQL wrappers for each function in __lake__internal__nsp__.
- Added pytest cases to verify correctness and pushdown behavior.