### PR TITLE
Re-enable PG18 tests in test_base_worker_launcher.py

### DIFF
--- a/pg_extension_base/include/pg_extension_base/pg_extension_base_ids.h
+++ b/pg_extension_base/include/pg_extension_base/pg_extension_base_ids.h
@@ -22,6 +22,6 @@
 #define PG_EXTENSION_BASE_NAME "pg_extension_base"
 
 /* cached extension IDs for pg_extension_base */
-extern PGDLLEXPORT CachedExtensionIds *PgExtensionBase;
+extern PGDLLEXPORT CachedExtensionIds * PgExtensionBase;
 
 extern PGDLLEXPORT void InitializePgExtensionBaseCache(void);

--- a/pg_extension_base/tests/pytests/test_base_worker_launcher.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_launcher.py
@@ -5,12 +5,6 @@ from utils_pytest import *
 import server_params
 
 
-@pytest.fixture(autouse=True)
-def skip_if_unsupported(superuser_conn):
-    if superuser_conn.server_version >= 180000:
-        pytest.xfail("postgres 18 does not support this feature")
-
-
 def test_server_start(superuser_conn):
     result = get_pg_extension_workers(superuser_conn)
     assert result[0]["datname"] == None
@@ -124,7 +118,7 @@ def test_create_drop_pg_extension_base(superuser_conn):
 
     assert count_pg_extension_base_workers(superuser_conn) == 1
 
-    # drop the pg_base_base extension
+    # drop the pg_extension_base extension
     run_command("DROP EXTENSION pg_extension_base CASCADE", superuser_conn)
     superuser_conn.commit()
 
@@ -311,6 +305,6 @@ def get_pg_extension_workers(conn):
 
 
 def count_pg_extension_base_workers(conn):
-    query = "SELECT count(*) FROM pg_stat_activity WHERE backend_type LIKE 'pg base extension %'"
+    query = "SELECT count(*) FROM pg_stat_activity WHERE backend_type = 'pg base extension worker'"
     result = run_query(query, conn)
     return result[0]["count"]


### PR DESCRIPTION
Some base worker tests were disabled as part of PG18 support. The test in question checked the number of base workers 100ms after committing a transaction that dropped and recreated an extension with a base worker. There was no base worker when a base worker was expected. This is most likely due to a timing change.

If the server starter fails to acquire a database lock which is acquired by DROP EXTENSION, it goes into a long (30 second) iteration, while the test only waits 100ms.

Dropping and recreating an extension in a transaction is not very strange for stateless extensions (e.g. idempotent creation scripts that do `DROP EXTENSION IF EXISTS ..; CREATE EXTENSION ..`), so in general it seems somewhat useful for the server starter to react more quickly.

This PR makes the server starter wait for the lock, which mostly means it cannot start base workers for other databases during a DROP DATABASE or DROP EXTENSION, but those are very rare commands that usually do not happen directly at server start.

This does increase the likelihood that the server starter will try to start a base worker for a database that no longer exists, since it tries to start the worker immediately after a DROP DATABASE is gone. That's not a correctness issue, since the worker will fail and not get restarted, but to avoid errors there's an extra check for database existence.