### PR TITLE
Remove max CSV line size limitation

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/client.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/client.h
@@ -25,7 +25,6 @@
 #define DEFAULT_PGDUCK_SERVER_CONNINFO "host=/tmp port=5332"
 
 #define DEFAULT_DUCKDB_MAX_LINE_SIZE (2097152)
-#define DUCKDB_MAX_SAFE_CSV_LINE_SIZE 32000000
 
 /* settings */
 extern char *PgduckServerConninfo;

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -87,16 +87,6 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 
 	if (maxLineSize > 0)
 	{
-		if (maxLineSize >= DUCKDB_MAX_SAFE_CSV_LINE_SIZE)
-		{
-			/*
-			 * Sadly gotta abort here, since DuckDB has breakage in CSV lines
-			 * longer than 32MB, at least as of 1.1.
-			 */
-			ereport(ERROR, (errmsg("row exceeds maximum size of %d", DUCKDB_MAX_SAFE_CSV_LINE_SIZE),
-							errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED)));
-		}
-
 		/* use maxLineSize + 1 to include end-of-line */
 		appendStringInfo(&command, ", max_line_size=%d", maxLineSize + 1);
 	}


### PR DESCRIPTION
This PR removes the restriction that CSV lines cannot be more than 32000000 characters, since that was only necessary for older DuckDB versions.