### PR TITLE
Support external writes to Iceberg tables using Postgres catalog

### DIFF
--- a/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
+++ b/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
@@ -259,10 +259,11 @@ HandleInternalCatalogUpdate(char *namespaceName, char *tableName,
 		 * the function manager. The sync function itself uses SPI internally,
 		 * but that's fine since we're not in an SPI context here.
 		 */
+		Oid			argTypes[1] = {REGCLASSOID};
 		Oid			syncFuncOid = LookupFuncName(
 											list_make2(makeString("lake_table"),
 													  makeString("sync_iceberg_metadata_from_external_write")),
-											1, (Oid[]){REGCLASSOID}, true);
+											1, argTypes, true);
 
 		if (OidIsValid(syncFuncOid))
 		{

--- a/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
+++ b/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
@@ -251,17 +251,13 @@ HandleInternalCatalogUpdate(char *namespaceName, char *tableName,
 		SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg),
 							  SECURITY_LOCAL_USERID_CHANGE);
 
-		DECLARE_SPI_ARGS(1);
-		SPI_ARG_VALUE(1, OIDOID, relationId, false);
-
-		SPI_START();
-
-		bool		readOnly = false;
-
-		SPI_EXECUTE("SELECT lake_table.sync_iceberg_metadata_from_external_write($1)",
-					readOnly);
-
-		SPI_END();
+		/*
+		 * Call the sync function directly (not via SPI) to avoid nested SPI
+		 * calls, since the sync function itself uses SPI internally.
+		 */
+		extern Datum sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS);
+		DirectFunctionCall1(sync_iceberg_metadata_from_external_write,
+							ObjectIdGetDatum(relationId));
 
 		SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 	}

--- a/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
+++ b/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
@@ -114,8 +114,25 @@ external_catalog_modification(PG_FUNCTION_ARGS)
 		prevMetadataLocationIsNull ? NULL : TextDatumGetCString(prevMetadataLocationDatum);
 
 	char	   *databaseName = get_database_name(MyDatabaseId);
+	bool		isInternalCatalog = (strcmp(catalogName, databaseName) == 0);
 
-	if (strcmp(catalogName, databaseName) == 0)
+	/* For UPDATE, check if catalog_name is being changed */
+	if (TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
+	{
+		Datum		oldCatalogNameDatum = heap_getattr(trigdata->tg_trigtuple, 1,
+													   trigdata->tg_relation->rd_att, &isnull);
+		char	   *oldCatalogName = TextDatumGetCString(oldCatalogNameDatum);
+		bool		wasInternalCatalog = (strcmp(oldCatalogName, databaseName) == 0);
+
+		if (isInternalCatalog != wasInternalCatalog)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("modifying the internal catalog is currently only supported via pg_lake_iceberg tables")));
+		}
+	}
+
+	if (isInternalCatalog)
 	{
 		/*
 		 * For the current database catalog, only UPDATE is supported.
@@ -132,15 +149,13 @@ external_catalog_modification(PG_FUNCTION_ARGS)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("INSERT to the %s catalog is only supported via CREATE TABLE ... USING iceberg",
-							databaseName)));
+					 errmsg("modifying the internal catalog is currently only supported via pg_lake_iceberg tables")));
 		}
 		else if (TRIGGER_FIRED_BY_DELETE(trigdata->tg_event))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("DELETE from the %s catalog is only supported via DROP TABLE",
-							databaseName)));
+					 errmsg("modifying the internal catalog is currently only supported via pg_lake_iceberg tables")));
 		}
 		else
 		{

--- a/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
+++ b/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
@@ -26,6 +26,8 @@
 #include "commands/extension.h"
 #include "commands/trigger.h"
 #include "executor/spi.h"
+#include "nodes/makefuncs.h"
+#include "parser/parse_func.h"
 #include "utils/builtins.h"
 #include "utils/elog.h"
 #include "utils/rel.h"
@@ -252,12 +254,20 @@ HandleInternalCatalogUpdate(char *namespaceName, char *tableName,
 							  SECURITY_LOCAL_USERID_CHANGE);
 
 		/*
-		 * Call the sync function directly (not via SPI) to avoid nested SPI
-		 * calls, since the sync function itself uses SPI internally.
+		 * Use OidFunctionCall1 to call the sync function. This is safe because
+		 * OidFunctionCall doesn't use SPI - it calls the function directly via
+		 * the function manager. The sync function itself uses SPI internally,
+		 * but that's fine since we're not in an SPI context here.
 		 */
-		extern Datum sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS);
-		DirectFunctionCall1(sync_iceberg_metadata_from_external_write,
-							ObjectIdGetDatum(relationId));
+		Oid			syncFuncOid = LookupFuncName(
+											list_make2(makeString("lake_table"),
+													  makeString("sync_iceberg_metadata_from_external_write")),
+											1, (Oid[]){REGCLASSOID}, true);
+
+		if (OidIsValid(syncFuncOid))
+		{
+			OidFunctionCall1(syncFuncOid, ObjectIdGetDatum(relationId));
+		}
 
 		SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 	}

--- a/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
+++ b/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
@@ -23,6 +23,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/namespace.h"
 #include "commands/dbcommands.h"
+#include "commands/extension.h"
 #include "commands/trigger.h"
 #include "executor/spi.h"
 #include "utils/builtins.h"
@@ -33,8 +34,13 @@
 
 #include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/extensions/pg_lake_iceberg.h"
+#include "pg_lake/extensions/pg_lake_table.h"
+#include "pg_extension_base/spi_helpers.h"
 
 PG_FUNCTION_INFO_V1(external_catalog_modification);
+
+static void HandleInternalCatalogUpdate(char *namespaceName, char *tableName,
+										char *metadataLocation, char *prevMetadataLocation);
 
 
 /*
@@ -109,35 +115,154 @@ external_catalog_modification(PG_FUNCTION_ARGS)
 
 	if (strcmp(catalogName, databaseName) == 0)
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("writes to the %s catalog are currently only supported via pg_lake_iceberg tables",
-						databaseName)));
-	}
-
-	/*
-	 * Postgres only allows INSTEAD OF triggers on views. We are using this
-	 * trigger to prevent external tools from modifying the iceberg catalog.
-	 * But given that we use INSTEAD OF trigger on a view, we still need to
-	 * handle the INSERT, UPDATE, DELETE operations on the base table.
-	 */
-	if (TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
-	{
-		UpdateExternalCatalogMetadataLocation(catalogName, namespaceName, tableName, metadataLocation, prevMetadataLocation);
-	}
-	else if (TRIGGER_FIRED_BY_INSERT(trigdata->tg_event))
-	{
-		InsertExternalIcebergCatalogTable(catalogName, namespaceName, tableName, metadataLocation);
-	}
-	else if (TRIGGER_FIRED_BY_DELETE(trigdata->tg_event))
-	{
-		DeleteExternalIcebergCatalogTable(catalogName, namespaceName, tableName);
+		/*
+		 * For the current database catalog, only UPDATE is supported.
+		 * This allows external Iceberg clients to write new metadata
+		 * and then update the metadata_location, triggering a sync
+		 * of the internal pg_lake catalog state.
+		 */
+		if (TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
+		{
+			HandleInternalCatalogUpdate(namespaceName, tableName,
+										metadataLocation, prevMetadataLocation);
+		}
+		else if (TRIGGER_FIRED_BY_INSERT(trigdata->tg_event))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("INSERT to the %s catalog is only supported via CREATE TABLE ... USING iceberg",
+							databaseName)));
+		}
+		else if (TRIGGER_FIRED_BY_DELETE(trigdata->tg_event))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("DELETE from the %s catalog is only supported via DROP TABLE",
+							databaseName)));
+		}
+		else
+		{
+			pg_unreachable();
+		}
 	}
 	else
 	{
-		/* no other command is supported on view triggers */
-		pg_unreachable();
+		/*
+		 * Postgres only allows INSTEAD OF triggers on views. We are using
+		 * this trigger to prevent external tools from modifying the iceberg
+		 * catalog. But given that we use INSTEAD OF trigger on a view, we
+		 * still need to handle the INSERT, UPDATE, DELETE operations on the
+		 * base table.
+		 */
+		if (TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
+		{
+			UpdateExternalCatalogMetadataLocation(catalogName, namespaceName, tableName, metadataLocation, prevMetadataLocation);
+		}
+		else if (TRIGGER_FIRED_BY_INSERT(trigdata->tg_event))
+		{
+			InsertExternalIcebergCatalogTable(catalogName, namespaceName, tableName, metadataLocation);
+		}
+		else if (TRIGGER_FIRED_BY_DELETE(trigdata->tg_event))
+		{
+			DeleteExternalIcebergCatalogTable(catalogName, namespaceName, tableName);
+		}
+		else
+		{
+			/* no other command is supported on view triggers */
+			pg_unreachable();
+		}
 	}
 
 	return PointerGetDatum(rettuple);
+}
+
+
+/*
+ * HandleInternalCatalogUpdate handles UPDATE to the iceberg_tables view
+ * for tables that belong to the current database catalog (i.e., internal
+ * pg_lake iceberg tables).
+ *
+ * This allows external Iceberg clients (Spark, PyIceberg) to:
+ * 1. Write new data/metadata files to object storage
+ * 2. UPDATE iceberg_tables SET metadata_location = <new>, previous_metadata_location = <old>
+ *
+ * The function validates optimistic concurrency via previous_metadata_location,
+ * updates the internal catalog, and triggers a sync of the pg_lake catalog
+ * state (data files, schema, partition specs) from the new metadata.
+ */
+static void
+HandleInternalCatalogUpdate(char *namespaceName, char *tableName,
+							char *metadataLocation, char *prevMetadataLocation)
+{
+	if (metadataLocation == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("metadata_location cannot be NULL")));
+
+	if (prevMetadataLocation == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("previous_metadata_location is required for optimistic concurrency control")));
+
+	/* resolve namespace + table name to a relation OID */
+	bool		missingOk = false;
+	Oid			namespaceOid = get_namespace_oid(namespaceName, missingOk);
+	Oid			relationId = get_relname_relid(tableName, namespaceOid);
+
+	if (!OidIsValid(relationId))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("table \"%s.%s\" does not exist",
+						namespaceName, tableName)));
+
+	/*
+	 * Lock the row and get the current metadata_location for optimistic
+	 * concurrency validation.
+	 */
+	bool		forUpdate = true;
+	char	   *currentMetadataLocation =
+		GetIcebergCatalogMetadataLocation(relationId, forUpdate);
+
+	if (currentMetadataLocation == NULL ||
+		strcmp(currentMetadataLocation, prevMetadataLocation) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+				 errmsg("metadata_location has been modified concurrently"),
+				 errdetail("Expected previous_metadata_location \"%s\" but found \"%s\".",
+						   prevMetadataLocation,
+						   currentMetadataLocation ? currentMetadataLocation : "(null)")));
+
+	/* update the internal catalog with the new metadata location */
+	UpdateInternalCatalogMetadataLocation(relationId, metadataLocation,
+										  prevMetadataLocation);
+
+	/*
+	 * If pg_lake_table is installed, trigger a sync of the internal catalog
+	 * (data files, schema, partition specs) from the new metadata.
+	 */
+	Oid			pgLakeTableExtOid = get_extension_oid(PG_LAKE_TABLE, true);
+
+	if (OidIsValid(pgLakeTableExtOid))
+	{
+		Oid			savedUserId = InvalidOid;
+		int			savedSecurityContext = 0;
+
+		GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
+		SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg),
+							  SECURITY_LOCAL_USERID_CHANGE);
+
+		DECLARE_SPI_ARGS(1);
+		SPI_ARG_VALUE(1, OIDOID, relationId, false);
+
+		SPI_START();
+
+		bool		readOnly = false;
+
+		SPI_EXECUTE("SELECT lake_table.sync_iceberg_metadata_from_external_write($1)",
+					readOnly);
+
+		SPI_END();
+
+		SetUserIdAndSecContext(savedUserId, savedSecurityContext);
+	}
 }

