### PR TITLE
Pushdown uuid functions

### DIFF
--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -110,6 +110,123 @@ inline void AtanhPG(DataChunk &args, ExpressionState &state, Vector &result)
 
 
 /*
+  * Extract timestamp from UUID, mimicking Postgres behavior.
+ * Postgres supports UUID v1 and v7 (above 18), returning NULL for other versions.
+ * DuckDB's uuid_extract_timestamp only supports v7 and throws an error for others.
+ */
+inline void UUIDExtractTimestampPG(DataChunk &args, ExpressionState &state, Vector &result)
+{
+	D_ASSERT(args.ColumnCount() == 2);
+	auto &input_vector = args.data[0];
+	auto &version_vector = args.data[1];
+	auto count = args.size();
+
+	// Prepare input in unified format
+	UnifiedVectorFormat vdata;
+	input_vector.ToUnifiedFormat(count, vdata);
+
+	UnifiedVectorFormat vdata_version;
+	version_vector.ToUnifiedFormat(count, vdata_version);
+
+	auto input_data = UnifiedVectorFormat::GetData<hugeint_t>(vdata);
+	auto pg_version_data = UnifiedVectorFormat::GetData<int32_t>(vdata_version);
+	auto result_data = FlatVector::GetData<timestamp_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		auto version_idx = vdata_version.sel->get_index(i);
+
+		// Propagate input NULL
+		if (!vdata.validity.RowIsValid(idx)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		auto uuid_val = input_data[idx];
+		auto pg_version = pg_version_data[version_idx];
+
+		// Check if RFC 4122 variant (bits 10xxxxxx in the variant field)
+		// The variant field is in byte 8 (counting from 0)
+		uint8_t variant_byte = static_cast<uint8_t>((uuid_val.lower >> 56) & 0xFF);
+		if ((variant_byte & 0xc0) != 0x80) {
+			// Not RFC 4122 variant, return NULL
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		// Extract version (first 4 bits of byte 6)
+		// DuckDB stores UUID with XOR flip on the upper 64 bits, so we need to undo it
+		uint64_t unsigned_upper = static_cast<uint64_t>(uuid_val.upper) ^ (uint64_t(1) << 63);
+		uint8_t version = (static_cast<uint8_t>((unsigned_upper) >> 8) & 0xf0) >> 4;
+
+		if (version == 1) {
+			// UUID v1: Extract timestamp from time_low, time_mid, and time_hi_and_version fields
+			// Mimic PostgreSQL's uuid_extract_timestamp implementation
+
+			// Extract individual bytes from the UUID (bytes 0-7 are in upper)
+			// We already have unsigned_upper computed above
+			uint8_t data[8];
+			for (int j = 0; j < 8; j++) {
+				data[j] = static_cast<uint8_t>((unsigned_upper >> (56 - j * 8)) & 0xFF);
+			}
+
+			// Extract timestamp following PostgreSQL's exact logic
+			// See: src/backend/utils/adt/uuid.c:uuid_extract_timestamp()
+			uint64_t tms = ((uint64_t) data[0] << 24)
+				+ ((uint64_t) data[1] << 16)
+				+ ((uint64_t) data[2] << 8)
+				+ ((uint64_t) data[3])
+				+ ((uint64_t) data[4] << 40)
+				+ ((uint64_t) data[5] << 32)
+				+ (((uint64_t) data[6] & 0xf) << 56)
+				+ ((uint64_t) data[7] << 48);
+
+			// Convert 100-ns intervals to microseconds
+			int64_t timestamp_us = static_cast<int64_t>(tms / 10);
+
+			// Adjust from UUID epoch (1582-10-15) to Postgres epoch (2000-01-01)
+			// This matches PostgreSQL's calculation exactly
+			constexpr int64_t POSTGRES_EPOCH_JDATE = 2451545; // date2j(2000, 1, 1)
+			constexpr int64_t UUIDV1_EPOCH_JDATE = 2299161;   // date2j(1582, 10, 15)
+			constexpr int64_t SECS_PER_DAY = 86400;
+			constexpr int64_t USECS_PER_SEC = 1000000;
+			constexpr int64_t UUID_TO_PG_EPOCH_US = 
+				(POSTGRES_EPOCH_JDATE - UUIDV1_EPOCH_JDATE) * SECS_PER_DAY * USECS_PER_SEC;
+
+			timestamp_us -= UUID_TO_PG_EPOCH_US;
+
+			// Convert from Postgres epoch (2000-01-01) to Unix epoch (1970-01-01)
+			// Unix epoch is 946684800 seconds (30 years) before Postgres epoch
+			// So we ADD this offset to convert from Postgres timestamp to Unix timestamp
+			constexpr int64_t PG_TO_UNIX_EPOCH_US = 946684800LL * USECS_PER_SEC;
+			timestamp_us += PG_TO_UNIX_EPOCH_US;
+
+			result_data[i] = timestamp_t{timestamp_us};
+		}
+		// UUID v7 is supported in Postgres 18 and above
+		else if (version == 7 && pg_version >= 180000) {
+			// UUID v7: Extract timestamp from first 48 bits (Unix timestamp in milliseconds)
+			int64_t upper = uuid_val.upper;
+			// Flip the top byte to handle signed representation
+			upper ^= NumericLimits<int64_t>::Minimum();
+			int64_t unix_ts_milli = upper >> 16;
+
+			// Convert milliseconds to microseconds
+			constexpr int64_t kMilliToMicro = 1000;
+			int64_t unix_ts_us = kMilliToMicro * unix_ts_milli;
+
+			result_data[i] = timestamp_t{unix_ts_us};
+		}
+		else {
+			// Not a timestamp-containing UUID version, return NULL
+			result_validity.SetInvalid(i);
+		}
+	}
+}
+
+
+/*
  * InitcapPG implements the Postgres initcap(text) function for the
  * C collation.
  *
@@ -696,6 +813,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 			IcebergByteSizeBind);
 		loader.RegisterFunction(iceberg_byte_size);
 	}
+
+	auto uuid_extract_timestamp_pg = ScalarFunction("uuid_extract_timestamp_pg", {LogicalType::UUID, LogicalType::INTEGER}, LogicalType::TIMESTAMP_TZ, UUIDExtractTimestampPG);
+	loader.RegisterFunction(uuid_extract_timestamp_pg);
 
 	PgLakeUtilityFunctions::RegisterFunctions(loader);
 	PgLakeFileSystemFunctions::RegisterFunctions(loader);

--- a/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
+++ b/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
@@ -1,1 +1,7 @@
 -- Upgrade script for pg_lake_engine from 3.4 to 3.5
+
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_timestamp_pg(uuid, integer)
+ RETURNS timestamp with time zone
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -24,6 +24,7 @@
 #include "catalog/pg_operator.h"
 #include "catalog/pg_operator_d.h"
 #include "catalog/pg_proc.h"
+#include "catalog/pg_type.h"
 #include "common/hashfn.h"
 #include "pg_lake/extensions/pg_lake_spatial.h"
 #include "pg_lake/extensions/postgis.h"
@@ -146,6 +147,9 @@ static ExpressionRewriter GetOperatorRewriter(Oid functionId);
 static char *GetOperatorRewriteFunctionName(Oid functionId);
 
 static Node *RewriteFuncExprBtrim(Node *node, void *context);
+#if PG_VERSION_NUM >= 170000
+static Node *RewriteFuncExprUuidExtractTimestamp(Node *node, void *context);
+#endif
 static Node *RewriteFunctionCallExpression(Oid functionId, Node *node, void *context);
 static Node *RewriteFuncExprCast(Node *node, void *context);
 static Node *RewriteFuncExprExtract(Node *node, void *context);
@@ -349,6 +353,13 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 	{
 		"pg_catalog", "decode", RewriteFuncExprDecode, 0
 	},
+
+#if PG_VERSION_NUM >= 170000
+	/* uuid functions */
+	{
+		"pg_catalog", "uuid_extract_timestamp", RewriteFuncExprUuidExtractTimestamp, 0
+	},
+#endif
 
 };
 
