### PR TITLE
Fix CSV with CLRF newlines

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/sniff_csv.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/sniff_csv.h
@@ -21,4 +21,4 @@
 #include "nodes/pg_list.h"
 
 extern PGDLLEXPORT void SniffCSV(char *url, CopyDataCompression compression, List *options,
-								 char **delimiter, char **quote, char **escape, bool *header);
+								 char **delimiter, char **quote, char **escape, bool *header, char **newLine);

--- a/pg_lake_engine/src/csv/csv_options.c
+++ b/pg_lake_engine/src/csv/csv_options.c
@@ -73,12 +73,12 @@ NormalizedExternalCSVOptions(List *inputOptions)
 	char	   *quote = NULL;
 	char	   *escape = NULL;
 	char	   *nullStr = NULL;
+	char	   *newLineStr = NULL;
 	Node	   *forceQuote = NULL;
 
 	bool		hasHeader = false;
 	bool		hasQuote = false;
 	bool		hasEscape = false;
-	bool		hasNewLine = false;
 	bool		hasSkip = false;
 
 	if (!autoDetect)
@@ -90,11 +90,11 @@ NormalizedExternalCSVOptions(List *inputOptions)
 		delimiter = ",";
 		quote = "\"";
 		escape = "\"";
+		newLineStr = "\\n";
 		nullStr = "";
 		forceQuote = NULL;
 
 		/* not exposed to user */
-		hasNewLine = true;
 		hasSkip = true;
 	}
 
@@ -123,6 +123,10 @@ NormalizedExternalCSVOptions(List *inputOptions)
 		{
 			escape = defGetString(option);
 			hasEscape = true;
+		}
+		else if (strcmp(option->defname, "new_line") == 0)
+		{
+			newLineStr = defGetString(option);
 		}
 		else if (strcmp(option->defname, "null") == 0)
 		{
@@ -173,10 +177,9 @@ NormalizedExternalCSVOptions(List *inputOptions)
 		options = lappend(options,
 						  makeDefElem("force_quote", forceQuote, -1));
 
-	/* 'auto_detect = false' defaults - not exposed to user */
-	if (hasNewLine)
+	if (newLineStr != NULL)
 		options = lappend(options,
-						  makeDefElem("new_line", (Node *) makeString("\\n"), -1));
+						  makeDefElem("new_line", (Node *) makeString(newLineStr), -1));
 
 	if (hasSkip)
 		options = lappend(options,

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -2204,14 +2204,14 @@ static Node *
 RewriteFuncExprHyperbolic(Node *node, void *context)
 {
 	FuncExpr   *funcExpr = castNode(FuncExpr, node);
-	List *funcName;
+	List	   *funcName;
 
 	switch (funcExpr->funcid)
 	{
 		case F_ACOSH:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP), makeString("acosh_pg"));
 			break;
-		
+
 		case F_ATANH:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP), makeString("atanh_pg"));
 			break;
@@ -2220,8 +2220,9 @@ RewriteFuncExprHyperbolic(Node *node, void *context)
 			elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
 	}
 
-	Oid argTypes[] = {FLOAT8OID};
-	int argCount = 1;
+	Oid			argTypes[] = {FLOAT8OID};
+	int			argCount = 1;
+
 	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
 
 	return (Node *) funcExpr;

--- a/pg_lake_engine/src/pgduck/sniff_csv.c
+++ b/pg_lake_engine/src/pgduck/sniff_csv.c
@@ -33,7 +33,7 @@
  */
 void
 SniffCSV(char *url, CopyDataCompression compression, List *options,
-		 char **delimiter, char **quote, char **escape, bool *header)
+		 char **delimiter, char **quote, char **escape, bool *header, char **newLine)
 {
 	StringInfoData command;
 
@@ -45,7 +45,7 @@ SniffCSV(char *url, CopyDataCompression compression, List *options,
 		ereport(ERROR, (errmsg("couldn't find files at %s", url)));
 
 	appendStringInfo(&command,
-					 "SELECT Delimiter, Quote, Escape, HasHeader FROM sniff_csv(%s",
+					 "SELECT Delimiter, Quote, Escape, HasHeader, NewLineDelimiter FROM sniff_csv(%s",
 					 quote_literal_cstr((char *) linitial(outputFiles)));
 
 	if (compression != DATA_COMPRESSION_INVALID)
@@ -94,6 +94,12 @@ SniffCSV(char *url, CopyDataCompression compression, List *options,
 		*escape = pstrdup(rawValue);
 
 		*header = strcasecmp(PQgetvalue(result, 0, 3), "t") == 0;
+
+		rawValue = PQgetvalue(result, 0, 4);
+		if (strcmp(rawValue, "") == 0)
+			rawValue = "\\n";
+
+		*newLine = pstrdup(rawValue);
 
 		PQclear(result);
 	}

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -237,7 +237,7 @@ _PG_init(void)
 							   GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							   NULL, NULL, NULL);
 
-    DefineCustomStringVariable("pg_lake_iceberg.rest_catalog_oauth_host_path",
+	DefineCustomStringVariable("pg_lake_iceberg.rest_catalog_oauth_host_path",
 							   NULL,
 							   NULL,
 							   &RestCatalogOauthHostPath,

--- a/pg_lake_table/src/describe/describe.c
+++ b/pg_lake_table/src/describe/describe.c
@@ -435,9 +435,10 @@ SniffCSVOptions(char *url, CopyDataCompression compression, List *options)
 	char	   *quote = NULL;
 	char	   *escape = NULL;
 	bool		header = NULL;
+	char	   *newLine = NULL;
 
 	SniffCSV(url, compression, options,
-			 &delimiter, &quote, &escape, &header);
+			 &delimiter, &quote, &escape, &header, &newLine);
 
 	if (!HasOption((List *) options, "delimiter") && *delimiter != '\0')
 	{
@@ -467,6 +468,14 @@ SniffCSVOptions(char *url, CopyDataCompression compression, List *options)
 											   -1));
 	}
 
