### PR TITLE
Support iceberg schema type change

### DIFF
--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -33,6 +33,7 @@
 #include "utils/typcache.h"
 
 static FieldStructElement * DeepCopyFieldStructElement(FieldStructElement * structElementField);
+static bool FieldTypesEqual(const Field * fieldA, const Field * fieldB);
 
 /*
  * DeepCopyField deep copies a Field.
@@ -158,10 +159,48 @@ pg_cmp_s32(int32 a, int32 b)
 
 
 /*
+ * FieldTypesEqual recursively compares two Field structs for type equality.
+ */
+static bool
+FieldTypesEqual(const Field * fieldA, const Field * fieldB)
+{
+	if (fieldA->type != fieldB->type)
+		return false;
+
+	switch (fieldA->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			return strcmp(fieldA->field.scalar.typeName,
+						  fieldB->field.scalar.typeName) == 0;
+		case FIELD_TYPE_LIST:
+			return FieldTypesEqual(fieldA->field.list.element,
+								   fieldB->field.list.element);
+		case FIELD_TYPE_MAP:
+			return FieldTypesEqual(fieldA->field.map.key,
+								   fieldB->field.map.key) &&
+				FieldTypesEqual(fieldA->field.map.value,
+								fieldB->field.map.value);
+		case FIELD_TYPE_STRUCT:
+			{
+				if (fieldA->field.structType.nfields != fieldB->field.structType.nfields)
+					return false;
+				for (size_t i = 0; i < fieldA->field.structType.nfields; i++)
+				{
+					if (!FieldTypesEqual(fieldA->field.structType.fields[i].type,
+										 fieldB->field.structType.fields[i].type))
+						return false;
+				}
+				return true;
+			}
+		default:
+			return false;
+	}
+}
+
+
+/*
 * SchemaFieldsEquivalent compares two DataFileSchemaField structs for equivalence.
 * It returns true if they are equivalent, false otherwise.
-* Note that we do not compare the field->type here, as we do not allow changing
-* the type of any field in the schema, including nested types.
 */
 bool
 SchemaFieldsEquivalent(DataFileSchemaField * fieldA, DataFileSchemaField * fieldB)
@@ -184,11 +223,9 @@ SchemaFieldsEquivalent(DataFileSchemaField * fieldA, DataFileSchemaField * field
 	if (!PgStrcasecmpNullable(fieldA->initialDefault, fieldB->initialDefault))
 		return false;
 
-	/*
-	 * We don't allow changing any of the types of the fields in the schema,
-	 * including the fields of nested types. So we don't need to compare
-	 * anything about the field->type here.
-	 */
+	if (!FieldTypesEqual(fieldA->type, fieldB->type))
+		return false;
+
 	return true;
 }
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
@@ -403,10 +403,29 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == INT8OID)
 	{
-		binaryValue = FromLittleEndian64(binaryValue);
-		int64		longValue = *((int64 *) binaryValue);
+		/*
+		 * Per the Iceberg spec, column metrics are serialized using the type
+		 * at the time the data file was written. After an int -> long type
+		 * promotion, existing data files retain 4-byte int bounds while the
+		 * current schema expects 8-byte long. Widen on read.
+		 *
+		 * See:
+		 * https://iceberg.apache.org/spec/#binary-single-value-serialization
+		 */
+		if (binaryLen == sizeof(int32))
+		{
+			binaryValue = FromLittleEndian32(binaryValue);
+			int32		intValue = *((int32 *) binaryValue);
 
-		datum = Int64GetDatum(longValue);
+			datum = Int64GetDatum((int64) intValue);
+		}
+		else
+		{
+			binaryValue = FromLittleEndian64(binaryValue);
+			int64		longValue = *((int64 *) binaryValue);
+
+			datum = Int64GetDatum(longValue);
+		}
 	}
 	else if (pgType.postgresTypeOid == FLOAT4OID)
 	{
@@ -417,10 +436,25 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == FLOAT8OID)
 	{
-		binaryValue = FromLittleEndian64(binaryValue);
-		float8		doubleValue = *((float8 *) binaryValue);
+		/*
+		 * Same as int -> long above: after a float -> double type promotion,
+		 * existing data files retain 4-byte float bounds while the current
+		 * schema expects 8-byte double. Widen on read.
+		 */
+		if (binaryLen == sizeof(float4))
+		{
+			binaryValue = FromLittleEndian32(binaryValue);
+			float4		floatValue = *((float4 *) binaryValue);
 
-		datum = Float8GetDatum(doubleValue);
+			datum = Float8GetDatum((float8) floatValue);
+		}
+		else
+		{
+			binaryValue = FromLittleEndian64(binaryValue);
+			float8		doubleValue = *((float8 *) binaryValue);
+
+			datum = Float8GetDatum(doubleValue);
+		}
 	}
 	else if (pgType.postgresTypeOid == DATEOID)
 	{

--- a/pg_lake_table/include/pg_lake/ddl/ddl_changes.h
+++ b/pg_lake_table/include/pg_lake/ddl/ddl_changes.h
@@ -21,6 +21,8 @@
 #include "nodes/pg_list.h"
 #include "nodes/parsenodes.h"
 
+#include "pg_lake/pgduck/type.h"
+
 /*
  * DDLOperationType describes a type of ddl operation, which
  * cause catalog modification and possibly iceberg metadata modification.
@@ -37,6 +39,7 @@ typedef enum DDLOperationType
 	DDL_COLUMN_DROP_NOT_NULL = 8,
 	DDL_TABLE_SET_PARTITION_BY = 9,
 	DDL_TABLE_DROP_PARTITION_BY = 10,
+	DDL_COLUMN_ALTER_TYPE = 11,
 }			DDLOperationType;
 
 /*
@@ -54,6 +57,9 @@ typedef struct IcebergDDLOperation
 
 	/* applicable for set/drop default */
 	const char *writeDefault;
+
+	/* applicable for alter column type */
+	PGType		newPgType;
 
 	/* applicable for create iceberg table */
 	bool		hasCustomLocation;

--- a/pg_lake_table/include/pg_lake/fdw/schema_operations/field_id_mapping_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/schema_operations/field_id_mapping_catalog.h
@@ -46,6 +46,7 @@ extern PGDLLEXPORT List *GetRegisteredFieldForAttributes(Oid relationId, List *a
 extern PGDLLEXPORT DataFileSchemaField * GetRegisteredFieldForAttribute(Oid relationId, AttrNumber attrNo);
 extern PGDLLEXPORT AttrNumber GetAttributeForFieldId(Oid relationId, int fieldId);
 extern PGDLLEXPORT void UpdateRegisteredFieldWriteDefaultForAttribute(Oid relationId, AttrNumber attNum, const char *writeDefault);
+extern PGDLLEXPORT void UpdateRegisteredFieldTypeForAttribute(Oid relationId, AttrNumber attNum, PGType newPgType);
 extern PGDLLEXPORT int GetLargestRegisteredFieldId(Oid relationId);
 
 /*

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -462,16 +462,11 @@ CreateDDLOperationsForAlterTable(AlterTableStmt *alterStmt)
 			/*
 			 * At this point, PgLakeCommonParentProcessUtility has already
 			 * been called so the column type in pg_attribute is updated. We
-			 * read the new type from the relation.
+			 * read the new type from the relation. Collation is irrelevant to
+			 * Iceberg types, so we only look at the type OID and typmod.
 			 */
-			Oid			newTypeOid = InvalidOid;
-			int32		newTypMod = -1;
-			Oid			newCollId = InvalidOid;
-
-			get_atttypetypmodcoll(relationId, attrNo,
-								  &newTypeOid, &newTypMod, &newCollId);
-
-			PGType		newPgType = MakePGType(newTypeOid, newTypMod);
+			Form_pg_attribute attr = TupleDescAttr(tupleDesc, attrNo - 1);
+			PGType		newPgType = MakePGType(attr->atttypid, attr->atttypmod);
 
 			/*
 			 * Check whether the Iceberg type actually changes. The registered
@@ -1018,13 +1013,11 @@ ErrorIfUnsupportedAlterWritablePgLakeTableStmt(AlterTableStmt *alterStmt,
 									   "(wider precision, same scale).")));
 				}
 			}
-			else
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("ALTER TABLE %s command not supported for "
-								"%s tables", cmdTypeStr, tableTypeStr)));
-			}
+
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("ALTER TABLE %s command not supported for "
+							"%s tables", cmdTypeStr, tableTypeStr)));
 		}
 	}
 

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -53,12 +53,14 @@
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/iceberg/compatibility_mode.h"
+#include "pg_lake/iceberg/iceberg_field.h"
 #include "pg_lake/iceberg/metadata_operations.h"
 #include "pg_lake/fdw/partition_transform.h"
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/rel_utils.h"
 #include "pg_lake/util/table_type.h"
 
@@ -121,6 +123,7 @@ typedef struct PgLakeDDL
 static bool Allowed(Node *arg, Oid relationId);
 static bool Disallowed(Node *arg, Oid relationId);
 static bool DisallowedAddColumnWithUnsupportedConstraints(Node *arg, Oid relationId);
+static bool AllowedAlterColumnTypeForIceberg(Node *arg, Oid relationId);
 static bool DisallowedForWritableRestRenameTable(Node *arg, Oid relationId);
 static bool DisallowedForWritableRestSetSchema(Node *arg, Oid relationId);
 
@@ -157,7 +160,7 @@ static const PgLakeDDL PgLakeDDLs[] = {
 #if PG_VERSION_NUM >= 170000
 	ALTER_TABLE_DDL(AT_SetExpression, Disallowed, Disallowed),
 #endif
-	ALTER_TABLE_DDL(AT_AlterColumnType, Disallowed, Disallowed),
+	ALTER_TABLE_DDL(AT_AlterColumnType, AllowedAlterColumnTypeForIceberg, Disallowed),
 
 	/* allowed for writable tables, not allowed for iceberg tables */
 	ALTER_TABLE_DDL(AT_AddIdentity, Disallowed, Allowed),
@@ -450,6 +453,75 @@ CreateDDLOperationsForAlterTable(AlterTableStmt *alterStmt)
 			}
 
 			ddlOperations = lappend(ddlOperations, ddlOperation);
+		}
+		else if (subcommand->subtype == AT_AlterColumnType)
+		{
+			char	   *columnName = subcommand->name;
+			AttrNumber	attrNo = get_attnum(relationId, columnName);
+
+			/*
+			 * At this point, PgLakeCommonParentProcessUtility has already
+			 * been called so the column type in pg_attribute is updated. We
+			 * read the new type from the relation.
+			 */
+			Oid			newTypeOid = InvalidOid;
+			int32		newTypMod = -1;
+			Oid			newCollId = InvalidOid;
+
+			get_atttypetypmodcoll(relationId, attrNo,
+								  &newTypeOid, &newTypMod, &newCollId);
+
+			PGType		newPgType = MakePGType(newTypeOid, newTypMod);
+
+			/*
+			 * Check whether the Iceberg type actually changes. The registered
+			 * field still carries the old PG type (catalog is updated later
+			 * in ApplyDDLCatalogChanges). If old and new PG types map to the
+			 * same Iceberg scalar type name (e.g., int2 -> int4 both map to
+			 * Iceberg "int"), we only update the catalog and skip the DDL
+			 * operation so no new metadata.json is generated.
+			 */
+			DataFileSchemaField *existingField =
+				GetRegisteredFieldForAttribute(relationId, attrNo);
+
+			bool		icebergTypeUnchanged = false;
+
+			if (existingField->type->type == FIELD_TYPE_SCALAR)
+			{
+				int			subFieldIndex = 0;
+				Field	   *newIcebergField =
+					PostgresTypeToIcebergField(newPgType, false,
+											   &subFieldIndex);
+
+				if (newIcebergField->type == FIELD_TYPE_SCALAR &&
+					strcmp(existingField->type->field.scalar.typeName,
+						   newIcebergField->field.scalar.typeName) == 0)
+				{
+					icebergTypeUnchanged = true;
+				}
+			}
+
+			if (icebergTypeUnchanged)
+			{
+				/*
+				 * Iceberg type did not change, only PG type did. Update the
+				 * catalog directly and do not emit a DDL operation — no new
+				 * metadata.json is needed.
+				 */
+				UpdateRegisteredFieldTypeForAttribute(relationId, attrNo,
+													  newPgType);
+			}
+			else
+			{
+				IcebergDDLOperation *ddlOperation =
+					palloc0(sizeof(IcebergDDLOperation));
+
+				ddlOperation->type = DDL_COLUMN_ALTER_TYPE;
+				ddlOperation->attrNumber = attrNo;
+				ddlOperation->newPgType = newPgType;
+
+				ddlOperations = lappend(ddlOperations, ddlOperation);
+			}
 		}
 		else if (subcommand->subtype == AT_DropNotNull)
 		{
@@ -919,10 +991,40 @@ ErrorIfUnsupportedAlterWritablePgLakeTableStmt(AlterTableStmt *alterStmt,
 
 			const char *cmdTypeStr = PgLakeUnsupportedAlterTableToString(cmd);
 
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("ALTER TABLE %s command not supported for "
-							"%s tables", cmdTypeStr, tableTypeStr)));
+			if (cmd->subtype == AT_AlterColumnType &&
+				tableType == PG_LAKE_ICEBERG_TABLE_TYPE)
+			{
+				ColumnDef  *def = (ColumnDef *) cmd->def;
+
+				if (def->raw_default != NULL)
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("ALTER TABLE %s command not supported for "
+									"%s tables", cmdTypeStr, tableTypeStr),
+							 errdetail("USING requires rewriting data files, "
+									   "but Iceberg schema evolution is a "
+									   "metadata-only operation.")));
+				}
+				else
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("ALTER TABLE %s command not supported for "
+									"%s tables", cmdTypeStr, tableTypeStr),
+							 errdetail("Allowed type promotions for Iceberg tables "
+									   "are: int -> bigint, float -> double, and "
+									   "decimal(P,S) -> decimal(P',S) where P' > P "
+									   "(wider precision, same scale).")));
+				}
+			}
+			else
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("ALTER TABLE %s command not supported for "
+								"%s tables", cmdTypeStr, tableTypeStr)));
+			}
 		}
 	}
 
