### PR TITLE
Add automated installation script and improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Users connect only to PostgreSQL. The pg_lake extensions transparently delegate 
 ### First-time build
 ```bash
 # Install vcpkg dependencies (required once)
-export VCPKG_VERSION=2025.12.12
+export VCPKG_VERSION=2025.10.17
 git clone --recurse-submodules --branch $VCPKG_VERSION https://github.com/Microsoft/vcpkg.git
 ./vcpkg/bootstrap-vcpkg.sh
 ./vcpkg/vcpkg install azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl
@@ -188,6 +188,69 @@ pg_lake_benchmark (optional, for benchmarking)
 - `docs/query-data-lake-files.md`: Foreign table usage
 - `docs/data-lake-import-export.md`: COPY command usage
 
+## Maintaining Installation Documentation
+
+### Overview
+The repository provides both automated installation (`install.sh`) and comprehensive manual documentation (`docs/building-from-source.md`). These must be kept in sync when dependencies or build steps change.
+
+### install.sh
+- **Location**: `install.sh` at repository root
+- **Purpose**: Automated installation script for developers to quickly set up pg_lake environments
+- **Capabilities**:
+  - Installs to existing PostgreSQL (default) or builds PostgreSQL from source (--build-postgres)
+  - Installs vcpkg and Azure SDK dependencies
+  - Builds and installs pg_lake extensions
+  - Optionally installs test dependencies: PostGIS, pgAudit, pg_cron, azurite, pipenv, Java 21+, JDBC driver
+  - Initializes PostgreSQL database cluster
+- **Platform support**: RHEL/AlmaLinux, Debian/Ubuntu, macOS
+
+### docs/building-from-source.md
+- **Location**: `docs/building-from-source.md`
+- **Purpose**: Comprehensive manual installation guide with both automated and manual approaches
+- **Structure**:
+  1. Quick Start - points to install.sh for common cases
+  2. Manual installation to existing PostgreSQL - minimal steps for users with PostgreSQL already installed
+  3. Full development environment setup - detailed manual steps for building everything from source
+  4. Test dependencies - optional components for running test suite
+  5. Running tests - how to execute pytest suites
+
+### When to Update Both Files
+
+**System dependencies change:**
+- Update package lists in both `install.sh` (install_system_deps function) and `docs/building-from-source.md` (System Dependencies section)
+- Ensure all three platforms (Debian, RHEL, macOS) are updated consistently
+
+**PostgreSQL build process changes:**
+- Update `install.sh` (install_postgres function) and `docs/building-from-source.md` (Build PostgreSQL from Source section)
+- Keep configure flags, contrib modules, and test modules in sync
+
+**vcpkg or Azure SDK versions change:**
+- Update VCPKG_VERSION variable in `install.sh`, `docs/building-from-source.md`, and this CLAUDE.md file
+- Update vcpkg package names if they change
+
+**New test dependencies:**
+- Add to `install.sh` (install_test_deps function)
+- Add to `docs/building-from-source.md` (Test Dependencies section)
+- Update the installation checks to be idempotent (skip if already installed)
+
+**pg_lake build process changes:**
+- Usually handled by Makefile, but if manual steps needed, document in `docs/building-from-source.md`
+
+### Testing install.sh Changes
+Before committing changes to install.sh:
+1. Test on a clean environment if possible
+2. Test with both `--build-postgres` (full dev setup) and without (existing PostgreSQL)
+3. Test `--with-test-deps` flag to ensure all test dependencies install correctly
+4. Verify idempotency - running the script twice should not fail or duplicate work
+5. Check that the summary output shows correct environment variables and next steps
+
+### Documentation Best Practices
+- Keep install.sh focused on automation - don't add extensive comments explaining "why", put that in the docs
+- Keep docs/building-from-source.md comprehensive - explain the "why" behind each step
+- When adding new flags to install.sh, document them in the "Development Environment Options" section of the docs
+- System dependency lists should match exactly across install.sh and docs for each platform
+- Test the manual instructions in docs/building-from-source.md periodically to ensure they still work
+
 ## Code Conventions
 
 ### C code (PostgreSQL extensions and pgduck_server)
@@ -306,6 +369,6 @@ pg_lake_iceberg.default_location_prefix = 's3://bucket/prefix'
 
 ## CI and Testing Notes
 
-- JDBC driver path must be set for Spark verification tests: `JDBC_DRIVER_PATH=/usr/share/java/postgresql.jar`
-- Java 21+ required for Polaris REST catalog tests
-- Azure tests require `azurite` (install via npm: `npm install -g azurite`)
+- JDBC driver path must be set for Spark verification tests: `JDBC_DRIVER_PATH=~/pg_lake-deps/jdbc/postgresql-42.7.10.jar` (automatically installed by `./install.sh --with-test-deps`)
+- Java 21+ required for Polaris REST catalog tests (automatically installed by `./install.sh --with-test-deps`)
+- Azure tests require `azurite` (install via npm: `npm install -g azurite`, or use `./install.sh --with-test-deps`)

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -1,10 +1,243 @@
 # Building from source
 
+This guide covers installing pg_lake from source. For Docker-based setup, see [docker/LOCAL_DEV.md](../docker/LOCAL_DEV.md).
+
+## Add pg_lake to an Existing PostgreSQL Installation
+
+If you already have PostgreSQL 16, 17, or 18 installed, you can add pg_lake extensions using the automated installation script:
+
+```bash
+# Clone the repository
+git clone --recurse-submodules https://github.com/snowflake-labs/pg_lake.git
+cd pg_lake
+
+# Install pg_lake to your existing PostgreSQL
+# Or see "Manual Installation to Existing PostgreSQL" section below
+./install.sh
+
+# Start pgduck_server (required for pg_lake)
+pgduck_server --cache_dir /tmp/pg_lake_cache/
+
+# In another terminal, create the extensions
+psql -c "CREATE EXTENSION pg_lake CASCADE;"
+```
+
+**What this does:**
+1. Detects your existing PostgreSQL installation via `pg_config`
+2. Installs vcpkg and Azure SDK dependencies
+3. Builds and installs pg_lake extensions to your PostgreSQL installation
+4. Prints next steps for configuring and using pg_lake
+
+**Note:** System build dependencies are skipped by default (assuming they're installed if PostgreSQL exists). Use `--with-system-deps` if needed.
+
+**Prerequisites:**
+- PostgreSQL 16, 17, or 18 installed with `pg_config` in your PATH
+- `shared_preload_libraries = 'pg_extension_base'` in postgresql.conf ([see setup](#configure-postgresql))
+
+For manual installation steps, see [Manual Installation to Existing PostgreSQL](#manual-installation-to-existing-postgresql).
+
+## Full Development Environment Setup
+
+For pg_lake development (includes building PostgreSQL from source with debug symbols and test dependencies):
+
+```bash
+# Clone the repository
+git clone --recurse-submodules https://github.com/snowflake-labs/pg_lake.git
+cd pg_lake
+
+# Build complete development environment (PostgreSQL 18 from source, vcpkg, pg_lake, test deps)
+./install.sh --build-postgres --with-test-deps
+
+# Add PostgreSQL to your PATH
+export PATH=$HOME/pgsql/18/bin:$PATH
+
+# Start PostgreSQL
+pg_ctl -D $HOME/pgsql/18/data -l $HOME/pgsql/18/data/logfile start
+
+# Start pgduck_server (required for pg_lake)
+pgduck_server --cache_dir /tmp/pg_lake_cache/
+
+# In another terminal, create the extensions
+psql postgres -c "CREATE EXTENSION pg_lake CASCADE;"
+```
+
+For more options and control, see [Development Environment Options](#development-environment-options) below.
+
 ## Prerequisites
 
-To build `pg_lake`, you will need to install PostgreSQL and a few dependencies. For development, we recommend building PostgreSQL from source to get debug symbols and assertions. It also lets you install into your home directory to avoid needing superuser for a `make install`.
+**For adding to existing PostgreSQL:**
+- PostgreSQL 16, 17, or 18 with `pg_config` in PATH
+- Git, C/C++ compiler, CMake, Ninja
+- Internet connection
 
-## Install build dependencies for Debian based distros
+**For full development environment:**
+- All of the above
+- Python 3.11+ (for tests)
+- Additional system packages (automatically installed by installation script)
+
+The installation script will install all required build dependencies automatically. If you prefer to install dependencies manually, see the [Manual Development Environment Setup](#manual-development-environment-setup) section.
+
+## Configure PostgreSQL
+
+Before using pg_lake, you need to add `pg_extension_base` to PostgreSQL's `shared_preload_libraries`:
+
+```bash
+# Add to postgresql.conf
+echo "shared_preload_libraries = 'pg_extension_base'" >> $PGDATA/postgresql.conf
+
+# Or edit postgresql.conf manually to add:
+# shared_preload_libraries = 'pg_extension_base'
+
+# Restart PostgreSQL for the change to take effect
+pg_ctl restart -D $PGDATA
+```
+
+## Manual Installation to Existing PostgreSQL
+
+If you prefer to install pg_lake manually to your existing PostgreSQL installation:
+
+### Install Build Dependencies
+
+First, ensure you have the necessary build tools. For detailed system dependencies by platform, see the [Manual Development Environment Setup](#manual-development-environment-setup) section.
+
+**Minimum requirements:**
+```bash
+# Debian/Ubuntu
+sudo apt-get install -y build-essential cmake ninja-build git pkg-config curl python3-dev
+
+# RHEL/AlmaLinux
+sudo dnf install -y cmake ninja-build git pkgconfig curl gcc-c++ python3-devel
+
+# macOS
+brew install cmake ninja git pkg-config curl python@3
+
+# Note: For macOS, vcpkg requires cmake 3.31.1 (not the latest version)
+# See Manual Development Environment Setup for installation instructions
+```
+
+**Note for macOS users:** vcpkg has compatibility issues with the latest cmake. You need cmake 3.31.1. See the [macOS section](#macos) in Manual Development Environment Setup for installation instructions.
+
+### Install vcpkg and Azure SDK
+
+```bash
+# Install vcpkg
+export VCPKG_VERSION=2025.10.17
+git clone --recurse-submodules --branch $VCPKG_VERSION https://github.com/Microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh
+
+# Install Azure SDK packages (this may take a while)
+./vcpkg/vcpkg install azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl
+
+# Set environment variable
+export VCPKG_TOOLCHAIN_PATH="$(pwd)/vcpkg/scripts/buildsystems/vcpkg.cmake"
+```
+
+### Build and Install pg_lake
+
+```bash
+# Clone pg_lake
+git clone --recurse-submodules https://github.com/snowflake-labs/pg_lake.git
+cd pg_lake
+
+# Ensure pg_config is in PATH
+which pg_config
+
+# Build and install (first build will be slow due to DuckDB compilation)
+make install
+
+# For subsequent builds, use install-fast to skip rebuilding DuckDB
+make install-fast
+```
+
+### Start pgduck_server and Use pg_lake
+
+```bash
+# Set up AWS credentials (recommended)
+aws configure
+
+# Start pgduck_server (required for pg_lake)
+pgduck_server --cache_dir /tmp/pg_lake_cache/
+
+# In another terminal, create extensions
+psql -c "CREATE EXTENSION pg_lake CASCADE;"
+psql -c "SET pg_lake_iceberg.default_location_prefix TO 's3://your-bucket/pglake';"
+```
+
+## Development Environment Options
+
+The `install.sh` script provides flexible installation options:
+
+**Default behavior:** Installs pg_lake to an existing PostgreSQL installation (detects via `pg_config`)
+
+**With `--build-postgres`:** Builds PostgreSQL from source with debug symbols and initializes a database cluster
+
+### Basic Usage
+
+```bash
+# Install to existing PostgreSQL (default)
+./install.sh
+
+# Install with test dependencies
+./install.sh --with-test-deps
+
+# Build PostgreSQL 18 from source + pg_lake
+./install.sh --build-postgres
+
+# Build PostgreSQL 17 from source with test dependencies
+./install.sh --build-postgres --pg-version 17 --with-test-deps
+
+# Use multiple CPU cores for faster builds
+./install.sh --jobs 16
+```
+
+### Common Scenarios
+
+**Install only pg_lake (skip dependency installation):**
+
+```bash
+# Assumes vcpkg already installed
+./install.sh --skip-vcpkg
+```
+
+**Install with system dependencies:**
+
+```bash
+# If you need to install system build tools (cmake, ninja, etc.)
+./install.sh --with-system-deps
+```
+
+**Custom PostgreSQL installation prefix:**
+
+```bash
+# When building PostgreSQL from source
+./install.sh --build-postgres --prefix /opt/pgsql
+```
+
+### All Options
+
+Run `./install.sh --help` to see all available options:
+
+```
+--build-postgres            Build PostgreSQL from source and initialize database
+--pg-version VERSION        PostgreSQL version to build (16, 17, or 18) [default: 18]
+--prefix DIR                PostgreSQL installation prefix [default: auto-detect or $HOME/pgsql]
+--deps-dir DIR              Directory for dependencies [default: $HOME/pg_lake-deps]
+--jobs N                    Number of parallel build jobs [default: nproc]
+
+--with-system-deps          Install system build dependencies (auto-enabled with --build-postgres)
+--skip-vcpkg                Skip vcpkg and Azure SDK installation
+--skip-pg-lake              Skip building pg_lake extensions
+
+--with-test-deps            Install optional test dependencies (PostGIS, pgAudit, pg_cron, azurite)
+```
+
+## Manual Development Environment Setup
+
+If you prefer to set up a complete development environment manually (including building PostgreSQL from source), follow these steps.
+
+### Install System Build Dependencies
+
+#### Debian/Ubuntu
 
 ```bash
 apt-get update && \
