### PR TITLE
Allow long-form Azure URLs

### DIFF
--- a/duckdb_pglake/src/fs/file_cache_manager.cpp
+++ b/duckdb_pglake/src/fs/file_cache_manager.cpp
@@ -222,6 +222,7 @@ FileCacheManager::IsCacheableURL(string cacheDir, string url)
 
 	return StringUtil::StartsWith(url, "s3://") ||
 		   StringUtil::StartsWith(url, "gs://") ||
+		   StringUtil::StartsWith(url, "azure://") ||
 		   StringUtil::StartsWith(url, "az://") ||
 		   StringUtil::StartsWith(url, "abfss://") ||
 		   StringUtil::StartsWith(url, "https://") ||

--- a/pg_lake_benchmark/src/tpcds.c
+++ b/pg_lake_benchmark/src/tpcds.c
@@ -73,7 +73,7 @@ pg_lake_tpcds_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3:// and gs:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);

--- a/pg_lake_benchmark/src/tpch.c
+++ b/pg_lake_benchmark/src/tpch.c
@@ -70,7 +70,7 @@ pg_lake_tpch_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3:// and gs:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);
@@ -104,7 +104,7 @@ pg_lake_tpch_gen_partitioned(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3:// and gs:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);

--- a/pg_lake_copy/src/ddl/create_table.c
+++ b/pg_lake_copy/src/ddl/create_table.c
@@ -172,7 +172,7 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(definitionFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3:// and gs:// URLs are "
+							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are "
 								   "currently supported")));
 		}
 
@@ -192,7 +192,7 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(loadFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3:// and gs:// URLs are "
+							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are "
 								   "currently supported")));
 		}
 

--- a/pg_lake_engine/include/pg_lake/copy/copy_format.h
+++ b/pg_lake_engine/include/pg_lake/copy/copy_format.h
@@ -24,6 +24,7 @@
 
 #define S3_URL_PREFIX "s3://"
 #define GCS_URL_PREFIX "gs://"
+#define AZURE_URL_PREFIX "azure://"
 #define AZURE_BLOB_URL_PREFIX "az://"
 #define AZURE_DLS_URL_PREFIX "abfss://"
 #define HTTP_URL_PREFIX "http://"

--- a/pg_lake_engine/src/copy/copy_format.c
+++ b/pg_lake_engine/src/copy/copy_format.c
@@ -426,6 +426,7 @@ IsSupportedURL(const char *path)
 
 	return strncmp(path, S3_URL_PREFIX, strlen(S3_URL_PREFIX)) == 0 ||
 		strncmp(path, GCS_URL_PREFIX, strlen(GCS_URL_PREFIX)) == 0 ||
+		strncmp(path, AZURE_URL_PREFIX, strlen(AZURE_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_BLOB_URL_PREFIX, strlen(AZURE_BLOB_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_DLS_URL_PREFIX, strlen(AZURE_DLS_URL_PREFIX)) == 0 ||
 		strncmp(path, HTTP_URL_PREFIX, strlen(HTTP_URL_PREFIX)) == 0 ||

--- a/pg_lake_iceberg/src/iceberg/iceberg_functions.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_functions.c
@@ -49,7 +49,7 @@ iceberg_metadata(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3:// and gs:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
 	}
 
 	CheckURLReadAccess();
@@ -71,7 +71,7 @@ iceberg_files(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3:// and gs:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
 	}
 
 	CheckURLReadAccess();
@@ -144,7 +144,7 @@ iceberg_snapshots(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3:// and gs:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
 	}
 
 	CheckURLReadAccess();

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -333,7 +333,7 @@ IcebergDefaultLocationCheckHook(char **newvalue, void **extra, GucSource source)
 
 	if (!IsSupportedURL(newLocationPrefix))
 	{
-		GUC_check_errdetail("pg_lake_iceberg: only s3:// and gs:// URLs are currently "
+		GUC_check_errdetail("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// URLs are "
 							"supported as the default location prefix");
 		return false;
 	}

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
@@ -47,7 +47,10 @@ def test_pg_lake_iceberg_table_metadata(
         raise_error=False,
     )
 
-    assert "pg_lake_iceberg: only s3:// and gs:// are supported" in error
+    assert (
+        "pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported"
+        in error
+    )
 
     pg_conn.rollback()
 
@@ -106,7 +109,10 @@ def test_unsupported_url(installcheck, superuser_conn, iceberg_extension, s3):
 
     error = run_query(query, superuser_conn, raise_error=False)
 
-    assert "pg_lake_iceberg: only s3:// and gs:// are supported" in error
+    assert (
+        "pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported"
+        in error
+    )
 
 
 @pytest.fixture(scope="module")

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -382,14 +382,14 @@ ErrorIfUnsupportedLakeTable(CreateForeignTableStmt *createStmt)
 	if (!isWritable && !IsSupportedURL(path))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3:// and gs:// URLs are "
+						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are "
 							   "currently supported")));
 	}
 	else if (isWritable && !IsSupportedURL(location))
 	{
 
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3:// and gs:// URLs are "
+						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are "
 							   "currently supported")));
 	}
 

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -204,7 +204,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(path))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3:// and gs:// "
+								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// "
 									   "URLs are currently supported for the \"path\" "
 									   "option.")));
 
@@ -216,7 +216,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(value))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3:// and gs:// "
+								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// "
 									   "URLs are currently supported for the \"location\" "
 									   "option.")));
 
@@ -718,7 +718,7 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(location))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_iceberg: only s3:// and gs:// "
+								errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// "
 									   "URLs are currently supported for the \"location\" "
 									   "option.")));
 

