### PR TITLE
Prevent any name conflicts with DuckDB on `CachingFileSystem`

### DIFF
--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -316,35 +316,35 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	fs.UnregisterSubSystem("S3FileSystem");
 	fs.RegisterSubSystem(
-		make_uniq<CachingFileSystem>(
+		make_uniq<PGLakeCachingFileSystem>(
 			make_uniq<RegionAwareS3FileSystem>(BufferManager::GetBufferManager(instance))
 		)
 	);
 
 	fs.UnregisterSubSystem("AzureBlobStorageFileSystem");
 	fs.RegisterSubSystem(
-		make_uniq<CachingFileSystem>(
+		make_uniq<PGLakeCachingFileSystem>(
 			make_uniq<AzureBlobStorageFileSystem>(BufferManager::GetBufferManager(instance))
 		)
 	);
 
 	fs.UnregisterSubSystem("AzureDfsStorageFileSystem");
 	fs.RegisterSubSystem(
-		make_uniq<CachingFileSystem>(
+		make_uniq<PGLakeCachingFileSystem>(
 			make_uniq<AzureDfsStorageFileSystem>(BufferManager::GetBufferManager(instance))
 		)
 	);
 
 	fs.UnregisterSubSystem("HTTPFileSystem");
 	fs.RegisterSubSystem(
-		make_uniq<CachingFileSystem>(
+		make_uniq<PGLakeCachingFileSystem>(
 			make_uniq<HTTPFileSystem>()
 		)
 	);
 
 	fs.UnregisterSubSystem("HuggingFaceFileSystem");
 	fs.RegisterSubSystem(
-		make_uniq<CachingFileSystem>(
+		make_uniq<PGLakeCachingFileSystem>(
 			make_uniq<HuggingFaceFileSystem>()
 		)
 	);

--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -44,7 +44,7 @@ namespace duckdb {
  * as the return value goes out of scope on the caller side.
  */
 unique_ptr<FileHandle>
-CachingFileSystem::OpenFile(const string &fullUrl,
+PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 							FileOpenFlags openFlags,
 							optional_ptr<FileOpener> opener)
 {
@@ -185,7 +185,7 @@ CachingFileSystem::OpenFile(const string &fullUrl,
 * return true; otherwise, return false.
 */
 bool
-CachingFileSystem::ShouldCacheOnWrite(CachingFSFileHandle &pg_lakeHandle, int64_t additionalByteCount)
+PGLakeCachingFileSystem::ShouldCacheOnWrite(CachingFSFileHandle &pg_lakeHandle, int64_t additionalByteCount)
 {
 	if (pg_lakeHandle.cacheOnWriteHandle == nullptr)
 		return false;
@@ -221,7 +221,7 @@ CachingFileSystem::ShouldCacheOnWrite(CachingFSFileHandle &pg_lakeHandle, int64_
 * file cache lock.
 */
 void
-CachingFileSystem::CleanUpCacheOnWriteFile(CachingFSFileHandle &pg_lakeHandle)
+PGLakeCachingFileSystem::CleanUpCacheOnWriteFile(CachingFSFileHandle &pg_lakeHandle)
 {
 	if (pg_lakeHandle.cacheOnWriteHandle != nullptr)
 	{
@@ -251,7 +251,7 @@ CachingFileSystem::CleanUpCacheOnWriteFile(CachingFSFileHandle &pg_lakeHandle)
  * them.
  */
 vector<OpenFileInfo>
-CachingFileSystem::Glob(const string &urlPattern, FileOpener *opener)
+PGLakeCachingFileSystem::Glob(const string &urlPattern, FileOpener *opener)
 {
 	if (StringUtil::StartsWith(urlPattern, NO_CACHE_PREFIX))
 	{
@@ -274,7 +274,7 @@ CachingFileSystem::Glob(const string &urlPattern, FileOpener *opener)
  * with some modifications to avoid showing nocache prefix.
  */
 bool
-CachingFileSystem::ListFiles(const string &directory,
+PGLakeCachingFileSystem::ListFiles(const string &directory,
 							 const std::function<void(const string &, bool)> &callback,
 							 FileOpener *opener)
 {
@@ -302,7 +302,7 @@ CachingFileSystem::ListFiles(const string &directory,
  * removal from the remote file system.
  */
 void
-CachingFileSystem::RemoveFile(const string &filename,
+PGLakeCachingFileSystem::RemoveFile(const string &filename,
 							  optional_ptr<FileOpener> opener)
 {
 	optional_ptr<ClientContext> context = opener->TryGetClientContext();

--- a/duckdb_pglake/src/include/pg_lake/fs/caching_file_system.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/caching_file_system.hpp
@@ -28,7 +28,7 @@ namespace duckdb {
 
 
 /*
- * CachingFSFileHandle is the FileHandle returned by CachingFileSystem::OpenFile.
+ * CachingFSFileHandle is the FileHandle returned by PGLakeCachingFileSystem::OpenFile.
  *
  * It wraps around a remote file handle or a LocalFileSystem handle.
  */
@@ -109,11 +109,11 @@ public:
 };
 
 /*
- * CachingFileSystem is a wrapper around S3FileSystem that replaces
+ * PGLakeCachingFileSystem is a wrapper around S3FileSystem that replaces
  * the original to be able to intercept and modify certain calls. In
  * particular we use OpenFile to implement caching.
  */
-class CachingFileSystem : public FileSystem {
+class PGLakeCachingFileSystem : public FileSystem {
 public:
 	/* remote file system */
     unique_ptr<FileSystem> remoteFs;
@@ -121,7 +121,7 @@ public:
 	/* local file system (mainly for convenience) */
     LocalFileSystem localfs;
 
-	CachingFileSystem(unique_ptr<FileSystem> remoteFsParam)
+	PGLakeCachingFileSystem(unique_ptr<FileSystem> remoteFsParam)
 	{
 		remoteFs = std::move(remoteFsParam);
 	}


### PR DESCRIPTION
Nowadays, DuckDB also has [CachingFileSystem](https://github.com/duckdb/duckdb/blob/7f6b657e32fb8a5be83157f2853e1dbc80d1749f/src/storage/caching_file_system.cpp#L53) class.

Make sure we don't get any sorts of conflicts with that.