@@ -36,14 +269,18 @@ apt-get install -y \
     libtool \
     libjansson-dev \
     libcurl4-openssl-dev \
+    libpam0g-dev \
     curl \
     patch \
     g++ \
     libipc-run-perl \
-    jq
+    jq \
+    git \
+    pkg-config \
+    python3-dev
 ```
 
-## Install build dependencies for RHEL based distros
+#### RHEL/AlmaLinux/Rocky Linux
 
 ```bash
 dnf -y update && \
@@ -76,15 +313,22 @@ dnf -y install \
     jansson-devel \
     jq \
     libcurl-devel \
+    pam-devel \
     patch \
     which \
-    gcc-c++
+    gcc-c++ \
+    git \
+    pkgconfig \
+    python3-devel
 ```
 
-## Install build dependencies for MacOS
+#### macOS
 
 ```bash
+# Install Xcode Command Line Tools
 xcode-select --install
+
+# Install Homebrew packages
 brew update
 brew install \
     cmake \
@@ -111,105 +355,172 @@ brew install \
     diffutils \
     jq \
     ossp-uuid \
-    perl
+    perl \
+    pkg-config \
+    python@3
 
-# --- Configure environment variables for compilers ---
-export PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/flex/bin:$PATH"
-export LDFLAGS="-L/opt/homebrew/opt/icu4c/lib -L/opt/homebrew/opt/openssl@3/lib"
-export CPPFLAGS="-I/opt/homebrew/opt/icu4c/include -I/opt/homebrew/opt/openssl@3/include"
-export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig"
-
-```
-
-## pg_lake build and install steps
-After installing os specific build dependencies, you can follow below steps. The first time you build `pg_lake`, you'll need to build `duckdb_pglake` (a DuckDB extension). Unfortunately, building a DuckDB extension also involves building DuckDB, which can take a while. Additionally, building `pg_lake` requires `vcpkg` to manage dependencies for DuckDB extensions.
-
-```bash
-# install vcpkg dependencies
-export VCPKG_VERSION=2025.10.17 && \
-git clone --recurse-submodules --branch $VCPKG_VERSION https://github.com/Microsoft/vcpkg.git && \
-./vcpkg/bootstrap-vcpkg.sh && \
-./vcpkg/vcpkg install azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl && \
-export VCPKG_TOOLCHAIN_PATH="$(pwd)/vcpkg/scripts/buildsystems/vcpkg.cmake"
-
-# Make sure pg_config is in your PATH (e.g. export PATH=$HOME/pgsql-18/bin:$PATH):
-
-# Optionally, enable delta (read-only) support
-export PG_LAKE_DELTA_SUPPORT=1
-
-# install pg_lake extensions
-git clone --recurse-submodules https://github.com/snowflake-labs/pg_lake.git && \
-cd pg_lake && make install
-```
-
-**NOTE:** Run `make install-fast` instead of `make install` to skip rebuilding DuckDB if you have already built it once. This will significantly speed up the installation process.
-
-For MacOS to work with `vcpkg`, you will need to install `cmake` via `brew`, however you cannot use the latest version of CMake, due to compatibility issues with other DuckDB plugins.  To install a known-working version of `cmake` using `brew`, run the following:
-
-```bash
+# Install cmake 3.31.1 for vcpkg compatibility
 brew tap-new $USER/local-cmake
 brew tap homebrew/core --force
 brew extract --version=3.31.1 cmake $USER/local-cmake
 brew install $USER/local-cmake/cmake@3.31.1
+
+# Configure environment variables for compilers
+export PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/flex/bin:$PATH"
+export LDFLAGS="-L/opt/homebrew/opt/icu4c/lib -L/opt/homebrew/opt/openssl@3/lib"
+export CPPFLAGS="-I/opt/homebrew/opt/icu4c/include -I/opt/homebrew/opt/openssl@3/include"
+export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig"
 ```
 
-### Setting up PostgreSQL
+**Note for macOS:** For vcpkg to work correctly with DuckDB plugins, you cannot use the latest version of CMake. The commands above install a known-working version (3.31.1).
 
-pg_lake is supported with PostgreSQL 16, 17 and 18.
+### Build PostgreSQL from Source
 
-You might need to configure Postgres with necessary args and flags. Below is an example for Postgres 18 on MacOS, with debugging flags and needed libraries:
+pg_lake is supported with PostgreSQL 16, 17, and 18. For development, we recommend building PostgreSQL from source to get debug symbols and assertions.
+
 ```bash
