### PR TITLE
Add `pg_lake_iceberg.default_catalog`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,7 @@ extend-exclude = [
     "*.avro",
     "*.spec",
     "*.out",
+    "pg_lake_table/tests/pytests/test_object_store_catalog.py"
 ]
 
 [default.extend-identifiers]

--- a/pg_lake_engine/include/pg_lake/util/catalog_type.h
+++ b/pg_lake_engine/include/pg_lake/util/catalog_type.h
@@ -17,6 +17,12 @@
 
 #pragma once
 
+/*
+* The allowed values for IcebergDefaultCatalog, case insensitive.
+*/
+#define POSTGRES_CATALOG_NAME "postgres"
+#define OBJECT_STORE_CATALOG_NAME "object_store"
+#define REST_CATALOG_NAME "rest"
 
 typedef enum IcebergCatalogType
 {

--- a/pg_lake_engine/src/utils/catalog_type.c
+++ b/pg_lake_engine/src/utils/catalog_type.c
@@ -76,7 +76,7 @@ HasRestCatalogTableOption(List *options)
 {
 	char	   *catalog = GetStringOption(options, "catalog", false);
 
-	return catalog ? strncasecmp(catalog, "rest", strlen("rest")) == 0 : false;
+	return catalog ? pg_strncasecmp(catalog, REST_CATALOG_NAME, strlen(catalog)) == 0 : false;
 }
 
 
@@ -89,7 +89,7 @@ HasObjectStoreCatalogTableOption(List *options)
 {
 	char	   *catalog = GetStringOption(options, "catalog", false);
 
-	return catalog ? strncasecmp(catalog, "object_store", strlen("object_store")) == 0 : false;
+	return catalog ? pg_strncasecmp(catalog, OBJECT_STORE_CATALOG_NAME, strlen(catalog)) == 0 : false;
 }
 
 
@@ -102,5 +102,5 @@ HasReadOnlyOption(List *options)
 {
 	char	   *readOnly = GetStringOption(options, "read_only", false);
 
-	return readOnly ? strncasecmp(readOnly, "true", strlen("true")) == 0 : false;
+	return readOnly ? pg_strncasecmp(readOnly, "true", strlen("true")) == 0 : false;
 }

--- a/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/catalog.h
@@ -21,11 +21,18 @@
 
 #include "pg_lake/util/rel_utils.h"
 
+
 /*
  * Default location prefix for pg_lake_iceberg tables. Used when the location
  * option is not specified at "CREATE FOREIGN SERVER pg_lake_iceberg OPTIONS ()".
  */
 extern char *IcebergDefaultLocationPrefix;
+
+/*
+ * Default catalog pg_lake_iceberg tables. Used when the catalog
+ * option is not specified at "CREATE TABLE ... USING iceberg (catalog=)".
+ */
+extern PGDLLEXPORT char *IcebergDefaultCatalog;
 
 
 /*

--- a/pg_lake_iceberg/src/iceberg/catalog.c
+++ b/pg_lake_iceberg/src/iceberg/catalog.c
@@ -32,6 +32,7 @@
 
 
 char	   *IcebergDefaultLocationPrefix = NULL;
+char	   *IcebergDefaultCatalog = POSTGRES_CATALOG_NAME;
 
 static char *GetIcebergExternalMetadataLocation(Oid relationId);
 static char *GetIcebergCatalogMetadataLocationInternal(Oid relationId, bool isPrevMetadata, bool forUpdate);

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -254,7 +254,7 @@ GetObjectStoreCatalogInfoFromCatalog(Oid relationId, char **catalogName, char **
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("catalog_name option is missing for object_store catalog iceberg table %s",
+				 errmsg("catalog_name option is missing for " OBJECT_STORE_CATALOG_NAME " catalog iceberg table %s",
 						get_rel_name(relationId))));
 	}
 
@@ -263,7 +263,7 @@ GetObjectStoreCatalogInfoFromCatalog(Oid relationId, char **catalogName, char **
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("catalog_namespace option is missing for object_store catalog iceberg table %s",
+				 errmsg("catalog_namespace option is missing for " OBJECT_STORE_CATALOG_NAME " catalog iceberg table %s",
 						get_rel_name(relationId))));
 	}
 
@@ -272,7 +272,7 @@ GetObjectStoreCatalogInfoFromCatalog(Oid relationId, char **catalogName, char **
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("catalog_table_name option is missing for object_store catalog iceberg table %s",
+				 errmsg("catalog_table_name option is missing for for " OBJECT_STORE_CATALOG_NAME " catalog iceberg table %s",
 						get_rel_name(relationId))));
 	}
 }
@@ -327,7 +327,11 @@ PushMetadataLocationToObjectStoreCatalog(void)
 					 "  lake_table.get_table_schema(c.table_name)"
 					 "  FROM lake_iceberg.tables_internal c"
 					 "  JOIN pg_foreign_table f ON (c.table_name = f.ftrelid)"
-					 "  WHERE 'catalog=object_store' = ANY (f.ftoptions)");
+					 "  WHERE EXISTS ("
+					 "		SELECT 1"
+					 "		FROM unnest(f.ftoptions) opt"
+					 "		WHERE LOWER(opt) = LOWER('catalog=" OBJECT_STORE_CATALOG_NAME "')"
+					 "		)");
 
 	/*
 	 * we don't use this param, but our SPI Apis rely on at least one arg, so
@@ -462,7 +466,7 @@ ErrorIfExternalObjectStoreCatalogDoesNotExist(const char *catalogName)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("object store catalog does not exist for \"%s\"", catalogName)));
+				 errmsg(OBJECT_STORE_CATALOG_NAME " catalog does not exist for \"%s\"", catalogName)));
 	}
 }
 
@@ -493,7 +497,7 @@ GetExternalObjectStoreCatalogFilePath(const char *catalogName)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("pg_lake_iceberg.object_store_catalog_location_prefix is not set"),
-				 errdetail("Set the GUC to use catalog=object_store.")));
+				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 
 	if (ExternalObjectStorePrefix == NULL)
@@ -501,7 +505,7 @@ GetExternalObjectStoreCatalogFilePath(const char *catalogName)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("pg_lake_iceberg.external_object_store_prefix is not set"),
-				 errdetail("Set the GUC to use catalog=object_store.")));
+				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 
 	return psprintf("%s/%s/%s/catalog.json", defaultPrefix,
@@ -518,7 +522,7 @@ GetInternalObjectStoreCatalogFilePath(const char *catalogName)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("pg_lake_iceberg.object_store_catalog_location_prefix is not set"),
-				 errdetail("Set the GUC to use catalog=object_store.")));
+				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 
 	if (InternalObjectStorePrefix == NULL)
@@ -526,7 +530,7 @@ GetInternalObjectStoreCatalogFilePath(const char *catalogName)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("pg_lake_iceberg.internal_object_store_prefix is not set"),
-				 errdetail("Set the GUC to use catalog=object_store.")));
+				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 
 	return psprintf("%s/%s/%s/catalog.json", defaultPrefix,

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -33,6 +33,7 @@
 #include "catalog/pg_foreign_table.h"
 #include "commands/defrem.h"
 #include "commands/extension.h"
+#include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/partitioning/partition_by_parser.h"
 #include "pg_lake/permissions/roles.h"
 #include "pg_lake/copy/copy_format.h"
@@ -721,7 +722,7 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 			 * We only accept "rest" and "postgres" for now. If not provided,
 			 * assume "postgres" by default. Don't allow anything.
 			 */
-			if (strcmp(icebergCatalogName, "rest") == 0)
+			if (pg_strncasecmp(icebergCatalogName, REST_CATALOG_NAME, strlen(icebergCatalogName)) == 0)
 			{
 				/*
 				 * at this point, we cannot tell whether it's read only or
@@ -730,7 +731,7 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 				 */
 				icebergCatalogType = REST_CATALOG_READ_ONLY;
 			}
-			else if (strcmp(icebergCatalogName, "object_store") == 0)
+			else if (pg_strncasecmp(icebergCatalogName, OBJECT_STORE_CATALOG_NAME, strlen(icebergCatalogName)) == 0)
 			{
 
 				/*
@@ -740,13 +741,13 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 				 */
 				icebergCatalogType = OBJECT_STORE_READ_ONLY;
 			}
-			else if (strcmp(icebergCatalogName, "postgres") == 0)
+			else if (pg_strncasecmp(icebergCatalogName, POSTGRES_CATALOG_NAME, strlen(icebergCatalogName)) == 0)
 				icebergCatalogType = POSTGRES_CATALOG;
 			else
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("invalid catalog option: %s", icebergCatalogName),
-						 errdetail("Only \"rest\" and \"postgres\" are supported for now.")));
+						 errdetail("Only " REST_CATALOG_NAME " and " POSTGRES_CATALOG_NAME " are supported for now.")));
 		}
 		else if (catalog == ForeignTableRelationId && strcmp(def->defname, "read_only") == 0)
 		{

--- a/pg_lake_table/tests/pytests/test_iceberg_rename_ddl.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_rename_ddl.py
@@ -8,7 +8,8 @@ def test_alter_table_set_schema(pg_conn, s3, extension, with_default_location):
     run_command("CREATE SCHEMA second_schema;", pg_conn)
 
     run_command(
-        "CREATE TABLE first_schema.test_table (a int, b int) USING iceberg", pg_conn
+        "CREATE TABLE first_schema.test_table (a int, b int) USING iceberg WITH (catalog='postgres')",
+        pg_conn,
     )
     run_command(
         "INSERT INTO first_schema.test_table SELECT i,i FROM generate_series(0,9)i",
@@ -70,7 +71,8 @@ def test_alter_table_rename(pg_conn, s3, extension, with_default_location):
     run_command("CREATE SCHEMA first_schema;", pg_conn)
 
     run_command(
-        "CREATE TABLE first_schema.test_table (a int, b int) USING iceberg", pg_conn
+        "CREATE TABLE first_schema.test_table (a int, b int) USING iceberg WITH (catalog='Postgres')",
+        pg_conn,
     )
     run_command(
         "INSERT INTO first_schema.test_table SELECT i,i FROM generate_series(0,9)i",
@@ -131,6 +133,7 @@ def test_alter_table_rename(pg_conn, s3, extension, with_default_location):
 
 
 def test_alter_schema_rename(pg_conn, s3, extension, with_default_location):
+    run_command("SET pg_lake_iceberg.default_catalog TO 'POSTGRES'", pg_conn)
 
     run_command("CREATE SCHEMA first_schema;", pg_conn)
 
@@ -179,12 +182,15 @@ def test_alter_schema_rename(pg_conn, s3, extension, with_default_location):
     assert results[0][0] == "second_schema"
 
     pg_conn.rollback()
+    run_command("RESET pg_lake_iceberg.default_catalog", pg_conn)
 
 
 def test_alter_database_rename(superuser_conn, s3, extension, with_default_location):
     location = f"s3://{TEST_BUCKET}/test_alter_database_rename/"
     dbname = "db_to_rename"
     superuser_conn.autocommit = True
+    run_command("SET pg_lake_iceberg.default_catalog TO 'postgres'", superuser_conn)
+
     run_command(f"CREATE DATABASE {dbname};", superuser_conn)
 
     conn_to_db = open_pg_conn_to_db(dbname)
@@ -210,6 +216,8 @@ def test_alter_database_rename(superuser_conn, s3, extension, with_default_locat
 
     superuser_conn.autocommit = True
     run_command(f"DROP DATABASE {dbname}_new WITH (FORCE);", superuser_conn)
+    run_command("RESET pg_lake_iceberg.default_catalog", superuser_conn)
+
     superuser_conn.autocommit = False
 
 

--- a/pg_lake_table/tests/pytests/test_polaris_catalog.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog.py
@@ -101,7 +101,7 @@ def test_create_namespace(
         pg_conn,
         raise_error=False,
     )
-    assert "writable REST catalog iceberg tables do not" in str(res)
+    assert "writable rest catalog iceberg tables do not" in str(res)
     pg_conn.rollback()
 
     res = run_command(
@@ -109,7 +109,7 @@ def test_create_namespace(
         pg_conn,
         raise_error=False,
     )
-    assert "writable REST catalog iceberg tables do not" in str(res)
+    assert "writable rest catalog iceberg tables do not" in str(res)
     pg_conn.rollback()
 
     run_command(f"""DROP SCHEMA "{namespace}" CASCADE""", pg_conn)

--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -52,11 +52,11 @@ def test_writable_rest_basic_flow(
 
     run_command(f"""CREATE SCHEMA test_writable_rest_basic_flow""", pg_conn)
     run_command(
-        f"""CREATE TABLE test_writable_rest_basic_flow.writable_rest USING iceberg WITH (catalog='rest') AS SELECT 100 AS a""",
+        f"""CREATE TABLE test_writable_rest_basic_flow.writable_rest USING iceberg WITH (catalog='REST') AS SELECT 100 AS a""",
         pg_conn,
     )
     run_command(
-        f"""CREATE TABLE test_writable_rest_basic_flow.writable_rest_2 USING iceberg WITH (catalog='rest') AS SELECT 1000 AS a""",
+        f"""CREATE TABLE test_writable_rest_basic_flow.writable_rest_2 USING iceberg WITH (catalog='rEst') AS SELECT 1000 AS a""",
         pg_conn,
     )
 
@@ -195,8 +195,9 @@ def test_writable_rest_ddl(
         return
 
     run_command(f"""CREATE SCHEMA test_writable_rest_ddl""", pg_conn)
+    run_command("SET pg_lake_iceberg.default_catalog TO 'rest'", pg_conn)
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.writable_rest USING iceberg WITH (catalog='rest') AS SELECT 100 AS a""",
+        f"""CREATE TABLE test_writable_rest_ddl.writable_rest USING iceberg AS SELECT 100 AS a""",
         pg_conn,
     )
     run_command(
@@ -205,7 +206,7 @@ def test_writable_rest_ddl(
     )
 
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.writable_rest_3 USING iceberg WITH (catalog='rest', partition_by='a') AS SELECT 10000 AS a UNION SELECT 10001 as a""",
+        f"""CREATE TABLE test_writable_rest_ddl.writable_rest_3 USING iceberg WITH (partition_by='a') AS SELECT 10000 AS a UNION SELECT 10001 as a""",
         pg_conn,
     )
 
@@ -217,7 +218,7 @@ def test_writable_rest_ddl(
     )
     pg_conn.commit()
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_1() USING iceberg WITH (catalog='rest', read_only=True, catalog_table_name='writable_rest')""",
+        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_1() USING iceberg WITH (read_only=True, catalog_table_name='writable_rest')""",
         pg_conn,
     )
 
@@ -244,7 +245,7 @@ def test_writable_rest_ddl(
     )
     pg_conn.commit()
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_2() USING iceberg WITH (catalog='rest', read_only=True, catalog_table_name='writable_rest')""",
+        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_2() USING iceberg WITH (read_only=True, catalog_table_name='writable_rest')""",
         pg_conn,
     )
 
@@ -289,7 +290,7 @@ def test_writable_rest_ddl(
     )
     pg_conn.commit()
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_3() USING iceberg WITH (catalog='rest', read_only=True, catalog_table_name='writable_rest')""",
+        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_3() USING iceberg WITH (read_only=True, catalog_table_name='writable_rest')""",
         pg_conn,
     )
 
@@ -306,7 +307,7 @@ def test_writable_rest_ddl(
     assert columns[5][0] == "f"
 
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_4() USING iceberg WITH (catalog='rest', read_only=True, catalog_table_name='writable_rest_2')""",
+        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_4() USING iceberg WITH (read_only=True, catalog_table_name='writable_rest_2')""",
         pg_conn,
     )
 
@@ -340,7 +341,7 @@ def test_writable_rest_ddl(
     )
 
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_5() USING iceberg WITH (catalog='rest', read_only=True, catalog_table_name='writable_rest')""",
+        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_5() USING iceberg WITH (read_only=True, catalog_table_name='writable_rest')""",
         pg_conn,
     )
 
@@ -374,11 +375,11 @@ def test_writable_rest_ddl(
     )
     pg_conn.commit()
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_6() USING iceberg WITH (catalog='rest', read_only=True, catalog_table_name='writable_rest_2')""",
+        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_6() USING iceberg WITH (read_only=True, catalog_table_name='writable_rest_2')""",
         pg_conn,
     )
     run_command(
-        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_7() USING iceberg WITH (catalog='rest', read_only=True, catalog_table_name='writable_rest')""",
+        f"""CREATE TABLE test_writable_rest_ddl.readable_rest_7() USING iceberg WITH (read_only=True, catalog_table_name='writable_rest')""",
         pg_conn,
     )
 
@@ -413,6 +414,7 @@ def test_writable_rest_ddl(
 
     run_command(f"""DROP SCHEMA test_writable_rest_ddl CASCADE""", pg_conn)
     pg_conn.commit()
+    run_command("RESET pg_lake_iceberg.default_catalog", pg_conn)
 
 
 @pytest.mark.parametrize(
@@ -433,10 +435,11 @@ def test_writable_rest_vacuum(
 
     if installcheck:
         return
+    run_command("SET pg_lake_iceberg.default_catalog TO 'REST'", pg_conn)
 
     run_command(f"""CREATE SCHEMA test_writable_rest_vacuum""", pg_conn)
     run_command(
-        f"""CREATE TABLE test_writable_rest_vacuum.writable_rest USING iceberg WITH (catalog='rest', autovacuum_enabled=False) AS SELECT 100 AS a""",
+        f"""CREATE TABLE test_writable_rest_vacuum.writable_rest USING iceberg WITH (autovacuum_enabled=False) AS SELECT 100 AS a""",
         pg_conn,
     )
     pg_conn.commit()
@@ -517,6 +520,8 @@ def test_writable_rest_vacuum(
 
     # ensure dropping schema drops the table properly
     ensure_table_dropped("test_writable_rest_vacuum", "writable_rest", superuser_conn)
+
+    run_command("RESET pg_lake_iceberg.default_catalog", pg_conn)
 
 
 def test_writable_drop_table(


### PR DESCRIPTION
Now that we have 3 different catalogs, it can be convenient to be able to control the default catalog.

`postgres` is the default value, so no behavioral change.