--- a/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
+++ b/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
@@ -238,7 +238,7 @@ HandleInternalCatalogUpdate(char *namespaceName, char *tableName,
 	 */
 	bool		forUpdate = true;
 	char	   *currentMetadataLocation =
-		GetIcebergCatalogMetadataLocation(relationId, forUpdate);
+		GetIcebergMetadataLocation(relationId, forUpdate);
 
 	if (currentMetadataLocation == NULL ||
 		strcmp(currentMetadataLocation, prevMetadataLocation) != 0)

--- a/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
+++ b/pg_lake_iceberg/src/iceberg/external_metadata_modification.c
@@ -135,10 +135,10 @@ external_catalog_modification(PG_FUNCTION_ARGS)
 	if (isInternalCatalog)
 	{
 		/*
-		 * For the current database catalog, only UPDATE is supported.
-		 * This allows external Iceberg clients to write new metadata
-		 * and then update the metadata_location, triggering a sync
-		 * of the internal pg_lake catalog state.
+		 * For the current database catalog, only UPDATE is supported. This
+		 * allows external Iceberg clients to write new metadata and then
+		 * update the metadata_location, triggering a sync of the internal
+		 * pg_lake catalog state.
 		 */
 		if (TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
 		{
@@ -266,19 +266,20 @@ HandleInternalCatalogUpdate(char *namespaceName, char *tableName,
 
 		GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
 		SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg),
-							  SECURITY_LOCAL_USERID_CHANGE);
+							   SECURITY_LOCAL_USERID_CHANGE);
 
 		/*
-		 * Use OidFunctionCall1 to call the sync function. This is safe because
-		 * OidFunctionCall doesn't use SPI - it calls the function directly via
-		 * the function manager. The sync function itself uses SPI internally,
-		 * but that's fine since we're not in an SPI context here.
+		 * Use OidFunctionCall1 to call the sync function. This is safe
+		 * because OidFunctionCall doesn't use SPI - it calls the function
+		 * directly via the function manager. The sync function itself uses
+		 * SPI internally, but that's fine since we're not in an SPI context
+		 * here.
 		 */
 		Oid			argTypes[1] = {REGCLASSOID};
 		Oid			syncFuncOid = LookupFuncName(
-											list_make2(makeString("lake_table"),
-													  makeString("sync_iceberg_metadata_from_external_write")),
-											1, argTypes, true);
+												 list_make2(makeString("lake_table"),
+															makeString("sync_iceberg_metadata_from_external_write")),
+												 1, argTypes, true);
 
 		if (OidIsValid(syncFuncOid))
 		{

--- a/pg_lake_table/include/pg_lake/ddl/alter_table.h
+++ b/pg_lake_table/include/pg_lake/ddl/alter_table.h
@@ -32,3 +32,11 @@ typedef void (*PgLakeAlterTableRenameColumnHookType) (Oid relationOid, RenameStm
 
 extern PGDLLEXPORT PgLakeAlterTableHookType PgLakeAlterTableHook;
 extern PGDLLEXPORT PgLakeAlterTableRenameColumnHookType PgLakeAlterTableRenameColumnHook;
+
+/*
+ * When true, ProcessAlterTable skips Iceberg DDL processing (field_id
+ * registration and metadata tracking).  Used by
+ * sync_iceberg_metadata_from_external_write to add/drop columns without
+ * triggering a new metadata write.
+ */
+extern bool SkipIcebergDDLProcessing;

--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -61,6 +61,8 @@ bool		PartitionFieldsCatalogExists(void);
 /* functions to write to files catalog */
 extern PGDLLEXPORT void ApplyDataFileCatalogChanges(Oid relationId, List *metadataOperations);
 int64		GenerateDataFileId(void);
+int64		AddDataFileToTable(Oid relationId, const char *path, int64 rowCount,
+							   int64 fileSize, DataFileContent content, int64 rowIdStart);
 
 /* when enabling row_ids, we need to explicit update first_row_id */
 void		UpdateDataFileFirstRowId(Oid relationId, int64 fileId, int64 firstRowId);

--- a/pg_lake_table/include/pg_lake/sync/sync_external_metadata.h
+++ b/pg_lake_table/include/pg_lake/sync/sync_external_metadata.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "postgres.h"
+#include "fmgr.h"

--- a/pg_lake_table/pg_lake_table--3.2--3.3.sql
+++ b/pg_lake_table/pg_lake_table--3.2--3.3.sql
@@ -9,3 +9,10 @@ ALTER TABLE lake_table.data_file_column_stats REPLICA IDENTITY FULL;
 ALTER TABLE lake_table.partition_specs REPLICA IDENTITY FULL;
 ALTER TABLE lake_table.partition_fields REPLICA IDENTITY FULL;
 ALTER TABLE lake_table.data_file_partition_values REPLICA IDENTITY FULL;
+
+-- Sync function for external writes to Iceberg tables.
+-- Called by the iceberg_tables INSTEAD OF trigger when an external client
+-- updates metadata_location for a table in the current database catalog.
+CREATE FUNCTION lake_table.sync_iceberg_metadata_from_external_write(regclass)
+    RETURNS void AS 'MODULE_PATHNAME', 'sync_iceberg_metadata_from_external_write'
+    LANGUAGE C STRICT;

--- a/pg_lake_table/pg_lake_table--3.2--3.3.sql
+++ b/pg_lake_table/pg_lake_table--3.2--3.3.sql
@@ -9,10 +9,3 @@ ALTER TABLE lake_table.data_file_column_stats REPLICA IDENTITY FULL;
 ALTER TABLE lake_table.partition_specs REPLICA IDENTITY FULL;
 ALTER TABLE lake_table.partition_fields REPLICA IDENTITY FULL;
 ALTER TABLE lake_table.data_file_partition_values REPLICA IDENTITY FULL;
-
--- Sync function for external writes to Iceberg tables.
--- Called by the iceberg_tables INSTEAD OF trigger when an external client
--- updates metadata_location for a table in the current database catalog.
-CREATE FUNCTION lake_table.sync_iceberg_metadata_from_external_write(regclass)
-    RETURNS void AS 'MODULE_PATHNAME', 'sync_iceberg_metadata_from_external_write'
-    LANGUAGE C STRICT;

--- a/pg_lake_table/pg_lake_table--3.3--3.4.sql
+++ b/pg_lake_table/pg_lake_table--3.3--3.4.sql
@@ -1,1 +1,8 @@
 -- Upgrade script for pg_lake_table from 3.3 to 3.4
+
+-- Sync function for external writes to Iceberg tables.
+-- Called by the iceberg_tables INSTEAD OF trigger when an external client
+-- updates metadata_location for a table in the current database catalog.
+CREATE FUNCTION lake_table.sync_iceberg_metadata_from_external_write(regclass)
+    RETURNS void AS 'MODULE_PATHNAME', 'sync_iceberg_metadata_from_external_write'
+    LANGUAGE C STRICT;

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -124,6 +124,7 @@ static bool DisallowedForWritableRestSetSchema(Node *arg, Oid relationId);
 
 PgLakeAlterTableHookType PgLakeAlterTableHook = NULL;
 PgLakeAlterTableRenameColumnHookType PgLakeAlterTableRenameColumnHook = NULL;
+bool		SkipIcebergDDLProcessing = false;
 
 /*
  * Below is the support matrix for ALTER TABLE commands, which pg_lake
@@ -304,6 +305,14 @@ ProcessAlterTable(ProcessUtilityParams * processUtilityParams, void *arg)
 	 * so PgLakeCommonProcessUtility would recurse back into this function.
 	 */
 	PgLakeCommonParentProcessUtility(processUtilityParams);
+
+	/*
+	 * When syncing from externally-written Iceberg metadata, we only need the
+	 * ALTER TABLE to modify pg_attribute.  Skip field_id registration and
+	 * metadata tracking so we don't conflict with the external metadata.
+	 */
+	if (SkipIcebergDDLProcessing)
+		return true;
 
 	List	   *schemaDDLOperations = NIL;
 

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -692,6 +692,14 @@ PostProcessRenameWritablePgLakeTable(ProcessUtilityParams * params, void *arg)
 		!(renameStmt->renameType == OBJECT_TABLE ||
 		  renameStmt->renameType == OBJECT_FOREIGN_TABLE))
 	{
+		/*
+		 * When syncing from externally-written Iceberg metadata, the rename
+		 * is already reflected in the new metadata file; skip our own DDL
+		 * tracking and metadata write.
+		 */
+		if (SkipIcebergDDLProcessing)
+			return;
+
 		/* schema has changed, update the metadata */
 		IcebergDDLOperation *ddlOperation = palloc0(sizeof(IcebergDDLOperation));
 

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -78,8 +78,6 @@ PgLakeAddDataFileHookType PgLakeAddDataFileHook = NULL;
 static void FillDataFileColumnStats(TableDataFile * dataFile, int64 fieldId, int rowIndex);
 static void FillPartitionFieldFromCatalog(TableDataFile * dataFile, List *partitionTransforms,
 										  int64 partitionFieldId, int rowIndex);
-static int64 AddDataFileToTable(Oid relationId, const char *path, int64 rowCount,
-								int64 fileSize, DataFileContent content, int64 rowIdStart);
 static void AddDeletionFileMapping(Oid relationId, const char *path,
 								   const char *sourcePath);
 static void AddNewRowIdMapping(Oid relationId, const char *path, List *rowIdRanges);
@@ -937,7 +935,7 @@ GetTotalDeletedRowCountFromCatalog(Oid relationId)
  * For deletion files, deletedFrom indicates which file we are deleting from (can
  * be NULL if deleting from multiple files/unknown).
  */
-static int64
+int64
 AddDataFileToTable(Oid relationId, const char *path, int64 rowCount, int64 fileSize,
 				   DataFileContent content, int64 rowIdStart)
 {

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -61,16 +61,16 @@
 
 PG_FUNCTION_INFO_V1(sync_iceberg_metadata_from_external_write);
 
-static void SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata *metadata);
+static void SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata * metadata);
 static void FetchExistingFieldMappings(Oid relationId, int **fieldIds,
 									   int16 **attnums, int *count);
 static void ExecuteAlterTableViaSPI(const char *cmd);
-static void SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata *metadata);
-static void SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata);
-static char *ColumnBoundBinaryToText(ColumnBound *bound, int fieldId,
-									 IcebergTableSchema *schema);
-static List *BuildColumnStatsForManifestEntry(IcebergManifestEntry *manifestEntry,
-											  IcebergTableSchema *schema);
+static void SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata * metadata);
+static void SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata * metadata);
+static char *ColumnBoundBinaryToText(ColumnBound * bound, int fieldId,
+									 IcebergTableSchema * schema);
+static List *BuildColumnStatsForManifestEntry(IcebergManifestEntry * manifestEntry,
+											  IcebergTableSchema * schema);
 
 
 /*
@@ -97,8 +97,9 @@ sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS)
 
 	/*
 	 * Suppress the ProcessAlterTable hook's Iceberg DDL processing while we
-	 * add/drop columns.  We manage field_id_mappings ourselves and do not want
-	 * the hook to register duplicate mappings or schedule a metadata write.
+	 * add/drop columns.  We manage field_id_mappings ourselves and do not
+	 * want the hook to register duplicate mappings or schedule a metadata
+	 * write.
 	 */
 	SkipIcebergDDLProcessing = true;
 
@@ -189,7 +190,7 @@ ExecuteAlterTableViaSPI(const char *cmd)
  * Iceberg schema, we DROP COLUMN (but keep the mapping for reading old files).
  */
 static void
-SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
+SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata * metadata)
 {
 	IcebergTableSchema *icebergSchema = GetCurrentIcebergTableSchema(metadata);
 
@@ -308,8 +309,8 @@ SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 			continue;
 
 		/*
-		 * Check if the column is already dropped in pg_attribute (could happen
-		 * if this sync runs multiple times).
+		 * Check if the column is already dropped in pg_attribute (could
+		 * happen if this sync runs multiple times).
 		 */
 		Relation	rel = RelationIdGetRelation(relationId);
 		TupleDesc	tupdesc = RelationGetDescr(rel);
@@ -359,7 +360,7 @@ SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
  * we register it. We also update the default_spec_id.
  */
 static void
-SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
+SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata * metadata)
 {
 	/* get the largest spec_id currently in catalog */
 	int			largestCatalogSpecId = GetLargestSpecId(relationId);
@@ -387,7 +388,7 @@ SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
  * Files that are no longer referenced are added to the deletion queue.
  */
 static void
-SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
+SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata * metadata)
 {
 	TimestampTz orphanedAt = GetCurrentTransactionStartTimestamp();
 
@@ -442,8 +443,8 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 	if (currentSnapshot == NULL)
 	{
 		/*
-		 * Empty table after external write. All old files are now unreferenced,
-		 * queue them for deletion.
+		 * Empty table after external write. All old files are now
+		 * unreferenced, queue them for deletion.
 		 */
 		if (oldFileHash != NULL)
 		{
@@ -477,7 +478,7 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 		hashCtl.hcxt = CurrentMemoryContext;
 
 		newFileHash = hash_create("new file paths",
-								  1024,		/* initial estimate */
+								  1024, /* initial estimate */
 								  &hashCtl,
 								  HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 	}
@@ -529,11 +530,11 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 
 			/* insert the data file into the catalog */
 			int64		fileId = AddDataFileToTable(relationId,
-												   dataFile->file_path,
-												   dataFile->record_count,
-												   dataFile->file_size_in_bytes,
-												   content,
-												   INVALID_ROW_ID);
+													dataFile->file_path,
+													dataFile->record_count,
+													dataFile->file_size_in_bytes,
+													content,
+													INVALID_ROW_ID);
 
 			/* insert column stats if available */
 			if (content == CONTENT_DATA)
@@ -561,8 +562,8 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 	}
 
 	/*
-	 * Queue old files that are no longer referenced for deletion.
-	 * Compare oldFileHash with newFileHash to find unreferenced files.
+	 * Queue old files that are no longer referenced for deletion. Compare
+	 * oldFileHash with newFileHash to find unreferenced files.
 	 */
 	if (oldFileHash != NULL && newFileHash != NULL)
 	{
@@ -594,8 +595,8 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
  * to Postgres text representation for the catalog.
  */
 static List *
-BuildColumnStatsForManifestEntry(IcebergManifestEntry *manifestEntry,
-								 IcebergTableSchema *schema)
+BuildColumnStatsForManifestEntry(IcebergManifestEntry * manifestEntry,
+								 IcebergTableSchema * schema)
 {
 	DataFile   *dataFile = &manifestEntry->data_file;
 
@@ -677,8 +678,8 @@ BuildColumnStatsForManifestEntry(IcebergManifestEntry *manifestEntry,
  * deserialization fails.
  */
 static char *
-ColumnBoundBinaryToText(ColumnBound *bound, int fieldId,
-						IcebergTableSchema *schema)
+ColumnBoundBinaryToText(ColumnBound * bound, int fieldId,
+						IcebergTableSchema * schema)
 {
 	if (bound->value == NULL || bound->value_length == 0)
 		return NULL;
@@ -702,9 +703,9 @@ ColumnBoundBinaryToText(ColumnBound *bound, int fieldId,
 
 	/* deserialize from Iceberg binary to Postgres Datum */
 	Datum		boundDatum = PGIcebergBinaryDeserialize(bound->value,
-													   bound->value_length,
-													   icebergField->type,
-													   pgType);
+														bound->value_length,
+														icebergField->type,
+														pgType);
 
 	/* convert Datum to text representation */
 	Oid			typoutput;

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -40,8 +40,10 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
+#include "pg_lake/cleanup/deletion_queue.h"
 #include "pg_lake/data_file/data_files.h"
 #include "pg_lake/data_file/data_file_stats.h"
+#include "pg_lake/ddl/alter_table.h"
 #include "pg_lake/extensions/pg_lake_iceberg.h"
 #include "pg_lake/extensions/pg_lake_table.h"
 #include "pg_lake/fdw/data_files_catalog.h"
@@ -55,6 +57,7 @@
 #include "pg_lake/iceberg/iceberg_type_binary_serde.h"
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_extension_base/spi_helpers.h"
+#include "utils/hsearch.h"
 
 PG_FUNCTION_INFO_V1(sync_iceberg_metadata_from_external_write);
 
@@ -92,9 +95,24 @@ sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS)
 
 	IcebergTableMetadata *metadata = ReadIcebergTableMetadata(metadataLocation);
 
-	SyncSchemaFromMetadata(relationId, metadata);
-	SyncPartitionSpecsFromMetadata(relationId, metadata);
-	SyncDataFilesFromMetadata(relationId, metadata);
+	/*
+	 * Suppress the ProcessAlterTable hook's Iceberg DDL processing while we
+	 * add/drop columns.  We manage field_id_mappings ourselves and do not want
+	 * the hook to register duplicate mappings or schedule a metadata write.
+	 */
+	SkipIcebergDDLProcessing = true;
+
+	PG_TRY();
+	{
+		SyncSchemaFromMetadata(relationId, metadata);
+		SyncPartitionSpecsFromMetadata(relationId, metadata);
+		SyncDataFilesFromMetadata(relationId, metadata);
+	}
+	PG_FINALLY();
+	{
+		SkipIcebergDDLProcessing = false;
+	}
+	PG_END_TRY();
 
 	PG_RETURN_VOID();
 }
@@ -366,10 +384,54 @@ SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
  * pg_lake catalog from the current snapshot in the Iceberg metadata.
  *
  * This clears all existing data files and repopulates them from the metadata.
+ * Files that are no longer referenced are added to the deletion queue.
  */
 static void
 SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 {
+	TimestampTz orphanedAt = GetCurrentTransactionStartTimestamp();
+
+	/*
+	 * Get the list of old file paths before clearing, so we can queue
+	 * unreferenced files for deletion.
+	 */
+	bool		dataOnly = false;
+	bool		newFilesOnly = false;
+	bool		forUpdate = false;
+	Snapshot	snapshot = GetActiveSnapshot();
+
+	List	   *oldDataFiles = GetTableDataFilesFromCatalog(relationId, dataOnly,
+															newFilesOnly, forUpdate,
+															NULL, snapshot);
+
+	/* build a hash table of old file paths for quick lookup */
+	HTAB	   *oldFileHash = NULL;
+
+	if (oldDataFiles != NIL)
+	{
+		HASHCTL		hashCtl;
+
+		memset(&hashCtl, 0, sizeof(hashCtl));
+		hashCtl.keysize = MAX_S3_PATH_LENGTH;
+		hashCtl.entrysize = MAX_S3_PATH_LENGTH;
+		hashCtl.hcxt = CurrentMemoryContext;
+
+		oldFileHash = hash_create("old file paths",
+								  list_length(oldDataFiles),
+								  &hashCtl,
+								  HASH_ELEM | HASH_CONTEXT);
+
+		ListCell   *oldFileCell = NULL;
+
+		foreach(oldFileCell, oldDataFiles)
+		{
+			TableDataFile *oldFile = lfirst(oldFileCell);
+			bool		found = false;
+
+			hash_search(oldFileHash, oldFile->path, HASH_ENTER, &found);
+		}
+	}
+
 	/* clear all existing data files from the catalog */
 	RemoveAllDataFilesFromPgLakeCatalogFromTable(relationId);
 
@@ -379,7 +441,21 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 
 	if (currentSnapshot == NULL)
 	{
-		/* empty table after external write, no data files to sync */
+		/*
+		 * Empty table after external write. All old files are now unreferenced,
+		 * queue them for deletion.
+		 */
+		if (oldFileHash != NULL)
+		{
+			HASH_SEQ_STATUS hashSeq;
+			char	   *filePath = NULL;
+
+			hash_seq_init(&hashSeq, oldFileHash);
+			while ((filePath = hash_seq_search(&hashSeq)) != NULL)
+			{
+				InsertDeletionQueueRecord(filePath, relationId, orphanedAt);
+			}
+		}
 		return;
 	}
 
@@ -387,6 +463,24 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 
 	/* fetch all manifests from the current snapshot */
 	List	   *manifests = FetchManifestsFromSnapshot(currentSnapshot, NULL);
+
+	/* track new file paths to identify unreferenced files later */
+	HTAB	   *newFileHash = NULL;
+
+	if (oldFileHash != NULL)
+	{
+		HASHCTL		hashCtl;
+
+		memset(&hashCtl, 0, sizeof(hashCtl));
+		hashCtl.keysize = MAX_S3_PATH_LENGTH;
+		hashCtl.entrysize = MAX_S3_PATH_LENGTH;
+		hashCtl.hcxt = CurrentMemoryContext;
+
+		newFileHash = hash_create("new file paths",
+								  1024,		/* initial estimate */
+								  &hashCtl,
+								  HASH_ELEM | HASH_CONTEXT);
+	}
 
 	ListCell   *manifestCell = NULL;
 
@@ -405,6 +499,14 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 			IcebergManifestEntry *entry = lfirst(entryCell);
 
 			DataFile   *dataFile = &entry->data_file;
+
+			/* track this new file path */
+			if (newFileHash != NULL)
+			{
+				bool		found = false;
+
+				hash_search(newFileHash, dataFile->file_path, HASH_ENTER, &found);
+			}
 
 			/* map Iceberg content type to pg_lake content type */
 			DataFileContent content;
@@ -454,6 +556,30 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 												   manifest->partition_spec_id,
 												   fileId,
 												   &dataFile->partition);
+			}
+		}
+	}
+
+	/*
+	 * Queue old files that are no longer referenced for deletion.
+	 * Compare oldFileHash with newFileHash to find unreferenced files.
+	 */
+	if (oldFileHash != NULL && newFileHash != NULL)
+	{
+		HASH_SEQ_STATUS hashSeq;
+		char	   *oldFilePath = NULL;
+
+		hash_seq_init(&hashSeq, oldFileHash);
+		while ((oldFilePath = hash_seq_search(&hashSeq)) != NULL)
+		{
+			bool		found = false;
+
+			hash_search(newFileHash, oldFilePath, HASH_FIND, &found);
+
+			if (!found)
+			{
+				/* file is no longer referenced, queue for deletion */
+				InsertDeletionQueueRecord(oldFilePath, relationId, orphanedAt);
 			}
 		}
 	}

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -39,6 +39,7 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
+#include "utils/snapmgr.h"
 
 #include "pg_lake/cleanup/deletion_queue.h"
 #include "pg_lake/data_file/data_files.h"

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -398,7 +398,7 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 	bool		dataOnly = false;
 	bool		newFilesOnly = false;
 	bool		forUpdate = false;
