### PR TITLE
Add a compile-time flag for delta support

### DIFF
--- a/.github/workflows/pytest_all.yml
+++ b/.github/workflows/pytest_all.yml
@@ -13,6 +13,7 @@ env:
   CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
   CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
   ORG: snowflake-labs
+  PG_LAKE_DELTA_SUPPORT: 1
 
 jobs:
   build-image-almalinux:

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -134,6 +134,9 @@ export VCPKG_TOOLCHAIN_PATH="$(pwd)/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 # Make sure pg_config is in your PATH (e.g. export PATH=$HOME/pgsql-18/bin:$PATH):
 
+# Optionally, enable delta (read-only) support
+export PG_LAKE_DELTA_SUPPORT=1
+
 # install pg_lake extensions
 git clone --recurse-submodules https://github.com/snowflake-labs/pg_lake.git && \
 cd pg_lake && make install

--- a/docs/file-formats-reference.md
+++ b/docs/file-formats-reference.md
@@ -34,6 +34,8 @@ The following formats are supported:
 | delta | External [**Delta Lake table**](https://docs.databricks.com/en/delta/index.html) | n/a | No |
 | log | Log files such as [**S3 logs**](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html) | n/a | Yes (for s3:) |
 
+Note: delta requires compiling pg\_lake with `export PG_LAKE_DELTA_SUPPORT=1`.
+
 ## Parquet format
 
 Parquet files are the most versatile format for importing and exporting data in `pg_lake`. They are self-describing in terms of column names, types, and compression, and use columnar storage.

--- a/pg_lake_copy/tests/pytests/test_delta_copy.py
+++ b/pg_lake_copy/tests/pytests/test_delta_copy.py
@@ -6,6 +6,10 @@ from fixtures.delta import *
 from utils_pytest import *
 
 
+@pytest.mark.skipif(
+    os.getenv("PG_LAKE_DELTA_SUPPORT") != "1",
+    reason="Delta support not enabled",
+)
 def test_delta_definition_from(pg_conn, sample_delta_table):
     run_command(
         f"""
@@ -31,6 +35,10 @@ def test_delta_definition_from(pg_conn, sample_delta_table):
     pg_conn.rollback()
 
 
+@pytest.mark.skipif(
+    os.getenv("PG_LAKE_DELTA_SUPPORT") != "1",
+    reason="Delta support not enabled",
+)
 def test_delta_load_from(pg_conn, sample_delta_table):
     run_command(
         f"""
@@ -48,6 +56,10 @@ def test_delta_load_from(pg_conn, sample_delta_table):
     pg_conn.rollback()
 
 
+@pytest.mark.skipif(
+    os.getenv("PG_LAKE_DELTA_SUPPORT") != "1",
+    reason="Delta support not enabled",
+)
 def test_delta_copy(pg_conn, sample_delta_table):
     run_command(
         f"""

--- a/pg_lake_engine/Makefile
+++ b/pg_lake_engine/Makefile
@@ -5,10 +5,11 @@ MODULE_big = $(EXTENSION)
 DATA = $(wildcard $(EXTENSION)--*--*.sql) $(EXTENSION)--3.0.sql
 SOURCES := $(wildcard src/*.c) $(wildcard src/*/*.c)
 OBJS := $(patsubst %.c,%.o,$(sort $(SOURCES)))
-
 SHLIB_LINK_INTERNAL = $(libpq)
 
-PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -I../pg_extension_base/include -std=gnu99 -g
+PG_LAKE_DELTA_SUPPORT ?= 0
+
+PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -I../pg_extension_base/include -std=gnu99 -g -DPG_LAKE_DELTA_SUPPORT=$(PG_LAKE_DELTA_SUPPORT)
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)

--- a/pg_lake_engine/src/copy/copy_format.c
+++ b/pg_lake_engine/src/copy/copy_format.c
@@ -47,9 +47,11 @@ static CopyDataFormatName DataFormatNames[] =
 	{
 		"iceberg", DATA_FORMAT_ICEBERG
 	},
+#if PG_LAKE_DELTA_SUPPORT == 1
 	{
 		"delta", DATA_FORMAT_DELTA
 	},
+#endif
 	{
 		"gdal", DATA_FORMAT_GDAL
 	},

--- a/pg_lake_iceberg/include/pg_lake/iceberg/data_file_stats.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/data_file_stats.h
@@ -23,8 +23,8 @@
 #include "pg_lake/iceberg/api.h"
 
 extern PGDLLEXPORT void SetIcebergDataFileStats(const DataFileStats * dataFileStats,
-												int64_t *recordCount,
-												int64_t *fileSizeInBytes,
+												int64_t * recordCount,
+												int64_t * fileSizeInBytes,
 												ColumnBound * *lowerBounds,
 												size_t *nLowerBounds,
 												ColumnBound * *upperBounds,

--- a/pg_lake_iceberg/src/iceberg/data_file_stats.c
+++ b/pg_lake_iceberg/src/iceberg/data_file_stats.c
@@ -38,8 +38,8 @@ static ColumnBound * CreateColumnBoundForLeafField(LeafField * leafField, char *
  */
 void
 SetIcebergDataFileStats(const DataFileStats * dataFileStats,
-						int64_t *recordCount,
-						int64_t *fileSizeInBytes,
+						int64_t * recordCount,
+						int64_t * fileSizeInBytes,
 						ColumnBound * *lowerBounds,
 						size_t *nLowerBounds,
 						ColumnBound * *upperBounds,

--- a/pg_lake_table/tests/pytests/test_delta_read_only.py
+++ b/pg_lake_table/tests/pytests/test_delta_read_only.py
@@ -4,6 +4,10 @@ from fixtures.delta import *
 from datetime import datetime, date, timezone
 
 
+@pytest.mark.skipif(
+    os.getenv("PG_LAKE_DELTA_SUPPORT") != "1",
+    reason="Delta support not enabled",
+)
 def test_delta_pg_lake_table(pg_conn, sample_delta_table, extension):
     run_command(
         f"""
@@ -56,6 +60,10 @@ def test_delta_pg_lake_table(pg_conn, sample_delta_table, extension):
     pg_conn.rollback()
 
 
+@pytest.mark.skipif(
+    os.getenv("PG_LAKE_DELTA_SUPPORT") != "1",
+    reason="Delta support not enabled",
+)
 def test_delta_with_filename(pg_conn, sample_delta_table, extension):
 
     run_command(

--- a/pgduck_server/Makefile
+++ b/pgduck_server/Makefile
@@ -10,9 +10,11 @@ PG_INCLUDEDIR = $(shell $(PG_CONFIG) --includedir)
 # PGXS: Locates PostgreSQL extension building infrastructure using 'pg_config'.
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 
+PG_LAKE_DELTA_SUPPORT ?= 0
+
 # compile with C11 option to use modern C
 # use duckdb.h from the duckdb submodule
-PG_CPPFLAGS = -std=c11 -I$(PG_INCLUDEDIR) -Iinclude
+PG_CPPFLAGS = -std=c11 -I$(PG_INCLUDEDIR) -Iinclude -DPG_LAKE_DELTA_SUPPORT=$(PG_LAKE_DELTA_SUPPORT)
 
 # Add dependencies
 SHLIB_LINK_INTERNAL = $(libpq)

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -271,12 +271,15 @@ duckdb_global_init(char *databaseFilePath,
 	if (run_command_on_duckdb("LOAD spatial") == DuckDBError)
 		return DUCKDB_INITIALIZATION_ERROR;
 
+#if PG_LAKE_DELTA_SUPPORT == 1
+
 	/*
 	 * Load delta explicitly on start-up if extension install is disabled. We
 	 * cannot install it later so it must be there already.
 	 */
 	if (!allowExtensionInstall && run_command_on_duckdb("LOAD delta") == DuckDBError)
 		return DUCKDB_INITIALIZATION_ERROR;
+#endif
 
 	/*
 	 * Load function aliases/macros for pushdown. XXX If we get more than a


### PR DESCRIPTION
Delta dependencies are not always available, so can be helpful to disable.