### PR TITLE
Bump all versions to 3.2

### DIFF
--- a/pg_extension_updater/pg_extension_updater--3.1--3.2.sql
+++ b/pg_extension_updater/pg_extension_updater--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_extension_updater from 3.1 to 3.2

--- a/pg_extension_updater/pg_extension_updater.control
+++ b/pg_extension_updater/pg_extension_updater.control
@@ -1,5 +1,5 @@
 comment = 'Automatic extension updater'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_extension_updater'
 requires = 'pg_extension_base'
 relocatable = false

--- a/pg_lake/pg_lake--3.1--3.2.sql
+++ b/pg_lake/pg_lake--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake from 3.1 to 3.2

--- a/pg_lake/pg_lake.control
+++ b/pg_lake/pg_lake.control
@@ -1,6 +1,6 @@
 # pg_lake extension
 comment = 'Data lake extension by Snowflake'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_lake'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_benchmark/pg_lake_benchmark--3.1--3.2.sql
+++ b/pg_lake_benchmark/pg_lake_benchmark--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_benchmark from 3.1 to 3.2

--- a/pg_lake_benchmark/pg_lake_benchmark.control
+++ b/pg_lake_benchmark/pg_lake_benchmark.control
@@ -1,6 +1,6 @@
 # pg_lake_benchmark extension
 comment = 'Benchmark for PgLake and Iceberg tables'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_lake_benchmark'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_copy/pg_lake_copy--3.1--3.2.sql
+++ b/pg_lake_copy/pg_lake_copy--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_copy from 3.1 to 3.2

--- a/pg_lake_copy/pg_lake_copy.control
+++ b/pg_lake_copy/pg_lake_copy.control
@@ -1,5 +1,5 @@
 comment = 'Copy to/from data lake files'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_lake_copy'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_engine/pg_lake_engine--3.1--3.2.sql
+++ b/pg_lake_engine/pg_lake_engine--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_engine from 3.1 to 3.2

--- a/pg_lake_engine/pg_lake_engine.control
+++ b/pg_lake_engine/pg_lake_engine.control
@@ -1,5 +1,5 @@
 comment = 'Query engine for data lake queries'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_lake_engine'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_iceberg/pg_lake_iceberg--3.1--3.2.sql
+++ b/pg_lake_iceberg/pg_lake_iceberg--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_iceberg from 3.1 to 3.2

--- a/pg_lake_iceberg/pg_lake_iceberg.control
+++ b/pg_lake_iceberg/pg_lake_iceberg.control
@@ -1,5 +1,5 @@
 comment = 'Iceberg implementation in Postgres'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_lake_iceberg'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_spatial/pg_lake_spatial--3.1--3.2.sql
+++ b/pg_lake_spatial/pg_lake_spatial--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_spatial from 3.1 to 3.2

--- a/pg_lake_spatial/pg_lake_spatial.control
+++ b/pg_lake_spatial/pg_lake_spatial.control
@@ -1,6 +1,6 @@
 # pg_lake_spatial extension
 comment = 'Geospatial file format support'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_lake_spatial'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_table/pg_lake_table--3.1--3.2.sql
+++ b/pg_lake_table/pg_lake_table--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_table from 3.1 to 3.2

--- a/pg_lake_table/pg_lake_table.control
+++ b/pg_lake_table/pg_lake_table.control
@@ -1,6 +1,6 @@
 # pg_lake_table extension
 comment = 'Data lake tables and Iceberg tables'
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_lake_table'
 relocatable = false
 schema = pg_catalog

--- a/pg_map/pg_map--3.1--3.2.sql
+++ b/pg_map/pg_map--3.1--3.2.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_map from 3.1 to 3.2

--- a/pg_map/pg_map.control
+++ b/pg_map/pg_map.control
@@ -1,4 +1,4 @@
-default_version = '3.1'
+default_version = '3.2'
 module_pathname = '$libdir/pg_map'
 relocatable = false
 schema = pg_catalog


### PR DESCRIPTION
Via command: python3 ./tools/bump_extension_versions.py 3.2


Skipped pg_extension_base as it has already been bumped

```sql
create extension pg_lake cascade;
NOTICE:  installing required extension "pg_lake_table"
NOTICE:  installing required extension "pg_lake_engine"
NOTICE:  installing required extension "pg_extension_base"
NOTICE:  installing required extension "pg_map"
NOTICE:  installing required extension "pg_lake_iceberg"
NOTICE:  installing required extension "pg_lake_copy"
CREATE EXTENSION
Time: 568.382 ms
postgres=# \dx
                                List of installed extensions
┌───────────────────┬─────────┬────────────┬───────────────────────────────────────────────┐
│       Name        │ Version │   Schema   │                  Description                  │
├───────────────────┼─────────┼────────────┼───────────────────────────────────────────────┤
│ btree_gist        │ 1.7     │ public     │ support for indexing common datatypes in GiST │
│ pg_extension_base │ 3.2     │ pg_catalog │ Extension development kit by Snowflake        │
│ pg_lake           │ 3.2     │ pg_catalog │ Data lake extension by Snowflake              │
│ pg_lake_copy      │ 3.2     │ pg_catalog │ Copy to/from data lake files                  │
│ pg_lake_engine    │ 3.2     │ pg_catalog │ Query engine for data lake queries            │
│ pg_lake_iceberg   │ 3.2     │ pg_catalog │ Iceberg implementation in Postgres            │
│ pg_lake_table     │ 3.2     │ pg_catalog │ Data lake tables and Iceberg tables           │
│ pg_map            │ 3.2     │ pg_catalog │ Map type for Postgres                         │
│ plpgsql           │ 1.0     │ pg_catalog │ PL/pgSQL procedural language                  │
└───────────────────┴─────────┴────────────┴───────────────────────────────────────────────┘
(9 rows)


```