@@ -1117,6 +1219,124 @@ Allowed(Node *arg, Oid relationId)
 static bool
 Disallowed(Node *arg, Oid relationId)
 {
+	return false;
+}
+
+
+/*
+ * AllowedAlterColumnTypeForIceberg validates whether a column type change
+ * is allowed for an Iceberg table per the Iceberg spec v2 type promotion rules.
+ *
+ * The Iceberg spec allows the following type promotions:
+ *   - int -> long
+ *   - float -> double
+ *   - decimal(P, S) -> decimal(P', S) where P' > P (wider precision, same scale)
+ *
+ * See: https://iceberg.apache.org/spec/#schema-evolution
+ */
+static bool
+AllowedAlterColumnTypeForIceberg(Node *arg, Oid relationId)
+{
+	AlterTableCmd *cmd = (AlterTableCmd *) arg;
+
+	Assert(cmd->subtype == AT_AlterColumnType);
+
+	char	   *columnName = cmd->name;
+	ColumnDef  *def = (ColumnDef *) cmd->def;
+	TypeName   *newTypeName = def->typeName;
+
+	/*
+	 * Reject USING clause. USING requires rewriting data files, but Iceberg
+	 * schema evolution is metadata-only so data files are never rewritten.
+	 */
+	if (def->raw_default != NULL)
+		return false;
+
+	/* resolve the new type OID and typmod */
+	int32		newTypMod = 0;
+	Oid			newTypeOid = InvalidOid;
+
+	typenameTypeIdAndMod(NULL, newTypeName, &newTypeOid, &newTypMod);
+
+	/* get the current column type from the relation */
+	AttrNumber	attrNum = get_attnum(relationId, columnName);
+
+	if (attrNum == InvalidAttrNumber)
+		return false;
+
+	Oid			currentTypeOid = InvalidOid;
+	int32		currentTypMod = -1;
+	Oid			currentCollId = InvalidOid;
+
+	get_atttypetypmodcoll(relationId, attrNum,
+						  &currentTypeOid, &currentTypMod, &currentCollId);
+
+	/* same type is always allowed (no-op from Iceberg perspective) */
+	if (currentTypeOid == newTypeOid && currentTypMod == newTypMod)
+		return true;
+
+	/* int2 -> int4 is allowed as noop, int2 is stored as int32 in Iceberg */
+	if (currentTypeOid == INT2OID && newTypeOid == INT4OID)
+		return true;
+
+	/*
+	 * Iceberg type promotion: int -> long
+	 *
+	 * PostgreSQL int2 and int4 both map to Iceberg "int", and int8 maps to
+	 * Iceberg "long". So we allow int2/int4 -> int8.
+	 */
+	if ((currentTypeOid == INT4OID || currentTypeOid == INT2OID) &&
+		newTypeOid == INT8OID)
+		return true;
+
+	/*
+	 * Iceberg type promotion: float -> double
+	 *
+	 * PostgreSQL float4 maps to Iceberg "float" and float8 maps to Iceberg
+	 * "double". So we allow float4 -> float8.
+	 */
+	if (currentTypeOid == FLOAT4OID && newTypeOid == FLOAT8OID)
+		return true;
+
+	/*
+	 * Iceberg type promotion: decimal(P, S) -> decimal(P', S) where P' > P
+	 *
+	 * Both must be numeric, the new precision must be greater, and the scale
+	 * must remain the same.
+	 */
+	if (currentTypeOid == NUMERICOID && newTypeOid == NUMERICOID)
+	{
+		int			currentPrecision = -1;
+		int			currentScale = -1;
+		int			newPrecision = -1;
+		int			newScale = -1;
+
+		/*
+		 * A numeric whose precision/scale exceeds the Iceberg decimal limits
+		 * (or that is unbounded) is not stored as an Iceberg decimal; it maps
+		 * to double/string instead. Promoting to such a type is therefore not
+		 * a decimal -> decimal promotion and cannot be done as a
+		 * metadata-only schema change, so reject it before any new metadata
+		 * is generated.
+		 */
+		if (IsUnsupportedNumericForIceberg(newTypeOid, newTypMod))
+			return false;
+
+		GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(currentTypMod,
+															 &currentPrecision,
+															 &currentScale);
+		GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(newTypMod,
+															 &newPrecision,
+															 &newScale);
+
+		/* new precision must be wider and scale must stay the same */
+		if (newPrecision > currentPrecision && newScale == currentScale)
+			return true;
+
+		return false;
+	}
+
+	/* all other type changes are disallowed */
 	return false;
 }
 

--- a/pg_lake_table/src/ddl/ddl_changes.c
+++ b/pg_lake_table/src/ddl/ddl_changes.c
@@ -293,6 +293,14 @@ ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 			/* update lake_iceberg.internal_tables specId */
 			UpdateDefaultPartitionSpecId(relationId, DEFAULT_SPEC_ID);
 		}
+		else if (ddlOperation->type == DDL_COLUMN_ALTER_TYPE)
+		{
+			/* update field type in catalog */
+			AttrNumber	attrNumber = ddlOperation->attrNumber;
+			PGType		newPgType = ddlOperation->newPgType;
+
+			UpdateRegisteredFieldTypeForAttribute(relationId, attrNumber, newPgType);
+		}
 		else if (ddlOperation->type == DDL_TABLE_RENAME ||
 				 ddlOperation->type == DDL_COLUMN_DROP_NOT_NULL)
 		{
@@ -321,7 +329,8 @@ DDLsRequireIcebergSchemaChange(List *ddlOperations)
 			ddlOperation->type == DDL_COLUMN_DROP ||
 			ddlOperation->type == DDL_COLUMN_SET_DEFAULT ||
 			ddlOperation->type == DDL_COLUMN_DROP_DEFAULT ||
-			ddlOperation->type == DDL_COLUMN_DROP_NOT_NULL)
+			ddlOperation->type == DDL_COLUMN_DROP_NOT_NULL ||
+			ddlOperation->type == DDL_COLUMN_ALTER_TYPE)
 		{
 			return true;
 		}

--- a/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
+++ b/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
@@ -802,6 +802,56 @@ UpdateRegisteredFieldWriteDefaultForAttribute(Oid relationId, AttrNumber attNum,
 }
 
 /*
+ * UpdateRegisteredFieldTypeForAttribute updates the field_pg_type and
+ * field_pg_typemod for a given column in the field mapping catalog.
+ * This is used when a column type is promoted (e.g. int -> long).
+ */
+void
+UpdateRegisteredFieldTypeForAttribute(Oid relationId, AttrNumber attNum, PGType newPgType)
+{
+	/* switch to schema owner */
+	Oid			savedUserId = InvalidOid;
+	int			savedSecurityContext = 0;
+
+	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
+	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
+
+	StringInfo	query = makeStringInfo();
+
+	appendStringInfo(query, "UPDATE " MAPPING_TABLE_NAME
+					 " SET field_pg_type = $1, field_pg_typemod = $2 "
+					 "WHERE table_name OPERATOR(pg_catalog.=) $3 AND "
+					 "pg_attnum OPERATOR(pg_catalog.=) $4 AND "
+					 "parent_field_id IS NULL "
+					 "RETURNING field_id");
+
+	DECLARE_SPI_ARGS(4);
+
+	SPI_ARG_VALUE(1, OIDOID, newPgType.postgresTypeOid, false);
+	SPI_ARG_VALUE(2, INT4OID, newPgType.postgresTypeMod, false);
+	SPI_ARG_VALUE(3, OIDOID, relationId, false);
+	SPI_ARG_VALUE(4, INT2OID, attNum, false);
+
+	SPI_START();
+
+	bool		readOnly = false;
+
+	SPI_EXECUTE(query->data, readOnly);
+
+	if (SPI_processed != 1)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("Failed to update field type for column %d in relation %u", attNum, relationId)));
+	}
+
+	SPI_END();
+
+	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
+}
+
+
+/*
 * GetLargestRegisteredFieldId returns the largest field ID for a given relation.
 */
 int

--- a/pg_lake_table/src/transaction/external_heavy_asserts.c
+++ b/pg_lake_table/src/transaction/external_heavy_asserts.c
@@ -34,6 +34,9 @@
 #include "pg_lake/rest_catalog/rest_catalog.h"
 #include "pg_lake/transaction/track_iceberg_metadata_changes.h"
 #include "pg_lake/transaction/transaction_hooks.h"
+#include "pg_lake/iceberg/iceberg_type_binary_serde.h"
+#include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/util/numeric.h"
 
 #ifdef USE_ASSERT_CHECKING
 static void EnsureIcebergPartitionMetadataInSync(Oid relationId, int largestSpecId,
@@ -43,6 +46,14 @@ static void AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relati
 static void AssertInternalAndExternalIcebergDataFileColumnStatsMatch(List *internalColumnStatsList,
 																	 List *externalLowerBounds,
 																	 List *externalUpperBounds);
+static void NormalizeColumnBound(Field * field, unsigned char *externalValue,
+								 size_t externalLen, unsigned char **normalizedValue,
+								 size_t *normalizedLen);
+static void NormalizePartitionFieldValue(IcebergScalarAvroType internalType,
+										 unsigned char *externalValue,
+										 size_t externalLen,
+										 unsigned char **normalizedValue,
+										 size_t *normalizedLen);
 static List *RemoveDroppedFieldBounds(const List *existingLeafFields, ColumnBound * bounds, size_t boundsLen);
 static int	TableDataFileCompare(const ListCell *a, const ListCell *b);
 static int	DataFileCompare(const ListCell *a, const ListCell *b);
@@ -59,6 +70,10 @@ static void ErrorIfScanListsAreNotEqual(List *scanList1, List *scanList2, const 
 static void AssertInternalAndExternalTableSchemaMatch(Oid relationId, DataFileSchema * internalSchema);
 static int	FieldCompare(const ListCell *a, const ListCell *b);
 static void AssertInternalAndExternalLeafFieldsMatch(Oid relationId, List *internalLeafFields);
+static unsigned char *SerializeColumnBoundTextForTypePromotion(char *columnBoundText,
+															   Field * field,
+															   size_t externalBoundLen,
+															   size_t *binaryLen);
 
 #endif
 
@@ -473,12 +488,21 @@ AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relationId, bool d
 						 errmsg("internal and external iceberg data file partition field name mismatch")));
 			}
 