--- a/pg_lake_table/src/util/s3_file_utils.c
+++ b/pg_lake_table/src/util/s3_file_utils.c
@@ -59,7 +59,7 @@ pg_lake_file_size(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_size: only %s urls are supported", S3_URL_PREFIX),
+		ereport(ERROR, (errmsg("file_size: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -88,8 +88,7 @@ pg_lake_list_files(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(globURL) || !IsFileListSupportedUrl(globURL))
-		ereport(ERROR, (errmsg("list_files: only %s and %s urls are supported",
-							   S3_URL_PREFIX, GCS_URL_PREFIX),
+		ereport(ERROR, (errmsg("list_files: only s3://, gs://, az://, azure://, abfss://, and hf:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -135,6 +134,7 @@ IsFileListSupportedUrl(char *path)
 
 	return strncmp(path, S3_URL_PREFIX, strlen(S3_URL_PREFIX)) == 0 ||
 		strncmp(path, GCS_URL_PREFIX, strlen(GCS_URL_PREFIX)) == 0 ||
+		strncmp(path, AZURE_URL_PREFIX, strlen(AZURE_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_BLOB_URL_PREFIX, strlen(AZURE_BLOB_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_DLS_URL_PREFIX, strlen(AZURE_DLS_URL_PREFIX)) == 0 ||
 		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0;
@@ -151,8 +151,7 @@ pg_lake_file_exists(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_exists: only %s and %s urls are supported",
-							   S3_URL_PREFIX, GCS_URL_PREFIX),
+		ereport(ERROR, (errmsg("file_exists: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -206,8 +205,7 @@ pg_lake_file_preview(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(url))
-		ereport(ERROR, (errmsg("file_preview: only %s and %s urls are supported",
-							   S3_URL_PREFIX, GCS_URL_PREFIX),
+		ereport(ERROR, (errmsg("file_preview: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -255,7 +253,7 @@ pg_lake_delete_file(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("delete_file: only %s urls are supported", S3_URL_PREFIX),
+		ereport(ERROR, (errmsg("delete_file: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLWriteAccess();

--- a/pg_lake_table/tests/pytests/test_create_as_select.py
+++ b/pg_lake_table/tests/pytests/test_create_as_select.py
@@ -57,7 +57,7 @@ def test_unsupported_url(s3, pg_conn, extension):
         pg_conn,
         raise_error=False,
     )
-    assert "only s3:// and gs:// URLs" in error
+    assert "only s3://, gs://, az://, azure://, and abfss:// URLs" in error
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
+++ b/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
@@ -274,7 +274,7 @@ def test_create_table_load_from_invalid_url(
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3:// and gs:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
     )
 
     pg_conn.rollback()
@@ -287,7 +287,7 @@ def test_create_table_load_from_invalid_url(
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3:// and gs:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
     )
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_file_preview.py
+++ b/pg_lake_table/tests/pytests/test_file_preview.py
@@ -55,7 +55,9 @@ def test_file_preview_non_s3_url(pg_conn, extension):
         pg_conn,
         raise_error=False,
     )
-    assert "only s3:// and gs:// urls are supported" in error
+    assert (
+        "only s3://, gs://, az://, azure://, and abfss:// urls are supported" in error
+    )
     pg_conn.rollback()
 
 

--- a/pg_lake_table/tests/pytests/test_list_file.py
+++ b/pg_lake_table/tests/pytests/test_list_file.py
@@ -30,7 +30,10 @@ def test_list_files_non_s3_url(pg_conn, generate_data_on_s3):
         pg_conn,
         raise_error=False,
     )
-    assert "only s3:// and gs:// urls are supported" in error
+    assert (
+        "only s3://, gs://, az://, azure://, abfss://, and hf:// urls are supported"
+        in error
+    )
     pg_conn.rollback()
 
 

--- a/pg_lake_table/tests/pytests/test_queries.py
+++ b/pg_lake_table/tests/pytests/test_queries.py
@@ -1331,7 +1331,8 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
 
     except psycopg2.errors.FeatureNotSupported as e:
         assert (
-            "pg_lake_table: only s3:// and gs:// URLs are currently supported" in str(e)
+            "pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+            in str(e)
         )
         cur.close()
         pg_conn.commit()
@@ -1355,7 +1356,7 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
     except psycopg2.errors.FeatureNotSupported as e:
         assert (
             str(e)
-            == 'pg_lake_table: only s3:// and gs:// URLs are currently supported for the "path" option.\n'
+            == 'pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported for the "path" option.\n'
         )
         cur.close()
         pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_writable_iceberg.py
+++ b/pg_lake_table/tests/pytests/test_writable_iceberg.py
@@ -110,7 +110,7 @@ def test_writable_iceberg_create_wrong_option(pg_conn, extension):
         raise_error=False,
     )
     assert (
-        'pg_lake_iceberg: only s3:// and gs:// URLs are currently supported for the "location" option.'
+        'pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported for the "location" option.'
         in str(error)
     )
     pg_conn.rollback()


### PR DESCRIPTION
We so far only allowed `az://contaier/...` URLs for Azure, but it's quite common to use the longer form `azure://account_name.blob.core.windows.net/container` format.

This PR adds support for the longer form. There are some tests, though Azurite does not support using the `.blob.core.windows.net` suffix, verified that manually.

Can be tested by creating a secret on pgduck_server:
```sql
CREATE SECRET azsecret (
    TYPE AZURE,
    CONNECTION_STRING '...'
);
```