### PR TITLE
Add function to run attached worker with query results

### DIFF
--- a/pg_extension_base/include/pg_extension_base/attached_worker.h
+++ b/pg_extension_base/include/pg_extension_base/attached_worker.h
@@ -20,6 +20,7 @@
 #include "postmaster/bgworker.h"
 #include "storage/dsm.h"
 #include "storage/shm_mq.h"
+#include "utils/tuplestore.h"
 
 /*
  * AttachedWorker contains references to a background worker that
@@ -31,6 +32,9 @@ typedef struct AttachedWorker
 	dsm_segment *sharedMemorySegment;
 	shm_mq_handle *outputQueue;
 
+	/* tuple queue for returning query results (NULL if not returning) */
+	shm_mq_handle *tupleQueue;
+
 	/* background worker handle */
 	pid_t		workerPid;
 	BackgroundWorkerHandle *workerHandle;
@@ -40,6 +44,13 @@ extern PGDLLEXPORT AttachedWorker * StartAttachedWorker(char *command);
 extern PGDLLEXPORT AttachedWorker * StartAttachedWorkerInDatabase(char *command,
 																  char *databaseName,
 																  char *userName);
+extern PGDLLEXPORT AttachedWorker * StartAttachedWorkerReturning(char *command);
+extern PGDLLEXPORT AttachedWorker * StartAttachedWorkerInDatabaseReturning(char *command,
+																		   char *databaseName,
+																		   char *userName);
 extern PGDLLEXPORT char *ReadFromAttachedWorker(AttachedWorker * worker, bool wait);
+extern PGDLLEXPORT void ReadResultsFromAttachedWorker(AttachedWorker * worker,
+													  Tuplestorestate *store,
+													  TupleDesc *resultDesc);
 extern PGDLLEXPORT bool IsAttachedWorkerRunning(AttachedWorker * worker);
 extern PGDLLEXPORT void EndAttachedWorker(AttachedWorker * worker);

--- a/pg_extension_base/pg_extension_base--3.2--3.3.sql
+++ b/pg_extension_base/pg_extension_base--3.2--3.3.sql
@@ -1,1 +1,10 @@
 -- Upgrade script for pg_extension_base from 3.2 to 3.3
+
+/* run a command in a worker and return the query results */
+CREATE FUNCTION extension_base.run_attached_returning(command text, dbname text DEFAULT current_database())
+ RETURNS SETOF record
+ LANGUAGE c STRICT
+AS 'MODULE_PATHNAME', $function$pg_extension_base_run_attached_worker_returning$function$;
+
+COMMENT ON FUNCTION extension_base.run_attached_returning(text,text)
+ IS 'run a command in a separate attached worker and return the query results';

--- a/pg_extension_base/tests/pytests/test_attached_workers.py
+++ b/pg_extension_base/tests/pytests/test_attached_workers.py
@@ -112,6 +112,260 @@ def test_parent_cancellation(superuser_conn, pg_extension_base):
     superuser_conn.rollback()
 
 
