### PR TITLE
Fix flaky test_set_operation_pushdown 

### DIFF
--- a/pg_lake_table/tests/pytests/test_set_operation_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_set_operation_pushdown.py
@@ -73,7 +73,7 @@ queries = [
     ],
     [
         "INTERSECT",
-        "SELECT DISTINCT U.id, U.metric1 FROM Users_f U WHERE EXISTS (SELECT 1 FROM Events_f E WHERE U.id = E.id INTERSECT SELECT id FROM Users_f WHERE metric2 < 100);",
+        "SELECT DISTINCT U.id, U.metric1 FROM Users_f U WHERE EXISTS (SELECT E.id FROM Events_f E WHERE U.id = E.id INTERSECT SELECT id FROM Users_f WHERE metric2 < 100);",
     ],
     [
         "UNION",
@@ -107,4 +107,4 @@ def test_set_operation_pushdown(create_pushdown_tables, pg_conn):
 
         # then replace table names for ensuring SET OPERATION pushdown
         expected_exprs = query_data[0]
-        assert_remote_query_contains_expression(query, query[0], pg_conn)
+        assert_remote_query_contains_expression(query, expected_exprs, pg_conn)


### PR DESCRIPTION
Fixes a flaky test, e.g. https://github.com/Snowflake-Labs/pg_lake/actions/runs/22599338293/job/65477757652

The EXISTS subquery was intersecting a literal `1` against id values, which only returned rows when user id=1 had metric2 < 100 (~0.5% failure rate). Use E.id instead so the INTERSECT operates on matching columns. Also fix the pushdown assertion that was checking for the character "S" (query[0]) instead of the expected set operation keyword.