-./configure --prefix=$HOME/pgsql/18 --enable-cassert --enable-debug --enable-injection-points CFLAGS="-ggdb -O0 -fno-omit-frame-pointer" CPPFLAGS="-g -O0" --with-lz4 --with-icu --with-zstd --with-libxslt --with-libxml --with-readline --with-openssl --with-includes=/opt/homebrew/include/ --with-libraries=/opt/homebrew/lib PG_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+# Clone PostgreSQL (version 18 example)
+git clone https://github.com/postgres/postgres.git -b REL_18_STABLE
+cd postgres
+
+# Configure (Linux example)
+./configure \
+    --prefix=$HOME/pgsql/18 \
+    --enable-injection-points \
+    --enable-tap-tests \
+    --enable-debug \
+    --enable-cassert \
+    --enable-depend \
+    CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" \
+    --with-openssl \
+    --with-libxml \
+    --with-libxslt \
+    --with-icu \
+    --with-lz4 \
+    --with-pam \
+    --with-python
+
+# Configure (macOS example)
+./configure \
+    --prefix=$HOME/pgsql/18 \
+    --enable-injection-points \
+    --enable-tap-tests \
+    --enable-debug \
+    --enable-cassert \
+    --enable-depend \
+    CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" \
+    --with-openssl \
+    --with-libxml \
+    --with-libxslt \
+    --with-icu \
+    --with-lz4 \
+    --with-python \
+    --with-readline \
+    --with-includes=/opt/homebrew/include/ \
+    --with-libraries=/opt/homebrew/lib \
+    PG_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+
+# Build and install
 make -j 16 && make install
 
-# btree_gist needed for CREATE EXTENSION pg_lake CASCADE
-make -C contrib/btree_gist
-make -C contrib/btree_gist install
+# Install all contrib modules (includes auto_explain, pg_stat_statements, btree_gist, etc.)
+make -C contrib install
+
+# Install test modules (optional, for test suite)
+make -C src/test/modules/injection_points install
+make -C src/test/isolation install
+
+# Add PostgreSQL to PATH
+export PATH=$HOME/pgsql/18/bin:$PATH
 ```
 
-To create a new PostgreSQL database directory, run initdb: 
+### Install vcpkg and Azure SDK Dependencies
+
+pg_lake requires vcpkg for managing Azure SDK dependencies:
 
 ```bash
-$ which initdb
-$ HOME/pgsql/18/bin/initdb
-$ initdb -k -D $HOME/pgsql/18/datastore --locale=C.UTF-8
-...snip...
-Success. You can now start the database server using:
+# Install vcpkg
+export VCPKG_VERSION=2025.10.17
+git clone --recurse-submodules --branch $VCPKG_VERSION https://github.com/Microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh
 
-    pg_ctl -D $HOME/pgsql/18/datastore -l logfile start
+# Install Azure SDK packages (this may take a while)
+./vcpkg/vcpkg install azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl
+
+# Set environment variable for pg_lake build
+export VCPKG_TOOLCHAIN_PATH="$(pwd)/vcpkg/scripts/buildsystems/vcpkg.cmake"
 ```
 
-To set up PgLake, you need to add `pg_extension_base` to `shared_preload_libraries`, which will load other modules as needed.
-```
-echo "shared_preload_libraries = 'pg_extension_base'" >> ~/<path_to_conf_file>/postgresql.conf
-```
+### Build and Install pg_lake
 
-### Using `pg_lake`
-
-To use `pg_lake`, you need to make sure `pgduck_server` is running.
 ```bash
-# Recommended to set up AWS credentials first:
+# Clone pg_lake repository
+git clone --recurse-submodules https://github.com/snowflake-labs/pg_lake.git
+cd pg_lake
+
+# Make sure pg_config is in your PATH
+export PATH=$HOME/pgsql/18/bin:$PATH
+
+# Build and install pg_lake
+# First build will be slow due to DuckDB compilation
+make install
+
+# For subsequent builds, use install-fast to skip rebuilding DuckDB
+make install-fast
+```
+
+**Note:** The first `make install` will take a while because it needs to build DuckDB. Subsequent builds can use `make install-fast` to skip rebuilding DuckDB if it hasn't changed.
+
+### Initialize PostgreSQL Database
+
+```bash
+# Create a new database cluster
+initdb -k -D $HOME/pgsql/18/data --locale=C.UTF-8
+
+# Configure shared_preload_libraries
+echo "shared_preload_libraries = 'pg_extension_base'" >> $HOME/pgsql/18/data/postgresql.conf
+
+# Start PostgreSQL
+pg_ctl -D $HOME/pgsql/18/data -l $HOME/pgsql/18/data/logfile start
+```
+
+### Start pgduck_server and Use pg_lake
+
+To use pg_lake, you need to have `pgduck_server` running:
+
+```bash
+# (Recommended) Set up AWS credentials first
 aws configure
 
-export PATH=$HOME/pgsql/18/bin:$PATH
-pgduck_server
+# Start pgduck_server
+pgduck_server --cache_dir /tmp/pg_lake_cache/
 ```
 
 Unless you are making changes to `pgduck_server`, it is generally ok to keep an unrelated instance running.
 
-You can use `psql` to create `pg_lake` extensions and start using its features:
+Connect to PostgreSQL and create the pg_lake extensions:
 
 ```sql
 CREATE EXTENSION pg_lake CASCADE;
+
+-- Set S3 location for Iceberg tables
+SET pg_lake_iceberg.default_location_prefix TO 's3://your-bucket/pglake';
+
+-- Test with a simple Iceberg table
+CREATE TABLE test(id int, name text) USING iceberg;
+INSERT INTO test VALUES (1, 'Alice'), (2, 'Bob');
+SELECT * FROM test;
+
+-- Test COPY to Parquet
 \copy (select s x, s y from generate_series(1,10) s) to '/tmp/xy.parquet' with (format 'parquet')
 ```
 
-### Running pgduck_server under a separate Linux user
+### Running pgduck_server under a Separate Linux User
 
-It is possible to run `pgduck_server` under a separate Linux user by setting permissions on the database directory after initialization. If postgres is running under the `postgres` user, the simplest approach is to add the pgduck user to the postgres group.
+It is possible to run `pgduck_server` under a separate Linux user by setting permissions on the database directory. If postgres is running under the `postgres` user, the simplest approach is to add the pgduck user to the postgres group.
 
 ```bash
-# Create pgduck and add it to the postgres group
+# Create pgduck user and add it to the postgres group
 sudo adduser pgduck
 sudo usermod -a -G postgres pgduck
 
@@ -219,60 +530,56 @@ export PGDATA=/home/postgres/18/
 initdb -D $PGDATA -g --locale=C.UTF-8
 # or: chmod 750 $PGDATA $PGDATA/base
 
-# Make sure pgsql_tmp directory exists (gets created automatically, otherwise)
+# Make sure pgsql_tmp directory exists
 mkdir -p $PGDATA/base/pgsql_tmp
 
-# Allow group to read and write pgsql_tmp and all files created within it
+# Allow group to read and write pgsql_tmp
 chmod 2770 $PGDATA/base/pgsql_tmp
 
-# Make sure pgduck can execute pgduck_server binary, has credentials set up
-
-# Run pgduck_server as pgduck, set postgres as the unix socket group owner
+# Run pgduck_server as pgduck user with postgres as unix socket group
 sudo su pgduck -c "pgduck_server --unix_socket_group postgres --duckdb_database_file_path /cache/duckdb.db --cache_dir /cache/files"
 ```
 
-Verify whether COPY in Parquet format to/from stdout/stdin and S3 all work.
+Verify that COPY in Parquet format to/from stdout/stdin and S3 all work.
 
+## Test Environment Setup
 
-## Regression tests
+To run the full test suite, you need to install additional dependencies. These are optional if you only want to use pg_lake.
 
-First, let's get ready for running the tests.
+### Test Dependencies
 
-### Test Prerequisites
-You need to follow below instructions to successfully run all tests locally:
+- **Python 3.11+** with pipenv
+- **PostGIS** (dependency of pg_lake_spatial)
+- **pgAudit** (used in test suite)
+- **pg_cron** (used in test suite)
+- **Java 21+** (for Spark verification tests and Polaris catalog tests)
+- **PostgreSQL JDBC driver** (for Spark tests)
+- **azurite** (for Azure storage tests)
 
-- You need to install `pipenv` with >= python3.11 to run tests. Be careful to install correct python version if not exists e.g. ```apt install python3.11```. Then you should make sure you use it while creating pipenv environment. (e.g. ```pipenv --python 3.11```)
-- You need to have `pgaudit` extension installed
-- You need to install `jdk21` and `jdbc driver for Postgres`, then export `JDBC_DRIVER_PATH`. (required to run tests where we verify pg_lake_iceberg table results on spark)
-- You need to have JAVA 21 (or higher) installed to run tests with Polaris catalog
-- You need to have `pg_cron` installed.
-
-Build PostgreSQL from source:
+The automated installation script can install these for you:
 
 ```bash
-# IPC::Run module needed for --enable-tap-tests, MacOS command
-brew install cpanminus
-cpanm IPC::Run
-
-# configure and build PG from source
-git clone git@github.com:postgres/postgres.git -b REL_18_STABLE
-cd postgres
-./configure --enable-injection-points --enable-tap-tests --enable-debug --enable-cassert --enable-depend CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" --with-openssl --with-libxml --with-libxslt --with-icu --with-lz4 --with-python --prefix=$HOME/pgsql/18/
-make -j 16 && make install
-
-# install relevant test packages
-make -C src/test/modules/injection_points install
-make -C src/test/isolation install
-
-# use the same prefix as Postgres' configure
-# add isolation-tester to the PATH
-export PATH=$HOME/pgsql/18/lib/pgxs/src/test/isolation:$PATH
+./install.sh --with-test-deps
 ```
 
-Build PostGIS (dependency of pg_lake_spatial (install postgis before `make install-pg_lake_spatial`)):
+Or install them manually:
+
+### Install Python Dependencies
 
 ```bash
