### PR TITLE
Fix compiler warnings

### DIFF
--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -56,8 +56,8 @@ bool		RestCatalogEnableVendedCredentials = true;
 /*
 * Should always be accessed via GetRestCatalogAccessToken()
 */
-char	   *RestCatalogAccessToken = NULL;
-TimestampTz RestCatalogAccessTokenExpiry = 0;
+static char *RestCatalogAccessToken = NULL;
+static TimestampTz RestCatalogAccessTokenExpiry = 0;
 
 static char *GetRestCatalogAccessToken(bool forceRefreshToken);
 static void FetchRestCatalogAccessToken(char **accessToken, int *expiresIn);

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -323,7 +323,7 @@ set_unix_socket_permissions(char *unixSocketPath, char *groupName, int permissio
 }
 
 
-volatile sig_atomic_t running = 1;
+static volatile sig_atomic_t running = 1;
 
 /* basic sigint handler */
 static void

--- a/pgduck_server/src/pidfile.c
+++ b/pgduck_server/src/pidfile.c
@@ -28,8 +28,8 @@
 #include "utils/pidfile.h"
 #define MAXPGPATH 1024
 
-int			my_pidfile;
-char		pidfile_path[MAXPGPATH];
+static int	my_pidfile;
+static char	pidfile_path[MAXPGPATH];
 
 /**
  * @brief Creates and locks a PID file.


### PR DESCRIPTION
## Description

Getting compiler warnings like the following:
```
src/pgserver/pgserver.c:326:23: warning: no previous extern declaration for non-static variable 'running'
[-Wmissing-variable-declarations]
  326 | volatile sig_atomic_t running = 1;
      |                       ^
src/pgserver/pgserver.c:326:10: note: declare 'static' if the variable is not intended to be used outside
of this translation unit
  326 | volatile sig_atomic_t running = 1;
      |          ^
```

These variables are only used internally so making them static seems correct.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