@@ -1687,6 +1698,45 @@ RewriteFuncExprDecode(Node *node, void *context)
 
 	return (Node *) funcExpr;
 }
+
+
+#if PG_VERSION_NUM >= 170000
+/*
+ * RewriteFuncExprUuidExtractTimestamp rewrites uuid_extract_timestamp(..) function calls
+ * to use the custom uuid_extract_timestamp_pg(..) function that mimics Postgres behavior.
+ *
+ * Postgres returns NULL for UUID versions that don't contain timestamps (v1 and v7 (>=pg18 ) only).
+ * DuckDB's uuid_extract_timestamp throws an error for non-v7 UUIDs.
+ */
+static Node *
+RewriteFuncExprUuidExtractTimestamp(Node *node, void *context)
+{
+	FuncExpr   *funcExpr = castNode(FuncExpr, node);
+	int			argCount = list_length(funcExpr->args);
+
+	/* uuid_extract_timestamp should have exactly 1 argument */
+	if (argCount != 1)
+		return node;
+
+	Node	   *firstArg = linitial(funcExpr->args);
+
+	if (exprType(firstArg) != UUIDOID)
+		return node;
+
+	/* add the second argument, the Postgres version number */
+	funcExpr->args = list_make2(firstArg, MakeIntConst(PG_VERSION_NUM));
+	argCount = 2;
+
+	/* Rewrite to uuid_extract_timestamp_pg(uuid) */
+	List	   *funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
+									  makeString("uuid_extract_timestamp_pg"));
+	Oid			argTypes[] = {UUIDOID, INT4OID};
+
+	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
+
+	return (Node *) funcExpr;
+}
+#endif
 
 
 /*

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -451,6 +451,14 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"encode", 'f', 2, {"bytea", "text"}, IsEncodeShippable},
 	{"decode", 'f', 2, {"text", "text"}, IsDecodeShippable},
 
+#if PG_VERSION_NUM >= 170000
+	{"uuid_extract_version", 'f', 1, {"uuid"}, NULL},
+	{"uuid_extract_timestamp", 'f', 1, {"uuid"}, NULL},
+#endif
+#if PG_VERSION_NUM >= 180000
+	{"uuidv7", 'f', 0, {}, NULL},
+#endif
+
 	/* trim() */
 };
 