-	Snapshot	snapshot = GetActiveSnapshot();
+	Snapshot	snapshot = GetTransactionSnapshot();
 
 	List	   *oldDataFiles = GetTableDataFilesFromCatalog(relationId, dataOnly,
 															newFilesOnly, forUpdate,

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -419,7 +419,7 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 		oldFileHash = hash_create("old file paths",
 								  list_length(oldDataFiles),
 								  &hashCtl,
-								  HASH_ELEM | HASH_CONTEXT);
+								  HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 
 		ListCell   *oldFileCell = NULL;
 
@@ -479,7 +479,7 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
 		newFileHash = hash_create("new file paths",
 								  1024,		/* initial estimate */
 								  &hashCtl,
-								  HASH_ELEM | HASH_CONTEXT);
+								  HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 	}
 
 	ListCell   *manifestCell = NULL;

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -1,0 +1,592 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * sync_external_metadata.c
+ *
+ * Syncs the internal pg_lake catalog state (schema, partition specs, data files)
+ * from new Iceberg metadata written by an external client.
+ *
+ * Called via:
+ *   SELECT lake_table.sync_iceberg_metadata_from_external_write(regclass)
+ *
+ * This is triggered by an UPDATE to the iceberg_tables view for tables in the
+ * current database catalog.
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "miscadmin.h"
+
+#include "access/relation.h"
+#include "access/table.h"
+#include "catalog/namespace.h"
+#include "executor/spi.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+
+#include "pg_lake/data_file/data_files.h"
+#include "pg_lake/data_file/data_file_stats.h"
+#include "pg_lake/extensions/pg_lake_iceberg.h"
+#include "pg_lake/extensions/pg_lake_table.h"
+#include "pg_lake/fdw/data_files_catalog.h"
+#include "pg_lake/fdw/data_file_stats_catalog.h"
+#include "pg_lake/fdw/schema_operations/field_id_mapping_catalog.h"
+#include "pg_lake/fdw/writable_table.h"
+#include "pg_lake/iceberg/api.h"
+#include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/data_file_stats.h"
+#include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/iceberg/iceberg_type_binary_serde.h"
+#include "pg_lake/partitioning/partition_spec_catalog.h"
+#include "pg_extension_base/spi_helpers.h"
+
+PG_FUNCTION_INFO_V1(sync_iceberg_metadata_from_external_write);
+
+static void SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata *metadata);
+static void FetchExistingFieldMappings(Oid relationId, int **fieldIds,
+									   int16 **attnums, int *count);
+static void ExecuteAlterTableViaSPI(const char *cmd);
+static void SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata *metadata);
+static void SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata);
+static char *ColumnBoundBinaryToText(ColumnBound *bound, int fieldId,
+									 IcebergTableSchema *schema);
+static List *BuildColumnStatsForManifestEntry(IcebergManifestEntry *manifestEntry,
+											  IcebergTableSchema *schema);
+
+
+/*
+ * sync_iceberg_metadata_from_external_write syncs the pg_lake internal
+ * catalog state from the current Iceberg metadata for the given table.
+ *
+ * This performs three sub-steps:
+ * 1. Schema sync: add/drop columns on the foreign table to match the
+ *    Iceberg schema, and update field_id_mappings.
+ * 2. Partition spec sync: register any new partition specs.
+ * 3. Data file full resync: clear and repopulate lake_table.files and
+ *    associated stats/partition values from the metadata snapshot.
+ */
+Datum
+sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS)
+{
+	Oid			relationId = PG_GETARG_OID(0);
+
+	/* read the new metadata from object storage */
+	bool		forUpdate = false;
+	char	   *metadataLocation = GetIcebergMetadataLocation(relationId, forUpdate);
+
+	IcebergTableMetadata *metadata = ReadIcebergTableMetadata(metadataLocation);
+
+	SyncSchemaFromMetadata(relationId, metadata);
+	SyncPartitionSpecsFromMetadata(relationId, metadata);
+	SyncDataFilesFromMetadata(relationId, metadata);
+
+	PG_RETURN_VOID();
+}
+
+
+/*
+ * FetchExistingFieldMappings retrieves all top-level field_id_mappings
+ * for the given relation via SPI.
+ */
+static void
+FetchExistingFieldMappings(Oid relationId, int **fieldIds,
+						   int16 **attnums, int *count)
+{
+	MemoryContext callerContext = CurrentMemoryContext;
+
+	DECLARE_SPI_ARGS(1);
+	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
+
+	bool		readOnly = true;
+
+	SPI_EXECUTE("SELECT field_id, pg_attnum FROM " MAPPING_TABLE_NAME
+				" WHERE table_name OPERATOR(pg_catalog.=) $1"
+				" AND parent_field_id IS NULL", readOnly);
+
+	*count = SPI_processed;
+	*fieldIds = NULL;
+	*attnums = NULL;
+
+	if (*count > 0)
+	{
+		MemoryContext spiContext = MemoryContextSwitchTo(callerContext);
+
+		*fieldIds = palloc(sizeof(int) * *count);
+		*attnums = palloc(sizeof(int16) * *count);
+
+		MemoryContextSwitchTo(spiContext);
+
+		for (int i = 0; i < *count; i++)
+		{
+			bool		isNull = false;
+
+			(*fieldIds)[i] = GET_SPI_VALUE(INT4OID, i, 1, &isNull);
+			(*attnums)[i] = GET_SPI_VALUE(INT2OID, i, 2, &isNull);
+		}
+	}
+
+	SPI_END();
+}
+
+
+/*
+ * ExecuteAlterTableViaSPI runs an ALTER TABLE DDL command via SPI as the
+ * pg_lake_table extension owner.
+ */
+static void
+ExecuteAlterTableViaSPI(const char *cmd)
+{
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+	SPI_execute(cmd, false, 0);
+	SPI_END();
+}
+
+
+/*
+ * SyncSchemaFromMetadata syncs the foreign table columns and field_id_mappings
+ * with the current Iceberg schema from the metadata.
+ *
+ * For each field in the new Iceberg schema that doesn't have a mapping in
+ * field_id_mappings, we ADD COLUMN and register the mapping.
+ *
+ * For each top-level mapping whose field_id is no longer in the current
+ * Iceberg schema, we DROP COLUMN (but keep the mapping for reading old files).
+ */
+static void
+SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
+{
+	IcebergTableSchema *icebergSchema = GetCurrentIcebergTableSchema(metadata);
+
+	/* fetch existing field_id_mappings */
+	int		   *existingFieldIds = NULL;
+	int16	   *existingAttnums = NULL;
+	int			existingMappingCount = 0;
+
+	FetchExistingFieldMappings(relationId, &existingFieldIds,
+							   &existingAttnums, &existingMappingCount);
+
+	/* get relation's schema and namespace names for ALTER TABLE */
+	char	   *schemaName = get_namespace_name(get_rel_namespace(relationId));
+	char	   *tableName = get_rel_name(relationId);
+
+	/*
+	 * Step 1: Add new columns. For each field in the Iceberg schema that
+	 * doesn't have a mapping, add it.
+	 */
+	for (size_t fieldIdx = 0; fieldIdx < icebergSchema->fields_length; fieldIdx++)
+	{
+		DataFileSchemaField *icebergField = &icebergSchema->fields[fieldIdx];
+		int			fieldId = icebergField->id;
+
+		/* check if this field_id already has a mapping */
+		bool		found = false;
+
+		for (int mappingIdx = 0; mappingIdx < existingMappingCount; mappingIdx++)
+		{
+			if (existingFieldIds[mappingIdx] == fieldId)
+			{
+				found = true;
+				break;
+			}
+		}
+
+		if (found)
+			continue;
+
+		/* new field: convert Iceberg type to Postgres type */
+		PGType		pgType = IcebergFieldToPostgresType(icebergField->type);
+
+		char	   *pgTypeName = format_type_with_typemod(pgType.postgresTypeOid,
+														  pgType.postgresTypeMod);
+
+		/* execute ALTER FOREIGN TABLE ... ADD COLUMN via SPI */
+		StringInfo	alterCmd = makeStringInfo();
+
+		appendStringInfo(alterCmd,
+						 "ALTER FOREIGN TABLE %s.%s ADD COLUMN %s %s",
+						 quote_identifier(schemaName),
+						 quote_identifier(tableName),
+						 quote_identifier(icebergField->name),
+						 pgTypeName);
+
+		ExecuteAlterTableViaSPI(alterCmd->data);
+
+		/*
+		 * After ADD COLUMN, look up the new attnum from pg_attribute.
+		 */
+		Relation	rel = RelationIdGetRelation(relationId);
+		TupleDesc	tupdesc = RelationGetDescr(rel);
+		AttrNumber	newAttNum = InvalidAttrNumber;
+
+		for (int attIdx = 0; attIdx < tupdesc->natts; attIdx++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, attIdx);
+
+			if (!attr->attisdropped &&
+				strcmp(NameStr(attr->attname), icebergField->name) == 0)
+			{
+				newAttNum = attr->attnum;
+				break;
+			}
+		}
+
+		RelationClose(rel);
+
+		if (newAttNum == InvalidAttrNumber)
+			elog(ERROR, "could not find column \"%s\" after ADD COLUMN",
+				 icebergField->name);
+
+		/* register the field mapping */
+		int			parentFieldId = INVALID_FIELD_ID;
+		const char *writeDefault = icebergField->writeDefault;
+		const char *initialDefault = icebergField->initialDefault;
+
+		RegisterIcebergColumnMapping(relationId, icebergField->type,
+									 newAttNum, parentFieldId, pgType,
+									 fieldId, writeDefault, initialDefault);
+	}
+
+	/*
+	 * Step 2: Drop removed columns. For each existing mapping whose field_id
+	 * is not in the current Iceberg schema, drop the column from the foreign
+	 * table.
+	 */
+	for (int mappingIdx = 0; mappingIdx < existingMappingCount; mappingIdx++)
+	{
+		int			mappedFieldId = existingFieldIds[mappingIdx];
+		AttrNumber	mappedAttnum = existingAttnums[mappingIdx];
+
+		/* check if this field_id still exists in the Iceberg schema */
+		bool		stillExists = false;
+
+		for (size_t fieldIdx = 0; fieldIdx < icebergSchema->fields_length; fieldIdx++)
+		{
+			if (icebergSchema->fields[fieldIdx].id == mappedFieldId)
+			{
+				stillExists = true;
+				break;
+			}
+		}
+
+		if (stillExists)
+			continue;
+
+		/*
+		 * Check if the column is already dropped in pg_attribute (could happen
+		 * if this sync runs multiple times).
+		 */
+		Relation	rel = RelationIdGetRelation(relationId);
+		TupleDesc	tupdesc = RelationGetDescr(rel);
+
+		if (mappedAttnum <= 0 || mappedAttnum > tupdesc->natts)
+		{
+			RelationClose(rel);
+			continue;
+		}
+
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, mappedAttnum - 1);
+
+		if (attr->attisdropped)
+		{
+			RelationClose(rel);
+			continue;
+		}
+
+		char	   *colName = pstrdup(NameStr(attr->attname));
+
+		RelationClose(rel);
+
+		/* execute ALTER FOREIGN TABLE ... DROP COLUMN via SPI */
+		StringInfo	dropCmd = makeStringInfo();
+
+		appendStringInfo(dropCmd,
+						 "ALTER FOREIGN TABLE %s.%s DROP COLUMN %s",
+						 quote_identifier(schemaName),
+						 quote_identifier(tableName),
+						 quote_identifier(colName));
+
+		ExecuteAlterTableViaSPI(dropCmd->data);
+
+		/*
+		 * We keep the field_id_mapping row: it is needed for reading older
+		 * data files that reference this field.
+		 */
+	}
+}
+
+
+/*
+ * SyncPartitionSpecsFromMetadata syncs the partition specs from the
+ * Iceberg metadata to the pg_lake catalog.
+ *
+ * For each spec in the metadata that doesn't already exist in the catalog,
+ * we register it. We also update the default_spec_id.
+ */
+static void
+SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
+{
+	/* get the largest spec_id currently in catalog */
+	int			largestCatalogSpecId = GetLargestSpecId(relationId);
+
+	for (int specIdx = 0; specIdx < metadata->partition_specs_length; specIdx++)
+	{
+		IcebergPartitionSpec *spec = &metadata->partition_specs[specIdx];
+
+		if (spec->spec_id <= largestCatalogSpecId)
+			continue;
+
+		InsertPartitionSpecAndPartitionFields(relationId, spec);
+	}
+
+	/* update the default spec id */
+	UpdateDefaultPartitionSpecId(relationId, metadata->default_spec_id);
+}
+
+
+/*
+ * SyncDataFilesFromMetadata performs a full resync of the data files in the
+ * pg_lake catalog from the current snapshot in the Iceberg metadata.
+ *
+ * This clears all existing data files and repopulates them from the metadata.
+ */
+static void
+SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata *metadata)
+{
+	/* clear all existing data files from the catalog */
+	RemoveAllDataFilesFromPgLakeCatalogFromTable(relationId);
+
+	/* get the current snapshot */
+	bool		missingOk = true;
+	IcebergSnapshot *currentSnapshot = GetCurrentSnapshot(metadata, missingOk);
+
+	if (currentSnapshot == NULL)
+	{
+		/* empty table after external write, no data files to sync */
+		return;
+	}
+
+	IcebergTableSchema *icebergSchema = GetCurrentIcebergTableSchema(metadata);
+
+	/* fetch all manifests from the current snapshot */
+	List	   *manifests = FetchManifestsFromSnapshot(currentSnapshot, NULL);
+
+	ListCell   *manifestCell = NULL;
+
+	foreach(manifestCell, manifests)
+	{
+		IcebergManifest *manifest = lfirst(manifestCell);
+
+		List	   *manifestEntries =
+			FetchManifestEntriesFromManifest(manifest,
+											 IsManifestEntryStatusScannable);
+
+		ListCell   *entryCell = NULL;
+
+		foreach(entryCell, manifestEntries)
+		{
+			IcebergManifestEntry *entry = lfirst(entryCell);
+
+			DataFile   *dataFile = &entry->data_file;
+
+			/* map Iceberg content type to pg_lake content type */
+			DataFileContent content;
+
+			switch (dataFile->content)
+			{
+				case ICEBERG_DATA_FILE_CONTENT_DATA:
+					content = CONTENT_DATA;
+					break;
+				case ICEBERG_DATA_FILE_CONTENT_POSITION_DELETES:
+					content = CONTENT_POSITION_DELETES;
+					break;
+				case ICEBERG_DATA_FILE_CONTENT_EQUALITY_DELETES:
+					content = CONTENT_EQUALITY_DELETES;
+					break;
+				default:
+					elog(ERROR, "unsupported data file content type: %d",
+						 dataFile->content);
+			}
+
+			/* insert the data file into the catalog */
+			int64		fileId = AddDataFileToTable(relationId,
+												   dataFile->file_path,
+												   dataFile->record_count,
+												   dataFile->file_size_in_bytes,
+												   content,
+												   INVALID_ROW_ID);
+
+			/* insert column stats if available */
+			if (content == CONTENT_DATA)
+			{
+				List	   *columnStatsList =
+					BuildColumnStatsForManifestEntry(entry, icebergSchema);
+
+				if (columnStatsList != NIL)
+					AddDataFileColumnStatsToCatalog(relationId,
+													dataFile->file_path,
+													columnStatsList);
+			}
+
+			/* insert partition values if available */
+			if (dataFile->partition.fields_length > 0 &&
+				(content == CONTENT_DATA ||
+				 content == CONTENT_POSITION_DELETES))
+			{
+				AddDataFilePartitionValueToCatalog(relationId,
+												   manifest->partition_spec_id,
+												   fileId,
+												   &dataFile->partition);
+			}
+		}
+	}
+}
+
+
+/*
+ * BuildColumnStatsForManifestEntry builds a list of DataFileColumnStats from
+ * the lower_bounds and upper_bounds in the manifest entry's data file.
+ *
+ * Each bound is stored in Iceberg binary format and needs to be converted
+ * to Postgres text representation for the catalog.
+ */
+static List *
+BuildColumnStatsForManifestEntry(IcebergManifestEntry *manifestEntry,
+								 IcebergTableSchema *schema)
+{
+	DataFile   *dataFile = &manifestEntry->data_file;
+
+	if (dataFile->lower_bounds_length == 0)
+		return NIL;
+
+	List	   *statsList = NIL;
+
+	for (size_t lowerIdx = 0; lowerIdx < dataFile->lower_bounds_length; lowerIdx++)
+	{
+		ColumnBound *lowerBound = &dataFile->lower_bounds[lowerIdx];
+		int			fieldId = lowerBound->column_id;
+
+		/* find matching upper bound */
+		ColumnBound *upperBound = NULL;
+
+		for (size_t upperIdx = 0; upperIdx < dataFile->upper_bounds_length; upperIdx++)
+		{
+			if (dataFile->upper_bounds[upperIdx].column_id == fieldId)
+			{
+				upperBound = &dataFile->upper_bounds[upperIdx];
+				break;
+			}
+		}
+
+		char	   *lowerBoundText = ColumnBoundBinaryToText(lowerBound, fieldId, schema);
+		char	   *upperBoundText = NULL;
+
+		if (upperBound != NULL)
+			upperBoundText = ColumnBoundBinaryToText(upperBound, fieldId, schema);
+
+		if (lowerBoundText == NULL)
+			continue;
+
+		/* find the iceberg field in the schema to get the PGType */
+		DataFileSchemaField *icebergField = NULL;
+
+		for (size_t fieldIdx = 0; fieldIdx < schema->fields_length; fieldIdx++)
+		{
+			if (schema->fields[fieldIdx].id == fieldId)
+			{
+				icebergField = &schema->fields[fieldIdx];
+				break;
+			}
+		}
+
+		if (icebergField == NULL)
+			continue;
+
+		PGType		pgType = IcebergFieldToPostgresType(icebergField->type);
+
+		DataFileColumnStats *colStats = palloc0(sizeof(DataFileColumnStats));
+
+		colStats->leafField.fieldId = fieldId;
+		colStats->leafField.pgType = pgType;
+		colStats->lowerBoundText = lowerBoundText;
+		colStats->upperBoundText = upperBoundText;
+
+		bool		forAddColumn = false;
+		int			subFieldIndex = fieldId;
+
+		colStats->leafField.field = PostgresTypeToIcebergField(pgType, forAddColumn,
+															   &subFieldIndex);
+		colStats->leafField.duckTypeName =
+			IcebergTypeNameToDuckdbTypeName(colStats->leafField.field->field.scalar.typeName);
+
+		statsList = lappend(statsList, colStats);
+	}
+
+	return statsList;
+}
+
+
+/*
+ * ColumnBoundBinaryToText converts an Iceberg binary column bound to
+ * Postgres text representation.
+ *
+ * Returns NULL if the field is not found in the schema or if the
+ * deserialization fails.
+ */
+static char *
+ColumnBoundBinaryToText(ColumnBound *bound, int fieldId,
+						IcebergTableSchema *schema)
+{
+	if (bound->value == NULL || bound->value_length == 0)
+		return NULL;
+
+	/* find the Iceberg field in the schema */
+	DataFileSchemaField *icebergField = NULL;
+
+	for (size_t fieldIdx = 0; fieldIdx < schema->fields_length; fieldIdx++)
+	{
+		if (schema->fields[fieldIdx].id == fieldId)
+		{
+			icebergField = &schema->fields[fieldIdx];
+			break;
+		}
+	}
+
+	if (icebergField == NULL)
+		return NULL;
+
+	PGType		pgType = IcebergFieldToPostgresType(icebergField->type);
+
+	/* deserialize from Iceberg binary to Postgres Datum */
+	Datum		boundDatum = PGIcebergBinaryDeserialize(bound->value,
+													   bound->value_length,
+													   icebergField->type,
+													   pgType);
+
+	/* convert Datum to text representation */
+	Oid			typoutput;
+	bool		typIsVarlena;
+
+	getTypeOutputInfo(pgType.postgresTypeOid, &typoutput, &typIsVarlena);
+
+	char	   *boundText = OidOutputFunctionCall(typoutput, boundDatum);
+
+	return boundText;
+}

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -100,9 +100,10 @@ sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS)
 
 	/*
 	 * Suppress the ProcessAlterTable / PostProcessRename hooks' Iceberg DDL
-	 * processing while we add/drop/rename columns. We manage field_id_mappings
-	 * ourselves and the metadata is already final on disk, so we don't want
-	 * the hooks to register duplicate mappings or schedule a metadata write.
+	 * processing while we add/drop/rename columns. We manage
+	 * field_id_mappings ourselves and the metadata is already final on disk,
+	 * so we don't want the hooks to register duplicate mappings or schedule a
+	 * metadata write.
 	 *
 	 * This is the only intended caller of SkipIcebergDDLProcessing. The flag
 	 * is process-global; we restore it in PG_FINALLY to avoid leaking state

--- a/pg_lake_table/src/sync/sync_external_metadata.c
+++ b/pg_lake_table/src/sync/sync_external_metadata.c
@@ -56,6 +56,7 @@
 #include "pg_lake/iceberg/data_file_stats.h"
 #include "pg_lake/iceberg/iceberg_field.h"
 #include "pg_lake/iceberg/iceberg_type_binary_serde.h"
+#include "pg_lake/iceberg/operations/find_referenced_files.h"
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_extension_base/spi_helpers.h"
 #include "utils/hsearch.h"
@@ -67,7 +68,8 @@ static void FetchExistingFieldMappings(Oid relationId, int **fieldIds,
 									   int16 **attnums, int *count);
 static void ExecuteAlterTableViaSPI(const char *cmd);
 static void SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata * metadata);
-static void SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata * metadata);
+static void SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata * metadata,
+									  const char *metadataLocation);
 static char *ColumnBoundBinaryToText(ColumnBound * bound, int fieldId,
 									 IcebergTableSchema * schema);
 static List *BuildColumnStatsForManifestEntry(IcebergManifestEntry * manifestEntry,
@@ -97,10 +99,14 @@ sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS)
 	IcebergTableMetadata *metadata = ReadIcebergTableMetadata(metadataLocation);
 
 	/*
-	 * Suppress the ProcessAlterTable hook's Iceberg DDL processing while we
-	 * add/drop columns.  We manage field_id_mappings ourselves and do not
-	 * want the hook to register duplicate mappings or schedule a metadata
-	 * write.
+	 * Suppress the ProcessAlterTable / PostProcessRename hooks' Iceberg DDL
+	 * processing while we add/drop/rename columns. We manage field_id_mappings
+	 * ourselves and the metadata is already final on disk, so we don't want
+	 * the hooks to register duplicate mappings or schedule a metadata write.
+	 *
+	 * This is the only intended caller of SkipIcebergDDLProcessing. The flag
+	 * is process-global; we restore it in PG_FINALLY to avoid leaking state
+	 * if the sync errors out partway through.
 	 */
 	SkipIcebergDDLProcessing = true;
 
