### PR TITLE
pgduck_server handles sigint/sigterm gracefully

### DIFF
--- a/pgduck_server/include/pgserver/client_threadpool.h
+++ b/pgduck_server/include/pgserver/client_threadpool.h
@@ -41,5 +41,6 @@ extern int	pgclient_threadpool_cancel_thread(int cancellationProcId, uint8 *canc
 extern int	pgclient_threadpool_cancel_thread(int cancellationProcId, int32 cancellationToken);
 #endif
 extern void pgclient_threadpool_set_duckdb_conn(int threadIndex, duckdb_connection conn);
+extern int	pgclient_threadpool_cancel_all(void);
 
 #endif							/* PGDUCK_CLIENT_THREAD_H */

--- a/pgduck_server/include/pgserver/pgserver.h
+++ b/pgduck_server/include/pgserver/pgserver.h
@@ -50,7 +50,7 @@ extern int	pgserver_init(PGServer * pgServer,
 						  int unixSocketPermissions,
 						  int port);
 extern int	pgserver_run(PGServer * pgServer);
-extern int	pgserver_destroy(PGServer * pgServer);
+extern void pgserver_destroy(PGServer * pgServer);
 
 
 #endif							/* PGDUCK_PG_SERVER_H */

--- a/pgduck_server/src/main.c
+++ b/pgduck_server/src/main.c
@@ -88,8 +88,7 @@ main(int argc, char *argv[])
 	if (pgserver_run(&pgServer) != STATUS_OK)
 		return STATUS_ERROR;
 
-	if (pgserver_destroy(&pgServer) != STATUS_OK)
-		return STATUS_ERROR;
+	pgserver_destroy(&pgServer);
 
 	return STATUS_OK;
 }

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -326,11 +326,86 @@ set_unix_socket_permissions(char *unixSocketPath, char *groupName, int permissio
 
 static volatile sig_atomic_t running = 1;
 
-/* basic sigint handler */
 static void
-handle_signal(int sig)
+handle_shutdown_signal(int sig)
 {
 	running = 0;
+}
+
+
+/*
+ * install_shutdown_signal_handlers -- install SIGINT/SIGTERM handlers.
+ *
+ * The handler simply sets `running = 0`.  SA_RESTART is deliberately
+ * *not* set so that accept() in the main loop returns -1/EINTR, giving
+ * the loop a chance to notice the flag and exit promptly.
+ */
+static int
+install_shutdown_signal_handlers(void)
+{
+	struct sigaction sa;
+
+	sa.sa_handler = handle_shutdown_signal;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;			/* no SA_RESTART — accept() must return
+								 * EINTR */
+
+	if (sigaction(SIGINT, &sa, NULL) == -1 ||
+		sigaction(SIGTERM, &sa, NULL) == -1)
+	{
+		PGDUCK_SERVER_ERROR("sigaction failed: %s", strerror(errno));
+		return STATUS_ERROR;
+	}
+
+	return STATUS_OK;
+}
+
+
+/*
+ * disable_shutdown_signals -- block SIGINT/SIGTERM in the calling thread.
+ *
+ * Used before pthread_create() so the child thread inherits a blocked
+ * mask and never receives these signals.
+ */
+static int
+disable_shutdown_signals(void)
+{
+	sigset_t	sigs;
+
+	sigemptyset(&sigs);
+	sigaddset(&sigs, SIGINT);
+	sigaddset(&sigs, SIGTERM);
+
+	if (pthread_sigmask(SIG_BLOCK, &sigs, NULL) != 0)
+	{
+		PGDUCK_SERVER_ERROR("pthread_sigmask failed: %s", strerror(errno));
+		return STATUS_ERROR;
+	}
+
+	return STATUS_OK;
+}
+
+
+/*
+ * enable_shutdown_signals -- unblock SIGINT/SIGTERM and re-install the
+ * shutdown signal handlers so accept() can be interrupted again.
+ */
+static int
+enable_shutdown_signals(void)
+{
+	sigset_t	sigs;
+
+	sigemptyset(&sigs);
+	sigaddset(&sigs, SIGINT);
+	sigaddset(&sigs, SIGTERM);
+
+	if (pthread_sigmask(SIG_UNBLOCK, &sigs, NULL) != 0)
+	{
+		PGDUCK_SERVER_ERROR("pthread_sigmask failed: %s", strerror(errno));
+		return STATUS_ERROR;
+	}
+
+	return STATUS_OK;
 }
 
 
@@ -340,30 +415,8 @@ handle_signal(int sig)
 int
 pgserver_run(PGServer * pgServer)
 {
-	/* install signal handlers */
-	struct sigaction sa;
-
-	/* Use our custom handler */
-	sa.sa_handler = handle_signal;
-
-	/* Do not block any other signals during handling */
-	sigemptyset(&sa.sa_mask);
-
-	/* CRITICAL: Do NOT set the SA_RESTART flag. */
-	/* This ensures that system calls like accept() are interrupted. */
-	sa.sa_flags = 0;
-
-	/* Install the handler for SIGINT and SIGTERM */
-	if (sigaction(SIGINT, &sa, NULL) == -1)
-	{
-		perror("sigaction for SIGINT failed");
-		exit(STATUS_ERROR);
-	}
-	if (sigaction(SIGTERM, &sa, NULL) == -1)
-	{
-		perror("sigaction for SIGTERM failed");
-		exit(STATUS_ERROR);
-	}
+	if (install_shutdown_signal_handlers() != STATUS_OK)
+		return STATUS_ERROR;
 
 	while (running)
 	{
@@ -376,20 +429,21 @@ pgserver_run(PGServer * pgServer)
 
 		if (client->clientSocket < 0)
 		{
+			int			save_errno = errno;
+
+			pg_free(client);
+
 			/*
-			 * accept() returns -1/EINTR when interrupted by a signal.  Our
-			 * SIGINT/SIGTERM handler sets running = 0 so that the while-loop
-			 * exits on the next iteration.  Free the unused PGClient and
-			 * re-check the loop condition instead of calling exit().
+			 * EINTR can come from our shutdown handler (running == 0) or from
+			 * unrelated sources like a debugger attaching (ptrace). In either
+			 * case, just retry the loop — the while-condition takes care of
+			 * the shutdown case.
 			 */
-			if (errno == EINTR)
-			{
-				pg_free(client);
+			if (save_errno == EINTR)
 				continue;
-			}
 
 			PGDUCK_SERVER_ERROR("Could not accept the client: %s",
-								strerror(errno));
+								strerror(save_errno));
 
 			/*
 			 * TODO: We can probably recover from this error, but lets handle
@@ -435,6 +489,9 @@ pgserver_run(PGServer * pgServer)
 		initState->startFunction = pgServer->startFunction;
 		initState->pgClient = client;
 
+		if (disable_shutdown_signals() != STATUS_OK)
+			exit(STATUS_ERROR);
+
 		if (pgserver_create_client_thread(initState) != OK)
 		{
 			PGDUCK_SERVER_ERROR("Thread creation failed for client %d", client->clientSocket);
@@ -443,19 +500,61 @@ pgserver_run(PGServer * pgServer)
 			pg_free(client);
 			pg_free(initState);
 			pgclient_threadpool_free_slot(threadIndex);
-			continue;
 		}
-	}
 
-	PGDUCK_SERVER_LOG("Done running");
+		if (enable_shutdown_signals() != STATUS_OK)
+			exit(STATUS_ERROR);
+	}
 
 	return STATUS_OK;
 }
 
 
 /*
+ * pgserver_destroy performs a graceful shutdown of the server.
+ *
+ * 1. Close the listening socket so no new connections are accepted.
+ * 2. Interrupt every active DuckDB query so client threads can send a
+ *    proper error to their clients instead of an abrupt TCP reset.
+ * 3. Brief grace period to let interrupted threads finish their error
+ *    path and close their sockets cleanly.
+ *
+ * We don't join the client threads (they are detached), so the grace
+ * period is best-effort.  When main() returns, exit() will tear down
+ * any remaining threads.
+ */
+void
+pgserver_destroy(PGServer * pgServer)
+{
+	PGDUCK_SERVER_LOG("Shutting down: closing listening socket");
+	closesocket(pgServer->listeningSocket);
+	pgServer->listeningSocket = -1;
+
+	int			interrupted = pgclient_threadpool_cancel_all();
+
+	if (interrupted > 0)
+	{
+		PGDUCK_SERVER_LOG("Shutting down: interrupted %d active connection(s), "
+						  "waiting briefly for them to finish", interrupted);
+
+		/*
+		 * 2 seconds is generous for the threads to send an error to their
+		 * client and run through pgclient_thread_cleanup.
+		 */
+		pg_usleep(2 * 1000000L);
+	}
+
+	PGDUCK_SERVER_LOG("Done running");
+}
+
+
+/*
  * pgserver_create_client_thread creates a new thread for the client.
  * We use PTHREAD_CREATE_DETACHED so that we don't have to join the threads.
+ *
+ * The caller must block shutdown signals before calling this function
+ * so the new thread inherits a blocked mask and never receives
+ * SIGINT/SIGTERM.
  */
 static int
 pgserver_create_client_thread(const PgClientThreadInitState * initState)
@@ -501,18 +600,10 @@ pgclient_thread_main(void *arg)
 	PgClientThreadInitState *initState = (PgClientThreadInitState *) arg;
 
 	/*
-	 * Block SIGINT and SIGTERM in client threads so that these signals are
-	 * always delivered to the main thread.  Without this, the OS may route a
-	 * termination signal to a client thread; that thread's handler sets
-	 * `running = 0`, but the main thread's accept() is never interrupted,
-	 * causing the server to hang instead of shutting down.
+	 * SIGINT/SIGTERM are already blocked — pgserver_create_client_thread()
+	 * blocks them before pthread_create(), so this thread inherits a blocked
+	 * mask.  No per-thread sigmask call needed.
 	 */
-	sigset_t	sigs;
-
-	sigemptyset(&sigs);
-	sigaddset(&sigs, SIGINT);
-	sigaddset(&sigs, SIGTERM);
-	pthread_sigmask(SIG_BLOCK, &sigs, NULL);
 
 	/* cleanup handler */
 	pthread_cleanup_push(pgclient_thread_cleanup, arg);
@@ -550,18 +641,6 @@ pgclient_thread_cleanup(void *arg)
 }
 
 
-/*
- * cleanup on successful exists.
- *
- * TODO: not called ever yet
- */
-int
-pgserver_destroy(PGServer * pgServer)
-{
-	closesocket(pgServer->listeningSocket);
-
-	return STATUS_OK;
-}
 
 
 /*

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -198,4 +198,7 @@ def test_s3_get_region_invalid(pgduck_conn):
         pgduck_conn,
         raise_error=False,
     )
-    assert "Could not establish connection error" in error
+    assert (
+        "Could not establish connection error" in error
+        or "server closed the connection" in error
+    )

--- a/pgduck_server/tests/pytests/test_server_start.py
+++ b/pgduck_server/tests/pytests/test_server_start.py
@@ -4,6 +4,7 @@ import os
 import signal
 import time
 import tempfile
+import threading
 from utils_pytest import *
 import platform
 
@@ -326,7 +327,99 @@ def test_server_pidfile_signal(send_signal):
         assert pid.isdigit()
         pid = int(pid)
         os.kill(pid, send_signal)
-        time.sleep(1)
+
+    # wait for the process to exit (graceful shutdown may take a moment)
+    server.process.wait(timeout=10)
 
     # pidfile cleaned up
     assert not os.path.exists(pidfile_path)
+
+
+@pytest.mark.parametrize("num_clients", [3, 5])
+@pytest.mark.parametrize("send_signal", [signal.SIGINT, signal.SIGTERM])
+def test_graceful_shutdown_with_active_clients(send_signal, num_clients):
+    """Server should interrupt active queries and shut down gracefully.
+
+    Starts *num_clients* connections each running a long query, sends
+    *send_signal*, and verifies:
+      - the server exits within a reasonable timeout,
+      - the "interrupted N active connection(s)" message is logged,
+      - the "Done running" message is logged,
+      - each client thread received an error (connection reset or interrupt).
+    """
+    server = PgDuckServer(port=PGDUCK_PORT, need_output=True)
+    assert is_server_listening(server.socket_path)
+
+    # Thread-safe queue to collect errors from client threads.
+    error_queue = queue.Queue()
+    barrier = threading.Barrier(num_clients + 1)
+
+    long_running_query = (
+        "SELECT SUM(generate_series) FROM generate_series(0, 999999999999)"
+    )
+
+    def run_query_on_client(idx):
+        conn = psycopg2.connect(host=PGDUCK_UNIX_DOMAIN_PATH, port=PGDUCK_PORT)
+        cur = conn.cursor()
+        try:
+            # Signal that this client is connected and about to run its query.
+            barrier.wait(timeout=10)
+            cur.execute(long_running_query)
+        except Exception as e:
+            error_queue.put((idx, e))
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    threads = []
+    for i in range(num_clients):
+        t = threading.Thread(target=run_query_on_client, args=(i,))
+        t.start()
+        threads.append(t)
+
+    # Wait until all clients are connected and have issued their query.
+    barrier.wait(timeout=10)
+    # Small extra delay so the queries are actually running server-side.
+    time.sleep(0.3)
+
+    # Send the signal.
+    server.process.send_signal(send_signal)
+
+    # The server runs a 2-second grace period, so give it a generous timeout.
+    try:
+        server.process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        server.process.kill()
+        server.process.wait(timeout=5)
+        pytest.fail(
+            f"Server did not exit within 15s after {send_signal.name} "
+            f"with {num_clients} active clients"
+        )
+
+    # Wait for all client threads to finish.
+    for t in threads:
+        t.join(timeout=5)
+
+    server_output = get_server_output(server.output_queue)
+
+    # The server must have interrupted active connections.
+    assert "interrupted" in server_output and "active connection(s)" in server_output, (
+        f"Expected 'interrupted ... active connection(s)' in server output, "
+        f"got: {server_output}"
+    )
+
+    # Clean shutdown path must have been reached.
+    assert "Done running" in server_output
+
+    # Drain the error queue and verify every client saw an error.
+    errors = {}
+    while not error_queue.empty():
+        idx, err = error_queue.get_nowait()
+        errors[idx] = err
+
+    assert len(errors) == num_clients, (
+        f"Expected {num_clients} client errors, got {len(errors)}; "
+        f"missing clients: {set(range(num_clients)) - errors.keys()}"
+    )


### PR DESCRIPTION
Fixes hanging issue in pgduck_server tests by handling signals (sigint, sigterm) always in the main thread gracefully.