### PR TITLE
Leave preserve_insertion_order as is

### DIFF
--- a/pg_lake_engine/include/pg_lake/data_file/data_file_stats.h
+++ b/pg_lake_engine/include/pg_lake/data_file/data_file_stats.h
@@ -107,7 +107,6 @@ extern PGDLLEXPORT StatsCollector * GetDataFileStatsListFromPGResult(PGresult *r
 extern PGDLLEXPORT StatsCollector * ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 																		   List *leafFields,
 																		   DataFileSchema * schema,
-																		   bool disablePreserveInsertionOrder,
 																		   char *destinationPath,
 																		   CopyDataFormat destinationFormat);
 extern PGDLLEXPORT bool ShouldSkipStatistics(LeafField * leafField);

--- a/pg_lake_engine/src/data_file/data_file_stats.c
+++ b/pg_lake_engine/src/data_file/data_file_stats.c
@@ -83,7 +83,6 @@ StatsCollector *
 ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 									   List *leafFields,
 									   DataFileSchema * schema,
-									   bool disablePreserveInsertionOrder,
 									   char *destinationPath,
 									   CopyDataFormat destinationFormat)
 {
@@ -93,13 +92,6 @@ ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 
 	PG_TRY();
 	{
-		if (disablePreserveInsertionOrder)
-		{
-			result = ExecuteQueryOnPGDuckConnection(pgDuckConn, "SET preserve_insertion_order TO 'false';");
-			CheckPGDuckResult(pgDuckConn, result);
-			PQclear(result);
-		}
-
 		result = ExecuteQueryOnPGDuckConnection(pgDuckConn, copyCommand);
 		CheckPGDuckResult(pgDuckConn, result);
 
@@ -137,13 +129,6 @@ ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 		}
 
 		PQclear(result);
-
-		if (disablePreserveInsertionOrder)
-		{
-			result = ExecuteQueryOnPGDuckConnection(pgDuckConn, "RESET preserve_insertion_order;");
-			CheckPGDuckResult(pgDuckConn, result);
-			PQclear(result);
-		}
 	}
 	PG_FINALLY();
 	{

--- a/pg_lake_engine/src/pgduck/delete_data.c
+++ b/pg_lake_engine/src/pgduck/delete_data.c
@@ -100,7 +100,6 @@ PerformDeleteFromParquet(char *sourcePath,
 	return ExecuteCopyToCommandOnPGDuckConnection(command.data,
 												  leafFields,
 												  schema,
-												  false,
 												  destinationPath,
 												  DATA_FORMAT_PARQUET);
 }

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -392,12 +392,9 @@ WriteQueryResultTo(char *query,
 	/* end WITH options */
 	appendStringInfoString(&command, ")");
 
-	bool		disablePreserveInsertionOrder = TargetRowGroupSizeMB > 0;
-
 	return ExecuteCopyToCommandOnPGDuckConnection(command.data,
 												  leafFields,
 												  schema,
-												  disablePreserveInsertionOrder,
 												  destinationPath,
 												  destinationFormat);
 }


### PR DESCRIPTION
Fixes #160

We sometimes observe seemingly spurious cases where we get an error that suggests preserve_insertion_order is true, while we only ever set it to false. However, we also reset it when setting it the session.

It appears that resetting makes it globally true:
```
postgres=> select current_setting('preserve_insertion_order');
┌─────────────────────────────────────────────┐
│ current_setting('preserve_insertion_order') │
├─────────────────────────────────────────────┤
│ f                                           │
└─────────────────────────────────────────────┘
(1 row)

Time: 0.815 ms
postgres=> set preserve_insertion_order to false;
SET
Time: 0.860 ms
postgres=> select current_setting('preserve_insertion_order');
┌─────────────────────────────────────────────┐
│ current_setting('preserve_insertion_order') │
├─────────────────────────────────────────────┤
│ f                                           │
└─────────────────────────────────────────────┘
(1 row)

Time: 2.347 ms
postgres=> reset preserve_insertion_order;
SET
Time: 1.045 ms
postgres=> select current_setting('preserve_insertion_order');
┌─────────────────────────────────────────────┐
│ current_setting('preserve_insertion_order') │
├─────────────────────────────────────────────┤
│ t                                           │
└─────────────────────────────────────────────┘
(1 row)

Time: 1.276 ms
```
This PR removes the logic of setting it in the session, since we already made it globally false.