-git clone git@github.com:postgis/postgis.git
+# Install pipenv (if not already installed)
+pip3 install --user pipenv
+
+# Install test dependencies
+pipenv install --dev
+```
+
+### Build PostGIS
+
+PostGIS is required for pg_lake_spatial extension:
+
+```bash
+git clone https://github.com/postgis/postgis.git
 cd postgis
 ./autogen.sh
 ./configure --prefix=$HOME/pgsql/18/
@@ -280,15 +587,19 @@ make -j 16
 make install
 ```
 
-Build pgaudit (used in test suite):
+### Build pgAudit
+
+pgAudit is used in the test suite:
 
 ```bash
-git clone git@github.com:pgaudit/pgaudit.git
+git clone https://github.com/pgaudit/pgaudit.git
 cd pgaudit
 make USE_PGXS=1 install
-``` 
+```
 
-Build pg_cron:
+### Build pg_cron
+
+pg_cron is used in the test suite:
 
 ```bash
 git clone https://github.com/citusdata/pg_cron.git
@@ -296,137 +607,218 @@ cd pg_cron
 make install
 ```
 
-Azure tests use azurite, which needs to be installed via npm.
+### Install azurite (for Azure Tests)
+
+Azure tests use azurite, which requires Node.js and npm:
 
 ```bash
-# On Ubuntu
-sudo apt-get -y install nodejs npm
+# Ubuntu/Debian
+sudo apt-get install -y nodejs npm
 
-# On RHEL
-sudo yum install -y nodejs npm
+# RHEL/AlmaLinux
+sudo dnf install -y nodejs npm
 
-# On MacOS
+# macOS
 brew install node
 
-# Afterwards
+# Install azurite
 npm install -g azurite
 ```
 
-### Running tests
+### Java and JDBC Driver
 
+Some tests verify pg_lake_iceberg table results using Apache Spark, which requires Java 21+ and the PostgreSQL JDBC driver.
 
-We primarily use pytest for regression tests. You first need to install the required packages via pipenv: 
+**Note:** `./install.sh --with-test-deps` automatically installs Java 21+ and downloads the JDBC driver for you.
+
+To install manually:
 
 ```bash
-pipenv install --dev
+# Install Java 21 or higher
+# Ubuntu/Debian
+sudo apt-get install -y openjdk-21-jdk
+
+# RHEL/AlmaLinux (install -devel package for full JDK including javac)
+sudo dnf install -y java-21-openjdk-devel
+
+# macOS
+brew install openjdk@21
+
+# Download PostgreSQL JDBC driver (version 42.7.10)
+mkdir -p ~/pg_lake-deps/jdbc
+curl -L -o ~/pg_lake-deps/jdbc/postgresql-42.7.10.jar \
+  https://jdbc.postgresql.org/download/postgresql-42.7.10.jar
+
+# Set environment variable (add to ~/.bashrc or ~/.zshrc):
+export JDBC_DRIVER_PATH=~/pg_lake-deps/jdbc/postgresql-42.7.10.jar
 ```
 
-You can then run tests using:
+## Running Tests
+
+We primarily use pytest for regression tests.
+
+### Run All Tests
 
 ```bash
+# Run all local tests
 make check
+
+# Run end-to-end tests (requires S3/cloud access)
+make check-e2e
+
+# Run upgrade tests
+make check-upgrade
 ```
 
-You can also run installcheck locally using:
+### Run Component-Specific Tests
 
 ```bash
-pgduck_server/pgduck_server --init_file_path pgduck_server/tests/test_secrets.sql --cache_dir /tmp/cache &
-make installcheck
+# Test specific extensions
+make check-pg_lake_table
+make check-pg_lake_iceberg
+make check-pgduck_server
+
+# Run isolation tests
+make check-isolation_pg_lake_table
 ```
 
-Note that there are several PostgreSQL settings that may affect the installcheck result (e.g. timezone, `pg_lake_iceberg.default_location_prefix`).
+### Run Individual Pytest Tests
 
+```bash
+cd pg_lake_table
+PYTHONPATH=../test_common pipenv run pytest -v tests/pytests/test_specific.py
+PYTHONPATH=../test_common pipenv run pytest -v tests/pytests/test_specific.py::test_function_name
+```
 
-### Running PostgreSQL tests with our extensions
+### Run installcheck Tests
 
-We also run `postgres installcheck` with our extensions created. That makes us sure that we do not break regular Postgres behavior. The make target for it is `installcheck-postgres`. You need to `export PG_REGRESS_DIR=<pg_src_dir>/test/regress` and set some GUCS before running the tests as shown below:
+installcheck tests run against installed extensions in a running PostgreSQL instance:
+
+```bash
+# Start pgduck_server with test configuration
+pgduck_server --init_file_path pgduck_server/tests/test_secrets.sql --cache_dir /tmp/cache &
+
+# Run installcheck
+make installcheck
+
+# Run installcheck for specific component
+make installcheck-pg_lake_table
+```
+
+**Note:** There are several PostgreSQL settings that may affect the installcheck result (e.g., timezone, `pg_lake_iceberg.default_location_prefix`).
+
+### Running PostgreSQL Tests with pg_lake Extensions
+
+We also run PostgreSQL's own regression tests with pg_lake extensions loaded to ensure we don't break regular PostgreSQL behavior:
+
+```bash
+# Set PostgreSQL source directory
+export PG_REGRESS_DIR=/path/to/postgres/src/test/regress
+
+# Configure PostgreSQL for testing
+psql postgres << EOF
+ALTER SYSTEM SET compute_query_id='regress';
+ALTER SYSTEM SET pg_lake_table.hide_objects_created_by_lake=true;
+SELECT pg_reload_conf();
+EOF
+
+# Run PostgreSQL tests with pg_lake in shared_preload_libraries
+make installcheck-postgres PG_REGRESS_DIR=$PG_REGRESS_DIR
+
+# Run PostgreSQL tests with pg_lake extensions created
+make installcheck-postgres-with_extensions_created PG_REGRESS_DIR=$PG_REGRESS_DIR
+```
+
+### Why pytest?
+
+We have avoided traditional SQL regression tests because:
+
+- They lack programmatic testing capabilities
+- They require repetitive patterns that are hard to maintain
+- They often have non-deterministic output (e.g., unordered SELECT results)
+- They're sensitive to small implementation details
+- pytest is widely used and well-supported by AI tools for test generation
+
+## Running S3-Compatible Service (MinIO) Locally
+
+pg_lake heavily relies on S3 storage. However, using real S3 can introduce significant latency during local testing. You can use MinIO for local S3-compatible storage.
+
+### Installation and Setup of MinIO
+
+**1. Install MinIO:**
+
+```bash
+# macOS
+brew install minio
+
+# Linux - download from https://min.io/download
+wget https://dl.min.io/server/minio/release/linux-amd64/minio
+chmod +x minio
+sudo mv minio /usr/local/bin/
+```
+
+**2. Start MinIO Server:**
+
+```bash
+# Remove leftovers from previous run if needed
+rm -rf /tmp/data
+
+# Start server
+minio server /tmp/data
+```
+
+**3. Access MinIO UI:**
+
+Open your browser and go to http://localhost:9000/
+
+**4. Create Access and Secret Keys:**
+
+From the MinIO UI, create access credentials. For simplicity, use:
+- Access Key: `testkey`
+- Secret Key: `testpassword`
+
+**5. Add MinIO Profile to ~/.aws/config:**
+
+```ini
+[services testing-minio]
+s3 =
+   endpoint_url = http://localhost:9000
+
+[profile minio]
+region = us-east-1
+services = testing-minio
+aws_access_key_id = testkey
+aws_secret_access_key = testpassword
+```
+
+**6. Create a Bucket:**
+
+From the MinIO UI, create a bucket named `localbucket`.
+
+**7. Configure DuckDB Secret in pgduck_server:**
+
+Connect to pgduck_server and create the S3 secret:
 
 ```sql
-postgres> ALTER SYSTEM SET compute_query_id='regress';
-postgres> ALTER SYSTEM SET pg_lake_table.hide_objects_created_by_lake=true;
-postgres> SELECT pg_reload_conf();
+psql -p 5332 -h /tmp
 
--- runs postgres tests with our extensions in shared_preload_libraries
-make installcheck-postgres PG_REGRESS_DIR=<pg_src_dir>/test/regress
-
--- runs postgres tests with our extensions created
-make installcheck-postgres-with_extensions_created PG_REGRESS_DIR=<pg_src_dir>/test/regress
+CREATE SECRET s3testMinio (
+    TYPE S3,
+    KEY_ID 'testkey',
+    SECRET 'testpassword',
+    ENDPOINT 'localhost:9000',
+    SCOPE 's3://localbucket',
+    URL_STYLE 'path',
+    USE_SSL false
+);
 ```
 
