### PR TITLE
Add GUC to disable vended credentials header for REST catalog

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
@@ -32,6 +32,7 @@ extern char *RestCatalogClientId;
 extern char *RestCatalogClientSecret;
 extern char *RestCatalogScope;
 extern int	RestCatalogAuthType;
+extern bool RestCatalogEnableVendedCredentials;
 
 #define REST_CATALOG_AUTH_TOKEN_PATH "%s/api/catalog/v1/oauth/tokens"
 

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -306,6 +306,16 @@ _PG_init(void)
 							   GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							   NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("pg_lake_iceberg.rest_catalog_enable_vended_credentials",
+							 gettext_noop("Enable requesting vended credentials from REST catalog."),
+							 gettext_noop("When disabled, the X-Iceberg-Access-Delegation header is not sent. "
+										  "Disable this for S3-compatible storage that does not support AWS STS."),
+							 &RestCatalogEnableVendedCredentials,
+							 true,
+							 PGC_SUSET,
+							 GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
+
 	AvroInit();
 }
 

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -51,7 +51,7 @@ char	   *RestCatalogClientId = NULL;
 char	   *RestCatalogClientSecret = NULL;
 char	   *RestCatalogScope = "PRINCIPAL_ROLE:ALL";
 int			RestCatalogAuthType = REST_CATALOG_AUTH_TYPE_DEFAULT;
-
+bool		RestCatalogEnableVendedCredentials = true;
 
 /*
 * Should always be accessed via GetRestCatalogAccessToken()
@@ -118,9 +118,12 @@ StartStageRestCatalogIcebergTableCreate(Oid relationId)
 	 * different headers or authentication methods. TODO: We currently do not
 	 * use vended credentials, but should we?
 	 */
-	char	   *vendedCreds = pstrdup("X-Iceberg-Access-Delegation: vended-credentials");
+	if (RestCatalogEnableVendedCredentials)
+	{
+		char	   *vendedCreds = pstrdup("X-Iceberg-Access-Delegation: vended-credentials");
 
-	headers = lappend(headers, vendedCreds);
+		headers = lappend(headers, vendedCreds);
+	}
 
 	HttpResult	httpResult = SendRequestToRestCatalog(HTTP_POST, postUrl, body->data, headers);
 


### PR DESCRIPTION
## Description

Some Iceberg REST catalogs do not support AWS STS credential vending. When pg_lake sends the `X-Iceberg-Access-Delegation: vended-credentials` header to these catalogs, it can cause issues or errors.

This PR adds a new GUC `pg_lake_iceberg.rest_catalog_enable_vended_credentials` that allows users to disable sending this header.

**Usage:**
```sql
SET pg_lake_iceberg.rest_catalog_enable_vended_credentials TO false;
```

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
