### PR TITLE
Add OOM to fatal errors in pgduck_server

### DIFF
--- a/pgduck_server/include/command_line/command_line.h
+++ b/pgduck_server/include/command_line/command_line.h
@@ -36,6 +36,7 @@ typedef struct
 	unsigned int port;
 	unsigned int max_clients;
 	char	   *memory_limit;
+	bool		continue_on_oom;
 	int64_t		cache_on_write_max_size;
 
 	char	   *duckdb_database_file_path;

--- a/pgduck_server/include/pgsession/pgsession.h
+++ b/pgduck_server/include/pgsession/pgsession.h
@@ -180,4 +180,6 @@ typedef struct PGSession
 /* per-client entrance point for the pgsession logic */
 extern void *pgsession_handle_connection(void *input);
 
+extern int	oom_is_fatal;
+
 #endif							/* // PGDUCK_PG_SESSION_H */

--- a/pgduck_server/src/command_line/command_line.c
+++ b/pgduck_server/src/command_line/command_line.c
@@ -60,6 +60,7 @@ print_usage()
 	printf(" --port <port>                 		Specify the port number, default is %d\n", DEFAULT_PORT);
 	printf(" --max_clients <max_clients>		Specify the maximum allowed clients, default is %d\n", DEFAULT_MAX_CLIENTS);
 	printf(" --memory_limit=<memory_limit>		Optionally specify the maximum memory of pgduck_server similar to DuckDB's memory_limit, the default is 80 percent of the system memory\n");
+	printf(" --continue_on_oom                  If out of memory error occurs, continue operating\n");
 	printf(" --cache_on_write_max_size=<size>   Optionally specify the maximum allowed cache size on write\n");
 	printf(" --duckdb_database_file_path <path>	Specify the database file path for DuckDB, default is %s\n", DEFAULT_DUCKDB_DATABASE_FILE_PATH);
 	printf(" --check_cli_params_only       		Only check the cli arguments, do not run the server\n");
@@ -87,6 +88,7 @@ parse_arguments(int argc, char *argv[])
 		.port = DEFAULT_PORT,
 		.max_clients = DEFAULT_MAX_CLIENTS,
 		.memory_limit = NULL,
+		.continue_on_oom = false,
 		.cache_on_write_max_size = DEFAULT_CACHE_ON_WRITE_MAX_SIZE,
 		.duckdb_database_file_path = DEFAULT_DUCKDB_DATABASE_FILE_PATH,
 		.init_file_path = NULL,
@@ -109,6 +111,7 @@ parse_arguments(int argc, char *argv[])
 		{"port", required_argument, NULL, 'P'},
 		{"max_clients", required_argument, NULL, 'M'},
 		{"memory_limit", required_argument, NULL, 'l'},
+		{"continue_on_oom", no_argument, NULL, 'O'},
 		{"cache_on_write_max_size", required_argument, NULL, 'L'},
 		{"duckdb_database_file_path", required_argument, NULL, 'D'},
 		{"cache_dir", required_argument, NULL, 'C'},
@@ -143,6 +146,9 @@ parse_arguments(int argc, char *argv[])
 			case 'l':
 				if (optarg)
 					options.memory_limit = strdup(optarg);
+				break;
+			case 'O':
+				options.continue_on_oom = true;
 				break;
 			case 'm':
 				{

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -72,7 +72,10 @@
 #define TRANSMIT_QUOTE_CHAR '"'
 #define TRANSMIT_END_OF_LINE_CHAR '\n'
 
-#define IS_FATAL_DUCKDB_ERROR(error) ((error) == DUCKDB_ERROR_FATAL || (error) == DUCKDB_ERROR_INTERNAL)
+#define IS_FATAL_DUCKDB_ERROR(error) \
+	((error) == DUCKDB_ERROR_FATAL || \
+	 (error) == DUCKDB_ERROR_INTERNAL || \
+	 (oom_is_fatal && (error) == DUCKDB_ERROR_OUT_OF_MEMORY))
 
 typedef struct DuckDBResultColumn
 {

--- a/pgduck_server/src/main.c
+++ b/pgduck_server/src/main.c
@@ -49,6 +49,8 @@ main(int argc, char *argv[])
 	if (options.debug)
 		pgduck_log_min_messages = DEBUG1;
 
+	oom_is_fatal = !options.continue_on_oom;
+
 	/* first, make sure duckdb is accessible */
 	DuckDBStatus duckDbStatus = duckdb_global_init(options.duckdb_database_file_path,
 												   options.cache_dir,

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -88,7 +88,9 @@
 	 (status) == DUCKDB_FATAL_ERROR || \
 	 (status) == DUCKDB_OUT_OF_MEMORY_ERROR)
 
-#define IS_FATAL_DUCKDB_ERROR(status) ((status) == DUCKDB_FATAL_ERROR)
+#define IS_FATAL_DUCKDB_STATUS(status) \
+	((status) == DUCKDB_FATAL_ERROR || \
+	 (oom_is_fatal && (status) == DUCKDB_OUT_OF_MEMORY_ERROR))
 
 /* The main functions that implement PG protocol */
 static int	pgsession_send_auth_ok(PGSession * pgSession);
@@ -115,6 +117,9 @@ static int	process_bind_message(PGSession * pgSession, StringInfo inputMessage);
 static int	process_execute_message(PGSession * pgSession, StringInfo inputMessage);
 
 static bool is_transmit_query(const char *queryString);
+
+/* global flag on whether to exit on OOM */
+int			oom_is_fatal = true;
 
 /*
  * Per-client entrance point for the pgsession logic.
@@ -406,7 +411,7 @@ process_query_message(PGSession * pgSession, StringInfo inputMessage)
 		pfree(errorMessage);
 
 		/* we report the error above, but need to terminate afterwards */
-		if (IS_FATAL_DUCKDB_ERROR(status))
+		if (IS_FATAL_DUCKDB_STATUS(status))
 			exit(EXIT_FAILURE);
 
 		return sentErrorMsg;


### PR DESCRIPTION
DuckDB is still showing signs of memory leaks in production. To avoid persistent failure, this PR changes pgduck_server to treat out of memory as a fatal error and let the platform restart. This will increase disruption for more ephemeral OOM issues, though those should be rare at this point as DuckDB normally spills to disk.