### PR TITLE
Fix --cache_on_write_max_size CLI parsing for values > 2GB

### DIFF
--- a/pgduck_server/include/utils/string_utils.h
+++ b/pgduck_server/include/utils/string_utils.h
@@ -24,8 +24,10 @@
 #define STRING_UTILS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 bool		string_to_int(const char *str, int *number);
+bool		string_to_int64(const char *str, int64_t *number);
 
 
 #endif							/* // STRING_UTILS_H */

--- a/pgduck_server/src/command_line/command_line.c
+++ b/pgduck_server/src/command_line/command_line.c
@@ -225,9 +225,9 @@ parse_arguments(int argc, char *argv[])
 				}
 			case 'L':
 				{
-					int			cache_on_write_max_size = 0;
+					int64_t		cache_on_write_max_size = 0;
 
-					if (!string_to_int(optarg, &cache_on_write_max_size))
+					if (!string_to_int64(optarg, &cache_on_write_max_size))
 					{
 						fprintf(stderr, "Error: cache_on_write_max_size should be an integer\n");
 						exit(EXIT_FAILURE);

--- a/pgduck_server/src/utils/string_utils.c
+++ b/pgduck_server/src/utils/string_utils.c
@@ -32,7 +32,7 @@
 #include "utils/string_utils.h"
 
 /*
- * converts given string to 64 bit integer value.
+ * converts given string to 32 bit integer value.
  * returns 0 upon failure and sets error flag.
  */
 bool
@@ -68,6 +68,48 @@ string_to_int(const char *str, int *number)
 		return false;
 	}
 	else if (n < INT_MIN || n > INT_MAX)
+	{
+		return false;
+	}
+
+	*number = n;
+
+	return true;
+}
+
+/*
+ * converts given string to 64 bit integer value.
+ * returns false upon failure.
+ */
+bool
+string_to_int64(const char *str, int64_t *number)
+{
+	char	   *endptr;
+	long long int n;
+
+	if (str == NULL)
+	{
+		return false;
+	}
+
+	if (number == NULL)
+	{
+		return false;
+	}
+
+	errno = 0;
+
+	n = strtoll(str, &endptr, 10);
+
+	if (str == endptr)
+	{
+		return false;
+	}
+	else if (errno != 0)
+	{
+		return false;
+	}
+	else if (*endptr != '\0')
 	{
 		return false;
 	}

--- a/pgduck_server/tests/pytests/test_cli.py
+++ b/pgduck_server/tests/pytests/test_cli.py
@@ -77,6 +77,15 @@ def test_cache_on_write():
     assert_common_output(stderr, max_cache_on_write="1000")
 
 
+def test_cache_on_write_large_value():
+    # Test 10GB value (larger than INT_MAX ~2.1GB)
+    returncode, stdout, stderr = run_cli_command(
+        ["--cache_on_write_max_size", "10737418240"]
+    )
+    assert returncode == 0
+    assert_common_output(stderr, max_cache_on_write="10737418240")
+
+
 def test_no_extension_installation():
     returncode, stdout, stderr = run_cli_command(["--no_extension_install"])
     assert returncode == 0


### PR DESCRIPTION
## Description
Fix `--cache_on_write_max_size` CLI option to accept values larger than 2GB.

The option was parsed as `int` (32-bit), which rejected values larger than ~2.1GB (INT_MAX). Changed to `int64_t` to match the struct definition.

- Add `string_to_int64()` function in `string_utils.c`
- Update `command_line.c` to use `int64_t` and `string_to_int64()`
- Add test case for 10GB value

Happy to adjust if needed!

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [ ] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**