-			if (internalPartitionField->value_type.physical_type != externalPartitionField->value_type.physical_type)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_INTERNAL_ERROR),
-						 errmsg("internal and external iceberg data file partition field physical type mismatch")));
-			}
+			/*
+			 * Normalize the external value.  For type promotions (e.g.
+			 * int→long, float→double) the external bytes are in the
+			 * pre-promotion encoding; NormalizePartitionFieldValue widens
+			 * them to the current type so we can compare byte-for-byte with
+			 * the internal value.  For non-promotion cases this is an
+			 * identity operation.
+			 */
+			unsigned char *normalizedValue = NULL;
+			size_t		normalizedLen = 0;
+
+			NormalizePartitionFieldValue(internalPartitionField->value_type,
+										 (unsigned char *) externalPartitionField->value,
+										 externalPartitionField->value_length,
+										 &normalizedValue, &normalizedLen);
 
 			/*
 			 * we serialize boolean 1 byte per spec but spark serializes it as
@@ -487,30 +511,168 @@ AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relationId, bool d
 			bool		mismatchBoolLength = internalPartitionField->value_type.physical_type == ICEBERG_AVRO_PHYSICAL_TYPE_BOOL &&
 				internalPartitionField->value_length == 1 && externalPartitionField->value_length == 4;
 
-			if (internalPartitionField->value_length != externalPartitionField->value_length && !mismatchBoolLength)
+			if (!mismatchBoolLength)
 			{
-				ereport(ERROR,
-						(errcode(ERRCODE_INTERNAL_ERROR),
-						 errmsg("internal and external iceberg data file partition field value length mismatch %zu %zu for %s",
-								internalPartitionField->value_length,
-								externalPartitionField->value_length,
-								internalPartitionField->field_name)));
-			}
+				if (internalPartitionField->value_length != normalizedLen)
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INTERNAL_ERROR),
+							 errmsg("internal and external iceberg data file partition field value length mismatch %zu %zu for %s",
+									internalPartitionField->value_length,
+									normalizedLen,
+									internalPartitionField->field_name)));
+				}
 
-			if (memcmp(internalPartitionField->value,
-					   externalPartitionField->value,
-					   internalPartitionField->value_length) != 0 && !mismatchBoolLength)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_INTERNAL_ERROR),
-						 errmsg("internal and external iceberg data file partition field value mismatch %s:%s for %s",
-								(char *) internalPartitionField->value,
-								(char *) externalPartitionField->value,
-								internalPartitionField->field_name)));
+				if (memcmp(internalPartitionField->value,
+						   normalizedValue,
+						   internalPartitionField->value_length) != 0)
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INTERNAL_ERROR),
+							 errmsg("internal and external iceberg data file partition field value mismatch for %s",
+									internalPartitionField->field_name)));
+				}
 			}
 		}
 	}
 }
+
+/*
+ * NormalizePartitionFieldValue deserializes an external partition field value
+ * (which may be encoded in a pre-promotion type, e.g. 4-byte int) through
+ * PGIcebergBinaryDeserialize (which handles widening), then re-serializes
+ * using the current field type via PGIcebergBinarySerializePartitionFieldValue.
+ * The result is in the current type's binary encoding so it can be compared
+ * byte-for-byte with the internally-serialized partition value.
+ *
+ * When there is no type promotion the external bytes already match the
+ * internal type, so this is an identity operation.
+ */
+static void
+NormalizePartitionFieldValue(IcebergScalarAvroType internalType,
+							 unsigned char *externalValue,
+							 size_t externalLen,
+							 unsigned char **normalizedValue,
+							 size_t *normalizedLen)
+{
+	PGType		pgType;
+
+	/*
+	 * A NULL or empty external value carries no bytes to widen, e.g. a NULL
+	 * partition value (NaN numerics are stored as NULL) or an empty string.
+	 * There is nothing to normalize, so pass it through unchanged. This also
+	 * avoids the non-NULL Assert in PGIcebergBinaryDeserialize.
+	 */
+	if (externalValue == NULL || externalLen == 0)
+	{
+		*normalizedValue = externalValue;
+		*normalizedLen = externalLen;
+		return;
+	}
+
+	/* Map the Avro physical+logical type to the PGType of the current schema */
+	switch (internalType.physical_type)
+	{
+		case ICEBERG_AVRO_PHYSICAL_TYPE_INT32:
+			if (internalType.logical_type == ICEBERG_AVRO_LOGICAL_TYPE_DATE)
+				pgType = MakePGType(DATEOID, -1);
+			else
+				pgType = MakePGType(INT4OID, -1);
+			break;
+		case ICEBERG_AVRO_PHYSICAL_TYPE_INT64:
+			if (internalType.logical_type == ICEBERG_AVRO_LOGICAL_TYPE_TIMESTAMP)
+				pgType = MakePGType(TIMESTAMPTZOID, -1);
+			else if (internalType.logical_type == ICEBERG_AVRO_LOGICAL_TYPE_TIME)
+				pgType = MakePGType(TIMEOID, -1);
+			else
+				pgType = MakePGType(INT8OID, -1);
+			break;
+		case ICEBERG_AVRO_PHYSICAL_TYPE_FLOAT:
+			pgType = MakePGType(FLOAT4OID, -1);
+			break;
+		case ICEBERG_AVRO_PHYSICAL_TYPE_DOUBLE:
+			pgType = MakePGType(FLOAT8OID, -1);
+			break;
+		case ICEBERG_AVRO_PHYSICAL_TYPE_BOOL:
+			pgType = MakePGType(BOOLOID, -1);
+			break;
+		case ICEBERG_AVRO_PHYSICAL_TYPE_STRING:
+			pgType = MakePGType(TEXTOID, -1);
+			break;
+		case ICEBERG_AVRO_PHYSICAL_TYPE_BINARY:
+			if (internalType.logical_type == ICEBERG_AVRO_LOGICAL_TYPE_UUID)
+				pgType = MakePGType(UUIDOID, -1);
+			else if (internalType.logical_type == ICEBERG_AVRO_LOGICAL_TYPE_DECIMAL)
+
+				/*
+				 * NUMERIC partition columns are stored with a BINARY physical
+				 * type and a DECIMAL logical type (see
+				 * partition_transform.c). Rebuild the NUMERIC type with the
+				 * field's precision/scale so the value is deserialized as a
+				 * numeric rather than raw bytea.
+				 */
+				pgType = MakePGType(NUMERICOID,
+									make_numeric_typmod(internalType.precision,
+														internalType.scale));
+			else
+				pgType = MakePGType(BYTEAOID, -1);
+			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("unexpected partition field physical type %d",
+							internalType.physical_type)));
+			return;				/* keep compiler happy */
+	}
+
+	bool		forAddColumn = false;
+	int			subFieldIndex = 0;
+	Field	   *field = PostgresTypeToIcebergField(pgType, forAddColumn,
+												   &subFieldIndex);
+
+	Datum		datum = PGIcebergBinaryDeserialize(externalValue, externalLen,
+												   field, pgType);
+
+	*normalizedValue = PGIcebergBinarySerializePartitionFieldValue(datum, field,
+																   pgType,
+																   normalizedLen);
+}
+
+
+/*
+ * NormalizeColumnBound deserializes an external column bound (which may be
+ * encoded in a pre-promotion type, e.g. 4-byte int) through
+ * PGIcebergBinaryDeserialize (which handles widening), then re-serializes
+ * using the current field type.  The result is in the current type's binary
+ * encoding so it can be compared byte-for-byte with the internally-serialized
+ * bound.
+ *
+ * Per the Iceberg spec, column metrics "must be computed using the type
+ * at the time the data file is written."  After a type promotion the reader
+ * must widen the value.
+ * See https://iceberg.apache.org/spec/#schema-evolution
+ */
+static void
+NormalizeColumnBound(Field * field, unsigned char *externalValue,
+					 size_t externalLen, unsigned char **normalizedValue,
+					 size_t *normalizedLen)
+{
+	/* See the matching note in NormalizePartitionFieldValue. */
+	if (externalValue == NULL || externalLen == 0)
+	{
+		*normalizedValue = externalValue;
+		*normalizedLen = externalLen;
+		return;
+	}
+
+	PGType		pgType = IcebergFieldToPostgresType(field);
+	Datum		datum = PGIcebergBinaryDeserialize(externalValue, externalLen,
+												   field, pgType);
+
+	*normalizedValue = PGIcebergBinarySerializeBoundValue(datum, field, pgType,
+														  normalizedLen);
+}
+
 
 /*
  * AssertInternalAndExternalIcebergDataFileColumnStatsMatch checks if the internal and external
@@ -550,12 +712,28 @@ AssertInternalAndExternalIcebergDataFileColumnStatsMatch(List *internalColumnSta
 		}
 
 		size_t		internalLowerBoundLen = 0;
-		unsigned char *internalLowerBound = IcebergSerializeColumnBoundText(pstrdup(internalColumnStats->lowerBoundText),
-																			internalColumnStats->leafField.field,
-																			&internalLowerBoundLen);
+		unsigned char *internalLowerBound =
+			SerializeColumnBoundTextForTypePromotion(pstrdup(internalColumnStats->lowerBoundText),
+													 internalColumnStats->leafField.field,
+													 externalLowerBound->value_length,
+													 &internalLowerBoundLen);
 
-		if (internalLowerBoundLen != externalLowerBound->value_length ||
-			memcmp(internalLowerBound, externalLowerBound->value, internalLowerBoundLen) != 0)
+		/*
+		 * Normalize the external bound through PGIcebergBinaryDeserialize
+		 * (which handles widening for type promotions like int->long,
+		 * float->double) then re-serialize with the current type.  This
+		 * ensures both sides use the same binary encoding for comparison.
+		 */
+		size_t		normalizedLowerLen = 0;
+		unsigned char *normalizedLower = NULL;
+
+		NormalizeColumnBound(internalColumnStats->leafField.field,
+							 (unsigned char *) externalLowerBound->value,
+							 externalLowerBound->value_length,
+							 &normalizedLower, &normalizedLowerLen);
+
+		if (internalLowerBoundLen != normalizedLowerLen ||
+			memcmp(internalLowerBound, normalizedLower, internalLowerBoundLen) != 0)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
@@ -563,12 +741,22 @@ AssertInternalAndExternalIcebergDataFileColumnStatsMatch(List *internalColumnSta
 		}
 
 		size_t		internalUpperBoundLen = 0;
-		unsigned char *internalUpperBound = IcebergSerializeColumnBoundText(pstrdup(internalColumnStats->upperBoundText),
-																			internalColumnStats->leafField.field,
-																			&internalUpperBoundLen);
+		unsigned char *internalUpperBound =
+			SerializeColumnBoundTextForTypePromotion(pstrdup(internalColumnStats->upperBoundText),
+													 internalColumnStats->leafField.field,
+													 externalUpperBound->value_length,
+													 &internalUpperBoundLen);
 
-		if (internalUpperBoundLen != externalUpperBound->value_length ||
-			memcmp(internalUpperBound, externalUpperBound->value, internalUpperBoundLen) != 0)
+		size_t		normalizedUpperLen = 0;
+		unsigned char *normalizedUpper = NULL;
+
+		NormalizeColumnBound(internalColumnStats->leafField.field,
+							 (unsigned char *) externalUpperBound->value,
+							 externalUpperBound->value_length,
+							 &normalizedUpper, &normalizedUpperLen);
+
+		if (internalUpperBoundLen != normalizedUpperLen ||
+			memcmp(internalUpperBound, normalizedUpper, internalUpperBoundLen) != 0)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
@@ -582,6 +770,68 @@ AssertInternalAndExternalIcebergDataFileColumnStatsMatch(List *internalColumnSta
 					 errmsg("internal and external iceberg data file stats column field type is not scalar")));
 		}
 	}
+}
+
+
+/*
+ * SerializeColumnBoundTextForTypePromotion serializes the given column bound
+ * text to Iceberg binary format, accounting for type promotions (e.g.
+ * float→double, int→long).
+ *
+ * externalBoundLen is the byte-width of the corresponding manifest binary
+ * bound.  After a type promotion the external bound retains its pre-promotion
+ * width while the internal text was produced under the same pre-promotion
+ * type.  Parsing the text directly as the current (wider) type gives a
+ * different value than widening the original narrow binary.
+ *
+ * For example, text "1.1" parsed as float4 then widened to float8 gives
+ *   (float8)(float4)1.1 ≈ 1.10000002
+ * but parsed directly as float8 gives
+ *   float8(1.1) ≈ 1.10000000000000009
+ *
+ * When externalBoundLen indicates a pre-promotion width we parse the text
+ * through the pre-promotion type first, then widen, so the resulting binary
+ * matches the widening path taken by PGIcebergBinaryDeserialize.
+ */
+static unsigned char *
+SerializeColumnBoundTextForTypePromotion(char *columnBoundText, Field * field,
+										 size_t externalBoundLen,
+										 size_t *binaryLen)
+{
+	PGType		pgType = IcebergFieldToPostgresType(field);
+	Datum		boundDatum;
+
+	if (pgType.postgresTypeOid == FLOAT8OID &&
+		externalBoundLen == sizeof(float4))
+	{
+		/* float → double promotion: parse text as float4, then widen */
+		PGType		preType = MakePGType(FLOAT4OID, -1);
+		Datum		narrowDatum = ColumnBoundDatum(columnBoundText, preType);
+		float4		floatValue = DatumGetFloat4(narrowDatum);
+
+		boundDatum = Float8GetDatum((float8) floatValue);
+	}
+	else if (pgType.postgresTypeOid == INT8OID &&
+			 externalBoundLen == sizeof(int32))
+	{
+		/* int → long promotion: parse text as int4, then widen */
+		PGType		preType = MakePGType(INT4OID, -1);
+		Datum		narrowDatum = ColumnBoundDatum(columnBoundText, preType);
+		int32		intValue = DatumGetInt32(narrowDatum);
+
+		boundDatum = Int64GetDatum((int64) intValue);
+	}
+	else
+	{
+		/* no promotion: parse text as current type */
+		boundDatum = ColumnBoundDatum(columnBoundText, pgType);
+	}
+
+	/* serialize the bound value to binary */
+	unsigned char *binaryValue =
+		PGIcebergBinarySerializeBoundValue(boundDatum, field, pgType, binaryLen);
+
+	return binaryValue;
 }
 
 

