### PR TITLE
Add empty overlay port for OpenSSL

### DIFF
--- a/duckdb_pglake/vcpkg.json
+++ b/duckdb_pglake/vcpkg.json
@@ -4,5 +4,10 @@
     "azure-storage-blobs-cpp",
     "azure-storage-files-datalake-cpp",
     "openssl"
-  ]
+  ],
+  "vcpkg-configuration": {
+    "overlay-ports": [
+      "./vcpkg_ports"
+    ]
+  }
 }

--- a/duckdb_pglake/vcpkg_ports/openssl/portfile.cmake
+++ b/duckdb_pglake/vcpkg_ports/openssl/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/duckdb_pglake/vcpkg_ports/openssl/vcpkg.json
+++ b/duckdb_pglake/vcpkg_ports/openssl/vcpkg.json
@@ -1,0 +1,5 @@
+{
+    "name": "openssl",
+    "version": "9.9.9",
+    "description": "Empty port to force usage of system OpenSSL"
+}


### PR DESCRIPTION
Switch to the installed OpenSSL library instead of pulling it from vcpkg and static linking.