### PR TITLE
Fix substring_pg crash on macOS due to long vs int64_t type mismatch

### DIFF
--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -124,7 +124,7 @@ inline void SubstringPG(DataChunk &args, ExpressionState &state, Vector &result)
 	{
 		auto &length_vector = args.data[2];
 
-		TernaryExecutor::Execute<string_t, long, int64_t, string_t>(
+		TernaryExecutor::Execute<string_t, int64_t, int64_t, string_t>(
 			input_vector, offset_vector, length_vector, result, args.size(),
 			[&](string_t input_string, int64_t offset, int64_t length)
 		{


### PR DESCRIPTION
fixes #175

TernaryExecutor template used 'long' for offset but function was registered with BIGINT (int64_t). These are distinct types on macOS ARM64, causing DuckDB's type verification to fail.

No tests added because we already have: https://github.com/Snowflake-Labs/pg_lake/blob/e9057c3cadbd78fedaa22fd6b82e4fb916a6a38e/pg_lake_table/tests/pytests/test_text_function_pushdown.py#L278

And, this test was crashing before the fix on my local machine, and passes now.