### PR TITLE
Make write-through caching robust to file system errors

### DIFF
--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -161,11 +161,22 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 
 				if (directoryExists)
 				{
-					cacheOnWriteHandle =
-						localfs.OpenFile(cacheFilePath + cacheManager->STAGING_SUFFIX,
-										FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+					try
+					{
+						cacheOnWriteHandle =
+							localfs.OpenFile(cacheFilePath + cacheManager->STAGING_SUFFIX,
+											FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+						cacheOnWritePath = cacheFilePath;
 
-					cacheOnWritePath = cacheFilePath;
+					}
+					catch (Exception &ex)
+					{
+						ErrorData error(ex);
+
+						PGDUCK_SERVER_DEBUG("cannot use local cache for %s because the file "
+											"cannot be opened for write: %s", cacheFilePath.c_str(), error.Message().c_str());
+						cacheOnWriteHandle = nullptr;
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Before this commit, we assumed that cache file creation or writing to the cache file never errors out. Well, that's definitely not true. Especially with small cache sizes, it can be pretty common to have file system errors, when the disk is full.

With this commit, if opening the cache file or writing to the cache file fails, we skip write-through caching. We also make sure to clean up anything that have been written as part of write-through caching.

Note that we refer this concept as `cacheOnWrite` in the code, we should perhaps change that on a follow-up PR to keep things simpler.

Closes #123 
