### PR TITLE
Dynamically link OpenSSL

### DIFF
--- a/duckdb_pglake/CMakeLists.txt
+++ b/duckdb_pglake/CMakeLists.txt
@@ -6,6 +6,11 @@ set(TARGET_NAME duckdb_pglake)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
+# Force use of system OpenSSL instead of vcpkg to avoid static linking
+# Set CMAKE_FIND_PACKAGE_PREFER_CONFIG to OFF to use FindOpenSSL.cmake from CMake
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG_BEFORE_OpenSSL OFF)
+set(OPENSSL_USE_STATIC_LIBS FALSE)
+# Look for OpenSSL in system paths first
 find_package(OpenSSL 3 REQUIRED)
 find_library(PG_LIBDIR pq REQUIRED)
 find_path(PG_INCLUDEDIR libpq-fe.h REQUIRED)
@@ -65,6 +70,8 @@ endif()
 target_link_libraries(${EXTENSION_NAME}
                       ${PG_LIBDIR}/${LIBPQ_NAME}
                       Azure::azure-identity Azure::azure-storage-blobs Azure::azure-storage-files-datalake)
+# Note: OpenSSL libraries are NOT linked here to avoid static linking.
+# OpenSSL symbols are available via libpq.so which already links to libssl.so
 target_include_directories(
   ${EXTENSION_NAME} PRIVATE Azure::azure-identity Azure::azure-storage-blobs
                             Azure::azure-storage-files-datalake)

--- a/duckdb_pglake/Makefile
+++ b/duckdb_pglake/Makefile
@@ -111,6 +111,16 @@ install: $(LIB_NAME)
 	install duckdb/src/include/duckdb.h $(DESTDIR)$(PG_INCLUDEDIR)
 	install duckdb/src/include/duckdb.hpp $(DESTDIR)$(PG_INCLUDEDIR)
 	install duckdb/src/include/duckdb_extension.h $(DESTDIR)$(PG_INCLUDEDIR)
+	# Install vcpkg OpenSSL libraries if using dynamic triplet
+ifneq ("${VCPKG_TARGET_TRIPLET}", "")
+ifeq ($(findstring dynamic,${VCPKG_TARGET_TRIPLET}),dynamic)
+	@if [ -f build/release/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/libssl.so.3 ]; then \
+		echo "Installing vcpkg OpenSSL libraries..."; \
+		install build/release/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/libssl.so.3 $(DESTDIR)$(PG_LIBDIR)/; \
+		install build/release/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/libcrypto.so.3 $(DESTDIR)$(PG_LIBDIR)/; \
+	fi
+endif
+endif
 
 uninstall:
 	rm -f $(DESTDIR)$(PG_LIBDIR)/$(LIB_NAME)

--- a/duckdb_pglake/patches/duckdb/dynamic_openssl.patch
+++ b/duckdb_pglake/patches/duckdb/dynamic_openssl.patch
@@ -1,0 +1,32 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,5 +1,11 @@
+ include_directories(include ../third_party/fmt/include)
+ 
++# Find OpenSSL for dynamic linking (required by extensions)
++set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
++set(OPENSSL_USE_STATIC_LIBS FALSE)
++find_package(OpenSSL 3 REQUIRED)
++message(STATUS "Found OpenSSL for dynamic linking: ${OPENSSL_LIBRARIES}")
++
+ if(AMALGAMATION_BUILD)
+   add_library(duckdb SHARED "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
+ 
+@@ -66,6 +72,8 @@ if(AMALGAMATION_BUILD)
+                  SOVERSION ${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION})
+   endif()
+   target_link_libraries(duckdb ${DUCKDB_SYSTEM_LIBS})
++  # Link OpenSSL dynamically to the shared library
++  target_link_libraries(duckdb PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+   link_threads(duckdb PUBLIC)
+   link_extension_libraries(duckdb PRIVATE)
+ 
+@@ -143,6 +151,8 @@ else()
+   endif()
+ 
+   target_link_libraries(duckdb PUBLIC ${DUCKDB_LINK_LIBS})
++  # Link OpenSSL dynamically to the shared library
++  target_link_libraries(duckdb PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+   link_threads(duckdb PUBLIC)
+   link_extension_libraries(duckdb PRIVATE)
+ 

--- a/duckdb_pglake/vcpkg.json
+++ b/duckdb_pglake/vcpkg.json
@@ -2,7 +2,6 @@
   "dependencies": [
     "azure-identity-cpp",
     "azure-storage-blobs-cpp",
-    "azure-storage-files-datalake-cpp",
-    "openssl"
+    "azure-storage-files-datalake-cpp"
   ]
 }


### PR DESCRIPTION
DuckDB statically links various versions of OpenSSL. This PR switches to dynamically linking OpenSSL. So far couldn't quite manage without patching DuckDB.

Build using `export VCPKG_TARGET_TRIPLET=arm64-linux-dynamic` or `export VCPKG_TARGET_TRIPLET=arm64-osx-dynamic`