+def test_returning_simple(superuser_conn, pg_extension_base):
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT 1 as a, 2 as b$$) AS t(a int, b int)",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["a"] == 1
+    assert result[0]["b"] == 2
+
+
+def test_returning_multiple_rows(superuser_conn, pg_extension_base):
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT generate_series(1,5) as x$$) AS t(x int)",
+        superuser_conn,
+    )
+    assert len(result) == 5
+    assert [r["x"] for r in result] == [1, 2, 3, 4, 5]
+
+
+def test_returning_nulls(superuser_conn, pg_extension_base):
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT 1 as a, NULL::text as b$$) AS t(a int, b text)",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["a"] == 1
+    assert result[0]["b"] is None
+
+
+def test_returning_various_types(superuser_conn, pg_extension_base):
+    result = run_query(
+        """SELECT * FROM extension_base.run_attached_returning(
+            $$SELECT 42 as i, 3.14::float8 as f, true as b, 'hello'::text as t$$
+        ) AS t(i int, f float8, b bool, t text)""",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["i"] == 42
+    assert abs(result[0]["f"] - 3.14) < 0.001
+    assert result[0]["b"] == True
+    assert result[0]["t"] == "hello"
+
+
+def test_returning_empty(superuser_conn, pg_extension_base):
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT 1 as a WHERE false$$) AS t(a int)",
+        superuser_conn,
+    )
+    assert len(result) == 0
+
+
+def test_returning_error(superuser_conn, pg_extension_base):
+    error = run_command(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT 1/0$$) AS t(x int)",
+        superuser_conn,
+        raise_error=False,
+    )
+    assert "division" in error
+
+    superuser_conn.rollback()
+
+
+def test_returning_array(superuser_conn, pg_extension_base):
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT ARRAY[1,2,3] as a, ARRAY['x','y'] as b$$) AS t(a int[], b text[])",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["a"] == [1, 2, 3]
+    assert result[0]["b"] == ["x", "y"]
+
+
+def test_returning_composite(superuser_conn, pg_extension_base):
+    run_command("CREATE TYPE test_composite AS (x int, y text)", superuser_conn)
+    superuser_conn.commit()
+
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT ROW(1, 'hello')::test_composite as c$$) AS t(c test_composite)",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["c"] == "(1,hello)"
+
+    run_command("DROP TYPE test_composite", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_returning_jsonb(superuser_conn, pg_extension_base):
+    result = run_query(
+        """SELECT * FROM extension_base.run_attached_returning(
+            $$SELECT '{"key": "value", "num": 42}'::jsonb as j$$
+        ) AS t(j jsonb)""",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["j"] == {"key": "value", "num": 42}
+
+
+def test_returning_bytea(superuser_conn, pg_extension_base):
+    result = run_query(
+        r"SELECT * FROM extension_base.run_attached_returning($$SELECT '\x deadbeef'::bytea as b$$) AS t(b bytea)",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert bytes(result[0]["b"]) == bytes.fromhex("deadbeef")
+
+
+def test_returning_nested_array(superuser_conn, pg_extension_base):
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT ARRAY[ARRAY[1,2],ARRAY[3,4]] as a$$) AS t(a int[])",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["a"] == [[1, 2], [3, 4]]
+
+
+def test_returning_with_notice(superuser_conn, pg_extension_base):
+    run_command(
+        """CREATE OR REPLACE FUNCTION notice_and_return()
+        RETURNS TABLE(x int, t text) AS $$
+        BEGIN
+            RAISE NOTICE 'hello from worker';
+            RETURN QUERY SELECT 1, 'one';
+            RAISE NOTICE 'second notice';
+            RETURN QUERY SELECT 2, 'two';
+        END$$ LANGUAGE plpgsql""",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    # clear any prior notices
+    superuser_conn.notices.clear()
+
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT * FROM notice_and_return()$$) AS t(x int, t text)",
+        superuser_conn,
+    )
+    assert len(result) == 2
+    assert result[0]["x"] == 1
+    assert result[0]["t"] == "one"
+    assert result[1]["x"] == 2
+    assert result[1]["t"] == "two"
+
+    # verify notices were forwarded to the client
+    notices = [
+        n
+        for n in superuser_conn.notices
+        if "hello from worker" in n or "second notice" in n
+    ]
+    assert len(notices) == 2
+
+    run_command("DROP FUNCTION notice_and_return()", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_returning_with_warning(superuser_conn, pg_extension_base):
+    run_command(
+        """CREATE OR REPLACE FUNCTION warn_and_return()
+        RETURNS int AS $$
+        BEGIN
+            RAISE WARNING 'this is a warning';
+            RETURN 42;
+        END$$ LANGUAGE plpgsql""",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    superuser_conn.notices.clear()
+
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT * FROM warn_and_return()$$) AS t(x int)",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["x"] == 42
+
+    warnings = [n for n in superuser_conn.notices if "this is a warning" in n]
+    assert len(warnings) == 1
+
+    run_command("DROP FUNCTION warn_and_return()", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_run_attached_with_notice(superuser_conn, pg_extension_base):
+    run_command(
+        """CREATE OR REPLACE FUNCTION notice_side_effect()
+        RETURNS void AS $$
+        BEGIN
+            RAISE NOTICE 'side effect notice';
+        END$$ LANGUAGE plpgsql""",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    superuser_conn.notices.clear()
+
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached($$SELECT notice_side_effect()$$)",
+        superuser_conn,
+    )
+    assert result[0]["command_tag"] == "SELECT 1"
+
+    notices = [n for n in superuser_conn.notices if "side effect notice" in n]
+    assert len(notices) == 1
+
+    run_command("DROP FUNCTION notice_side_effect()", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_returning_fatal_does_not_kill_session(superuser_conn, pg_extension_base):
+    # A FATAL error in the worker (e.g. connecting to a non-existent database)
+    # should be reported as ERROR to the parent, not kill the session.
+    error = run_command(
+        "SELECT * FROM extension_base.run_attached_returning("
+        "$$SELECT 1$$, 'nonexistent_db_12345') AS t(x int)",
+        superuser_conn,
+        raise_error=False,
+    )
+    assert error is not None
+    assert "nonexistent_db_12345" in error or "does not exist" in error
+
+    superuser_conn.rollback()
+
+    # the session should still be alive
+    result = run_query("SELECT 1 as alive", superuser_conn)
+    assert result[0]["alive"] == 1
+
+
+def test_run_attached_fatal_does_not_kill_session(superuser_conn, pg_extension_base):
+    # Same for the non-returning path
+    error = run_command(
+        "SELECT * FROM extension_base.run_attached("
+        "$$SELECT 1$$, 'nonexistent_db_12345')",
+        superuser_conn,
+        raise_error=False,
+    )
+    assert error is not None
+    assert "nonexistent_db_12345" in error or "does not exist" in error
+
+    superuser_conn.rollback()
+
+    result = run_query("SELECT 1 as alive", superuser_conn)
+    assert result[0]["alive"] == 1
+
+
+def test_returning_in_other_db(superuser_conn, pg_extension_base):
+    result = run_query(
+        f"SELECT * FROM extension_base.run_attached_returning('SELECT 1 as a', '{server_params.PG_DATABASE}') AS t(a int)",
+        superuser_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["a"] == 1
+
+
 def test_nologin_role(superuser_conn, pg_extension_base):
     run_command("CREATE ROLE no_login nologin superuser ", superuser_conn)
     current_user = run_query("SELECT user", superuser_conn)[0][0]
@@ -138,3 +392,59 @@ def test_nologin_role(superuser_conn, pg_extension_base):
     # cleanup
     run_command("DROP ROLE no_login", superuser_conn)
     superuser_conn.commit()
+
+
+def test_returning_column_count_mismatch(superuser_conn, pg_extension_base):
+    # Query returns 2 columns but AS clause expects 1
+    error = run_command(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT 1 as a, 2 as b$$) AS t(a int)",
+        superuser_conn,
+        raise_error=False,
+    )
+    assert error is not None
+    assert "column" in error
+
+    superuser_conn.rollback()
+
+    # session should still be alive
+    result = run_query("SELECT 1 as alive", superuser_conn)
+    assert result[0]["alive"] == 1
+
+
+def test_returning_type_mismatch(superuser_conn, pg_extension_base):
+    # Query returns text but AS clause expects int
+    error = run_command(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT 'hello'::text as a$$) AS t(a int)",
+        superuser_conn,
+        raise_error=False,
+    )
+    assert error is not None
+    assert (
+        "type" in error.lower()
+        or "mismatch" in error.lower()
+        or "text" in error
+        or "integer" in error
+    )
+
+    superuser_conn.rollback()
+
+    # session should still be alive
+    result = run_query("SELECT 1 as alive", superuser_conn)
+    assert result[0]["alive"] == 1
+
+
+def test_returning_more_columns_expected(superuser_conn, pg_extension_base):
+    # Query returns 1 column but AS clause expects 3
+    error = run_command(
+        "SELECT * FROM extension_base.run_attached_returning($$SELECT 1 as a$$) AS t(a int, b int, c int)",
+        superuser_conn,
+        raise_error=False,
+    )
+    assert error is not None
+    assert "column" in error
+
+    superuser_conn.rollback()
+
+    # session should still be alive
+    result = run_query("SELECT 1 as alive", superuser_conn)
+    assert result[0]["alive"] == 1


### PR DESCRIPTION
This PR adds infrastructure to run a query in a background worker and get the results of the query.

```sql
select now(), * from extension_base.run_attached_returning('select now(), current_Database()', 'template1') as res (x timestamptz, d name);
              now              |               x               |     d
-------------------------------+-------------------------------+-----------
 2026-02-16 12:41:45.955345+00 | 2026-02-16 12:41:45.958342+00 | template1
(1 row)
```