### PR TITLE
Add AWS extension to extension_config.cmake

### DIFF
--- a/duckdb_pglake/extension_config.cmake
+++ b/duckdb_pglake/extension_config.cmake
@@ -6,6 +6,11 @@ duckdb_extension_load(httpfs
     ADD_PATCHES
 )
 
+duckdb_extension_load(aws
+    GIT_URL https://github.com/duckdb/duckdb-aws
+    GIT_TAG 55bf3621fb7db254b473c94ce6360643ca38fac0
+)
+
 # Extension from this repo
 duckdb_extension_load(duckdb_pglake
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}

--- a/duckdb_pglake/vcpkg.json
+++ b/duckdb_pglake/vcpkg.json
@@ -3,7 +3,13 @@
     "azure-identity-cpp",
     "azure-storage-blobs-cpp",
     "azure-storage-files-datalake-cpp",
-    "openssl"
+    {
+      "name": "aws-sdk-cpp",
+      "features": [ "sso", "sts" , "identity-management"]
+    },
+    "zlib",
+    "openssl",
+    "curl"
   ],
   "vcpkg-configuration": {
     "overlay-ports": [


### PR DESCRIPTION
Simplify deployment by adding AWS to extension_config.cmake.