### PR TITLE
Add missing `catalog` to the object store catalog

### DIFF
--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -508,7 +508,7 @@ GetExternalObjectStoreCatalogFilePath(const char *catalogName)
 				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 
-	return psprintf("%s/%s/%s/catalog.json", defaultPrefix,
+	return psprintf("%s/%s/catalog/%s/catalog.json", defaultPrefix,
 					ExternalObjectStorePrefix, URLEncodePath(catalogName));
 }
 
@@ -533,7 +533,7 @@ GetInternalObjectStoreCatalogFilePath(const char *catalogName)
 				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 
-	return psprintf("%s/%s/%s/catalog.json", defaultPrefix,
+	return psprintf("%s/%s/catalog/%s/catalog.json", defaultPrefix,
 					InternalObjectStorePrefix, URLEncodePath(catalogName));
 }
 


### PR DESCRIPTION
Can be useful for adjusting the permissons on the object storage side.