+	if (!HasOption((List *) options, "new_line"))
+	{
+		options = lappend(options, makeDefElem("new_line",
+											   (Node *) makeString(newLine),
+											   -1));
+	}
+
+
 	return options;
 }
 
@@ -479,6 +488,7 @@ static bool
 HasAllSniffCSVOptions(List *options)
 {
 	return HasOption(options, "delimiter") &&
+		HasOption(options, "new_line") &&
 		HasOption(options, "quote") &&
 		HasOption(options, "escape") &&
 		HasOption(options, "header");

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -107,6 +107,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 	char	   *csvDelim = NULL;
 	char	   *csvQuote = NULL;
 	char	   *csvEscape = NULL;
+	char	   *csvNewLine = NULL;
 	char	   *csvNull = NULL;
 
 	bool		foundZipPath = false;
@@ -293,6 +294,20 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			csvOptionProvided = true;
 		}
+		else if (catalog == ForeignTableRelationId && strcmp(def->defname, "new_line") == 0)
+		{
+			csvNewLine = defGetString(def);
+
+			if (strcmp(csvNewLine, "\\n") != 0 &&
+				strcmp(csvNewLine, "\\r\\n") != 0 &&
+				strcmp(csvNewLine, "\\r") != 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("new_line must be one of \\n, \\r\\n, or \\r")));
+
+			csvOptionProvided = true;
+		}
+
 		else if (catalog == ForeignTableRelationId && strcmp(def->defname, "zip_path") == 0)
 		{
 			foundZipPath = true;
@@ -392,7 +407,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 	if (copyDataFormat != DATA_FORMAT_CSV && csvOptionProvided)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("\"header\", \"delimiter\", \"quote\", \"escape\" and \"null\" options "
+				 errmsg("\"header\", \"delimiter\", \"quote\", \"escape\", \"new_line\" and \"null\" options "
 						"are only supported for csv format tables")));
 
 	if (copyDataFormat == DATA_FORMAT_CSV)
@@ -479,6 +494,7 @@ InitPgLakeOptions(void)
 		{"delimiter", ForeignTableRelationId},
 		{"quote", ForeignTableRelationId},
 		{"escape", ForeignTableRelationId},
+		{"new_line", ForeignTableRelationId},
 		{"null", ForeignTableRelationId},
 
 		/* whether the table is writable */

--- a/pg_lake_table/tests/pytests/test_csv_options.py
+++ b/pg_lake_table/tests/pytests/test_csv_options.py
@@ -219,10 +219,7 @@ def test_fdw_table_csv_options_for_csv_format_only(pg_conn, extension):
         # can't get here, already failed
         assert False
     except psycopg2.errors.SyntaxError as e:
-        assert (
-            '"header", "delimiter", "quote", "escape" and "null" options are only supported for csv format tables'
-            in str(e)
-        )
+        assert "options are only supported for csv format tables" in str(e)
         cur.close()
         pg_conn.commit()
 
@@ -458,10 +455,7 @@ def test_fdw_table_non_csv_with_csv_options(pg_conn, extension):
         # can't get here, already failed
         assert False
     except psycopg2.errors.SyntaxError as e:
-        assert (
-            '"header", "delimiter", "quote", "escape" and "null" options are only supported for csv format tables'
-            in str(e)
-        )
+        assert "options are only supported for csv format tables" in str(e)
         cur.close()
         pg_conn.commit()
 


### PR DESCRIPTION
Fixes #144 by storing new_line as part of the foreign table options.

Note that the value is stored with explicit backslashes in the string, such that we can lazily pass the string back to read_csv.