@@ -108,7 +114,7 @@ sync_iceberg_metadata_from_external_write(PG_FUNCTION_ARGS)
 	{
 		SyncSchemaFromMetadata(relationId, metadata);
 		SyncPartitionSpecsFromMetadata(relationId, metadata);
-		SyncDataFilesFromMetadata(relationId, metadata);
+		SyncDataFilesFromMetadata(relationId, metadata, metadataLocation);
 	}
 	PG_FINALLY();
 	{
@@ -218,18 +224,66 @@ SyncSchemaFromMetadata(Oid relationId, IcebergTableMetadata * metadata)
 
 		/* check if this field_id already has a mapping */
 		bool		found = false;
+		AttrNumber	existingAttnum = InvalidAttrNumber;
 
 		for (int mappingIdx = 0; mappingIdx < existingMappingCount; mappingIdx++)
 		{
 			if (existingFieldIds[mappingIdx] == fieldId)
 			{
 				found = true;
+				existingAttnum = existingAttnums[mappingIdx];
 				break;
 			}
 		}
 
 		if (found)
+		{
+			/*
+			 * Field is already mapped — but the new schema may have renamed
+			 * it. Compare names and issue RENAME COLUMN if so. Iceberg field
+			 * IDs are stable across rename, so this is the only signal we
+			 * have that a rename happened.
+			 */
+			Relation	rel = RelationIdGetRelation(relationId);
+			TupleDesc	tupdesc = RelationGetDescr(rel);
+
+			if (existingAttnum <= 0 || existingAttnum > tupdesc->natts)
+			{
+				RelationClose(rel);
+				continue;
+			}
+
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, existingAttnum - 1);
+
+			if (attr->attisdropped)
+			{
+				RelationClose(rel);
+				continue;
+			}
+
+			if (strcmp(NameStr(attr->attname), icebergField->name) == 0)
+			{
+				RelationClose(rel);
+				continue;
+			}
+
+			char	   *currentName = pstrdup(NameStr(attr->attname));
+
+			RelationClose(rel);
+
+			StringInfo	renameCmd = makeStringInfo();
+
+			appendStringInfo(renameCmd,
+							 "ALTER FOREIGN TABLE %s.%s RENAME COLUMN %s TO %s",
+							 quote_identifier(schemaName),
+							 quote_identifier(tableName),
+							 quote_identifier(currentName),
+							 quote_identifier(icebergField->name));
+
+			ExecuteAlterTableViaSPI(renameCmd->data);
+
 			continue;
+		}
 
 		/* new field: convert Iceberg type to Postgres type */
 		PGType		pgType = IcebergFieldToPostgresType(icebergField->type);
@@ -385,17 +439,27 @@ SyncPartitionSpecsFromMetadata(Oid relationId, IcebergTableMetadata * metadata)
  * SyncDataFilesFromMetadata performs a full resync of the data files in the
  * pg_lake catalog from the current snapshot in the Iceberg metadata.
  *
- * This clears all existing data files and repopulates them from the metadata.
- * Files that are no longer referenced are added to the deletion queue.
+ * The pg_lake catalog only ever indexes the current snapshot (we don't expose
+ * time-travel reads), so we clear the catalog and repopulate it by walking
+ * the current snapshot's manifests.
+ *
+ * For deletion-queue purposes we need to be more careful: Iceberg metadata
+ * typically retains older snapshots, and external clients may keep them for
+ * their own time-travel reads. A file referenced only by a non-current but
+ * still-retained snapshot must NOT be queued for deletion. We compute the
+ * set of files referenced by ANY snapshot in the new metadata using
+ * IcebergFindAllReferencedFiles, and only queue old cataloged files that
+ * are absent from that set.
  */
 static void
-SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata * metadata)
+SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata * metadata,
+						  const char *metadataLocation)
 {
 	TimestampTz orphanedAt = GetCurrentTransactionStartTimestamp();
 
 	/*
-	 * Get the list of old file paths before clearing, so we can queue
-	 * unreferenced files for deletion.
+	 * Get the list of old cataloged file paths before clearing, so we can
+	 * later queue files no longer referenced by any retained snapshot.
 	 */
 	bool		dataOnly = false;
 	bool		newFilesOnly = false;
@@ -406,184 +470,123 @@ SyncDataFilesFromMetadata(Oid relationId, IcebergTableMetadata * metadata)
 															newFilesOnly, forUpdate,
 															NULL, snapshot);
 