--- a/pg_lake_table/tests/pytests/test_data_file_pruning.py
+++ b/pg_lake_table/tests/pytests/test_data_file_pruning.py
@@ -1938,6 +1938,116 @@ def test_clamped_infinity_data_file_pruning(
     pg_conn.commit()
 
 
+@pytest.mark.parametrize(
+    "schema, col_type, new_type, pre_vals, post_val, prune_filter_pre, prune_filter_post",
+    [
+        pytest.param(
+            "prune_promo_int",
+            "int",
+            "bigint",
+            # INT_MIN, 0, INT_MAX — boundary values for int4
+            [(-2147483648, 1), (0, 2), (2147483647, 3)],
+            # first value outside int4 range
+            ("2147483648", 4),
+            "a = -2147483648",
+            "a = 2147483648",
+            id="int_to_bigint",
+        ),
+        pytest.param(
+            "prune_promo_float",
+            "real",
+            "double precision",
+            # well-separated float4 values for distinct per-file min-max bounds
+            [(-100.5, 1), (0.0, 2), (100.5, 3)],
+            # post-promotion value clearly beyond the pre-promotion range
+            ("200.5", 4),
+            "a < -100",
+            "a > 200",
+            id="float_to_double",
+        ),
+        pytest.param(
+            "prune_promo_decimal",
+            "numeric(10,2)",
+            "numeric(20,2)",
+            # min, zero, max for numeric(10,2)
+            [(-99999999.99, 1), (0.00, 2), (99999999.99, 3)],
+            # value requiring wider precision (numeric(20,2))
+            ("99999999999999999.99", 4),
+            "a < -99999999",
+            "a > 9999999999",
+            id="decimal_widen_precision",
+        ),
+    ],
+)
+def test_data_file_pruning_after_type_promotion(
+    s3,
+    pg_conn,
+    extension,
+    with_default_location,
+    schema,
+    col_type,
+    new_type,
+    pre_vals,
+    post_val,
+    prune_filter_pre,
+    prune_filter_post,
+):
+    """Verify data file pruning still works after an Iceberg type promotion."""
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(
+        f"""
+        CREATE TABLE {schema}.tbl (a {col_type}, b int)
+        USING iceberg WITH (autovacuum_enabled='False');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Insert rows into separate data files so each has distinct min-max bounds
+    for a_val, b_val in pre_vals:
+        run_command(f"INSERT INTO {schema}.tbl VALUES ({a_val}, {b_val});", pg_conn)
+        pg_conn.commit()
+
+    # Promote column type
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN a TYPE {new_type};", pg_conn)
+    pg_conn.commit()
+
+    # Insert a row with promoted type precision
+    run_command(
+        f"INSERT INTO {schema}.tbl VALUES ({post_val[0]}, {post_val[1]});", pg_conn
+    )
+    pg_conn.commit()
+
+    total_files = len(pre_vals) + 1
+
+    # Verify all data readable
+    results = run_query(f"SELECT count(*) FROM {schema}.tbl", pg_conn)
+    assert results[0][0] == total_files
+
+    # Pruning on pre-promotion data: should hit exactly 1 file
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE {prune_filter_pre}",
+        pg_conn,
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Pruning on post-promotion data: should hit exactly 1 file
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE {prune_filter_post}",
+        pg_conn,
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Full scan should see all files
+    results = run_query(f"{explain_prefix} SELECT * FROM {schema}.tbl", pg_conn)
+    assert int(fetch_data_files_used(results)) == total_files
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
 @pytest.fixture(scope="module")
 def create_helper_functions(superuser_conn):
 

--- a/pg_lake_table/tests/pytests/test_ddl.py
+++ b/pg_lake_table/tests/pytests/test_ddl.py
@@ -62,6 +62,10 @@ def alter_stmts(pg_conn):
             "ALTER TABLE test_ddl.fdw ADD COLUMN new_col INT DEFAULT 10;",
             pg_lake_disallow=disallowed_only_for_writable,
         ),
+        AlterStmt(
+            "ALTER TABLE test_ddl.fdw ALTER COLUMN e TYPE bigint;",
+            pg_lake_disallow=disallowed_only_for_writable,
+        ),
         # pg_lake disallows for iceberg and writable tables
         AlterStmt(
             "ALTER TABLE test_ddl.fdw ALTER COLUMN a TYPE varchar(255);",

--- a/pg_lake_table/tests/pytests/test_iceberg_ddl.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_ddl.py
@@ -1,5 +1,6 @@
 import pytest
 from utils_pytest import *
+from helpers.spark import *
 
 import os
 import glob
@@ -1923,6 +1924,1054 @@ def test_use_same_schema_when_needed(pg_conn, s3, with_default_location):
     assert schema_id_8 == 0
 
     run_command("DROP SCHEMA test_use_same_schema_when_needed CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "test_id, col_def, promoted_type, expected_pg_type, initial_values, post_values, "
+    "select_cols, order_col, expected_results, expected_iceberg_type, str_compare_a",
+    [
+        pytest.param(
+            "int2_to_int4",
+            "a int2",
+            "int4",
+            "integer",
+            "(1)",
+            "(2)",
+            "a",
+            "a",
+            [[1], [2]],
+            None,
+            False,
+            id="int2-to-int4",
+        ),
+        pytest.param(
+            "int_to_bigint",
+            "a int, b int",
+            "bigint",
+            "bigint",
+            "(1, 2)",
+            f"({2**40}, 3)",
+            "a, b",
+            "b",
+            [[1, 2], [2**40, 3]],
+            "long",
+            False,
+            id="int-to-bigint",
+        ),
+        pytest.param(
+            "sm_to_bigint",
+            "a smallint, b int",
+            "bigint",
+            "bigint",
+            "(1, 2)",
+            f"({2**40}, 3)",
+            "a, b",
+            "b",
+            [[1, 2], [2**40, 3]],
+            None,
+            False,
+            id="smallint-to-bigint",
+        ),
+        pytest.param(
+            "float_to_double",
+            "a real, b int",
+            "double precision",
+            "double precision",
+            "(1.5, 1)",
+            "(1.23456789012345, 2)",
+            "a, b",
+            "b",
+            [[1.5, 1], [1.23456789012345, 2]],
+            "double",
+            False,
+            id="float-to-double",
+        ),
+        pytest.param(
+            "decimal_widen",
+            "a numeric(10,2), b int",
+            "numeric(20,2)",
+            None,
+            "(12345.67, 1)",
+            "(123456789012345.67, 2)",
+            "a, b",
+            "b",
+            [["12345.67", 1], ["123456789012345.67", 2]],
+            "decimal(20,2)",
+            True,
+            id="decimal-widen-precision",
+        ),
+    ],
+)
+def test_alter_column_type_promotion(
+    pg_conn,
+    s3,
+    with_default_location,
+    test_id,
+    col_def,
+    promoted_type,
+    expected_pg_type,
+    initial_values,
+    post_values,
+    select_cols,
+    order_col,
+    expected_results,
+    expected_iceberg_type,
+    str_compare_a,
+):
+    """Test allowed Iceberg type promotions per the Iceberg spec."""
+    schema = f"test_alter_type_{test_id}"
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"CREATE TABLE {schema}.tbl ({col_def}) USING iceberg;", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES {initial_values};", pg_conn)
+    pg_conn.commit()
+
+    run_command(
+        f"ALTER TABLE {schema}.tbl ALTER COLUMN a TYPE {promoted_type};",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    if expected_pg_type is not None:
+        result = run_query(
+            f"SELECT atttypid::regtype FROM pg_attribute "
+            f"WHERE attrelid = '{schema}.tbl'::regclass AND attname = 'a'",
+            pg_conn,
+        )
+        assert result == [[expected_pg_type]]
+
+    run_command(f"INSERT INTO {schema}.tbl VALUES {post_values};", pg_conn)
+    pg_conn.commit()
+
+    results = run_query(
+        f"SELECT {select_cols} FROM {schema}.tbl ORDER BY {order_col} ASC",
+        pg_conn,
+    )
+    if str_compare_a:
+        for row in results:
+            row[0] = str(row[0])
+    assert results == expected_results
+
+    if expected_iceberg_type is not None:
+        metadata_location = run_query(
+            f"SELECT metadata_location FROM iceberg_tables "
+            f"WHERE table_name = 'tbl' AND table_namespace = '{schema}'",
+            pg_conn,
+        )[0][0]
+        returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+        last_schema = returned_json["schemas"][-1]
+        a_field = [f for f in last_schema["fields"] if f["name"] == "a"][0]
+        assert a_field["type"] == expected_iceberg_type
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_disallowed_promotions(pg_conn, s3, with_default_location):
+    """Test that disallowed type promotions are rejected for Iceberg tables"""
+    run_command("CREATE SCHEMA test_alter_type_dis;", pg_conn)
+    run_command(
+        """CREATE TABLE test_alter_type_dis.tbl (
+            a int,
+            b bigint,
+            c double precision,
+            d numeric(10,2),
+            e text,
+            f real,
+            g numeric(32,8)
+        ) USING iceberg;""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    disallowed_cases = [
+        # int -> varchar (not an allowed promotion)
+        ("a", "varchar(255)", "int to varchar"),
+        # bigint -> int (narrowing not allowed)
+        ("b", "int", "bigint to int"),
+        # double -> float (narrowing not allowed)
+        ("c", "real", "double to float"),
+        # decimal: changing scale not allowed
+        ("d", "numeric(10,3)", "decimal scale change"),
+        # decimal: narrowing precision not allowed
+        ("d", "numeric(8,2)", "decimal precision narrowing"),
+        # text -> int (not an allowed promotion)
+        ("e", "int", "text to int"),
+        # int -> real (not an allowed promotion in Iceberg spec)
+        ("a", "real", "int to real"),
+        # float -> int (not an allowed promotion)
+        ("f", "int", "float to int"),
+        # decimal: widening beyond the Iceberg decimal precision limit (38)
+        # is not a decimal -> decimal promotion (it maps to double/string),
+        # so it must be rejected rather than silently corrupting metadata
+        ("g", "numeric(39,8)", "decimal precision beyond Iceberg limit"),
+    ]
+
+    for col, new_type, description in disallowed_cases:
+        error = run_command(
+            f"ALTER TABLE test_alter_type_dis.tbl ALTER COLUMN {col} TYPE {new_type};",
+            pg_conn,
+            raise_error=False,
+        )
+        assert "command not supported for pg_lake_iceberg tables" in str(
+            error
+        ), f"Expected error for {description}, got: {error}"
+        assert "Allowed type promotions for Iceberg tables are" in str(
+            error
+        ), f"Expected detail about allowed promotions for {description}, got: {error}"
+        pg_conn.rollback()
+
+    run_command("DROP SCHEMA test_alter_type_dis CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_using_clause_rejected(pg_conn, s3, with_default_location):
+    """Test that USING clause is rejected for Iceberg type promotions.
+
+    Iceberg schema evolution is metadata-only; data files are never rewritten,
+    so arbitrary USING expressions are not supported.
+    """
+    run_command("CREATE SCHEMA test_alter_using;", pg_conn)
+    run_command(
+        "CREATE TABLE test_alter_using.tbl (a int, b real) USING iceberg;",
+        pg_conn,
+    )
+    run_command("INSERT INTO test_alter_using.tbl VALUES (1, 1.5);", pg_conn)
+    pg_conn.commit()
+
+    # USING with an otherwise-allowed promotion (int -> bigint)
+    error = run_command(
+        "ALTER TABLE test_alter_using.tbl ALTER COLUMN a TYPE bigint USING a::bigint;",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "command not supported for pg_lake_iceberg tables" in str(error)
+    assert "USING requires rewriting data files" in str(error)
+    pg_conn.rollback()
+
+    # USING with an expression on an allowed promotion (float -> double)
+    error = run_command(
+        "ALTER TABLE test_alter_using.tbl ALTER COLUMN b TYPE double precision USING b * 2;",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "command not supported for pg_lake_iceberg tables" in str(error)
+    assert "USING requires rewriting data files" in str(error)
+    pg_conn.rollback()
+
+    # Verify the table is intact (nothing changed)
+    result = run_query("SELECT a, b FROM test_alter_using.tbl;", pg_conn)
+    assert result == [[1, 1.5]]
+
+    run_command("DROP SCHEMA test_alter_using CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_same_type_noop(pg_conn, s3, with_default_location):
+    """Test that changing to the same type is allowed (no-op)"""
+    run_command("CREATE SCHEMA test_alter_type_noop;", pg_conn)
+    run_command(
+        "CREATE TABLE test_alter_type_noop.tbl (a int, b numeric(10,2)) USING iceberg;",
+        pg_conn,
+    )
+    run_command("INSERT INTO test_alter_type_noop.tbl VALUES (1, 2.50);", pg_conn)
+    pg_conn.commit()
+
+    # same type should be allowed
+    run_command(
+        "ALTER TABLE test_alter_type_noop.tbl ALTER COLUMN a TYPE int;", pg_conn
+    )
+    run_command(
+        "ALTER TABLE test_alter_type_noop.tbl ALTER COLUMN b TYPE numeric(10,2);",
+        pg_conn,
+    )
+
+    results = run_query("SELECT a, b FROM test_alter_type_noop.tbl", pg_conn)
+    assert results == [[1, Decimal("2.50")]]
+
+    run_command("DROP SCHEMA test_alter_type_noop CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_on_empty_table(pg_conn, s3, with_default_location):
+    """Test type promotion on a table with no data"""
+    run_command("CREATE SCHEMA test_alter_type_empty;", pg_conn)
+    run_command(
+        "CREATE TABLE test_alter_type_empty.tbl (a int, b real) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        "ALTER TABLE test_alter_type_empty.tbl ALTER COLUMN a TYPE bigint;", pg_conn
+    )
+    run_command(
+        "ALTER TABLE test_alter_type_empty.tbl ALTER COLUMN b TYPE double precision;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # insert data with promoted types
+    run_command(
+        f"INSERT INTO test_alter_type_empty.tbl VALUES ({2**40}, 1.23456789012345);",
+        pg_conn,
+    )
+
+    results = run_query("SELECT a FROM test_alter_type_empty.tbl", pg_conn)
+    assert results == [[2**40]]
+
+    run_command("DROP SCHEMA test_alter_type_empty CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_combined_with_other_ddl(pg_conn, s3, with_default_location):
+    """Test type promotion combined with other DDL operations in the same ALTER TABLE"""
+    run_command("CREATE SCHEMA test_alter_type_combo;", pg_conn)
+    run_command(
+        "CREATE TABLE test_alter_type_combo.tbl (a int, b int, c int) USING iceberg;",
+        pg_conn,
+    )
+    run_command("INSERT INTO test_alter_type_combo.tbl VALUES (1, 2, 3);", pg_conn)
+    pg_conn.commit()
+
+    # combine type change with add and drop column
+    run_command(
+        "ALTER TABLE test_alter_type_combo.tbl ALTER COLUMN a TYPE bigint, ADD COLUMN d int, DROP COLUMN c;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 'test_alter_type_combo.tbl'::regclass AND attname = 'a'",
+        pg_conn,
+    )
+    assert result == [["bigint"]]
+
+    run_command(
+        f"INSERT INTO test_alter_type_combo.tbl VALUES ({2**40}, 20, 30);", pg_conn
+    )
+
+    results = run_query(
+        "SELECT a, b, d FROM test_alter_type_combo.tbl ORDER BY b ASC", pg_conn
+    )
+    assert results == [[1, 2, None], [2**40, 20, 30]]
+
+    run_command("DROP SCHEMA test_alter_type_combo CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_metadata_schema_evolution(
+    pg_conn, s3, with_default_location
+):
+    """Test that type promotion creates a new schema in Iceberg metadata"""
+    run_command("CREATE SCHEMA test_alter_type_meta;", pg_conn)
+    run_command(
+        "CREATE TABLE test_alter_type_meta.tbl (a int, b int) USING iceberg;", pg_conn
+    )
+    pg_conn.commit()
+
+    metadata_location = run_query(
+        "SELECT metadata_location FROM iceberg_tables WHERE table_name = 'tbl' AND table_namespace = 'test_alter_type_meta'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    assert returned_json["current-schema-id"] == 0
+    initial_schema = returned_json["schemas"][0]
+    assert initial_schema == {
+        "type": "struct",
+        "schema-id": 0,
+        "fields": [
+            {"id": 1, "name": "a", "type": "int", "required": False},
+            {"id": 2, "name": "b", "type": "int", "required": False},
+        ],
+    }
+
+    # promote a: int -> long
+    run_command(
+        "ALTER TABLE test_alter_type_meta.tbl ALTER COLUMN a TYPE bigint;", pg_conn
+    )
+    pg_conn.commit()
+
+    metadata_location = run_query(
+        "SELECT metadata_location FROM iceberg_tables WHERE table_name = 'tbl' AND table_namespace = 'test_alter_type_meta'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    assert returned_json["current-schema-id"] == 1
+    new_schema = returned_json["schemas"][-1]
+    assert new_schema == {
+        "type": "struct",
+        "schema-id": 1,
+        "fields": [
+            {"id": 1, "name": "a", "type": "long", "required": False},
+            {"id": 2, "name": "b", "type": "int", "required": False},
+        ],
+    }
+
+    # promote b: int -> long
+    run_command(
+        "ALTER TABLE test_alter_type_meta.tbl ALTER COLUMN b TYPE bigint;", pg_conn
+    )
+    pg_conn.commit()
+
+    metadata_location = run_query(
+        "SELECT metadata_location FROM iceberg_tables WHERE table_name = 'tbl' AND table_namespace = 'test_alter_type_meta'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    assert returned_json["current-schema-id"] == 2
+    new_schema = returned_json["schemas"][-1]
+    assert new_schema == {
+        "type": "struct",
+        "schema-id": 2,
+        "fields": [
+            {"id": 1, "name": "a", "type": "long", "required": False},
+            {"id": 2, "name": "b", "type": "long", "required": False},
+        ],
+    }
+
+    run_command("DROP SCHEMA test_alter_type_meta CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_int2_to_int4_no_metadata_change(
+    pg_conn, s3, with_default_location
+):
+    """int2 -> int4 both map to Iceberg 'int', so no new metadata.json should
+    be generated. The PG catalog type should change, data should remain readable,
+    and the Iceberg schema should stay identical."""
+    schema = "test_int2_int4_noop"
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"CREATE TABLE {schema}.tbl (a int2, b int) USING iceberg;", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (1, 10);", pg_conn)
+    pg_conn.commit()
+
+    # capture metadata location and schema before ALTER
+    metadata_before = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'tbl' AND table_namespace = '{schema}'",
+        pg_conn,
+    )[0][0]
+    json_before = normalize_json(read_s3_operations(s3, metadata_before))
+    schema_id_before = json_before["current-schema-id"]
+
+    # promote int2 -> int4 (no-op for Iceberg)
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN a TYPE int4;", pg_conn)
+    pg_conn.commit()
+
+    # PG catalog should reflect the new PG type
+    result = run_query(
+        f"SELECT atttypid::regtype FROM pg_attribute "
+        f"WHERE attrelid = '{schema}.tbl'::regclass AND attname = 'a'",
+        pg_conn,
+    )
+    assert result == [["integer"]]
+
+    # metadata_location must not have changed — no new metadata.json written
+    metadata_after = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'tbl' AND table_namespace = '{schema}'",
+        pg_conn,
+    )[0][0]
+    assert metadata_after == metadata_before, (
+        f"metadata.json should not be regenerated for int2->int4, "
+        f"but location changed from {metadata_before} to {metadata_after}"
+    )
+
+    # Iceberg schema-id must be unchanged
+    json_after = normalize_json(read_s3_operations(s3, metadata_after))
+    assert json_after["current-schema-id"] == schema_id_before
+
+    # the Iceberg schema still says "int" for column a
+    last_schema = json_after["schemas"][-1]
+    a_field = [f for f in last_schema["fields"] if f["name"] == "a"][0]
+    assert a_field["type"] == "int"
+
+    # data is still readable after the promotion
+    run_command(f"INSERT INTO {schema}.tbl VALUES (2, 20);", pg_conn)
+    pg_conn.commit()
+
+    results = run_query(f"SELECT a, b FROM {schema}.tbl ORDER BY b ASC", pg_conn)
+    assert results == [[1, 10], [2, 20]]
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_partitioned_table(pg_conn, s3, with_default_location):
+    """Test type promotion on a partitioned iceberg table does not break
+    partitioning, partition pruning, or data file pruning."""
+    schema = "test_alter_type_part"
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+
+    # Create a partitioned table: partition by identity on column b
+    # Use separate inserts so each value of (a, b) lands in its own data file.
+    run_command(
+        f"""
+        CREATE TABLE {schema}.tbl (a int, b int)
+        USING iceberg WITH (partition_by = 'b');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Insert 4 rows into separate data files across 2 partitions (b=10, b=20)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (1, 10);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (2, 10);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (3, 20);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (4, 20);", pg_conn)
+    pg_conn.commit()
+
+    # ── Baseline: verify pruning works BEFORE type promotion ──
+
+    # Partition pruning: b=10 should scan 2 data files (skip the b=20 partition)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10", pg_conn
+    )
+    assert fetch_data_files_used(results) == "2"
+
+    # Data file pruning on non-partition column: a=1 should scan 1 file
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE a = 1", pg_conn
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # Combined: b=10 AND a=1 → 1 file
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10 AND a = 1",
+        pg_conn,
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # ── Promote non-partition column a: int → bigint ──
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN a TYPE bigint;", pg_conn)
+    pg_conn.commit()
+
+    # Verify column type changed
+    result = run_query(
+        f"SELECT atttypid::regtype FROM pg_attribute "
+        f"WHERE attrelid = '{schema}.tbl'::regclass AND attname = 'a'",
+        pg_conn,
+    )
+    assert result == [["bigint"]]
+
+    # Insert bigint-range data into each partition
+    run_command(f"INSERT INTO {schema}.tbl VALUES ({2**40}, 10);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES ({2**41}, 20);", pg_conn)
+    pg_conn.commit()
+
+    # Verify all data readable
+    results = run_query(f"SELECT a, b FROM {schema}.tbl ORDER BY a ASC", pg_conn)
+    assert results == [
+        [1, 10],
+        [2, 10],
+        [3, 20],
+        [4, 20],
+        [2**40, 10],
+        [2**41, 20],
+    ]
+
+    # ── Verify pruning still works AFTER promoting non-partition column ──
+
+    # Partition pruning: b=10 → 3 files (2 old + 1 new in b=10 partition)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10", pg_conn
+    )
+    assert fetch_data_files_used(results) == "3"
+
+    # Data file pruning: a=1 → still 1 file (old pre-promotion data file)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE a = 1", pg_conn
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # Data file pruning: a={2**40} → 1 file (the new bigint data file)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE a = {2**40}",
+        pg_conn,
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # ── Verify Iceberg metadata reflects the type change ──
+    metadata_location = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'tbl' AND table_namespace = '{schema}'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    last_schema = returned_json["schemas"][-1]
+    a_field = [f for f in last_schema["fields"] if f["name"] == "a"][0]
+    assert a_field["type"] == "long"
+
+    # Partition spec still intact
+    partition_specs = returned_json["partition-specs"]
+    last_spec = partition_specs[-1]
+    assert len(last_spec["fields"]) == 1  # identity(b)
+
+    # ── Promote the partition column b: int → bigint ──
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN b TYPE bigint;", pg_conn)
+    pg_conn.commit()
+
+    # Verify column type changed
+    result = run_query(
+        f"SELECT atttypid::regtype FROM pg_attribute "
+        f"WHERE attrelid = '{schema}.tbl'::regclass AND attname = 'b'",
+        pg_conn,
+    )
+    assert result == [["bigint"]]
+
+    # Insert data into a new partition value after promoting partition column
+    run_command(f"INSERT INTO {schema}.tbl VALUES (100, 30);", pg_conn)
+    pg_conn.commit()
+
+    # Verify all data readable
+    results = run_query(f"SELECT a, b FROM {schema}.tbl ORDER BY a ASC", pg_conn)
+    assert results == [
+        [1, 10],
+        [2, 10],
+        [3, 20],
+        [4, 20],
+        [100, 30],
+        [2**40, 10],
+        [2**41, 20],
+    ]
+
+    # ── Verify pruning still works AFTER promoting partition column ──
+
+    # Partition pruning: b=10 → 3 files (old b=10 partition)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10", pg_conn
+    )
+    assert fetch_data_files_used(results) == "3"
+
+    # Partition pruning: b=30 → 1 file (new partition after promotion)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 30", pg_conn
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # Data file pruning: a=3 → 1 file
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE a = 3", pg_conn
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # Verify schema shows both promotions
+    metadata_location = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'tbl' AND table_namespace = '{schema}'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    last_schema = returned_json["schemas"][-1]
+    a_field = [f for f in last_schema["fields"] if f["name"] == "a"][0]
+    b_field = [f for f in last_schema["fields"] if f["name"] == "b"][0]
+    assert a_field["type"] == "long"
+    assert b_field["type"] == "long"
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_numeric_partition_promotion(
+    pg_conn, s3, with_default_location
+):
+    """Widen a NUMERIC identity partition column, decimal(P,S) -> decimal(P',S).
+
+    NUMERIC partition values are stored with a BINARY physical type and a DECIMAL
+    logical type, so writing into a table that still has pre-promotion partition
+    data files exercises the heavy-assert stats normalization path
+    (NormalizePartitionFieldValue), which must map the DECIMAL partition value
+    back to NUMERIC rather than treating it as raw bytea.
+    """
+    schema = "test_alter_type_num_part"
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+
+    # Partition by identity on a NUMERIC column with non-NULL values.
+    run_command(
+        f"""
+        CREATE TABLE {schema}.tbl (a int, b numeric(10,2))
+        USING iceberg WITH (partition_by = 'b');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Separate inserts so each row lands in its own data file: 2 files in the
+    # b=10.50 partition and 1 in the b=20.25 partition.
+    run_command(f"INSERT INTO {schema}.tbl VALUES (1, 10.50);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (2, 10.50);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (3, 20.25);", pg_conn)
+    pg_conn.commit()
+
+    # Baseline partition pruning before the promotion.
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10.50", pg_conn
+    )
+    assert fetch_data_files_used(results) == "2"
+
+    # ── Widen the numeric partition column: numeric(10,2) -> numeric(20,2) ──
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN b TYPE numeric(20,2);", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        f"SELECT atttypid::regtype FROM pg_attribute "
+        f"WHERE attrelid = '{schema}.tbl'::regclass AND attname = 'b'",
+        pg_conn,
+    )
+    assert result == [["numeric"]]
+
+    # Write again with the pre-promotion data files still present. Committing
+    # this write runs the heavy-assert stats check against the decimal(10,2)
+    # partition values, exercising the DECIMAL normalize path. One row reuses an
+    # existing partition value and one needs the widened precision.
+    run_command(f"INSERT INTO {schema}.tbl VALUES (4, 10.50);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES (5, 123456789012345678.90);", pg_conn)
+    pg_conn.commit()
+
+    # All rows, including pre-promotion partition data, remain readable.
+    results = run_query(f"SELECT a, b FROM {schema}.tbl ORDER BY a ASC", pg_conn)
+    for row in results:
+        row[1] = str(row[1])
+    assert results == [
+        [1, "10.50"],
+        [2, "10.50"],
+        [3, "20.25"],
+        [4, "10.50"],
+        [5, "123456789012345678.90"],
+    ]
+
+    # Partition pruning still works across pre/post-promotion files: the b=10.50
+    # partition now has 3 data files (2 pre-promotion + 1 after).
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10.50", pg_conn
+    )
+    assert fetch_data_files_used(results) == "3"
+
+    # Iceberg metadata reflects the widened decimal partition column.
+    metadata_location = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'tbl' AND table_namespace = '{schema}'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    last_schema = returned_json["schemas"][-1]
+    b_field = [f for f in last_schema["fields"] if f["name"] == "b"][0]
+    assert b_field["type"] == "decimal(20,2)"
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_alter_column_type_spark_comparison(
+    installcheck, spark_session, pg_conn, s3, with_default_location
+):
+    """Create the same table in Spark and pg_lake, perform identical type promotions,
+    verify both produce the same results, compare metadata schemas, and confirm
+    Spark can read pg_lake's metadata.json after type promotion."""
+    if installcheck:
+        return
+
+    pg_schema = "test_type_promo_pg"
+    spark_ns = "public"
+
+    run_command(f"CREATE SCHEMA {pg_schema};", pg_conn)
+
+    # ── 1. int → bigint ──
+
+    # Spark side
+    spark_session.sql(
+        f"CREATE TABLE {spark_ns}.spark_int_promo (a int, b int) USING iceberg"
+    )
+    spark_session.sql(f"INSERT INTO {spark_ns}.spark_int_promo VALUES (1, 10), (2, 20)")
+    spark_session.sql(
+        f"ALTER TABLE {spark_ns}.spark_int_promo ALTER COLUMN a TYPE bigint"
+    )
+    spark_session.sql(f"INSERT INTO {spark_ns}.spark_int_promo VALUES ({2**40}, 30)")
+
+    # pg_lake side — same operations
+    run_command(
+        f"CREATE TABLE {pg_schema}.int_tbl (a int, b int) USING iceberg;", pg_conn
+    )
+    run_command(f"INSERT INTO {pg_schema}.int_tbl VALUES (1, 10), (2, 20);", pg_conn)
+    pg_conn.commit()
+    run_command(f"ALTER TABLE {pg_schema}.int_tbl ALTER COLUMN a TYPE bigint;", pg_conn)
+    pg_conn.commit()
+    run_command(f"INSERT INTO {pg_schema}.int_tbl VALUES ({2**40}, 30);", pg_conn)
+    pg_conn.commit()
+
+    # Compare: query both natively
+    spark_query = f"SELECT a, b FROM {spark_ns}.spark_int_promo ORDER BY b ASC"
+    pg_query = f"SELECT a, b FROM {pg_schema}.int_tbl ORDER BY b ASC"
+
+    pg_lake_result = assert_query_result_on_spark_and_pg(
+        installcheck, spark_session, pg_conn, spark_query, pg_query
+    )
+
+    assert len(pg_lake_result) == 3
+    assert pg_lake_result == [[1, 10], [2, 20], [2**40, 30]]
+
+    # Compare full schemas JSON
+    spark_metadata_loc = (
+        spark_session.sql(
+            f"SELECT file FROM {spark_ns}.spark_int_promo.metadata_log_entries ORDER BY timestamp DESC"
+        )
+        .collect()[0]
+        .file
+    )
+    spark_json = normalize_json(read_s3_operations(s3, spark_metadata_loc))
+
+    pg_metadata_loc = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'int_tbl' AND table_namespace = '{pg_schema}'",
+        pg_conn,
+    )[0][0]
+    pg_json = normalize_json(read_s3_operations(s3, pg_metadata_loc))
+
+    assert_iceberg_schemas_equal(spark_json, pg_json, "int→bigint")
+
+    # Verify Spark can read pg_lake's metadata.json
+    # Disable vectorized reading: Spark 3.5 / Iceberg 1.4.3 vectorized reader
+    # crashes with ClassCastException when an old data file's Parquet physical
+    # type (int32) doesn't match the current schema type (int64) after promotion.
+    spark_session.conf.set("spark.sql.iceberg.vectorization.enabled", "false")
+    spark_register_table(
+        installcheck, spark_session, "int_tbl", pg_schema, pg_metadata_loc
+    )
+    spark_cross_query = f"SELECT a, b FROM {pg_schema}.int_tbl ORDER BY b ASC"
+    spark_cross = spark_session.sql(spark_cross_query).collect()
+    assert len(spark_cross) == 3
+    assert [spark_cross[0].a, spark_cross[0].b] == [1, 10]
+    assert [spark_cross[1].a, spark_cross[1].b] == [2, 20]
+    assert [spark_cross[2].a, spark_cross[2].b] == [2**40, 30]
+    spark_unregister_table(installcheck, spark_session, "int_tbl", pg_schema)
+    spark_session.conf.set("spark.sql.iceberg.vectorization.enabled", "true")
+
+    spark_session.sql(f"DROP TABLE {spark_ns}.spark_int_promo")
+
+    # ── 2. float → double ──
+
+    # Spark side
+    spark_session.sql(
+        f"CREATE TABLE {spark_ns}.spark_float_promo (a float, b int) USING iceberg"
+    )
+    spark_session.sql(f"INSERT INTO {spark_ns}.spark_float_promo VALUES (1.5, 1)")
+    spark_session.sql(
+        f"ALTER TABLE {spark_ns}.spark_float_promo ALTER COLUMN a TYPE double"
+    )
+    spark_session.sql(
+        f"INSERT INTO {spark_ns}.spark_float_promo VALUES (1.23456789012345, 2)"
+    )
+
+    # pg_lake side
+    run_command(
+        f"CREATE TABLE {pg_schema}.float_tbl (a real, b int) USING iceberg;", pg_conn
+    )
+    run_command(f"INSERT INTO {pg_schema}.float_tbl VALUES (1.5, 1);", pg_conn)
+    pg_conn.commit()
+    run_command(
+        f"ALTER TABLE {pg_schema}.float_tbl ALTER COLUMN a TYPE double precision;",
+        pg_conn,
+    )
+    pg_conn.commit()
+    run_command(
+        f"INSERT INTO {pg_schema}.float_tbl VALUES (1.23456789012345, 2);", pg_conn
+    )
+    pg_conn.commit()
+
+    spark_query = f"SELECT a, b FROM {spark_ns}.spark_float_promo ORDER BY b ASC"
+    pg_query = f"SELECT a, b FROM {pg_schema}.float_tbl ORDER BY b ASC"
+
+    pg_lake_result = assert_query_result_on_spark_and_pg(
+        installcheck, spark_session, pg_conn, spark_query, pg_query
+    )
+
+    assert len(pg_lake_result) == 2
+
+    # Compare full schemas JSON
+    spark_metadata_loc = (
+        spark_session.sql(
+            f"SELECT file FROM {spark_ns}.spark_float_promo.metadata_log_entries ORDER BY timestamp DESC"
+        )
+        .collect()[0]
+        .file
+    )
+    spark_json = normalize_json(read_s3_operations(s3, spark_metadata_loc))
+
+    pg_metadata_loc = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'float_tbl' AND table_namespace = '{pg_schema}'",
+        pg_conn,
+    )[0][0]
+    pg_json = normalize_json(read_s3_operations(s3, pg_metadata_loc))
+
+    assert_iceberg_schemas_equal(spark_json, pg_json, "float→double")
+
+    # Verify Spark can read pg_lake's metadata.json (vectorized off, same reason)
+    spark_session.conf.set("spark.sql.iceberg.vectorization.enabled", "false")
+    spark_register_table(
+        installcheck, spark_session, "float_tbl", pg_schema, pg_metadata_loc
+    )
+    spark_cross_query = f"SELECT a, b FROM {pg_schema}.float_tbl ORDER BY b ASC"
+    spark_cross = spark_session.sql(spark_cross_query).collect()
+    assert len(spark_cross) == 2
+    assert spark_cross[0].a == pytest.approx(1.5, abs=1e-6)
+    assert spark_cross[1].a == pytest.approx(1.23456789012345, abs=1e-10)
+    spark_unregister_table(installcheck, spark_session, "float_tbl", pg_schema)
+    spark_session.conf.set("spark.sql.iceberg.vectorization.enabled", "true")
+
+    spark_session.sql(f"DROP TABLE {spark_ns}.spark_float_promo")
+
+    # ── 3. decimal(P,S) → decimal(P',S) where P' > P ──
+
+    # Spark side
+    spark_session.sql(
+        f"CREATE TABLE {spark_ns}.spark_dec_promo (a decimal(10,2), b int) USING iceberg"
+    )
+    spark_session.sql(f"INSERT INTO {spark_ns}.spark_dec_promo VALUES (12345.67, 1)")
+    spark_session.sql(
+        f"ALTER TABLE {spark_ns}.spark_dec_promo ALTER COLUMN a TYPE decimal(20,2)"
+    )
+    spark_session.sql(
+        f"INSERT INTO {spark_ns}.spark_dec_promo VALUES (123456789012345.67, 2)"
+    )
+
+    # pg_lake side
+    run_command(
+        f"CREATE TABLE {pg_schema}.dec_tbl (a numeric(10,2), b int) USING iceberg;",
+        pg_conn,
+    )
+    run_command(f"INSERT INTO {pg_schema}.dec_tbl VALUES (12345.67, 1);", pg_conn)
+    pg_conn.commit()
+    run_command(
+        f"ALTER TABLE {pg_schema}.dec_tbl ALTER COLUMN a TYPE numeric(20,2);", pg_conn
+    )
+    pg_conn.commit()
+    run_command(
+        f"INSERT INTO {pg_schema}.dec_tbl VALUES (123456789012345.67, 2);", pg_conn
+    )
+    pg_conn.commit()
+
+    spark_query = f"SELECT a, b FROM {spark_ns}.spark_dec_promo ORDER BY b ASC"
+    pg_query = f"SELECT a, b FROM {pg_schema}.dec_tbl ORDER BY b ASC"
+
+    pg_lake_result = assert_query_result_on_spark_and_pg(
+        installcheck, spark_session, pg_conn, spark_query, pg_query
+    )
+
+    assert len(pg_lake_result) == 2
+
+    # Compare full schemas JSON
+    spark_metadata_loc = (
+        spark_session.sql(
+            f"SELECT file FROM {spark_ns}.spark_dec_promo.metadata_log_entries ORDER BY timestamp DESC"
+        )
+        .collect()[0]
+        .file
+    )
+    spark_json = normalize_json(read_s3_operations(s3, spark_metadata_loc))
+
+    pg_metadata_loc = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'dec_tbl' AND table_namespace = '{pg_schema}'",
+        pg_conn,
+    )[0][0]
+    pg_json = normalize_json(read_s3_operations(s3, pg_metadata_loc))
+
+    assert_iceberg_schemas_equal(spark_json, pg_json, "decimal widening")
+
+    # Verify Spark can read pg_lake's metadata.json
+    spark_register_table(
+        installcheck, spark_session, "dec_tbl", pg_schema, pg_metadata_loc
+    )
+    spark_cross_query = f"SELECT a, b FROM {pg_schema}.dec_tbl ORDER BY b ASC"
+    spark_cross = spark_session.sql(spark_cross_query).collect()
+    assert len(spark_cross) == 2
+    assert str(spark_cross[0].a) == "12345.67"
+    assert str(spark_cross[1].a) == "123456789012345.67"
+    spark_unregister_table(installcheck, spark_session, "dec_tbl", pg_schema)
+
+    spark_session.sql(f"DROP TABLE {spark_ns}.spark_dec_promo")
+
+    # ── 4. partitioned table: int → bigint on partition column ──
+
+    # Spark side
+    spark_session.sql(
+        f"CREATE TABLE {spark_ns}.spark_part_promo (a int, b int) "
+        f"USING iceberg PARTITIONED BY (b)"
+    )
+    spark_session.sql(
+        f"INSERT INTO {spark_ns}.spark_part_promo VALUES (1, 10), (2, 20)"
+    )
+    spark_session.sql(
+        f"ALTER TABLE {spark_ns}.spark_part_promo ALTER COLUMN b TYPE bigint"
+    )
+    spark_session.sql(f"INSERT INTO {spark_ns}.spark_part_promo VALUES (3, 30)")
+
+    # pg_lake side
+    run_command(
+        f"CREATE TABLE {pg_schema}.part_tbl (a int, b int) "
+        f"USING iceberg WITH (partition_by = 'b');",
+        pg_conn,
+    )
+    run_command(f"INSERT INTO {pg_schema}.part_tbl VALUES (1, 10), (2, 20);", pg_conn)
+    pg_conn.commit()
+    run_command(
+        f"ALTER TABLE {pg_schema}.part_tbl ALTER COLUMN b TYPE bigint;", pg_conn
+    )
+    pg_conn.commit()
+    run_command(f"INSERT INTO {pg_schema}.part_tbl VALUES (3, 30);", pg_conn)
+    pg_conn.commit()
+
+    spark_query = f"SELECT a, b FROM {spark_ns}.spark_part_promo ORDER BY a ASC"
+    pg_query = f"SELECT a, b FROM {pg_schema}.part_tbl ORDER BY a ASC"
+
+    pg_lake_result = assert_query_result_on_spark_and_pg(
+        installcheck, spark_session, pg_conn, spark_query, pg_query
+    )
+
+    assert len(pg_lake_result) == 3
+    assert pg_lake_result == [[1, 10], [2, 20], [3, 30]]
+
+    # Compare full schemas JSON
+    spark_metadata_loc = (
+        spark_session.sql(
+            f"SELECT file FROM {spark_ns}.spark_part_promo.metadata_log_entries ORDER BY timestamp DESC"
+        )
+        .collect()[0]
+        .file
+    )
+    spark_json = normalize_json(read_s3_operations(s3, spark_metadata_loc))
+
+    pg_metadata_loc = run_query(
+        f"SELECT metadata_location FROM iceberg_tables "
+        f"WHERE table_name = 'part_tbl' AND table_namespace = '{pg_schema}'",
+        pg_conn,
+    )[0][0]
+    pg_json = normalize_json(read_s3_operations(s3, pg_metadata_loc))
+
+    assert_iceberg_schemas_equal(spark_json, pg_json, "partitioned int→bigint")
+
+    # Verify Spark can read pg_lake's metadata.json (vectorized off, same reason)
+    spark_session.conf.set("spark.sql.iceberg.vectorization.enabled", "false")
+    spark_register_table(
+        installcheck, spark_session, "part_tbl", pg_schema, pg_metadata_loc
+    )
+    spark_cross_query = f"SELECT a, b FROM {pg_schema}.part_tbl ORDER BY a ASC"
+    spark_cross = spark_session.sql(spark_cross_query).collect()
+    assert len(spark_cross) == 3
+    assert [spark_cross[0].a, spark_cross[0].b] == [1, 10]
+    assert [spark_cross[1].a, spark_cross[1].b] == [2, 20]
+    assert [spark_cross[2].a, spark_cross[2].b] == [3, 30]
+    spark_unregister_table(installcheck, spark_session, "part_tbl", pg_schema)
+    spark_session.conf.set("spark.sql.iceberg.vectorization.enabled", "true")
+
+    spark_session.sql(f"DROP TABLE {spark_ns}.spark_part_promo")
+
+    # cleanup
+    run_command(f"DROP SCHEMA {pg_schema} CASCADE;", pg_conn)
     pg_conn.commit()
 
 

--- a/pg_lake_table/tests/pytests/test_iceberg_merge_manifest.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_merge_manifest.py
@@ -922,6 +922,166 @@ def test_partitioned_manifest_merge_with_updates(
     pg_conn.rollback()
 
 
+def test_manifest_merge_after_float4_to_float8_type_promotion(
+    s3,
+    pg_conn,
+    extension,
+    create_test_helper_functions,
+    reset_manifest_merge_settings,
+    with_default_location,
+):
+    """
+    Verify that manifest merge preserves correct min-max statistics after
+    a float4 -> float8 (real -> double precision) type promotion.
+
+    After promotion, older data files carry 4-byte float column bounds while
+    newer files carry 8-byte double bounds.  A manifest merge must handle
+    both widths correctly so that:
+      - all data remains readable,
+      - data-file pruning still works (no rows silently dropped),
+      - values with precision differences between float4 and float8 are
+        handled without rounding errors.
+    """
+    table_name = "test_merge_float_promo"
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+
+    run_command(
+        f"""
+        CREATE TABLE {table_name} (a real, b int)
+        USING pg_lake_iceberg;
+        ALTER FOREIGN TABLE {table_name} OPTIONS (ADD autovacuum_enabled 'false');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # disable manifest merge so we accumulate multiple manifests
+    run_command("SET pg_lake_iceberg.enable_manifest_merge_on_write = off", pg_conn)
+
+    # Use values with precision that differs between float4 and float8:
+    #   float4(1.1)  ≈ 1.10000002  (in float8 terms)
+    #   float8(1.1)  = 1.1000000000000001
+    # These are the kinds of values most likely to expose rounding issues.
+    run_command(f"INSERT INTO {table_name} VALUES (1.1, 1)", pg_conn)
+    pg_conn.commit()
+
+    run_command(f"INSERT INTO {table_name} VALUES (2.2, 2)", pg_conn)
+    pg_conn.commit()
+
+    run_command(f"INSERT INTO {table_name} VALUES (3.3, 3)", pg_conn)
+    pg_conn.commit()
+
+    # verify data before type change
+    results = run_query(f"SELECT a, b FROM {table_name} ORDER BY b", pg_conn)
+    assert len(results) == 3
+
+    # promote float4 -> float8
+    run_command(
+        f"ALTER TABLE {table_name} ALTER COLUMN a TYPE double precision;", pg_conn
+    )
+    pg_conn.commit()
+
+    # insert data with full float8 precision (values that cannot be
+    # represented exactly in float4)
+    run_command(f"INSERT INTO {table_name} VALUES (1.23456789012345, 4)", pg_conn)
+    pg_conn.commit()
+
+    run_command(f"INSERT INTO {table_name} VALUES (4.56789012345678, 5)", pg_conn)
+    pg_conn.commit()
+
+    # now enable manifest merge and trigger it
+    run_command("RESET pg_lake_iceberg.enable_manifest_merge_on_write", pg_conn)
+    run_command("SET pg_lake_iceberg.manifest_min_count_to_merge = 2", pg_conn)
+
+    # this insert triggers the merge (6th manifest, well above min_count=2)
+    run_command(f"INSERT INTO {table_name} VALUES (5.5, 6)", pg_conn)
+    pg_conn.commit()
+
+    # after merge we should have a single manifest (all merged)
+    metadata_location = run_query(
+        f"SELECT metadata_location FROM lake_iceberg.tables WHERE table_name = '{table_name}'",
+        pg_conn,
+    )[0][0]
+
+    manifests = run_query(
+        f"""SELECT added_files_count + existing_files_count
+            FROM lake_iceberg.current_manifests('{metadata_location}')""",
+        pg_conn,
+    )
+    total_files = sum(row[0] for row in manifests)
+    assert total_files == 6, f"Expected 6 data files after merge, got {total_files}"
+
+    # ── Verify all data is still readable and correct ──
+    results = run_query(f"SELECT a, b FROM {table_name} ORDER BY b", pg_conn)
+    assert len(results) == 6
+
+    # float4 values are read back as float8 after promotion
+    # verify the pre-promotion values survived the merge
+    assert results[0][1] == 1  # b=1
+    assert results[1][1] == 2  # b=2
+    assert results[2][1] == 3  # b=3
+
+    # post-promotion values with full float8 precision
+    assert results[3] == [1.23456789012345, 4]
+    assert results[4] == [4.56789012345678, 5]
+    assert results[5][1] == 6  # b=6
+
+    # ── Verify data file pruning works correctly after merge ──
+
+    # query with an int filter that isolates a pre-promotion data file
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {table_name} WHERE b = 1", pg_conn
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # query for post-promotion float8 data file
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {table_name} WHERE b = 4", pg_conn
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # ── Pruning on the promoted float column ──
+    # This is the critical test: min-max bounds on column "a" must survive
+    # the float4→float8 widening during manifest merge.
+    #
+    # Data files (each with 1 row):
+    #   File 1: a ≈ 1.1000000238 (float4 widened), b=1
+    #   File 2: a ≈ 2.2000000477 (float4 widened), b=2
+    #   File 3: a ≈ 3.2999999523 (float4 widened), b=3
+    #   File 4: a = 1.23456789012345 (native float8), b=4
+    #   File 5: a = 4.56789012345678 (native float8), b=5
+    #   File 6: a = 5.5 (native float8), b=6
+
+    # WHERE a < 1.15 should scan only File 1
+    #   (float4(1.1) widens to ≈1.1000000238 which is < 1.15)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {table_name} WHERE a < 1.15", pg_conn
+    )
+    assert fetch_data_files_used(results) == "1"
+
+    # WHERE a > 4.0 should scan Files 5 and 6 only
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {table_name} WHERE a > 4.0", pg_conn
+    )
+    assert fetch_data_files_used(results) == "2"
+
+    # verify no rows are lost with a range query that spans pre- and
+    # post-promotion data files
+    results = run_query(
+        f"SELECT count(*) FROM {table_name} WHERE a >= 1.0 AND a <= 6.0", pg_conn
+    )
+    assert results[0][0] == 6
+
+    # additional sanity: sum should match
+    results = run_query(f"SELECT sum(b) FROM {table_name}", pg_conn)
+    assert results[0][0] == 21  # 1+2+3+4+5+6
+
+    # cleanup
+    pg_conn.rollback()
+    run_command(f"DROP FOREIGN TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
 # a stress testing for partition changes and manifest compaction
 # randomly insert and update rows, then in between change the partition
 # spec so that we ensure multiple specs, positional deletes, copy-on-write

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1,6 +1,7 @@
 from utils_pytest import *
 import datetime
 import itertools
+import itertools
 import json
 import re
 import time
@@ -20,6 +21,9 @@ def drop_object_store_schemas(pg_conn):
     )
     pg_conn.commit()
     yield
+
+
+import pytest
 
 
 # don't accept 'catalog_name', 'catalog_namespace', 'catalog_table_name'
@@ -992,6 +996,222 @@ def test_complex_types_object_store(
         	""",
         pg_conn,
     )
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "schema, col_type, new_type, initial_val, initial_b, promoted_val, promoted_b, expected_pg_type",
+    [
+        pytest.param(
+            "os_type_promo",
+            "int",
+            "bigint",
+            "1",
+            2,
+            str(2**40),
+            3,
+            "bigint",
+            id="int_to_bigint",
+        ),
+        pytest.param(
+            "os_type_promo_f",
+            "real",
+            "double precision",
+            "1.5",
+            1,
+            "1.23456789012345",
+            2,
+            "double precision",
+            id="float_to_double",
+        ),
+        pytest.param(
+            "os_type_promo_d",
+            "numeric(10,2)",
+            "numeric(20,2)",
+            "12345.67",
+            1,
+            "123456789012345.67",
+            2,
+            "numeric",
+            id="decimal_widen_precision",
+        ),
+    ],
+)
+def test_object_store_alter_column_type(
+    pg_conn,
+    s3,
+    extension,
+    with_default_location,
+    adjust_object_store_settings,
+    schema,
+    col_type,
+    new_type,
+    initial_val,
+    initial_b,
+    promoted_val,
+    promoted_b,
+    expected_pg_type,
+):
+    """Test allowed Iceberg type promotions on object_store catalog tables"""
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(
+        f"""
+        CREATE TABLE {schema}.tbl (a {col_type}, b int)
+        USING iceberg WITH (catalog='object_store');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"INSERT INTO {schema}.tbl VALUES ({initial_val}, {initial_b});", pg_conn
+    )
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, schema, "tbl")
+
+    # promote column type
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN a TYPE {new_type};", pg_conn)
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, schema, "tbl")
+
+    # verify column type changed in PG catalog
+    result = run_query(
+        f"SELECT atttypid::regtype FROM pg_attribute "
+        f"WHERE attrelid = '{schema}.tbl'::regclass AND attname = 'a'",
+        pg_conn,
+    )
+    assert result == [[expected_pg_type]]
+
+    # insert data utilizing promoted type
+    run_command(
+        f"INSERT INTO {schema}.tbl VALUES ({promoted_val}, {promoted_b});", pg_conn
+    )
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, schema, "tbl")
+
+    # verify all data is readable
+    results = run_query(f"SELECT a, b FROM {schema}.tbl ORDER BY b ASC", pg_conn)
+    assert len(results) == 2
+    assert str(results[0][0]) == initial_val
+    assert results[0][1] == initial_b
+    assert str(results[1][0]) == promoted_val
+    assert results[1][1] == promoted_b
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_object_store_alter_column_type_disallowed(
+    pg_conn, s3, extension, with_default_location, adjust_object_store_settings
+):
+    """Test that disallowed type promotions are rejected for object_store catalog Iceberg tables"""
+    run_command("CREATE SCHEMA os_type_promo_dis;", pg_conn)
+    run_command(
+        """
+        CREATE TABLE os_type_promo_dis.tbl (a int, b bigint, c double precision, d numeric(10,2))
+        USING iceberg WITH (catalog='object_store');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    disallowed_cases = [
+        ("a", "varchar(255)", "int to varchar"),
+        ("b", "int", "bigint to int"),
+        ("c", "real", "double to float"),
+        ("d", "numeric(10,3)", "decimal scale change"),
+        ("d", "numeric(8,2)", "decimal precision narrowing"),
+        ("a", "real", "int to real"),
+    ]
+
+    for col, new_type, description in disallowed_cases:
+        error = run_command(
+            f"ALTER TABLE os_type_promo_dis.tbl ALTER COLUMN {col} TYPE {new_type};",
+            pg_conn,
+            raise_error=False,
+        )
+        assert error is not None, f"Expected error for {description}"
+        assert "not supported" in str(
+            error
+        ), f"Expected 'not supported' error for {description}, got: {error}"
+        assert "Allowed type promotions for Iceberg tables are" in str(
+            error
+        ), f"Expected detail message for {description}, got: {error}"
+        pg_conn.rollback()
+
+    run_command("DROP SCHEMA os_type_promo_dis CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_object_store_alter_column_type_with_reader(
+    pg_conn, s3, extension, with_default_location, adjust_object_store_settings
+):
+    """Test type promotion followed by data insert, verifying object_store reader sees changes"""
+    run_command("CREATE SCHEMA os_type_promo_rdr;", pg_conn)
+    run_command(
+        """
+        CREATE TABLE os_type_promo_rdr.tbl (a int, b real, c int)
+        USING iceberg WITH (catalog='object_store');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("INSERT INTO os_type_promo_rdr.tbl VALUES (1, 1.5, 10);", pg_conn)
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, "os_type_promo_rdr", "tbl")
+
+    # promote multiple columns
+    run_command(
+        "ALTER TABLE os_type_promo_rdr.tbl ALTER COLUMN a TYPE bigint;", pg_conn
+    )
+    run_command(
+        "ALTER TABLE os_type_promo_rdr.tbl ALTER COLUMN b TYPE double precision;",
+        pg_conn,
+    )
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, "os_type_promo_rdr", "tbl")
+
+    # insert data with promoted types
+    run_command(
+        f"INSERT INTO os_type_promo_rdr.tbl VALUES ({2**40}, 1.23456789012345, 20);",
+        pg_conn,
+    )
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, "os_type_promo_rdr", "tbl")
+
+    results = run_query(
+        "SELECT a, b, c FROM os_type_promo_rdr.tbl ORDER BY c ASC", pg_conn
+    )
+    assert results == [[1, 1.5, 10], [2**40, 1.23456789012345, 20]]
+
+    # create read-only reader and verify schema + data match
+    run_command(
+        """
+        CREATE TABLE os_type_promo_rdr.reader ()
+        USING iceberg WITH (catalog='object_store', read_only=True, catalog_table_name='tbl');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    reader_types = run_query(
+        "SELECT attname, atttypid::regtype FROM pg_attribute "
+        "WHERE attrelid = 'os_type_promo_rdr.reader'::regclass AND attnum > 0 "
+        "ORDER BY attnum",
+        pg_conn,
+    )
+    assert reader_types == [
+        ["a", "bigint"],
+        ["b", "double precision"],
+        ["c", "integer"],
+    ]
+
+    assert_tables_are_the_same(
+        pg_conn, "os_type_promo_rdr.tbl", "os_type_promo_rdr.reader"
+    )
+
+    run_command("DROP SCHEMA os_type_promo_rdr CASCADE;", pg_conn)
     pg_conn.commit()
 
 

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1,7 +1,6 @@
 from utils_pytest import *
 import datetime
 import itertools
-import itertools
 import json
 import re
 import time
@@ -21,9 +20,6 @@ def drop_object_store_schemas(pg_conn):
     )
     pg_conn.commit()
     yield
-
-
-import pytest
 
 
 # don't accept 'catalog_name', 'catalog_namespace', 'catalog_table_name'

--- a/pg_lake_table/tests/pytests/test_partition_pruning.py
+++ b/pg_lake_table/tests/pytests/test_partition_pruning.py
@@ -2195,6 +2195,115 @@ def test_clamped_numeric_nan_partition(
     pg_conn.rollback()
 
 
+@pytest.mark.parametrize(
+    "schema, col_type, new_type, pre_a_vals, post_a_val",
+    [
+        pytest.param(
+            "part_promo_int",
+            "int",
+            "bigint",
+            # INT_MIN and INT_MAX — int4 boundary values
+            [-2147483648, 2147483647],
+            # first value outside int4 range
+            "2147483648",
+            id="int_to_bigint",
+        ),
+        pytest.param(
+            "part_promo_float",
+            "real",
+            "double precision",
+            # near -FLOAT_MAX and +FLOAT_MAX — float4 boundary values
+            [-1e38, 1e38],
+            # value beyond float4 range, only representable in float8
+            "1e+200",
+            id="float_to_double",
+        ),
+        pytest.param(
+            "part_promo_decimal",
+            "numeric(10,2)",
+            "numeric(20,2)",
+            # min and max for numeric(10,2)
+            [-99999999.99, 99999999.99],
+            # value requiring wider precision (numeric(20,2))
+            "99999999999999999.99",
+            id="decimal_widen_precision",
+        ),
+    ],
+)
+def test_partition_pruning_after_type_promotion(
+    s3,
+    disable_data_file_pruning,
+    pg_conn,
+    extension,
+    with_default_location,
+    schema,
+    col_type,
+    new_type,
+    pre_a_vals,
+    post_a_val,
+):
+    """Verify partition pruning still works after promoting a non-partition column."""
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(
+        f"""
+        CREATE TABLE {schema}.tbl (a {col_type}, b int)
+        USING iceberg WITH (autovacuum_enabled='False', partition_by='b');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Insert rows into 2 partitions (b=10, b=20), one row each
+    run_command(f"INSERT INTO {schema}.tbl VALUES ({pre_a_vals[0]}, 10);", pg_conn)
+    run_command(f"INSERT INTO {schema}.tbl VALUES ({pre_a_vals[1]}, 20);", pg_conn)
+    pg_conn.commit()
+
+    # Baseline: partition pruning on b works before promotion
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10", pg_conn
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Promote non-partition column a
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN a TYPE {new_type};", pg_conn)
+    pg_conn.commit()
+
+    # Insert a row into a new partition (b=30) after promotion
+    run_command(f"INSERT INTO {schema}.tbl VALUES ({post_a_val}, 30);", pg_conn)
+    pg_conn.commit()
+
+    # Verify all data readable
+    results = run_query(f"SELECT count(*) FROM {schema}.tbl", pg_conn)
+    assert results[0][0] == 3
+
+    # Partition pruning: b=10 → 1 file (old partition, pre-promotion data)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 10", pg_conn
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Partition pruning: b=20 → 1 file (old partition, pre-promotion data)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 20", pg_conn
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Partition pruning: b=30 → 1 file (new partition, post-promotion data)
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM {schema}.tbl WHERE b = 30", pg_conn
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Full scan: all 3 files
+    results = run_query(f"{explain_prefix} SELECT * FROM {schema}.tbl", pg_conn)
+    assert int(fetch_data_files_used(results)) == 3
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
 # this test file aims to ensure partition pruning works
 @pytest.fixture(scope="module")
 def disable_data_file_pruning(superuser_conn):

--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -1,25 +1,6 @@
 from utils_pytest import *
 from helpers.polaris import *
-from urllib.parse import quote
-from urllib.parse import urlencode
-from pyiceberg.schema import Schema
-from pyiceberg.types import (
-    TimestampType,
-    FloatType,
-    IntegerType,
-    DoubleType,
-    StringType,
-    BinaryType,
-    FixedType,
-    NestedField,
-    ListType,
-    StructType,
-)
-import pyarrow
-from datetime import datetime, date, timezone
-from urllib.parse import quote, quote_plus
-from pyiceberg.expressions import EqualTo
-from pyiceberg.partitioning import PartitionSpec, PartitionField
+import pytest
 import json
 
 
@@ -3458,6 +3439,248 @@ def test_add_drop_columns(
     pg_conn.commit()
 
 
+@pytest.mark.parametrize(
+    "schema, col_type, new_type, initial_val, initial_b, promoted_val, promoted_b, expected_pg_type, expected_rest_type",
+    [
+        pytest.param(
+            "rest_type_promo",
+            "int",
+            "bigint",
+            "1",
+            2,
+            str(2**40),
+            3,
+            "bigint",
+            "long",
+            id="int_to_bigint",
+        ),
+        pytest.param(
+            "rest_type_promo_f",
+            "real",
+            "double precision",
+            "1.5",
+            1,
+            "1.23456789012345",
+            2,
+            "double precision",
+            "double",
+            id="float_to_double",
+        ),
+        pytest.param(
+            "rest_type_promo_d",
+            "numeric(10,2)",
+            "numeric(20,2)",
+            "12345.67",
+            1,
+            "123456789012345.67",
+            2,
+            "numeric",
+            "decimal",
+            id="decimal_widen_precision",
+        ),
+    ],
+)
+def test_rest_alter_column_type(
+    pg_conn,
+    superuser_conn,
+    installcheck,
+    s3,
+    extension,
+    create_types_helper_functions,
+    with_default_location,
+    polaris_session,
+    set_polaris_gucs,
+    create_http_helper_functions,
+    schema,
+    col_type,
+    new_type,
+    initial_val,
+    initial_b,
+    promoted_val,
+    promoted_b,
+    expected_pg_type,
+    expected_rest_type,
+):
+    """Test allowed Iceberg type promotions on REST catalog tables"""
+    if installcheck:
+        return
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(
+        f"""
+        CREATE TABLE {schema}.tbl (a {col_type}, b int)
+        USING iceberg WITH (catalog='rest');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"INSERT INTO {schema}.tbl VALUES ({initial_val}, {initial_b});", pg_conn
+    )
+    pg_conn.commit()
+
+    # promote column type
+    run_command(f"ALTER TABLE {schema}.tbl ALTER COLUMN a TYPE {new_type};", pg_conn)
+    pg_conn.commit()
+
+    # verify column type changed in PG catalog
+    result = run_query(
+        f"SELECT atttypid::regtype FROM pg_attribute "
+        f"WHERE attrelid = '{schema}.tbl'::regclass AND attname = 'a'",
+        pg_conn,
+    )
+    assert result == [[expected_pg_type]]
+
+    # insert data utilizing promoted type
+    run_command(
+        f"INSERT INTO {schema}.tbl VALUES ({promoted_val}, {promoted_b});", pg_conn
+    )
+    pg_conn.commit()
+
+    # verify all data is readable
+    results = run_query(f"SELECT a, b FROM {schema}.tbl ORDER BY b ASC", pg_conn)
+    assert len(results) == 2
+    assert str(results[0][0]) == initial_val
+    assert results[0][1] == initial_b
+    assert str(results[1][0]) == promoted_val
+    assert results[1][1] == promoted_b
+
+    # verify REST catalog metadata reflects the type change
+    metadata = get_rest_table_metadata(schema, "tbl", superuser_conn)
+    schemas = metadata["metadata"].get("schemas", [])
+    last_schema = schemas[-1]
+    field_a = next(f for f in last_schema["fields"] if f["name"] == "a")
+    assert (
+        expected_rest_type in field_a["type"]
+    ), f"Expected '{expected_rest_type}' in REST type but got {field_a['type']}"
+
+    assert_metadata_on_pg_catalog_and_rest_matches(schema, "tbl", superuser_conn)
+
+    run_command(f"DROP SCHEMA {schema} CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_rest_alter_column_type_disallowed_promotions(
+    pg_conn,
+    installcheck,
+    s3,
+    extension,
+    create_types_helper_functions,
+    with_default_location,
+    polaris_session,
+    set_polaris_gucs,
+    create_http_helper_functions,
+):
+    """Test that disallowed type promotions are rejected for REST catalog Iceberg tables"""
+    if installcheck:
+        return
+
+    run_command("CREATE SCHEMA rest_type_promo_dis;", pg_conn)
+    run_command(
+        """
+        CREATE TABLE rest_type_promo_dis.tbl (
+            a int,
+            b bigint,
+            c double precision,
+            d numeric(10,2)
+        ) USING iceberg WITH (catalog='rest');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    disallowed_cases = [
+        ("a", "varchar(255)", "int to varchar"),
+        ("b", "int", "bigint to int"),
+        ("c", "real", "double to float"),
+        ("d", "numeric(10,3)", "decimal scale change"),
+        ("d", "numeric(8,2)", "decimal precision narrowing"),
+        ("a", "real", "int to real"),
+    ]
+
+    for col, new_type, description in disallowed_cases:
+        error = run_command(
+            f"ALTER TABLE rest_type_promo_dis.tbl ALTER COLUMN {col} TYPE {new_type};",
+            pg_conn,
+            raise_error=False,
+        )
+        assert error is not None, f"Expected error for {description}"
+        assert "not supported" in str(
+            error
+        ), f"Expected 'not supported' error for {description}, got: {error}"
+        assert "Allowed type promotions for Iceberg tables are" in str(
+            error
+        ), f"Expected detail message for {description}, got: {error}"
+        pg_conn.rollback()
+
+    run_command("DROP SCHEMA rest_type_promo_dis CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_rest_alter_column_type_with_insert_after(
+    pg_conn,
+    superuser_conn,
+    installcheck,
+    s3,
+    extension,
+    create_types_helper_functions,
+    with_default_location,
+    polaris_session,
+    set_polaris_gucs,
+    create_http_helper_functions,
+):
+    """Test type promotion followed by data insert and read on REST catalog table"""
+    if installcheck:
+        return
+
+    run_command("CREATE SCHEMA rest_type_promo_ins;", pg_conn)
+    run_command(
+        """
+        CREATE TABLE rest_type_promo_ins.tbl (a int, b real, c int)
+        USING iceberg WITH (catalog='rest');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        "INSERT INTO rest_type_promo_ins.tbl VALUES (1, 1.5, 10);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # promote multiple columns in the same transaction
+    run_command(
+        "ALTER TABLE rest_type_promo_ins.tbl ALTER COLUMN a TYPE bigint;",
+        pg_conn,
+    )
+    run_command(
+        "ALTER TABLE rest_type_promo_ins.tbl ALTER COLUMN b TYPE double precision;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # insert data with promoted types
+    run_command(
+        f"INSERT INTO rest_type_promo_ins.tbl VALUES ({2**40}, 1.23456789012345, 20);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    results = run_query(
+        "SELECT a, b, c FROM rest_type_promo_ins.tbl ORDER BY c ASC", pg_conn
+    )
+    assert results == [[1, 1.5, 10], [2**40, 1.23456789012345, 20]]
+
+    assert_metadata_on_pg_catalog_and_rest_matches(
+        "rest_type_promo_ins", "tbl", superuser_conn
+    )
+
+    run_command("DROP SCHEMA rest_type_promo_ins CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
 def test_add_column_with_check_constraint(
     pg_conn,
     superuser_conn,
@@ -4272,7 +4495,9 @@ def assert_schemas_equal(namespace, table_name, superuser_conn, metadata):
             "bool": "boolean",
             "boolean": "boolean",
             "float": "float",
+            "real": "float",
             "double": "double",
+            "double precision": "double",
             "str": "string",
             "string": "text",
             "timestamp_tz": "timestamp_tz",
@@ -4283,8 +4508,11 @@ def assert_schemas_equal(namespace, table_name, superuser_conn, metadata):
             "uuid": "uuid",
             "binary": "binary",
             "decimal": "decimal",
+            "numeric": "decimal",
         }
-        return aliases.get(t, t)
+        # strip precision/scale from parameterized types like "decimal(20, 2)"
+        base = t.split("(")[0].strip()
+        return aliases.get(base, t)
 
     # schema checks
     schemas = metadata["metadata"].get("schemas", [])

--- a/test_common/helpers/iceberg.py
+++ b/test_common/helpers/iceberg.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import tempfile
 import time
 from pathlib import Path
@@ -801,3 +802,36 @@ def adjust_object_store_settings(superuser_conn):
     # otherwise the next test can see the still-set ALTER SYSTEM value
     run_command("SELECT pg_sleep(0.1)", superuser_conn)
     superuser_conn.commit()
+
+
+def assert_iceberg_schemas_equal(left_json, right_json, label=""):
+    """Compare the full schemas array from two Iceberg metadata JSONs.
+
+    Both engines should produce the same number of schema versions with
+    matching field definitions.  Field IDs and schema-ids are ignored
+    because they may be assigned differently by each engine.
+    """
+    def _norm_fields(fields):
+        return [
+            (f["name"],
+             re.sub(r"\s+", "", f["type"]) if isinstance(f["type"], str) else f["type"],
+             f.get("required", False))
+            for f in fields
+        ]
+
+    left_schemas = left_json["schemas"]
+    right_schemas = right_json["schemas"]
+
+    assert len(left_schemas) == len(right_schemas), (
+        f"[{label}] schema count mismatch: "
+        f"left has {len(left_schemas)}, right has {len(right_schemas)}"
+    )
+
+    for idx, (ls, rs) in enumerate(zip(left_schemas, right_schemas)):
+        left_fields = _norm_fields(ls["fields"])
+        right_fields = _norm_fields(rs["fields"])
+        assert left_fields == right_fields, (
+            f"[{label}] schema #{idx} field mismatch:\n"
+            f"  left:  {left_fields}\n"
+            f"  right: {right_fields}"
+        )


### PR DESCRIPTION
We should support schema type evolution according to [iceberg spec v2](https://iceberg.apache.org/spec/#schema-evolution), our current iceberg implementation. This should not require data file rewrite, but metadata-only operation.

- [x] make sure partition values of the existing files are interpreted correctly (the same value in old type) with the new type.
- [x] make sure data file stats of the existing files are interpreted correctly (the same value in old type) with the new type.
- [x] make sure to support all catalogs: postgres, rest and object_store.
- [x] add spark test
- [x] disallow it if it specifies "SET TYPE USING (expression)" syntax as this might require data file rewrite

Closes #222.