-### Pytests
+**8. Create an Iceberg Table Using MinIO:**
 
-We have so far avoided regular SQL regression tests. The reason is that we found those painful to maintain in past projects (read: `Citus`) because of the lack of programmatic testing and the relative rigour with which we write tests. We would often repeat the same patterns over and over again, and later find that we had non-deterministic output (e.g. unordered SELECT results) or output that was sensitive to small implementation details and other issues in many places, and it significantly slowed down development. Another reason for using pytest is that it's commonly used and therefore generative AI tools are quite proficient at writing tests.
-
-
-## Running `S3` Compatible Service `minio` Locally
-
-`pg_lake` heavily relies on `S3`. However, using `S3` can introduce significant latency, especially problematic in local testing environments. To mitigate this, you can use `minio` for local `S3`-compatible service setup.
-
-### Installation and Setup of `minio`
-
-
-1. **Install `minio`**:
-
-   ```bash
-   brew install minio
-   ```
-
-**Note**: For other systems, you can download `minio` binaries from the [official website](https://min.io/download).
-
-2. **Start the `minio` Server**:
-   ```bash
-   minio server /tmp/data
-   ```
-
-To remove leftovers from the previous run if needed, you can first run: `rm -rf /tmp/data`
-
-3. **Access `minio` UI**:
-   Open your browser and go to [http://localhost:9000/](http://localhost:9000/).
-
-4. **Create Access and Secret Keys from the minio UI**:
-We use the following for simplicity:
-
-   - Access Key: `testkey`
-   - Secret Key: `testpassword`
-
-5. **Add `minio` Profile to `~/.aws/config`**:
-   ```ini
-   [services testing-minio]
-   s3 =
-      endpoint_url = http://localhost:9000
-
-   [profile minio]
-   region = us-east-1
-   services = testing-minio
-   aws_access_key_id = testkey
-   aws_secret_access_key = testpassword
-   ```
-
-6. **Create a Bucket in `minio` UI**:
-   - Such as: `localbucket`. We use this bucket name in the rest of the steps.
-
-7. **Connect to `pgduck_server` and create the relevant `SECRET` on `DuckDB`**:
-   ```sql
-   psql -p 5332 -h /tmp
-   ```
-
-   ```sql
-   CREATE SECRET s3testMinio (
-       TYPE S3,
-       KEY_ID 'testkey',
-       SECRET 'testpassword',
-       ENDPOINT 'localhost:9000',
-       SCOPE 's3://localbucket',
-       URL_STYLE 'path',
-       USE_SSL false
-   );
-   ```
-
-8. **Create a Foreign Table that uses the `localbucket` in `minio`**:
-   ```sql
-   SET pg_lake_iceberg.default_location_prefix TO 's3://localbucket';
-   CREATE TABLE t_iceberg(a int) USING iceberg;
-   ```
+```sql
+SET pg_lake_iceberg.default_location_prefix TO 's3://localbucket';
+CREATE TABLE t_iceberg(a int) USING iceberg;
+```
 
 ## Automatically Bumping Extension Versions
 
@@ -437,8 +829,6 @@ python tools/bump_extension_versions.py 3.0
 ```
 
 What it does:
-
-   - Finds all folders containing a `.control` file.
-   - Updates the `default_version` field in each control file.
-   - Creates a new SQL stub for version upgrade (e.g., `pg_lake_engine--2.4--3.0.sql`).
-
+- Finds all folders containing a `.control` file
+- Updates the `default_version` field in each control file
+- Creates a new SQL stub for version upgrade (e.g., `pg_lake_engine--2.4--3.0.sql`)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,909 @@
+#!/bin/bash
+set -e
+
+# pg_lake Installation Script
+# Installs pg_lake extensions to PostgreSQL. Can optionally build PostgreSQL from source.
+
+# Determine script directory at the very beginning (before any cd commands)
+if command -v realpath &>/dev/null; then
+    PG_LAKE_REPO_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+elif command -v readlink &>/dev/null; then
+    PG_LAKE_REPO_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+else
+    PG_LAKE_REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Default configuration
+PG_VERSION=18
+INSTALL_PREFIX="$HOME/pgsql"
+PGLAKE_DEPS_DIR="$HOME/pg_lake-deps"
+JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+VCPKG_VERSION=2025.10.17
+
+# Feature flags (defaults optimized for adding pg_lake to existing PostgreSQL)
+SKIP_SYSTEM_DEPS=1        # Skip by default - assume deps installed if PostgreSQL exists
+BUILD_POSTGRES=0          # Off by default - use --build-postgres to enable
+SKIP_VCPKG=0
+SKIP_PG_LAKE=0
+WITH_TEST_DEPS=0
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_header() {
+    echo -e "${BLUE}==>${NC} ${GREEN}$1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}==>${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}Warning:${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}Error:${NC} $1" >&2
+}
+
+print_skip() {
+    echo -e "${YELLOW}Skipping:${NC} $1"
+}
+
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Install pg_lake extensions to PostgreSQL. By default, installs to an existing
+PostgreSQL installation. Use --build-postgres for full development setup.
+
+OPTIONS:
+    --build-postgres            Build PostgreSQL from source and initialize database
+    --pg-version VERSION        PostgreSQL version to build (16, 17, or 18) [default: 18]
+    --prefix DIR                PostgreSQL installation prefix [default: auto-detect or \$HOME/pgsql]
+    --deps-dir DIR              Directory for dependencies [default: \$HOME/pg_lake-deps]
+    --jobs N                    Number of parallel build jobs [default: nproc]
+
+    --with-system-deps          Install system build dependencies (auto-enabled with --build-postgres)
+    --skip-vcpkg                Skip vcpkg and Azure SDK installation
+    --skip-pg-lake              Skip building pg_lake extensions
+
+    --with-test-deps            Install optional test dependencies (PostGIS, pgAudit, pg_cron, azurite)
+
+    -h, --help                  Show this help message
+
+EXAMPLES:
+    # Install pg_lake to existing PostgreSQL (most common)
+    $0
+
+    # Install with test dependencies
+    $0 --with-test-deps
+
+    # Full development environment: build PostgreSQL 18 from source + pg_lake
+    $0 --build-postgres --with-test-deps
+
+    # Full development environment with PostgreSQL 17
+    $0 --build-postgres --pg-version 17 --with-test-deps
+
+    # Install only pg_lake (assumes vcpkg already set up)
+    $0 --skip-system-deps --skip-vcpkg
+
+EOF
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --pg-version)
+            PG_VERSION="$2"
+            shift 2
+            ;;
+        --prefix)
+            INSTALL_PREFIX="$2"
+            shift 2
+            ;;
+        --deps-dir)
+            PGLAKE_DEPS_DIR="$2"
+            shift 2
+            ;;
+        --jobs)
+            JOBS="$2"
+            shift 2
+            ;;
+        --build-postgres)
+            BUILD_POSTGRES=1
+            SKIP_SYSTEM_DEPS=0  # Auto-enable system deps when building PostgreSQL
+            shift
+            ;;
+        --with-system-deps)
+            SKIP_SYSTEM_DEPS=0
+            shift
+            ;;
+        --skip-vcpkg)
+            SKIP_VCPKG=1
+            shift
+            ;;
+        --skip-pg-lake)
+            SKIP_PG_LAKE=1
+            shift
+            ;;
+        --with-test-deps)
+            WITH_TEST_DEPS=1
+            SKIP_SYSTEM_DEPS=0  # Auto-enable system deps when building test dependencies
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate PostgreSQL version
+if [[ ! "$PG_VERSION" =~ ^(16|17|18)$ ]]; then
+    print_error "Invalid PostgreSQL version: $PG_VERSION. Must be 16, 17, or 18."
+    exit 1
+fi
+
+# Determine PostgreSQL branch
+case $PG_VERSION in
+    16) PG_BRANCH="REL_16_STABLE" ;;
+    17) PG_BRANCH="REL_17_STABLE" ;;
+    18) PG_BRANCH="REL_18_STABLE" ;;
+esac
+
+# Determine PostgreSQL installation paths
+if [[ $BUILD_POSTGRES -eq 0 ]]; then
+    # Not building PostgreSQL - try to detect existing installation
+    if command -v pg_config &>/dev/null; then
+        PG_INSTALL_DIR=$(pg_config --bindir | sed 's|/bin$||')
+        PG_BIN="$(pg_config --bindir)"
+        DETECTED_VERSION=$(pg_config --version | sed -n 's/^PostgreSQL \([0-9]\+\).*/\1/p')
+
+        # Warn if detected version doesn't match requested version
+        if [[ -n "$DETECTED_VERSION" ]] && [[ "$DETECTED_VERSION" != "$PG_VERSION" ]]; then
+            print_warning "Detected PostgreSQL $DETECTED_VERSION, but --pg-version is set to $PG_VERSION"
+            print_warning "Using detected version $DETECTED_VERSION"
+            PG_VERSION="$DETECTED_VERSION"
+        fi
+
+        # Set PGDATA if it exists
+        if [[ -n "$PGDATA" ]] && [[ -d "$PGDATA" ]]; then
+            : # Keep existing PGDATA
+        else
+            PGDATA="$PG_INSTALL_DIR/data"
+        fi
+    else
+        print_error "pg_config not found in PATH. Please either:"
+        print_error "  1. Install PostgreSQL and ensure pg_config is in PATH, or"
+        print_error "  2. Use --build-postgres to build PostgreSQL from source"
+        exit 1
+    fi
+else
+    # Building PostgreSQL from source
+    PG_INSTALL_DIR="$INSTALL_PREFIX/$PG_VERSION"
+    PG_BIN="$PG_INSTALL_DIR/bin"
+    PGDATA="$PG_INSTALL_DIR/data"
+fi
+
+# Detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        OS="macos"
+    elif [[ -f /etc/os-release ]]; then
+        . /etc/os-release
+        if [[ "$ID" == "debian" ]] || [[ "$ID" == "ubuntu" ]] || [[ "$ID_LIKE" == *"debian"* ]]; then
+            OS="debian"
+        elif [[ "$ID" == "rhel" ]] || [[ "$ID" == "almalinux" ]] || [[ "$ID" == "rocky" ]] || [[ "$ID_LIKE" == *"rhel"* ]]; then
+            OS="rhel"
+        else
+            print_error "Unsupported Linux distribution: $ID"
+            exit 1
+        fi
+    else
+        print_error "Unable to detect operating system"
+        exit 1
+    fi
+}
+
+# Install system dependencies
+install_system_deps() {
+    if [[ $SKIP_SYSTEM_DEPS -eq 1 ]]; then
+        print_skip "System dependencies installation"
+        return
+    fi
+
+    print_header "Installing system build dependencies for $OS"
+
+    case $OS in
+        debian)
+            sudo apt-get update
+            sudo apt-get install -y \
+                build-essential \
+                cmake \
+                ninja-build \
+                libreadline-dev \
+                zlib1g-dev \
+                flex \
+                bison \
+                libxml2-dev \
+                libxslt1-dev \
+                libicu-dev \
+                libssl-dev \
+                libgeos-dev \
+                libproj-dev \
+                libgdal-dev \
+                libjson-c-dev \
+                libprotobuf-c-dev \
+                protobuf-c-compiler \
+                diffutils \
+                uuid-dev \
+                libossp-uuid-dev \
+                liblz4-dev \
+                liblzma-dev \
+                libsnappy-dev \
+                perl \
+                libtool \
+                libjansson-dev \
+                libpam0g-dev \
+                libcurl4-openssl-dev \
+                curl \
+                patch \
+                g++ \
+                libipc-run-perl \
+                jq \
+                git \
+                pkg-config \
+                python3-dev
+            ;;
+        rhel)
+            sudo dnf -y update
+            sudo dnf -y install epel-release
+            sudo dnf config-manager --enable crb 2>/dev/null || sudo dnf config-manager --set-enabled crb 2>/dev/null || true
+            sudo dnf -y install \
+                cmake \
+                ninja-build \
+                readline-devel \
+                zlib-devel \
+                flex \
+                bison \
+                libxml2-devel \
+                libxslt-devel \
+                libicu-devel \
+                openssl-devel \
+                geos-devel \
+                proj-devel \
+                gdal-devel \
+                json-c-devel \
+                protobuf-c-devel \
+                uuid-devel \
+                lz4-devel \
+                xz-devel \
+                snappy-devel \
+                perl \
+                perl-IPC-Run \
+                perl-IPC-Cmd \
+                libtool \
+                jansson-devel \
+                jq \
+                pam-devel \
+                libcurl-devel \
+                patch \
+                which \
+                gcc-c++ \
+                git \
+                pkgconfig \
+                python3-devel
+            ;;
+        macos)
+            # Check for Xcode command line tools
+            if ! xcode-select -p &>/dev/null; then
+                print_info "Installing Xcode command line tools..."
+                xcode-select --install
+                print_warning "Please complete the Xcode installation and re-run this script."
+                exit 1
+            fi
+
+            brew update
+            brew install \
+                cmake \
+                ninja \
+                readline \
+                zlib \
+                libxml2 \
+                libxslt \
+                icu4c \
+                openssl@3 \
+                geos \
+                proj \
+                gdal \
+                json-c \
+                protobuf-c \
+                lz4 \
+                xz \
+                snappy \
+                jansson \
+                curl \
+                libtool \
+                flex \
+                bison \
+                diffutils \
+                jq \
+                ossp-uuid \
+                perl \
+                pkg-config \
+                python@3
+
+            # Install specific cmake version for vcpkg compatibility
+            if ! brew list cmake@3.31.1 &>/dev/null; then
+                print_info "Installing cmake 3.31.1 for vcpkg compatibility..."
+                brew tap-new $USER/local-cmake 2>/dev/null || true
+                brew tap homebrew/core --force
+                brew extract --version=3.31.1 cmake $USER/local-cmake
+                brew install $USER/local-cmake/cmake@3.31.1
+            fi
+            ;;
+    esac
+
+    print_info "System dependencies installed successfully"
+}
+
+# Build and install PostgreSQL
+install_postgres() {
+    if [[ $BUILD_POSTGRES -eq 0 ]]; then
+        return  # Not building PostgreSQL
+    fi
+
+    print_header "Building PostgreSQL $PG_VERSION from source"
+
+    # Check if already installed
+    if [[ -f "$PG_BIN/postgres" ]]; then
+        print_info "PostgreSQL $PG_VERSION already installed at $PG_INSTALL_DIR"
+        return
+    fi
+
+    mkdir -p "$PGLAKE_DEPS_DIR"
+    cd "$PGLAKE_DEPS_DIR"
+
+    # Clone if needed
+    if [[ ! -d "postgres-$PG_VERSION" ]]; then
+        print_info "Cloning PostgreSQL $PG_VERSION..."
+        git clone https://github.com/postgres/postgres.git -b "$PG_BRANCH" "postgres-$PG_VERSION"
+    else
+        print_info "PostgreSQL source already cloned"
+    fi
+
+    cd "postgres-$PG_VERSION"
+
+    # Check if IPC::Run is available for TAP tests
+    ENABLE_TAP_TESTS=""
+    if perl -MIPC::Run -e 1 2>/dev/null; then
+        print_info "Perl IPC::Run module available - enabling TAP tests"
+        ENABLE_TAP_TESTS="--enable-tap-tests"
+    else
+        print_warning "Perl IPC::Run module not available - TAP tests will be disabled"
+        print_warning "To enable TAP tests, install IPC::Run:"
+        print_warning "  NixOS: nix-env -iA nixpkgs.perlPackages.IPCRun"
+        print_warning "  Others: cpan IPC::Run"
+    fi
+
+    # Configure based on OS
+    print_info "Configuring PostgreSQL..."
+    if [[ "$OS" == "macos" ]]; then
+        # macOS-specific configuration
+        export PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/flex/bin:$PATH"
+        export LDFLAGS="-L/opt/homebrew/opt/icu4c/lib -L/opt/homebrew/opt/openssl@3/lib"
+        export CPPFLAGS="-I/opt/homebrew/opt/icu4c/include -I/opt/homebrew/opt/openssl@3/include"
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig"
+
+        ./configure \
+            --prefix="$PG_INSTALL_DIR" \
+            --enable-injection-points \
+            $ENABLE_TAP_TESTS \
+            --enable-debug \
+            --enable-cassert \
+            --enable-depend \
+            CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" \
+            --with-openssl \
+            --with-libxml \
+            --with-libxslt \
+            --with-icu \
+            --with-lz4 \
+            --with-python \
+            --with-readline \
+            --with-includes=/opt/homebrew/include/ \
+            --with-libraries=/opt/homebrew/lib \
+            PG_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+    else
+        # Linux configuration
+        ./configure \
+            --prefix="$PG_INSTALL_DIR" \
+            --enable-injection-points \
+            $ENABLE_TAP_TESTS \
+            --enable-debug \
+            --enable-cassert \
+            --enable-depend \
+            CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" \
+            --with-openssl \
+            --with-libxml \
+            --with-libxslt \
+            --with-icu \
+            --with-lz4 \
+            --with-pam \
+            --with-python
+    fi
+
+    print_info "Building PostgreSQL with $JOBS parallel jobs..."
+    make -j "$JOBS"
+    make install
+
+    # Install all contrib modules (required for tests)
+    print_info "Installing contrib modules..."
+    make -C contrib install
+
+    # Install test modules
+    if [[ -d src/test/modules/injection_points ]]; then
+        make -C src/test/modules/injection_points install
+    fi
+    if [[ -d src/test/isolation ]]; then
+        make -C src/test/isolation install
+    fi
+
+    print_info "PostgreSQL $PG_VERSION installed successfully to $PG_INSTALL_DIR"
+}
+
+# Install vcpkg and Azure dependencies
+install_vcpkg() {
+    if [[ $SKIP_VCPKG -eq 1 ]]; then
+        print_skip "vcpkg and Azure SDK installation"
+        return
+    fi
+
+    print_header "Installing vcpkg and Azure SDK dependencies"
+
+    mkdir -p "$PGLAKE_DEPS_DIR"
+    cd "$PGLAKE_DEPS_DIR"
+
+    # Clone vcpkg if needed
+    if [[ ! -d "vcpkg" ]]; then
+        print_info "Cloning vcpkg $VCPKG_VERSION..."
+        git clone --recurse-submodules --branch "$VCPKG_VERSION" https://github.com/Microsoft/vcpkg.git
+    else
+        print_info "vcpkg already cloned"
+    fi
+
+    # Bootstrap vcpkg if needed
+    if [[ ! -f "vcpkg/vcpkg" ]]; then
+        print_info "Bootstrapping vcpkg..."
+        cd vcpkg
+        ./bootstrap-vcpkg.sh
+        cd ..
+    else
+        print_info "vcpkg already bootstrapped"
+    fi
+
+    # Install packages
+    print_info "Installing Azure SDK packages (this may take a while)..."
+    ./vcpkg/vcpkg install azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl
+
+    # Set environment variable
+    export VCPKG_TOOLCHAIN_PATH="$PGLAKE_DEPS_DIR/vcpkg/scripts/buildsystems/vcpkg.cmake"
+
+    print_info "vcpkg installed successfully"
+}
+
+# Build and install pg_lake
+install_pg_lake() {
+    if [[ $SKIP_PG_LAKE -eq 1 ]]; then
+        print_skip "pg_lake build and installation"
+        return
+    fi
+
+    print_header "Building pg_lake extensions"
+
+    # Ensure pg_config is in PATH
+    export PATH="$PG_BIN:$PATH"
+
+    # Verify pg_config is accessible
+    if ! command -v pg_config &>/dev/null; then
+        print_error "pg_config not found in PATH. Please ensure PostgreSQL is installed."
+        exit 1
+    fi
+
+    # Set vcpkg toolchain path
+    if [[ -z "$VCPKG_TOOLCHAIN_PATH" ]] && [[ -d "$PGLAKE_DEPS_DIR/vcpkg" ]]; then
+        export VCPKG_TOOLCHAIN_PATH="$PGLAKE_DEPS_DIR/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    fi
+
+    # Verify we're in the pg_lake repository by checking for key files
+    if [[ ! -f "$PG_LAKE_REPO_DIR/Makefile" ]] || [[ ! -d "$PG_LAKE_REPO_DIR/pg_lake_engine" ]]; then
+        print_error "install.sh must be run from the pg_lake repository root"
+        print_error "Expected location: pg_lake repository containing Makefile and pg_lake_engine/"
+        print_error "Detected repository directory: $PG_LAKE_REPO_DIR"
+        exit 1
+    fi
+
+    print_info "Building pg_lake from repository at: $PG_LAKE_REPO_DIR"
+    cd "$PG_LAKE_REPO_DIR"
+    make install-fast
+
+    print_info "pg_lake extensions installed successfully"
+}
+
+# Initialize PostgreSQL database
+init_database() {
+    if [[ $BUILD_POSTGRES -eq 0 ]]; then
+        return  # Not building/initializing PostgreSQL
+    fi
+
+    print_header "Initializing PostgreSQL database cluster"
+
+    export PATH="$PG_BIN:$PATH"
+
+    # Check if already initialized
+    if [[ -f "$PGDATA/PG_VERSION" ]]; then
+        print_info "Database cluster already initialized at $PGDATA"
+        return
+    fi
+
+    mkdir -p "$(dirname "$PGDATA")"
+
+    print_info "Running initdb..."
+    "$PG_BIN/initdb" -k -D "$PGDATA" --locale=C.UTF-8
+
+    # Add pg_extension_base to shared_preload_libraries
+    print_info "Configuring shared_preload_libraries..."
+    echo "shared_preload_libraries = 'pg_extension_base'" >> "$PGDATA/postgresql.conf"
+
+    print_info "Database cluster initialized at $PGDATA"
+}
+
+# Install test dependencies
+install_test_deps() {
+    if [[ $WITH_TEST_DEPS -eq 0 ]]; then
+        return
+    fi
+
+    print_header "Installing test dependencies"
+
+    export PATH="$PG_BIN:$PATH"
+    mkdir -p "$PGLAKE_DEPS_DIR"
+    cd "$PGLAKE_DEPS_DIR"
+
+    # PostGIS
+    # Check if PostGIS is already installed by looking for the extension control file
+    if [[ -f "$PG_INSTALL_DIR/share/extension/postgis.control" ]]; then
+        print_info "PostGIS already installed"
+    else
+        print_info "Building PostGIS..."
+        if [[ ! -d "postgis" ]]; then
+            git clone https://github.com/postgis/postgis.git
+        fi
+        cd postgis
+        ./autogen.sh
+        ./configure --prefix="$PG_INSTALL_DIR"
+        make -j "$JOBS"
+        make install
+        cd ..
+    fi
+
+    # pgAudit
+    if [[ -f "$PG_INSTALL_DIR/share/extension/pgaudit.control" ]]; then
+        print_info "pgAudit already installed"
+    else
+        print_info "Building pgAudit..."
+        if [[ ! -d "pgaudit" ]]; then
+            git clone https://github.com/pgaudit/pgaudit.git
+        fi
+        cd pgaudit
+        make USE_PGXS=1 install
+        cd ..
+    fi
+
+    # pg_cron
+    if [[ -f "$PG_INSTALL_DIR/share/extension/pg_cron.control" ]]; then
+        print_info "pg_cron already installed"
+    else
+        print_info "Building pg_cron..."
+        if [[ ! -d "pg_cron" ]]; then
+            git clone https://github.com/citusdata/pg_cron.git
+        fi
+        cd pg_cron
+        make install
+        cd ..
+    fi
+
+    # Python/pip (needed for pipenv and azurite)
+    if ! command -v python3 &>/dev/null || ! command -v pip3 &>/dev/null; then
+        print_info "Installing Python 3 and pip..."
+        case $OS in
+            debian)
+                sudo apt-get install -y python3 python3-pip
+                ;;
+            rhel)
+                sudo dnf install -y python3 python3-pip
+                ;;
+            macos)
+                brew install python3
+                ;;
+        esac
+    else
+        print_info "Python 3 and pip already installed"
+    fi
+
+    # azurite (npm)
+    NPM_PREFIX="$PGLAKE_DEPS_DIR/npm-global"
+    if command -v azurite &>/dev/null; then
+        print_info "azurite already installed"
+    elif [[ -x "$NPM_PREFIX/bin/azurite" ]]; then
+        print_info "azurite already installed at $NPM_PREFIX/bin/azurite"
+    else
+        print_info "Installing azurite via npm..."
+        if ! command -v npm &>/dev/null; then
+            case $OS in
+                debian)
+                    sudo apt-get install -y nodejs npm
+                    ;;
+                rhel)
+                    sudo dnf install -y nodejs npm
+                    ;;
+                macos)
+                    brew install node
+                    ;;
+            esac
+        fi
+        # Install to a user-local prefix to avoid permission issues with
+        # system/Nix-managed npm installations
+        mkdir -p "$NPM_PREFIX"
+        npm install -g --prefix "$NPM_PREFIX" azurite
+    fi
+
+    # Add azurite to PATH for this session
+    if [[ -x "$NPM_PREFIX/bin/azurite" ]]; then
+        export PATH="$NPM_PREFIX/bin:$PATH"
+    fi
+
+    # Python/pipenv
+    if ! command -v pipenv &>/dev/null; then
+        print_info "Installing pipenv..."
+        if command -v pip3 &>/dev/null; then
+            pip3 install --user pipenv
+        elif command -v python3 &>/dev/null; then
+            python3 -m pip install --user pipenv
+        else
+            print_warning "pip3 or python3 not found. Please install pipenv manually:"
+            print_warning "  Debian/Ubuntu: sudo apt-get install pipenv"
+            print_warning "  RHEL/AlmaLinux: sudo dnf install pipenv"
+            print_warning "  macOS: brew install pipenv"
+            print_warning "  Or via pip: python3 -m pip install --user pipenv"
+        fi
+    else
+        print_info "pipenv already installed"
+    fi
+
+    # Java 21+ (needed for Spark verification tests and Polaris catalog tests)
+    JAVA_VERSION=""
+    if command -v java &>/dev/null; then
+        JAVA_VERSION=$(java -version 2>&1 | head -1 | sed -n 's/.*version "\([0-9]*\).*/\1/p')
+    fi
+
+    if [[ -n "$JAVA_VERSION" ]] && [[ "$JAVA_VERSION" -ge 21 ]]; then
+        print_info "Java $JAVA_VERSION already installed and in PATH"
+    else
+        if [[ -n "$JAVA_VERSION" ]]; then
+            print_warning "Java in PATH is version $JAVA_VERSION but 21+ is required for tests"
+        fi
+
+        # Install Java 21 if not present on the system
+        case $OS in
+            debian)
+                if ! dpkg -l openjdk-21-jdk &>/dev/null; then
+                    print_info "Installing Java 21..."
+                    sudo apt-get install -y openjdk-21-jdk
+                fi
+                JAVA_HOME=$(dirname $(dirname $(update-alternatives --list java 2>/dev/null | grep 21 | head -1))) 2>/dev/null || true
+                if [[ -z "$JAVA_HOME" ]]; then
+                    JAVA_HOME=$(ls -d /usr/lib/jvm/java-21-openjdk-* 2>/dev/null | head -1)
+                fi
+                ;;
+            rhel)
+                if ! rpm -q java-21-openjdk-devel &>/dev/null; then
+                    print_info "Installing Java 21 JDK..."
+                    sudo dnf install -y java-21-openjdk-devel
+                fi
+                JAVA_HOME=$(ls -d /usr/lib/jvm/java-21-openjdk-* 2>/dev/null | head -1)
+                ;;
+            macos)
+                if ! brew list openjdk@21 &>/dev/null; then
+                    print_info "Installing Java 21..."
+                    brew install openjdk@21
+                fi
+                JAVA_HOME="/opt/homebrew/opt/openjdk@21"
+                ;;
+        esac
+
+        # Ensure Java 21 is first in PATH
+        if [[ -n "$JAVA_HOME" ]] && [[ -d "$JAVA_HOME/bin" ]]; then
+            export JAVA_HOME
+            export PATH="$JAVA_HOME/bin:$PATH"
+            print_info "Using Java 21 from $JAVA_HOME"
+        else
+            print_warning "Could not locate Java 21 installation. Tests requiring Java 21 may fail."
+        fi
+    fi
+
+    # PostgreSQL JDBC driver (needed for Spark verification tests)
+    JDBC_DIR="$PGLAKE_DEPS_DIR/jdbc"
+    JDBC_VERSION="42.7.10"
+    JDBC_JAR="$JDBC_DIR/postgresql-${JDBC_VERSION}.jar"
+
+    if [[ -f "$JDBC_JAR" ]]; then
+        print_info "PostgreSQL JDBC driver already downloaded"
+    else
+        print_info "Downloading PostgreSQL JDBC driver ${JDBC_VERSION}..."
+        mkdir -p "$JDBC_DIR"
+        if command -v curl &>/dev/null; then
+            curl -L -o "$JDBC_JAR" "https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar"
+        elif command -v wget &>/dev/null; then
+            wget -O "$JDBC_JAR" "https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar"
+        else
+            print_error "Neither curl nor wget found. Please install one to download JDBC driver."
+            print_error "Or download manually from: https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar"
+            print_error "And place it at: $JDBC_JAR"
+        fi
+    fi
+
+    # Install Python test dependencies via pipenv
+    if command -v pipenv &>/dev/null; then
+        print_info "Installing Python test dependencies via pipenv..."
+        cd "$PG_LAKE_REPO_DIR"
+        pipenv install --dev
+    else
+        print_warning "pipenv not found in PATH. You may need to run 'pipenv install --dev' manually."
+        print_warning "Check that ~/.local/bin is in your PATH if pipenv was installed with --user."
+    fi
+
+    print_info "Test dependencies installed successfully"
+}
+
+# Print summary
+print_summary() {
+    print_header "Setup Complete!"
+    echo
+
+    if [[ $BUILD_POSTGRES -eq 1 ]]; then
+        # Built PostgreSQL from source
+        echo "PostgreSQL $PG_VERSION installed to: $PG_INSTALL_DIR"
+        if [[ -f "$PGDATA/PG_VERSION" ]]; then
+            echo "Database cluster initialized at: $PGDATA"
+        fi
+        echo
+        echo -e "${GREEN}Next steps:${NC}"
+        echo
+        echo "1. Add PostgreSQL to your PATH:"
+        echo "   export PATH=$PG_BIN:\$PATH"
+        echo
+        if [[ ! -f "$PGDATA/PG_VERSION" ]]; then
+            echo "2. Initialize the database:"
+            echo "   initdb -k -D $PGDATA --locale=C.UTF-8"
+            echo "   echo \"shared_preload_libraries = 'pg_extension_base'\" >> $PGDATA/postgresql.conf"
+            echo
+        fi
+        echo "2. Start PostgreSQL:"
+        echo "   pg_ctl -D $PGDATA -l $PGDATA/logfile start"
+        echo
+    else
+        # Using existing PostgreSQL
+        echo "pg_lake extensions installed to PostgreSQL $PG_VERSION at: $PG_INSTALL_DIR"
+        echo
+        echo -e "${GREEN}Next steps:${NC}"
+        echo
+        echo "1. Configure PostgreSQL (if not already done):"
+        echo "   Add to postgresql.conf: shared_preload_libraries = 'pg_extension_base'"
+        echo "   Restart PostgreSQL to load the library"
+        echo
+    fi
+
+    echo "2. Start pgduck_server (required for pg_lake):"
+    echo "   pgduck_server --cache_dir /tmp/pg_lake_cache/"
+    echo
+    echo "3. Connect and create pg_lake extensions:"
+    echo "   psql -c \"CREATE EXTENSION pg_lake CASCADE;\""
+    echo "   psql -c \"SET pg_lake_iceberg.default_location_prefix TO 's3://your-bucket/pglake';\""
+    echo
+
+    if [[ $WITH_TEST_DEPS -eq 1 ]]; then
+        JDBC_DIR="$PGLAKE_DEPS_DIR/jdbc"
+        JDBC_VERSION="42.7.10"
+        JDBC_JAR="$JDBC_DIR/postgresql-${JDBC_VERSION}.jar"
+
+        echo "4. Run tests:"
+        if [[ -f "$JDBC_JAR" ]]; then
+            echo "   export JDBC_DRIVER_PATH=$JDBC_JAR"
+        else
+            echo "   # Note: JDBC driver download may have failed. Set JDBC_DRIVER_PATH manually if needed."
+        fi
+        echo "   cd pg_lake"
+        echo "   make check"
+        echo
+    fi
+
+    echo -e "${BLUE}Documentation:${NC}"
+    echo "   Building from source: docs/building-from-source.md"
+    echo "   Iceberg tables: docs/iceberg-tables.md"
+    echo "   Query data lake files: docs/query-data-lake-files.md"
+    echo
+
+    if [[ $BUILD_POSTGRES -eq 1 ]] || [[ -d "$PGLAKE_DEPS_DIR/vcpkg" ]] || [[ $WITH_TEST_DEPS -eq 1 ]] || [[ "$OS" == "macos" ]]; then
+        echo -e "${YELLOW}Environment variables to add to your ~/.bashrc or ~/.zshrc:${NC}"
+        if [[ $BUILD_POSTGRES -eq 1 ]]; then
+            echo "   export PATH=$PG_BIN:\$PATH"
+        fi
+        if [[ -d "$PGLAKE_DEPS_DIR/vcpkg" ]]; then
+            echo "   export VCPKG_TOOLCHAIN_PATH=$PGLAKE_DEPS_DIR/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        fi
+        if [[ $WITH_TEST_DEPS -eq 1 ]]; then
+            NPM_PREFIX="$PGLAKE_DEPS_DIR/npm-global"
+            if [[ -d "$NPM_PREFIX/bin" ]]; then
+                echo "   export PATH=$NPM_PREFIX/bin:\$PATH  # azurite (required for Azure tests)"
+            fi
+            JDBC_DIR="$PGLAKE_DEPS_DIR/jdbc"
+            JDBC_VERSION="42.7.10"
+            JDBC_JAR="$JDBC_DIR/postgresql-${JDBC_VERSION}.jar"
+            echo "   export JDBC_DRIVER_PATH=$JDBC_JAR  # Required for Spark verification tests"
+            if [[ -n "$JAVA_HOME" ]]; then
+                echo "   export JAVA_HOME=$JAVA_HOME"
+                echo "   export PATH=\$JAVA_HOME/bin:\$PATH  # Java 21+ (required for Polaris catalog tests)"
+            fi
+        fi
+        if [[ "$OS" == "macos" ]]; then
+            echo "   export PATH=\"/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/flex/bin:\$PATH\""
+            echo "   export LDFLAGS=\"-L/opt/homebrew/opt/icu4c/lib -L/opt/homebrew/opt/openssl@3/lib\""
+            echo "   export CPPFLAGS=\"-I/opt/homebrew/opt/icu4c/include -I/opt/homebrew/opt/openssl@3/include\""
+            echo "   export PKG_CONFIG_PATH=\"/opt/homebrew/opt/icu4c/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig\""
+        fi
+    fi
+}
+
+# Main execution
+main() {
+    if [[ $BUILD_POSTGRES -eq 1 ]]; then
+        print_header "pg_lake Development Environment Setup (building PostgreSQL from source)"
+    else
+        print_header "pg_lake Installation (using existing PostgreSQL)"
+    fi
+    echo
+
+    detect_os
+    print_info "Detected OS: $OS"
+    print_info "PostgreSQL version: $PG_VERSION"
+    print_info "PostgreSQL location: $PG_INSTALL_DIR"
+    if [[ $BUILD_POSTGRES -eq 0 ]]; then
+        print_info "Mode: Installing to existing PostgreSQL"
+    else
+        print_info "Mode: Building PostgreSQL from source"
+    fi
+    print_info "Dependencies directory: $PGLAKE_DEPS_DIR"
+    print_info "Build jobs: $JOBS"
+    echo
+
+    install_system_deps
+    install_postgres
+    install_vcpkg
+    install_pg_lake
+    init_database
+    install_test_deps
+
+    echo
+    print_summary
+}
+
+main


### PR DESCRIPTION
I sometimes need to reinstall pg_lake in a fresh Linux environment, and find it a bit of a painful process that probably dissuades users. 

This PR adds an install.sh script that can take care of:
- building pg_lake from source (default)
- installing system dependencies
- installing test dependencies
- building postgres from source