### PR TITLE
Allow Iceberg table creation in extensions

### DIFF
--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -1090,14 +1090,21 @@ ProcessCreateIcebergTableFromCreateStmt(ProcessUtilityParams * params)
 		 * pg_lake_iceberg access method. This includes our own extensions
 		 * such as pg_lake_iceberg as well as other extensions that use
 		 * metadata tables, such as pg_cron.
+		 *
+		 * However, if the extension explicitly specifies USING iceberg, we
+		 * allow the iceberg table creation.
 		 */
 		if (createStmt->accessMethod == NULL &&
 			IsPgLakeIcebergAccessMethod(default_table_access_method))
 		{
 			createStmt->accessMethod = DEFAULT_TABLE_ACCESS_METHOD;
+			return false;
 		}
-
-		return false;
+		else if (createStmt->accessMethod != NULL &&
+				 !IsPgLakeIcebergAccessMethod(createStmt->accessMethod))
+		{
+			return false;
+		}
 	}
 
 	PgLakeTableType tableType = GetPgLakeTableTypeViaAccessMethod(createStmt->accessMethod);


### PR DESCRIPTION
We sort of block Iceberg table creation in extension scripts, but that seems unintentional. We mainly wanted to prevent tables created by extensions from becoming Iceberg tables due to default_access_method, without e.g. explicitly blocking foreign tables.