--- a/pg_lake_spatial/tests/pytests/test_internal_schema.py
+++ b/pg_lake_spatial/tests/pytests/test_internal_schema.py
@@ -21,6 +21,6 @@ def test_internal_schema(
     """,
         pg_conn,
     )[0][0]
-    assert result == 64
+    assert result == 65
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_uuid_function_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_uuid_function_pushdown.py
@@ -1,0 +1,203 @@
+import pytest
+import psycopg2
+import datetime
+from utils_pytest import *
+
+
+test_pushdown_cases = [
+    (
+        "uuid_extract_version in target list",
+        "SELECT uuid_extract_version(uuid_val) FROM test_uuid_function_pushdown.tbl ORDER BY 1",
+        "uuid_extract_version",
+        "170000",
+    ),
+    (
+        "uuid_extract_version in where clause",
+        "SELECT * FROM test_uuid_function_pushdown.tbl WHERE uuid_extract_version(uuid_val) = 1 ORDER BY uuid_val",
+        "uuid_extract_version",
+        "170000",
+    ),
+    (
+        "uuid_extract_version in order by clause",
+        "SELECT * FROM test_uuid_function_pushdown.tbl ORDER BY uuid_extract_version(uuid_val), uuid_val",
+        "uuid_extract_version",
+        "170000",
+    ),
+    (
+        "uuid_extract_timestamp in target list",
+        "SELECT uuid_val, uuid_extract_timestamp(uuid_val)::timestamp FROM test_uuid_function_pushdown.tbl ORDER BY 1,2",
+        "uuid_extract_timestamp",
+        "170000",
+    ),
+    (
+        "uuid_extract_timestamp in where clause",
+        "SELECT * FROM test_uuid_function_pushdown.tbl WHERE uuid_extract_timestamp(uuid_val) > now() ORDER BY uuid_val",
+        "uuid_extract_timestamp",
+        "170000",
+    ),
+    (
+        "uuid_extract_timestamp in order by clause",
+        "SELECT * FROM test_uuid_function_pushdown.tbl ORDER BY uuid_extract_timestamp(uuid_val), uuid_val",
+        "uuid_extract_timestamp",
+        "170000",
+    ),
+    (
+        "uuidv7 in target list",
+        "SELECT uuidv7() FROM test_uuid_function_pushdown.tbl ORDER BY 1",
+        "uuidv7",
+        "180000",
+    ),
+    (
+        "uuidv7 in where clause",
+        "SELECT * FROM test_uuid_function_pushdown.tbl WHERE uuid_val != uuidv7() ORDER BY uuid_val",
+        "uuidv7",
+        "180000",
+    ),
+    (
+        "uuidv7 in order by clause",
+        "SELECT * FROM test_uuid_function_pushdown.tbl ORDER BY uuidv7(), uuid_val",
+        "uuidv7",
+        "180000",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_id, query, expected_function, exist_at_pg_version",
+    test_pushdown_cases,
+    ids=[t[0] for t in test_pushdown_cases],
+)
+def test_uuid_function_pushdown(
+    create_uuid_test_table,
+    pg_conn,
+    test_id,
+    query,
+    expected_function,
+    exist_at_pg_version,
+):
+    if get_server_version(pg_conn) < int(exist_at_pg_version):
+        pytest.skip(
+            f"Skipping test {test_id} as it requires PostgreSQL version {exist_at_pg_version}"
+        )
+
+    assert_remote_query_contains_expression(query, expected_function, pg_conn)
+
+    if test_id == "uuidv7 in target list":
+        # uuidv7 generates random UUIDs, so we cannot test the results
+        return
+
+    assert_query_results_on_tables(
+        query,
+        pg_conn,
+        ["test_uuid_function_pushdown.tbl"],
+        ["test_uuid_function_pushdown.heap_tbl"],
+    )
+
+
+def test_uuid_extract_version_and_timestamp(create_uuid_test_table, pg_conn):
+    pg_version = get_server_version(pg_conn)
+
+    if pg_version < 170000:
+        pytest.skip(
+            "Skipping test_uuid_extract_version_and_timestamp as it requires PostgreSQL version 170000"
+        )
+
+    query = "SELECT uuid_extract_version(uuid_val), uuid_extract_timestamp(uuid_val)::timestamp FROM test_uuid_function_pushdown.tbl ORDER BY 1,2"
+
+    assert_query_results_on_tables(
+        query,
+        pg_conn,
+        ["test_uuid_function_pushdown.tbl"],
+        ["test_uuid_function_pushdown.heap_tbl"],
+    )
+
+    result = run_query(query, pg_conn)
+
+    if pg_version < 180000:
+        # no timestamp for UUID v7 in Postgres 17
+        assert result == [
+            [1, datetime.datetime(5001, 4, 26, 5, 27, 31, 380751)],
+            [4, None],
+            [5, None],
+            [7, None],
+            [None, None],
+        ]
+    else:
+        # timestamp for UUID v7 in Postgres 18 and above
+        assert result == [
+            [1, datetime.datetime(5001, 4, 26, 5, 27, 31, 380751)],
+            [4, None],
+            [5, None],
+            [7, datetime.datetime(2025, 5, 22, 19, 31, 40, 436000)],
+            [None, None],
+        ]
+
+
+@pytest.fixture
+def create_uuid_test_table(pg_conn, s3, extension, with_default_location):
+    # UUID v7 test values (contains timestamp)
+    uuid_v7_example = "0196f97a-db14-71c3-9132-9f0b1334466f"
+
+    # UUID v1 test value (contains timestamp) - from PostgreSQL documentation
+    # This is a valid UUID v1 that should extract a timestamp
+    uuid_v1_example = "a0eebc99-9c0b-1ef8-bb6d-6bb9bd380a11"
+
+    # UUID v4 test value (no timestamp)
+    uuid_v4_example = "550e8400-e29b-41d4-a716-446655440000"
+
+    # UUID v5 test value (no timestamp)
+    uuid_v5_example = "886313e1-3b8a-5372-9b90-0c9aee199e5d"
+
+    # create iceberg table
+    run_command(
+        f"""
+        CREATE SCHEMA IF NOT EXISTS test_uuid_function_pushdown;
+        CREATE TABLE test_uuid_function_pushdown.tbl
+        (
+            uuid_val uuid
+        ) USING iceberg;
+
+        INSERT INTO test_uuid_function_pushdown.tbl VALUES
+            (NULL),
+            ('{uuid_v7_example}'),
+            ('{uuid_v1_example}'),
+            ('{uuid_v4_example}'),
+            ('{uuid_v5_example}');
+        """,
+        pg_conn,
+    )
+
+    run_command(
+        f"""
+        CREATE TABLE test_uuid_function_pushdown.heap_tbl
+        (
+            uuid_val uuid
+        );
+        """,
+        pg_conn,
+    )
+
+    run_command(
+        f"""
+        INSERT INTO test_uuid_function_pushdown.heap_tbl VALUES
+            (NULL),
+            ('{uuid_v7_example}'::uuid),
+            ('{uuid_v1_example}'::uuid),
+            ('{uuid_v4_example}'::uuid),
+            ('{uuid_v5_example}'::uuid);
+        """,
+        pg_conn,
+    )
+
+    pg_conn.commit()
+
+    yield
+
+    pg_conn.rollback()
+
+    run_command("DROP SCHEMA test_uuid_function_pushdown CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def get_server_version(pg_conn):
+    return int(run_query("show server_version_num", pg_conn)[0][0])


### PR DESCRIPTION
Closes #151.

## What

Enables pushdown of PostgreSQL UUID functions to DuckDB (pgduck_server) so they execute in the columnar engine instead of falling back to PostgreSQL.

The following builtins are now shippable (PG 17+):
- `uuid_extract_version(uuid)`
- `uuid_extract_timestamp(uuid)`
- `uuidv7()` (PG 18+)

## Why the custom `uuid_extract_timestamp_pg`

DuckDB's `uuid_extract_timestamp` throws an error for non-v7 UUIDs, whereas PostgreSQL returns `NULL` for UUID versions that don't carry a timestamp. In addition, the set of versions that carry a timestamp differs by PostgreSQL version:

- **PG 17**: only UUID **v1** yields a timestamp.
- **PG 18+**: both **v1** and **v7** yield a timestamp.

To match Postgres semantics exactly, `uuid_extract_timestamp(uuid)` is rewritten to a custom DuckDB scalar function `uuid_extract_timestamp_pg(uuid, integer)` where the second argument is `PG_VERSION_NUM`. The function inspects the UUID variant/version bits and reproduces Postgres's extraction logic (see `src/backend/utils/adt/uuid.c`), returning `NULL` for versions that don't apply on the given PG version.

## Changes

- `duckdb_pglake`: register `uuid_extract_timestamp_pg` scalar function implementing PG-compatible timestamp extraction.
- `pg_lake_engine` rewrite: rewrite `uuid_extract_timestamp` calls to `uuid_extract_timestamp_pg`, injecting `PG_VERSION_NUM` (PG 17+ only).
- `pg_lake_engine` shippable list: mark `uuid_extract_version`, `uuid_extract_timestamp` (PG 17+) and `uuidv7` (PG 18+) as shippable.
- SQL upgrade: declare the internal `uuid_extract_timestamp_pg(uuid, integer)` function.
- Tests: `test_uuid_function_pushdown.py` covering the pushdown and version-dependent behavior.

Co-authored-by: manojks1999 <9743manoj@gmail.com>
