### PR TITLE
Skip caching if cache directory cannot be created

### DIFF
--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -157,13 +157,21 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 				* local file handle for the cache file, so we can write to it.
 				*/
 				string cacheFileDir = FileUtils::ExtractDirName(cacheFilePath);
-				FileUtils::EnsureLocalDirectoryExists(*context, cacheFileDir);
+				bool directoryExists = FileUtils::EnsureLocalDirectoryExists(*context, cacheFileDir);
 
-				cacheOnWriteHandle =
-					localfs.OpenFile(cacheFilePath + cacheManager->STAGING_SUFFIX,
-									 FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+				if (directoryExists)
+				{
+					cacheOnWriteHandle =
+						localfs.OpenFile(cacheFilePath + cacheManager->STAGING_SUFFIX,
+										FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
 
-				cacheOnWritePath = cacheFilePath;
+					cacheOnWritePath = cacheFilePath;
+				}
+				else
+				{
+					PGDUCK_SERVER_DEBUG("cannot use local cache for %s because the cache directory cannot "
+										"be created", cacheFilePath.c_str());
+				}
 			}
 		}
 	}

--- a/duckdb_pglake/src/fs/functions.cpp
+++ b/duckdb_pglake/src/fs/functions.cpp
@@ -315,6 +315,10 @@ static void ManageCacheExec(ClientContext &context, TableFunctionInput &data_p, 
 			case SKIPPED_CONCURRENT_MODIFY:
 				output.SetValue(2, rowInChunk, Value("skipped (cache file was modified concurrently)"));
 				break;
+			case SKIPPED_DIRECTORY_DOES_NOT_EXIST:
+				output.SetValue(2, rowInChunk, Value("skipped (cannot create directory)"));
+				break;
+
 		}
 
 		rowInChunk++;

--- a/duckdb_pglake/src/include/pg_lake/fs/file_cache_manager.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/file_cache_manager.hpp
@@ -41,6 +41,9 @@ extern const string NO_CACHE_PREFIX;
 */
 const string CACHE_FILE_PREFIX = "pgl-cache.";
 
+/* special values for cache file return code */
+const int64_t LOCK_CANNOT_BE_ACQUIRED = -1;
+const int64_t DIRECTORY_CANNOT_CREATED = -2;
 
 /*
  * CacheItem represents a file in cache or the cache queue.
@@ -93,7 +96,8 @@ enum CacheActionType
 	REMOVED,
 	SKIPPED_TOO_OLD,
 	SKIPPED_TOO_LARGE,
-	SKIPPED_CONCURRENT_MODIFY
+	SKIPPED_CONCURRENT_MODIFY,
+	SKIPPED_DIRECTORY_DOES_NOT_EXIST
 };
 
 /*

--- a/duckdb_pglake/src/include/pg_lake/fs/file_utils.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/file_utils.hpp
@@ -31,7 +31,7 @@ public:
 
 	static string ExtractDirName(const string &path);
 	static string ExtractFileName(const string &path);
-	static void EnsureLocalDirectoryExists(ClientContext &context, string dir_path);
+	static bool EnsureLocalDirectoryExists(ClientContext &context, string dir_path);
 	static int64_t CopyFile(ClientContext &context, string &source_path, string &destination_path);
 	static string GetMD5Base64(const char *buffer, idx_t bufferLength);
 


### PR DESCRIPTION
Handles some parts of #123, not closes.

When the cache drive for `pgduck_server` is full, trying to cache any new tables/files first may need to create the relevant cache folder. But when the disk is full, users get the following error on Postgres:

```
insert into public.events_iceberg select * from public.events_iceberg;select pg_size_pretty(lake_iceberg.table_size('public.events_iceberg'));
ERROR:  IO Error: Failed to create directory "/var/lib/duckdb/files/s3/6nmhen5cohitmhxoxoiyrspsmetujrxo/mxrx2fdbdfhn7ggc5uaevx4nee/postgres/public/events_iceberg/17538/data/0eb66c97-9b3f-4aa9-b587-0bd5d9baec14/": No space left on device
```

Instead, let's skip caching, and this commit implements that.