-	/* build a hash table of old file paths for quick lookup */
-	HTAB	   *oldFileHash = NULL;
+	/*
+	 * Build the set of files referenced by ANY snapshot in the new metadata.
+	 * IcebergFindAllReferencedFiles walks every snapshot in the metadata, not
+	 * just the current one, so files held only by retained-but-not-current
+	 * snapshots stay in this set and won't be queued for deletion below.
+	 */
+	HTAB	   *referencedFileHash = CreateFilesHash();
 
 	if (oldDataFiles != NIL)
 	{
-		HASHCTL		hashCtl;
+		List	   *referencedFiles = IcebergFindAllReferencedFiles((char *) metadataLocation);
+		ListCell   *fileCell = NULL;
 
-		memset(&hashCtl, 0, sizeof(hashCtl));
-		hashCtl.keysize = MAX_S3_PATH_LENGTH;
-		hashCtl.entrysize = MAX_S3_PATH_LENGTH;
-		hashCtl.hcxt = CurrentMemoryContext;
-
-		oldFileHash = hash_create("old file paths",
-								  list_length(oldDataFiles),
-								  &hashCtl,
-								  HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
-
-		ListCell   *oldFileCell = NULL;
-
-		foreach(oldFileCell, oldDataFiles)
+		foreach(fileCell, referencedFiles)
 		{
-			TableDataFile *oldFile = lfirst(oldFileCell);
-			bool		found = false;
+			char	   *path = lfirst(fileCell);
 
-			hash_search(oldFileHash, oldFile->path, HASH_ENTER, &found);
+			AppendFileToHash(path, referencedFileHash);
 		}
 	}
 
 	/* clear all existing data files from the catalog */
 	RemoveAllDataFilesFromPgLakeCatalogFromTable(relationId);
 
-	/* get the current snapshot */
+	/* repopulate the catalog from the current snapshot, if any */
 	bool		missingOk = true;
 	IcebergSnapshot *currentSnapshot = GetCurrentSnapshot(metadata, missingOk);
 
-	if (currentSnapshot == NULL)
+	if (currentSnapshot != NULL)
 	{
-		/*
-		 * Empty table after external write. All old files are now
-		 * unreferenced, queue them for deletion.
-		 */
-		if (oldFileHash != NULL)
+		IcebergTableSchema *icebergSchema = GetCurrentIcebergTableSchema(metadata);
+
+		List	   *manifests = FetchManifestsFromSnapshot(currentSnapshot, NULL);
+		ListCell   *manifestCell = NULL;
+
+		foreach(manifestCell, manifests)
 		{
-			HASH_SEQ_STATUS hashSeq;
-			char	   *filePath = NULL;
+			IcebergManifest *manifest = lfirst(manifestCell);
 
-			hash_seq_init(&hashSeq, oldFileHash);
-			while ((filePath = hash_seq_search(&hashSeq)) != NULL)
+			List	   *manifestEntries =
+				FetchManifestEntriesFromManifest(manifest,
+												 IsManifestEntryStatusScannable);
+
+			ListCell   *entryCell = NULL;
+
+			foreach(entryCell, manifestEntries)
 			{
-				InsertDeletionQueueRecord(filePath, relationId, orphanedAt);
-			}
-		}
-		return;
-	}
+				IcebergManifestEntry *entry = lfirst(entryCell);
 
-	IcebergTableSchema *icebergSchema = GetCurrentIcebergTableSchema(metadata);
+				DataFile   *dataFile = &entry->data_file;
 
-	/* fetch all manifests from the current snapshot */
-	List	   *manifests = FetchManifestsFromSnapshot(currentSnapshot, NULL);
+				/* map Iceberg content type to pg_lake content type */
+				DataFileContent content;
 
-	/* track new file paths to identify unreferenced files later */
-	HTAB	   *newFileHash = NULL;
+				switch (dataFile->content)
+				{
+					case ICEBERG_DATA_FILE_CONTENT_DATA:
+						content = CONTENT_DATA;
+						break;
+					case ICEBERG_DATA_FILE_CONTENT_POSITION_DELETES:
+						content = CONTENT_POSITION_DELETES;
+						break;
+					case ICEBERG_DATA_FILE_CONTENT_EQUALITY_DELETES:
+						content = CONTENT_EQUALITY_DELETES;
+						break;
+					default:
+						elog(ERROR, "unsupported data file content type: %d",
+							 dataFile->content);
+				}
 
-	if (oldFileHash != NULL)
-	{
-		HASHCTL		hashCtl;
+				int64		fileId = AddDataFileToTable(relationId,
+														dataFile->file_path,
+														dataFile->record_count,
+														dataFile->file_size_in_bytes,
+														content,
+														INVALID_ROW_ID);
 
-		memset(&hashCtl, 0, sizeof(hashCtl));
-		hashCtl.keysize = MAX_S3_PATH_LENGTH;
-		hashCtl.entrysize = MAX_S3_PATH_LENGTH;
-		hashCtl.hcxt = CurrentMemoryContext;
+				if (content == CONTENT_DATA)
+				{
+					List	   *columnStatsList =
+						BuildColumnStatsForManifestEntry(entry, icebergSchema);
 
-		newFileHash = hash_create("new file paths",
-								  1024, /* initial estimate */
-								  &hashCtl,
-								  HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
-	}
+					if (columnStatsList != NIL)
+						AddDataFileColumnStatsToCatalog(relationId,
+														dataFile->file_path,
+														columnStatsList);
+				}
 
-	ListCell   *manifestCell = NULL;
-
-	foreach(manifestCell, manifests)
-	{
-		IcebergManifest *manifest = lfirst(manifestCell);
-
-		List	   *manifestEntries =
-			FetchManifestEntriesFromManifest(manifest,
-											 IsManifestEntryStatusScannable);
-
-		ListCell   *entryCell = NULL;
-
-		foreach(entryCell, manifestEntries)
-		{
-			IcebergManifestEntry *entry = lfirst(entryCell);
-
-			DataFile   *dataFile = &entry->data_file;
-
-			/* track this new file path */
-			if (newFileHash != NULL)
-			{
-				bool		found = false;
-
-				hash_search(newFileHash, dataFile->file_path, HASH_ENTER, &found);
-			}
-
-			/* map Iceberg content type to pg_lake content type */
-			DataFileContent content;
-
-			switch (dataFile->content)
-			{
-				case ICEBERG_DATA_FILE_CONTENT_DATA:
-					content = CONTENT_DATA;
-					break;
-				case ICEBERG_DATA_FILE_CONTENT_POSITION_DELETES:
-					content = CONTENT_POSITION_DELETES;
-					break;
-				case ICEBERG_DATA_FILE_CONTENT_EQUALITY_DELETES:
-					content = CONTENT_EQUALITY_DELETES;
-					break;
-				default:
-					elog(ERROR, "unsupported data file content type: %d",
-						 dataFile->content);
-			}
-
-			/* insert the data file into the catalog */
-			int64		fileId = AddDataFileToTable(relationId,
-													dataFile->file_path,
-													dataFile->record_count,
-													dataFile->file_size_in_bytes,
-													content,
-													INVALID_ROW_ID);
-
-			/* insert column stats if available */
-			if (content == CONTENT_DATA)
-			{
-				List	   *columnStatsList =
-					BuildColumnStatsForManifestEntry(entry, icebergSchema);
-
-				if (columnStatsList != NIL)
-					AddDataFileColumnStatsToCatalog(relationId,
-													dataFile->file_path,
-													columnStatsList);
-			}
-
-			/* insert partition values if available */
-			if (dataFile->partition.fields_length > 0 &&
-				(content == CONTENT_DATA ||
-				 content == CONTENT_POSITION_DELETES))
-			{
-				AddDataFilePartitionValueToCatalog(relationId,
-												   manifest->partition_spec_id,
-												   fileId,
-												   &dataFile->partition);
+				if (dataFile->partition.fields_length > 0 &&
+					(content == CONTENT_DATA ||
+					 content == CONTENT_POSITION_DELETES))
+				{
+					AddDataFilePartitionValueToCatalog(relationId,
+													   manifest->partition_spec_id,
+													   fileId,
+													   &dataFile->partition);
+				}
 			}
 		}
 	}
 
 	/*
-	 * Queue old files that are no longer referenced for deletion. Compare
-	 * oldFileHash with newFileHash to find unreferenced files.
+	 * Queue any previously-cataloged file that is not referenced by any
+	 * retained snapshot in the new metadata. Files referenced only by older
+	 * but still-retained snapshots are intentionally left alone.
 	 */
-	if (oldFileHash != NULL && newFileHash != NULL)
+	ListCell   *oldFileCell = NULL;
+
+	foreach(oldFileCell, oldDataFiles)
 	{
-		HASH_SEQ_STATUS hashSeq;
-		char	   *oldFilePath = NULL;
+		TableDataFile *oldFile = lfirst(oldFileCell);
+		bool		found = false;
 
-		hash_seq_init(&hashSeq, oldFileHash);
-		while ((oldFilePath = hash_seq_search(&hashSeq)) != NULL)
-		{
-			bool		found = false;
+		hash_search(referencedFileHash, oldFile->path, HASH_FIND, &found);
 
-			hash_search(newFileHash, oldFilePath, HASH_FIND, &found);
-
-			if (!found)
-			{
-				/* file is no longer referenced, queue for deletion */
-				InsertDeletionQueueRecord(oldFilePath, relationId, orphanedAt);
-			}
-		}
+		if (!found)
+			InsertDeletionQueueRecord(oldFile->path, relationId, orphanedAt);
 	}
 }
 

--- a/pg_lake_table/tests/pytests/test_external_write.py
+++ b/pg_lake_table/tests/pytests/test_external_write.py
@@ -1,0 +1,353 @@
+import pytest
+import pyarrow as pa
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.types import LongType
+
+from utils_pytest import *
+
+
+TABLE_NAME = "test_ext_write"
+TABLE_NAMESPACE = "public"
+
+
+@pytest.fixture(scope="module")
+def iceberg_catalog(superuser_conn, s3):
+    """
+    Create a PyIceberg SqlCatalog whose catalog_name matches the current
+    database name.  This way, PyIceberg commits (append, overwrite,
+    schema evolution) go through the iceberg_tables INSTEAD OF trigger's
+    internal-catalog path and automatically sync the pg_lake catalog.
+    """
+    catalog_user = "iceberg_ext_writer"
+
+    result = run_query(
+        f"SELECT 1 FROM pg_roles WHERE rolname='{catalog_user}'", superuser_conn
+    )
+    if len(result) == 0:
+        run_command(f"CREATE USER {catalog_user}", superuser_conn)
+
+    run_command(f"GRANT iceberg_catalog TO {catalog_user}", superuser_conn)
+    superuser_conn.commit()
+
+    db_name = run_query("SELECT current_database()", superuser_conn)[0][0]
+
+    catalog = SqlCatalog(
+        db_name,
+        **{
+            "uri": f"postgresql+psycopg2://{catalog_user}@localhost:{server_params.PG_PORT}/{server_params.PG_DATABASE}",
+            "warehouse": f"s3://{TEST_BUCKET}/iceberg/",
+            "s3.endpoint": f"http://localhost:{MOTO_PORT}",
+            "s3.access-key-id": TEST_AWS_ACCESS_KEY_ID,
+            "s3.secret-access-key": TEST_AWS_SECRET_ACCESS_KEY,
+        },
+    )
+
+    try:
+        catalog.create_namespace(TABLE_NAMESPACE)
+    except Exception:
+        pass  # namespace may already exist
+
+    yield catalog
+    catalog.engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def grant_iceberg_tables_access(extension, app_user, superuser_conn):
+    """Grant the app_user UPDATE on iceberg_tables for manual UPDATE tests."""
+    run_command(
+        f"""
+        GRANT SELECT ON lake_iceberg.tables_internal TO {app_user};
+        GRANT UPDATE ON pg_catalog.iceberg_tables TO {app_user};
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+    yield
+    run_command(
+        f"""
+        REVOKE SELECT ON lake_iceberg.tables_internal FROM {app_user};
+        REVOKE UPDATE ON pg_catalog.iceberg_tables FROM {app_user};
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
+def test_external_write_basic(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    Create an Iceberg table via pg_lake, insert data, then append data
+    via PyIceberg.  PyIceberg's commit automatically updates the
+    iceberg_tables view, triggering the sync of internal catalog state.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_basic"
+
+    # create and populate via pg_lake
+    run_command(f"CREATE TABLE {tbl} (a int, b text) USING iceberg", pg_conn)
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, 'row' || i FROM generate_series(1,5) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # load the table via PyIceberg and append rows
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_basic"
+    )
+
+    new_data = pa.table(
+        {"a": [6, 7, 8], "b": ["ext6", "ext7", "ext8"]},
+        schema=pa.schema([pa.field("a", pa.int32()), pa.field("b", pa.string())]),
+    )
+    pyiceberg_table.append(new_data)
+
+    # verify data: should see all 8 rows
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 8
+
+    result = run_query(f"SELECT a, b FROM {tbl} ORDER BY a", pg_conn)
+    assert result == [
+        [1, "row1"],
+        [2, "row2"],
+        [3, "row3"],
+        [4, "row4"],
+        [5, "row5"],
+        [6, "ext6"],
+        [7, "ext7"],
+        [8, "ext8"],
+    ]
+
+    pg_conn.rollback()
+
+
+def test_external_write_schema_add_column(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    External writer adds a new column to the Iceberg schema and writes
+    data with it.  After the PyIceberg commits, the foreign table should
+    gain the new column.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_add_col"
+
+    # create and populate via pg_lake
+    run_command(f"CREATE TABLE {tbl} (a int, b text) USING iceberg", pg_conn)
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, 'row' || i FROM generate_series(1,3) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # evolve schema via PyIceberg: add column c (long)
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_add_col"
+    )
+
+    with pyiceberg_table.update_schema() as update:
+        update.add_column("c", LongType())
+
+    # write data with the new column
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_add_col"
+    )
+
+    new_data = pa.table(
+        {"a": [4], "b": ["ext4"], "c": [100]},
+        schema=pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.string()),
+                pa.field("c", pa.int64()),
+            ]
+        ),
+    )
+    pyiceberg_table.append(new_data)
+
+    # verify column c exists and data is correct
+    result = run_query(f"SELECT a, b, c FROM {tbl} ORDER BY a", pg_conn)
+    assert len(result) == 4
+    # old rows have NULL for column c
+    assert result[0] == [1, "row1", None]
+    assert result[1] == [2, "row2", None]
+    assert result[2] == [3, "row3", None]
+    assert result[3] == [4, "ext4", 100]
+
+    pg_conn.rollback()
+
+
+def test_external_write_schema_drop_column(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    External writer drops a column from the Iceberg schema.
+    After the PyIceberg commit, the foreign table should lose that column.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_drop_col"
+
+    # create with 3 columns
+    run_command(
+        f"CREATE TABLE {tbl} (a int, b text, c int) USING iceberg",
+        pg_conn,
+    )
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, 'row' || i, i * 10 FROM generate_series(1,3) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # drop column c via PyIceberg schema evolution
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_drop_col"
+    )
+
+    with pyiceberg_table.update_schema() as update:
+        update.delete_column("c")
+
+    # verify column c is gone; only a and b remain
+    result = run_query(f"SELECT a, b FROM {tbl} ORDER BY a", pg_conn)
+    assert len(result) == 3
+    assert result[0] == [1, "row1"]
+
+    # column c should not be queryable
+    error_raised = False
+    try:
+        run_query(f"SELECT c FROM {tbl}", pg_conn)
+    except Exception:
+        error_raised = True
+        pg_conn.rollback()
+
+    assert error_raised
+
+    pg_conn.rollback()
+
+
+def test_external_write_optimistic_concurrency_failure(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    grant_iceberg_tables_access,
+):
+    """
+    Attempt to UPDATE iceberg_tables with a wrong previous_metadata_location.
+    Should fail with a concurrency error.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_concurrency"
+
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1)", pg_conn)
+    pg_conn.commit()
+
+    error_raised = False
+    try:
+        run_command(
+            f"""
+            UPDATE iceberg_tables
+            SET metadata_location = 's3://fake/path/v2.metadata.json',
+                previous_metadata_location = 's3://wrong/prev/v1.metadata.json'
+            WHERE table_namespace = '{TABLE_NAMESPACE}'
+              AND table_name = '{TABLE_NAME}_concurrency'
+            """,
+            pg_conn,
+        )
+    except Exception as e:
+        error_raised = True
+        assert "metadata_location has been modified concurrently" in str(e)
+        pg_conn.rollback()
+
+    assert error_raised
+
+    pg_conn.rollback()
+
+
+def test_external_write_null_previous_metadata_location(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    grant_iceberg_tables_access,
+):
+    """
+    Attempt to UPDATE iceberg_tables without previous_metadata_location.
+    Should fail because it is required for concurrency control.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_null_prev"
+
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1)", pg_conn)
+    pg_conn.commit()
+
+    error_raised = False
+    try:
+        run_command(
+            f"""
+            UPDATE iceberg_tables
+            SET metadata_location = 's3://fake/path/v2.metadata.json'
+            WHERE table_namespace = '{TABLE_NAMESPACE}'
+              AND table_name = '{TABLE_NAME}_null_prev'
+            """,
+            pg_conn,
+        )
+    except Exception as e:
+        error_raised = True
+        assert "previous_metadata_location" in str(e)
+        pg_conn.rollback()
+
+    assert error_raised
+
+    pg_conn.rollback()
+
+
+def test_external_write_empty_table(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    External write that overwrites a table with empty data via PyIceberg.
+    The internal catalog should be cleared of data files.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_empty"
+
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1), (2), (3)", pg_conn)
+    pg_conn.commit()
+
+    # verify we have data
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 3
+
+    # use PyIceberg to overwrite with empty data
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_empty"
+    )
+    pyiceberg_table.overwrite(
+        pa.table({"a": pa.array([], type=pa.int32())}),
+    )
+
+    # table should now return 0 rows
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 0
+
+    pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_external_write.py
+++ b/pg_lake_table/tests/pytests/test_external_write.py
@@ -351,3 +351,282 @@ def test_external_write_empty_table(
     assert result[0][0] == 0
 
     pg_conn.rollback()
+
+
+def test_external_write_deletion_queue_on_overwrite(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    Verify that when PyIceberg overwrites a table, the old data files are
+    added to the deletion queue.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_overwrite"
+
+    # create and insert initial data
+    run_command(f"CREATE TABLE {tbl} (a int, b text) USING iceberg", pg_conn)
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, 'row' || i FROM generate_series(1,5) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # get the old data file paths before overwrite
+    old_files = run_query(
+        f"""
+        SELECT f.path
+        FROM lake_table.files f
+        JOIN pg_class c ON c.oid = f.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_overwrite'
+        ORDER BY f.path
+        """,
+        superuser_conn,
+    )
+    assert len(old_files) > 0, "Should have at least one data file before overwrite"
+    old_file_paths = [row[0] for row in old_files]
+
+    # use PyIceberg to overwrite with new data
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_overwrite"
+    )
+    new_data = pa.table(
+        {"a": [10, 20], "b": ["new1", "new2"]},
+        schema=pa.schema([pa.field("a", pa.int32()), pa.field("b", pa.string())]),
+    )
+    pyiceberg_table.overwrite(new_data)
+
+    # verify the new data is visible
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 2
+
+    # verify old files are in the deletion queue
+    queued_files = run_query(
+        f"""
+        SELECT dq.path
+        FROM lake_engine.deletion_queue dq
+        JOIN pg_class c ON c.oid = dq.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_overwrite'
+        ORDER BY dq.path
+        """,
+        superuser_conn,
+    )
+    queued_file_paths = [row[0] for row in queued_files]
+
+    # all old files should be in the deletion queue
+    for old_path in old_file_paths:
+        assert (
+            old_path in queued_file_paths
+        ), f"Old file {old_path} should be in deletion queue"
+
+    # verify orphaned_at timestamp is set
+    timestamps = run_query(
+        f"""
+        SELECT dq.orphaned_at IS NOT NULL
+        FROM lake_engine.deletion_queue dq
+        JOIN pg_class c ON c.oid = dq.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_overwrite'
+        """,
+        superuser_conn,
+    )
+    assert all(row[0] for row in timestamps), "All queued files should have orphaned_at timestamp"
+
+    pg_conn.rollback()
+
+
+def test_external_write_deletion_queue_on_empty(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    Verify that when PyIceberg overwrites a table with empty data,
+    ALL old data files are added to the deletion queue.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_empty"
+
+    # create and insert initial data
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1), (2), (3), (4), (5)", pg_conn)
+    pg_conn.commit()
+
+    # get the old data file paths
+    old_files = run_query(
+        f"""
+        SELECT f.path
+        FROM lake_table.files f
+        JOIN pg_class c ON c.oid = f.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_empty'
+        ORDER BY f.path
+        """,
+        superuser_conn,
+    )
+    old_file_count = len(old_files)
+    assert old_file_count > 0, "Should have at least one data file"
+    old_file_paths = [row[0] for row in old_files]
+
+    # use PyIceberg to overwrite with empty data
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_empty"
+    )
+    pyiceberg_table.overwrite(
+        pa.table({"a": pa.array([], type=pa.int32())}),
+    )
+
+    # verify table is empty
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 0
+
+    # verify ALL old files are in the deletion queue
+    queued_files = run_query(
+        f"""
+        SELECT dq.path
+        FROM lake_engine.deletion_queue dq
+        JOIN pg_class c ON c.oid = dq.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_empty'
+        ORDER BY dq.path
+        """,
+        superuser_conn,
+    )
+    queued_file_paths = [row[0] for row in queued_files]
+
+    assert (
+        len(queued_file_paths) == old_file_count
+    ), f"Expected {old_file_count} files in deletion queue, got {len(queued_file_paths)}"
+
+    for old_path in old_file_paths:
+        assert (
+            old_path in queued_file_paths
+        ), f"Old file {old_path} should be in deletion queue"
+
+    pg_conn.rollback()
+
+
+def test_external_write_deletion_queue_only_old_files(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    Verify that only old files (not new files) are added to the deletion queue
+    after an external write that keeps some files.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_selective"
+
+    # create and insert initial data
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1), (2), (3)", pg_conn)
+    pg_conn.commit()
+
+    # get old data files
+    old_files = run_query(
+        f"""
+        SELECT f.path
+        FROM lake_table.files f
+        JOIN pg_class c ON c.oid = f.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_selective'
+        ORDER BY f.path
+        """,
+        superuser_conn,
+    )
+    old_file_paths = [row[0] for row in old_files]
+
+    # append more data via PyIceberg
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_selective"
+    )
+    new_data = pa.table(
+        {"a": [4, 5, 6]},
+        schema=pa.schema([pa.field("a", pa.int32())]),
+    )
+    pyiceberg_table.append(new_data)
+
+    # verify we have 6 rows
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 6
+
+    # get new data files (after append)
+    new_files = run_query(
+        f"""
+        SELECT f.path
+        FROM lake_table.files f
+        JOIN pg_class c ON c.oid = f.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_selective'
+        ORDER BY f.path
+        """,
+        superuser_conn,
+    )
+    new_file_paths = [row[0] for row in new_files]
+
+    # after append, old files should still be there (no files queued for deletion)
+    queued_files_after_append = run_query(
+        f"""
+        SELECT dq.path
+        FROM lake_engine.deletion_queue dq
+        JOIN pg_class c ON c.oid = dq.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_selective'
+        """,
+        superuser_conn,
+    )
+    assert (
+        len(queued_files_after_append) == 0
+    ), "After append, no files should be in deletion queue"
+
+    # now overwrite the table
+    overwrite_data = pa.table(
+        {"a": [100, 200]},
+        schema=pa.schema([pa.field("a", pa.int32())]),
+    )
+    pyiceberg_table.overwrite(overwrite_data)
+
+    # verify we have 2 rows
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 2
+
+    # verify ALL old files (both original and appended) are in deletion queue
+    queued_files = run_query(
+        f"""
+        SELECT dq.path
+        FROM lake_engine.deletion_queue dq
+        JOIN pg_class c ON c.oid = dq.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_selective'
+        ORDER BY dq.path
+        """,
+        superuser_conn,
+    )
+    queued_file_paths = [row[0] for row in queued_files]
+
+    # all files from before the overwrite should be queued
+    for old_path in new_file_paths:
+        assert (
+            old_path in queued_file_paths
+        ), f"File {old_path} should be in deletion queue after overwrite"
+
+    # get current data files (after overwrite)
+    current_files = run_query(
+        f"""
+        SELECT f.path
+        FROM lake_table.files f
+        JOIN pg_class c ON c.oid = f.table_name
+        WHERE c.relname = '{TABLE_NAME}_del_selective'
+        """,
+        superuser_conn,
+    )
+    current_file_paths = [row[0] for row in current_files]
+
+    # current files should NOT be in the deletion queue
+    for current_path in current_file_paths:
+        assert (
+            current_path not in queued_file_paths
+        ), f"Current file {current_path} should NOT be in deletion queue"
+
+    pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_external_write.py
+++ b/pg_lake_table/tests/pytests/test_external_write.py
@@ -432,7 +432,9 @@ def test_external_write_deletion_queue_on_overwrite(
         """,
         superuser_conn,
     )
-    assert all(row[0] for row in timestamps), "All queued files should have orphaned_at timestamp"
+    assert all(
+        row[0] for row in timestamps
+    ), "All queued files should have orphaned_at timestamp"
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_external_write.py
+++ b/pg_lake_table/tests/pytests/test_external_write.py
@@ -621,9 +621,7 @@ def test_external_write_preserves_history_files(
     pyiceberg_table.append(
         pa.table(
             {"a": [4, 5], "b": ["ext4", "ext5"]},
-            schema=pa.schema(
-                [pa.field("a", pa.int32()), pa.field("b", pa.string())]
-            ),
+            schema=pa.schema([pa.field("a", pa.int32()), pa.field("b", pa.string())]),
         )
     )
 
@@ -690,9 +688,7 @@ def test_external_write_partition_spec_evolution(
     pyiceberg_table.append(
         pa.table(
             {"a": [4, 5], "b": [40, 50]},
-            schema=pa.schema(
-                [pa.field("a", pa.int32()), pa.field("b", pa.int32())]
-            ),
+            schema=pa.schema([pa.field("a", pa.int32()), pa.field("b", pa.int32())]),
         )
     )
 

--- a/pg_lake_table/tests/pytests/test_external_write.py
+++ b/pg_lake_table/tests/pytests/test_external_write.py
@@ -74,6 +74,28 @@ def grant_iceberg_tables_access(extension, app_user, superuser_conn):
     superuser_conn.commit()
 
 
+@pytest.fixture(scope="function")
+def grant_iceberg_tables_full_access(extension, app_user, superuser_conn):
+    """Grant the app_user INSERT/UPDATE/DELETE on iceberg_tables for trigger tests."""
+    run_command(
+        f"""
+        GRANT SELECT ON lake_iceberg.tables_internal TO {app_user};
+        GRANT INSERT, UPDATE, DELETE ON pg_catalog.iceberg_tables TO {app_user};
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+    yield
+    run_command(
+        f"""
+        REVOKE SELECT ON lake_iceberg.tables_internal FROM {app_user};
+        REVOKE INSERT, UPDATE, DELETE ON pg_catalog.iceberg_tables FROM {app_user};
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
 def test_external_write_basic(
     s3,
     pg_conn,
@@ -770,5 +792,362 @@ def test_external_write_rename_column(
     # data is intact — the rename is non-destructive
     result = run_query(f"SELECT a, b_renamed FROM {tbl} ORDER BY a", pg_conn)
     assert result == [[1, "row1"], [2, "row2"], [3, "row3"]]
+
+    pg_conn.rollback()
+
+
+def test_external_write_schema_and_data_in_two_commits(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    Two PyIceberg commits land between consecutive pg_lake reads:
+    first a schema add_column, then a write that uses the new column.
+    The sync triggered by the second commit must see both the new column
+    in the foreign table and the new file in the catalog. PyIceberg's
+    Python API serialises schema and data into separate commits, so this
+    is the closest "transactional" coverage we can express here.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_combined"
+
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1), (2)", pg_conn)
+    pg_conn.commit()
+
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_combined"
+    )
+
+    # commit 1: add column
+    with pyiceberg_table.update_schema() as update:
+        update.add_column("b", LongType())
+
+    # commit 2: write data using the new column
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_combined"
+    )
+    pyiceberg_table.append(
+        pa.table(
+            {"a": [3, 4], "b": [30, 40]},
+            schema=pa.schema([pa.field("a", pa.int32()), pa.field("b", pa.int64())]),
+        )
+    )
+
+    # both reads must reflect the post-second-commit state
+    result = run_query(f"SELECT a, b FROM {tbl} ORDER BY a", pg_conn)
+    assert result == [
+        [1, None],
+        [2, None],
+        [3, 30],
+        [4, 40],
+    ]
+
+    pg_conn.rollback()
+
+
+def test_external_write_nested_list_append(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    Append rows to a table that has a list column. The schema doesn't
+    change, but the sync still walks the field mapping for the list
+    element. If the data-file resync chokes on nested types, the file
+    won't be cataloged and reads will under-report.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_list"
+
+    run_command(f"CREATE TABLE {tbl} (a int, tags int[]) USING iceberg", pg_conn)
+    run_command(
+        f"INSERT INTO {tbl} VALUES (1, ARRAY[10, 20]), (2, ARRAY[30])",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    pyiceberg_table = iceberg_catalog.load_table(f"{TABLE_NAMESPACE}.{TABLE_NAME}_list")
+    pyiceberg_table.append(
+        pa.table(
+            {"a": [3], "tags": [[40, 50, 60]]},
+            schema=pa.schema(
+                [
+                    pa.field("a", pa.int32()),
+                    pa.field("tags", pa.list_(pa.field("element", pa.int32()))),
+                ]
+            ),
+        )
+    )
+
+    result = run_query(f"SELECT a, tags FROM {tbl} ORDER BY a", pg_conn)
+    assert result == [
+        [1, [10, 20]],
+        [2, [30]],
+        [3, [40, 50, 60]],
+    ]
+
+    pg_conn.rollback()
+
+
+def test_external_write_delete_rows(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    External client deletes a subset of rows via PyIceberg's delete().
+    Whether pyiceberg uses copy-on-write or merge-on-read (position
+    deletes), the sync must end up serving the correct row set; this
+    exercises the CONTENT_POSITION_DELETES branch in SyncDataFiles when
+    pyiceberg writes delete files, and the COW path when it rewrites.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_delete"
+
+    run_command(f"CREATE TABLE {tbl} (a int, b text) USING iceberg", pg_conn)
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, 'row' || i FROM generate_series(1,10) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_delete"
+    )
+
+    # delete rows where a > 5 — should leave 5 rows
+    pyiceberg_table.delete(delete_filter="a > 5")
+
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 5
+
+    result = run_query(f"SELECT a, b FROM {tbl} ORDER BY a", pg_conn)
+    assert result == [
+        [1, "row1"],
+        [2, "row2"],
+        [3, "row3"],
+        [4, "row4"],
+        [5, "row5"],
+    ]
+
+    pg_conn.rollback()
+
+
+def test_external_write_stats_populated(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    After PyIceberg writes a data file, the sync must populate
+    lake_table.data_file_column_stats with the lower/upper bounds parsed
+    from the Iceberg manifest. Without this, file-level pruning regresses
+    silently for externally-written files.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_stats"
+
+    run_command(f"CREATE TABLE {tbl} (a int, b text) USING iceberg", pg_conn)
+    pg_conn.commit()
+
+    # write a single file via PyIceberg with a known a-range [10, 30]
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_stats"
+    )
+    pyiceberg_table.append(
+        pa.table(
+            {"a": [10, 20, 30], "b": ["x", "y", "z"]},
+            schema=pa.schema([pa.field("a", pa.int32()), pa.field("b", pa.string())]),
+        )
+    )
+
+    # the sync should have populated column stats for both fields. Field IDs
+    # 1 and 2 correspond to a and b in the order they were declared.
+    stats = run_query(
+        f"""
+        SELECT field_id, lower_bound, upper_bound
+        FROM lake_table.data_file_column_stats
+        WHERE table_name = '{tbl}'::regclass
+        ORDER BY field_id
+        """,
+        superuser_conn,
+    )
+    assert stats == [
+        [1, "10", "30"],
+        [2, "x", "z"],
+    ], f"expected bounds for a in [10,30] and b in [x,z]; got {stats}"
+
+    pg_conn.rollback()
+
+
+def test_external_write_internal_catalog_insert_rejected(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    grant_iceberg_tables_full_access,
+):
+    """
+    INSERT into iceberg_tables for the current database catalog must be
+    rejected — internal catalog is only mutable via pg_lake DDL.
+    """
+    db_name = run_query("SELECT current_database()", pg_conn)[0][0]
+
+    error_raised = False
+    try:
+        run_command(
+            f"""
+            INSERT INTO iceberg_tables
+                (catalog_name, table_namespace, table_name, metadata_location)
+            VALUES
+                ('{db_name}', '{TABLE_NAMESPACE}', 'fake_internal',
+                 's3://fake/v1.metadata.json')
+            """,
+            pg_conn,
+        )
+    except Exception as e:
+        error_raised = True
+        assert (
+            "internal catalog is currently only supported via pg_lake_iceberg" in str(e)
+        )
+        pg_conn.rollback()
+
+    assert error_raised
+
+
+def test_external_write_internal_catalog_delete_rejected(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    grant_iceberg_tables_full_access,
+):
+    """
+    DELETE from iceberg_tables for the current database catalog must be
+    rejected — dropping internal tables goes through pg_lake DDL.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_internal"
+
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    pg_conn.commit()
+
+    error_raised = False
+    try:
+        run_command(
+            f"""
+            DELETE FROM iceberg_tables
+            WHERE table_namespace = '{TABLE_NAMESPACE}'
+              AND table_name = '{TABLE_NAME}_del_internal'
+            """,
+            pg_conn,
+        )
+    except Exception as e:
+        error_raised = True
+        assert (
+            "internal catalog is currently only supported via pg_lake_iceberg" in str(e)
+        )
+        pg_conn.rollback()
+
+    assert error_raised
+
+    pg_conn.rollback()
+
+
+def test_external_write_catalog_name_change_rejected(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    grant_iceberg_tables_access,
+):
+    """
+    UPDATE that changes catalog_name across the internal/external boundary
+    must be rejected — the row's identity is tied to which catalog owns it.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_catalog_change"
+
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1)", pg_conn)
+    pg_conn.commit()
+
+    # current row is internal; flip catalog_name to a foreign value
+    error_raised = False
+    try:
+        run_command(
+            f"""
+            UPDATE iceberg_tables
+            SET catalog_name = 'some_other_catalog',
+                metadata_location = metadata_location,
+                previous_metadata_location = metadata_location
+            WHERE table_namespace = '{TABLE_NAMESPACE}'
+              AND table_name = '{TABLE_NAME}_catalog_change'
+            """,
+            pg_conn,
+        )
+    except Exception as e:
+        error_raised = True
+        assert (
+            "internal catalog is currently only supported via pg_lake_iceberg" in str(e)
+        )
+        pg_conn.rollback()
+
+    assert error_raised
+
+    pg_conn.rollback()
+
+
+def test_external_write_unknown_table_rejected(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    grant_iceberg_tables_full_access,
+):
+    """
+    UPDATE on iceberg_tables for the internal catalog with a namespace/table
+    that doesn't resolve to a real relation must raise an undefined-table
+    error rather than silently no-op'ing.
+    """
+    db_name = run_query("SELECT current_database()", pg_conn)[0][0]
+
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_unknown"
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1)", pg_conn)
+    pg_conn.commit()
+
+    error_raised = False
+    try:
+        run_command(
+            f"""
+            UPDATE iceberg_tables
+            SET table_name = 'definitely_not_a_real_table',
+                metadata_location = metadata_location,
+                previous_metadata_location = metadata_location
+            WHERE catalog_name = '{db_name}'
+              AND table_namespace = '{TABLE_NAMESPACE}'
+              AND table_name = '{TABLE_NAME}_unknown'
+            """,
+            pg_conn,
+        )
+    except Exception as e:
+        error_raised = True
+        assert "does not exist" in str(e)
+        pg_conn.rollback()
+
+    assert error_raised
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_external_write.py
+++ b/pg_lake_table/tests/pytests/test_external_write.py
@@ -1,6 +1,7 @@
 import pytest
 import pyarrow as pa
 from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.transforms import IdentityTransform
 from pyiceberg.types import LongType
 
 from utils_pytest import *
@@ -362,8 +363,12 @@ def test_external_write_deletion_queue_on_overwrite(
     iceberg_catalog,
 ):
     """
-    Verify that when PyIceberg overwrites a table, the old data files are
-    added to the deletion queue.
+    PyIceberg overwrite() retains the previous snapshot by default, so
+    the old data files are still referenced via that snapshot. The sync
+    must NOT queue them for deletion — doing so would break time-travel
+    reads from external clients. (Snapshot expiration eventually orphans
+    them, but that's a separate path not exercised here; pyiceberg has
+    no Python API for expiration as of this writing.)
     """
     tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_overwrite"
 
@@ -403,38 +408,23 @@ def test_external_write_deletion_queue_on_overwrite(
     result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
     assert result[0][0] == 2
 
-    # verify old files are in the deletion queue
+    # the old data files are still referenced by the retained pre-overwrite
+    # snapshot, so they must NOT be in the deletion queue.
     queued_files = run_query(
         f"""
         SELECT dq.path
         FROM lake_engine.deletion_queue dq
         JOIN pg_class c ON c.oid = dq.table_name
         WHERE c.relname = '{TABLE_NAME}_del_overwrite'
-        ORDER BY dq.path
         """,
         superuser_conn,
     )
     queued_file_paths = [row[0] for row in queued_files]
 
-    # all old files should be in the deletion queue
     for old_path in old_file_paths:
         assert (
-            old_path in queued_file_paths
-        ), f"Old file {old_path} should be in deletion queue"
-
-    # verify orphaned_at timestamp is set
-    timestamps = run_query(
-        f"""
-        SELECT dq.orphaned_at IS NOT NULL
-        FROM lake_engine.deletion_queue dq
-        JOIN pg_class c ON c.oid = dq.table_name
-        WHERE c.relname = '{TABLE_NAME}_del_overwrite'
-        """,
-        superuser_conn,
-    )
-    assert all(
-        row[0] for row in timestamps
-    ), "All queued files should have orphaned_at timestamp"
+            old_path not in queued_file_paths
+        ), f"Old file {old_path} is still referenced by a retained snapshot and must not be queued"
 
     pg_conn.rollback()
 
@@ -448,8 +438,11 @@ def test_external_write_deletion_queue_on_empty(
     iceberg_catalog,
 ):
     """
-    Verify that when PyIceberg overwrites a table with empty data,
-    ALL old data files are added to the deletion queue.
+    Overwriting with empty data via PyIceberg still retains the previous
+    snapshot (which references the original data files), so those files
+    must NOT be queued for deletion despite the table being logically
+    empty. They become orphaned only after the retaining snapshot is
+    expired.
     """
     tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_empty"
 
@@ -485,27 +478,23 @@ def test_external_write_deletion_queue_on_empty(
     result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
     assert result[0][0] == 0
 
-    # verify ALL old files are in the deletion queue
+    # the original files are still referenced by the retained pre-overwrite
+    # snapshot, so they must NOT be in the deletion queue.
     queued_files = run_query(
         f"""
         SELECT dq.path
         FROM lake_engine.deletion_queue dq
         JOIN pg_class c ON c.oid = dq.table_name
         WHERE c.relname = '{TABLE_NAME}_del_empty'
-        ORDER BY dq.path
         """,
         superuser_conn,
     )
     queued_file_paths = [row[0] for row in queued_files]
 
-    assert (
-        len(queued_file_paths) == old_file_count
-    ), f"Expected {old_file_count} files in deletion queue, got {len(queued_file_paths)}"
-
     for old_path in old_file_paths:
         assert (
-            old_path in queued_file_paths
-        ), f"Old file {old_path} should be in deletion queue"
+            old_path not in queued_file_paths
+        ), f"Old file {old_path} is still referenced by a retained snapshot and must not be queued"
 
     pg_conn.rollback()
 
@@ -519,8 +508,12 @@ def test_external_write_deletion_queue_only_old_files(
     iceberg_catalog,
 ):
     """
-    Verify that only old files (not new files) are added to the deletion queue
-    after an external write that keeps some files.
+    Across an append + overwrite sequence, the deletion queue must stay
+    empty: every file remains referenced by at least one retained snapshot
+    (the pre-append snapshot for the originals, the post-append snapshot
+    for the appended ones, the post-overwrite snapshot for the new ones).
+    Nothing is orphaned until snapshot expiration runs, which happens
+    outside the sync path.
     """
     tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_selective"
 
@@ -529,48 +522,21 @@ def test_external_write_deletion_queue_only_old_files(
     run_command(f"INSERT INTO {tbl} VALUES (1), (2), (3)", pg_conn)
     pg_conn.commit()
 
-    # get old data files
-    old_files = run_query(
-        f"""
-        SELECT f.path
-        FROM lake_table.files f
-        JOIN pg_class c ON c.oid = f.table_name
-        WHERE c.relname = '{TABLE_NAME}_del_selective'
-        ORDER BY f.path
-        """,
-        superuser_conn,
-    )
-    old_file_paths = [row[0] for row in old_files]
-
-    # append more data via PyIceberg
+    # append more data via PyIceberg (creates a second snapshot)
     pyiceberg_table = iceberg_catalog.load_table(
         f"{TABLE_NAMESPACE}.{TABLE_NAME}_del_selective"
     )
-    new_data = pa.table(
-        {"a": [4, 5, 6]},
-        schema=pa.schema([pa.field("a", pa.int32())]),
+    pyiceberg_table.append(
+        pa.table(
+            {"a": [4, 5, 6]},
+            schema=pa.schema([pa.field("a", pa.int32())]),
+        )
     )
-    pyiceberg_table.append(new_data)
 
-    # verify we have 6 rows
     result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
     assert result[0][0] == 6
 
-    # get new data files (after append)
-    new_files = run_query(
-        f"""
-        SELECT f.path
-        FROM lake_table.files f
-        JOIN pg_class c ON c.oid = f.table_name
-        WHERE c.relname = '{TABLE_NAME}_del_selective'
-        ORDER BY f.path
-        """,
-        superuser_conn,
-    )
-    new_file_paths = [row[0] for row in new_files]
-
-    # after append, old files should still be there (no files queued for deletion)
-    queued_files_after_append = run_query(
+    queued_after_append = run_query(
         f"""
         SELECT dq.path
         FROM lake_engine.deletion_queue dq
@@ -580,55 +546,233 @@ def test_external_write_deletion_queue_only_old_files(
         superuser_conn,
     )
     assert (
-        len(queued_files_after_append) == 0
-    ), "After append, no files should be in deletion queue"
+        len(queued_after_append) == 0
+    ), "After append, no files should be queued for deletion"
 
-    # now overwrite the table
-    overwrite_data = pa.table(
-        {"a": [100, 200]},
-        schema=pa.schema([pa.field("a", pa.int32())]),
+    # now overwrite (creates a third snapshot; the first two are still retained)
+    pyiceberg_table.overwrite(
+        pa.table(
+            {"a": [100, 200]},
+            schema=pa.schema([pa.field("a", pa.int32())]),
+        )
     )
-    pyiceberg_table.overwrite(overwrite_data)
 
-    # verify we have 2 rows
     result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
     assert result[0][0] == 2
 
-    # verify ALL old files (both original and appended) are in deletion queue
-    queued_files = run_query(
+    queued_after_overwrite = run_query(
         f"""
         SELECT dq.path
         FROM lake_engine.deletion_queue dq
         JOIN pg_class c ON c.oid = dq.table_name
         WHERE c.relname = '{TABLE_NAME}_del_selective'
-        ORDER BY dq.path
         """,
         superuser_conn,
     )
-    queued_file_paths = [row[0] for row in queued_files]
+    assert (
+        len(queued_after_overwrite) == 0
+    ), "After overwrite, files retained by older snapshots must not be queued"
 
-    # all files from before the overwrite should be queued
-    for old_path in new_file_paths:
-        assert (
-            old_path in queued_file_paths
-        ), f"File {old_path} should be in deletion queue after overwrite"
+    pg_conn.rollback()
 
-    # get current data files (after overwrite)
-    current_files = run_query(
+
+def test_external_write_preserves_history_files(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    After an external append, the data files from the previous (now
+    historic) snapshot must NOT be queued for deletion: they are still
+    referenced by retained snapshots and external clients may rely on
+    them for time-travel reads.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_history"
+
+    run_command(f"CREATE TABLE {tbl} (a int, b text) USING iceberg", pg_conn)
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, 'row' || i FROM generate_series(1,3) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # snapshot the file paths before the external append
+    historic_files = run_query(
         f"""
         SELECT f.path
         FROM lake_table.files f
         JOIN pg_class c ON c.oid = f.table_name
-        WHERE c.relname = '{TABLE_NAME}_del_selective'
+        WHERE c.relname = '{TABLE_NAME}_history'
+        ORDER BY f.path
         """,
         superuser_conn,
     )
-    current_file_paths = [row[0] for row in current_files]
+    historic_paths = [row[0] for row in historic_files]
+    assert len(historic_paths) > 0
 
-    # current files should NOT be in the deletion queue
-    for current_path in current_file_paths:
+    # external client appends. Old snapshot is retained by default; new
+    # snapshot is what pg_lake reads from.
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_history"
+    )
+    pyiceberg_table.append(
+        pa.table(
+            {"a": [4, 5], "b": ["ext4", "ext5"]},
+            schema=pa.schema(
+                [pa.field("a", pa.int32()), pa.field("b", pa.string())]
+            ),
+        )
+    )
+
+    # historic files must NOT be in the deletion queue — they remain
+    # referenced by the retained pre-append snapshot.
+    queued = run_query(
+        f"""
+        SELECT dq.path
+        FROM lake_engine.deletion_queue dq
+        JOIN pg_class c ON c.oid = dq.table_name
+        WHERE c.relname = '{TABLE_NAME}_history'
+        """,
+        superuser_conn,
+    )
+    queued_paths = [row[0] for row in queued]
+
+    for hp in historic_paths:
         assert (
-            current_path not in queued_file_paths
-        ), f"Current file {current_path} should NOT be in deletion queue"
+            hp not in queued_paths
+        ), f"Historic file {hp} must not be queued for deletion"
+
+    # sanity: the table reads correctly after the append (5 total rows)
+    result = run_query(f"SELECT count(*) FROM {tbl}", pg_conn)
+    assert result[0][0] == 5
+
+    pg_conn.rollback()
+
+
+def test_external_write_partition_spec_evolution(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    External client evolves the partition spec (adds a new identity-
+    partitioned column). pg_lake must register the new spec and serve
+    correct results when reading rows written under it.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_part_evol"
+
+    run_command(
+        f"CREATE TABLE {tbl} (a int, b int) USING iceberg",
+        pg_conn,
+    )
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, i * 10 FROM generate_series(1,3) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_part_evol"
+    )
+
+    with pyiceberg_table.update_spec() as update:
+        update.add_field("b", IdentityTransform())
+
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_part_evol"
+    )
+    pyiceberg_table.append(
+        pa.table(
+            {"a": [4, 5], "b": [40, 50]},
+            schema=pa.schema(
+                [pa.field("a", pa.int32()), pa.field("b", pa.int32())]
+            ),
+        )
+    )
+
+    # the new spec must be visible in the pg_lake catalog
+    spec_count = run_query(
+        f"""
+        SELECT count(*)
+        FROM lake_table.partition_specs ps
+        JOIN pg_class c ON c.oid = ps.table_name
+        WHERE c.relname = '{TABLE_NAME}_part_evol'
+        """,
+        superuser_conn,
+    )
+    assert spec_count[0][0] >= 2, "expected the new partition spec to be registered"
+
+    # full result set is correct across both specs
+    result = run_query(f"SELECT a, b FROM {tbl} ORDER BY a", pg_conn)
+    assert result == [
+        [1, 10],
+        [2, 20],
+        [3, 30],
+        [4, 40],
+        [5, 50],
+    ]
+
+    pg_conn.rollback()
+
+
+def test_external_write_rename_column(
+    s3,
+    pg_conn,
+    superuser_conn,
+    extension,
+    with_default_location,
+    iceberg_catalog,
+):
+    """
+    External client renames a column. Iceberg field IDs are stable across
+    rename, so the sync must detect the name change and issue an ALTER
+    FOREIGN TABLE RENAME COLUMN — not silently drop+add (which would lose
+    the column's data on subsequent reads through the old name) and not
+    leave the foreign table out of sync with the new schema.
+    """
+    tbl = f"{TABLE_NAMESPACE}.{TABLE_NAME}_rename"
+
+    run_command(
+        f"CREATE TABLE {tbl} (a int, b text) USING iceberg",
+        pg_conn,
+    )
+    run_command(
+        f"INSERT INTO {tbl} SELECT i, 'row' || i FROM generate_series(1,3) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    pyiceberg_table = iceberg_catalog.load_table(
+        f"{TABLE_NAMESPACE}.{TABLE_NAME}_rename"
+    )
+
+    with pyiceberg_table.update_schema() as update:
+        update.rename_column("b", "b_renamed")
+
+    # the new column name must exist in the foreign table; old name must not
+    columns = run_query(
+        f"""
+        SELECT attname
+        FROM pg_attribute
+        WHERE attrelid = '{tbl}'::regclass
+          AND attnum > 0
+          AND NOT attisdropped
+        ORDER BY attnum
+        """,
+        pg_conn,
+    )
+    column_names = [row[0] for row in columns]
+    assert "b_renamed" in column_names, f"expected 'b_renamed' in {column_names}"
+    assert "b" not in column_names, f"old name 'b' still present in {column_names}"
+
+    # data is intact — the rename is non-destructive
+    result = run_query(f"SELECT a, b_renamed FROM {tbl} ORDER BY a", pg_conn)
+    assert result == [[1, "row1"], [2, "row2"], [3, "row3"]]
 
     pg_conn.rollback()


### PR DESCRIPTION
Background project I've had going on, needs a deeper look.

We expose Iceberg tables via the `iceberg_tables` view, which is supported by Spark and pyiceberg. However, we currently only support reads from that view. This PR adds support for writes to existing tables (i.e. updates on the view), by reading the metadata file being inserted, updating our internal metadata tables from it, and adjusting the schema if needed.