### PR TITLE
Cache in-progress table visibility to avoid SPI per file write

### DIFF
--- a/pg_lake_engine/include/pg_lake/cleanup/in_progress_files.h
+++ b/pg_lake_engine/include/pg_lake/cleanup/in_progress_files.h
@@ -28,3 +28,4 @@ extern PGDLLEXPORT void InsertInProgressFileRecord(char *path);
 extern PGDLLEXPORT void InsertInProgressFileRecordExtended(char *path, bool isPrefix, bool autoDeleteRecord);
 extern PGDLLEXPORT void DeleteInProgressFileRecord(char *path);
 extern PGDLLEXPORT void ReplaceInProgressPrefixPathWithFullPaths(char *prefixPath, List *fullPaths);
+extern PGDLLEXPORT void InvalidateInProgressTableVisibilityCache(void);

--- a/pg_lake_engine/src/extensions/pg_lake_engine.c
+++ b/pg_lake_engine/src/extensions/pg_lake_engine.c
@@ -18,6 +18,7 @@
 #include "postgres.h"
 
 #include "catalog/pg_type.h"
+#include "pg_lake/cleanup/in_progress_files.h"
 #include "pg_lake/extensions/pg_lake_engine.h"
 #include "pg_extension_base/extension_ids.h"
 #include "parser/parse_func.h"
@@ -58,7 +59,7 @@ InitializePgLakeEngineIdCache(void)
 
 
 /*
- * ClearIds clears all the cached OIDs.
+ * ClearIds clears all the cached OIDs and related caches.
  */
 static void
 ClearIds(void *queryEngineIds)
@@ -66,6 +67,9 @@ ClearIds(void *queryEngineIds)
 	Assert(queryEngineIds != NULL);
 
 	memset(queryEngineIds, '\0', sizeof(PgLakeEngineIds));
+
+	/* also reset the in-progress table visibility cache */
+	InvalidateInProgressTableVisibilityCache();
 }
 
 

--- a/pg_lake_table/tests/pytests/test_create_drop_extension.py
+++ b/pg_lake_table/tests/pytests/test_create_drop_extension.py
@@ -80,6 +80,58 @@ def test_create_extension_table_access_method(superuser_conn):
     superuser_conn.rollback()
 
 
+def test_drop_create_extension_insert_same_tx(superuser_conn, s3, app_user):
+    """
+    DROP + CREATE EXTENSION + CREATE TABLE + INSERT all in the same transaction.
+
+    This exercises InProgressTableVisibleToExternalTx(): after DROP + CREATE
+    EXTENSION, the in_progress_files table is recreated in the current tx.
+    The visibility check must detect that the table was created in the current
+    transaction (via rd_createSubid) and skip the run_attached insert to avoid
+    a self-deadlock on the AccessExclusiveLock held by the DDL.
+    """
+    run_command(
+        """
+        CREATE EXTENSION IF NOT EXISTS pg_lake_table CASCADE;
+    """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    url = f"s3://{TEST_BUCKET}/test_drop_create_ext_same_tx/"
+
+    run_command(
+        f"""
+        DROP EXTENSION pg_lake_engine CASCADE;
+        CREATE EXTENSION pg_lake_table CASCADE;
+        GRANT lake_read_write TO {app_user};
+
+        SET pg_lake_iceberg.default_location_prefix TO 's3://{TEST_BUCKET}';
+
+        CREATE TABLE test_same_tx (x int) USING iceberg;
+        INSERT INTO test_same_tx VALUES (1), (2), (3);
+    """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    result = run_query("SELECT count(*) FROM test_same_tx", superuser_conn)
+    assert result[0]["count"] == 3
+
+    result = run_query("SELECT * FROM test_same_tx ORDER BY x", superuser_conn)
+    assert [r["x"] for r in result] == [1, 2, 3]
+
+    # second transaction should work normally (visibility cached as true)
+    run_command("INSERT INTO test_same_tx VALUES (4)", superuser_conn)
+    superuser_conn.commit()
+
+    result = run_query("SELECT count(*) FROM test_same_tx", superuser_conn)
+    assert result[0]["count"] == 4
+
+    run_command("DROP TABLE test_same_tx", superuser_conn)
+    superuser_conn.commit()
+
+
 def create_table_with_data(superuser_conn):
     url = f"s3://{TEST_BUCKET}/test_create_drop_extension/"
 


### PR DESCRIPTION
`InsertInProgressFileRecordExtended` calls `InProgressTableVisibleToExternalTx` on every invocation. Previously this started a background worker via `run_attached` to check whether the `in_progress_files` table exists, adding a full SPI per-call, plus spinning up a bg worker.

For transactions that touch many tables or write many files, this overhead adds up significantly.

Replace the SPI check with a `rd_createSubid` inspection on the relation (the same technique PostgreSQL uses in `RELATION_IS_LOCAL` and `COPY FROM`).

If the table was created in the current transaction, it is not yet visible to external backends, so we skip the insert. So, files created in the same transaction that does `CREATE EXTENSION` is ignored. This is the same even before this commit, and that's really only relevant for test scenarios.

Once the result is true (the common case after extension creation is committed), we cache it and never recheck -- the cache is invalidated on CREATE/DROP EXTENSION via the existing `ClearIds` callback.
