### PR TITLE
Fix out of range date/timestamp and numeric values in iceberg tables

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/serialize.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/serialize.h
@@ -31,6 +31,8 @@ extern PGDLLEXPORT char *PGDuckOnlySerialize(Oid typeOid, Datum value);
 extern PGDLLEXPORT bool IsPGDuckSerializeRequired(PGType postgresType);
 extern PGDLLEXPORT char *IntervalOutForPGDuck(Datum value);
 extern bool IsContainerType(Oid postgresType);
+extern PGDLLEXPORT const char *ConvertBCToISOYearIfNeeded(const char *str);
+extern PGDLLEXPORT const char *ConvertISOYearToBCIfNeeded(const char *str);
 
 /*
  * IsSerializedAsContainer returns whether a type will be serialized as a

--- a/pg_lake_engine/include/pg_lake/pgduck/write_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/write_data.h
@@ -33,6 +33,22 @@ typedef enum ParquetVersion
 	PARQUET_VERSION_V2 = 2
 } ParquetVersion;
 
+/*
+ * Behavior for out-of-range values during Iceberg writes.
+ * Applies to temporal types (date, timestamp, timestamptz) and
+ * numeric types (NaN/Inf, unbounded precision overflow).
+ *
+ * Controlled by the pg_lake_iceberg.out_of_range_values GUC.
+ */
+typedef enum IcebergOutOfRange
+{
+	ICEBERG_OUT_OF_RANGE_ERROR = 0,
+	ICEBERG_OUT_OF_RANGE_CLAMP = 1,
+}			IcebergOutOfRange;
+
+/* pg_lake_iceberg.out_of_range_values */
+extern PGDLLEXPORT int IcebergOutOfRangeValues;
+
 /* pg_lake_table.default_parquet_version */
 extern PGDLLEXPORT int DefaultParquetVersion;
 

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -34,7 +34,6 @@
 #include "commands/defrem.h"
 #include "pg_lake/csv/csv_writer.h"
 #include "pg_lake/extensions/postgis.h"
-#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/pgduck/serialize.h"
 #include "pg_lake/util/numeric.h"
 #include "executor/executor.h"
@@ -142,8 +141,6 @@ static void CopySendInt16(CopyToState cstate, int16 val);
 static List *TupleDescColumnNameList(TupleDesc tupleDescriptor);
 static List *CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist);
 static bool ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType);
-static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr);
-static void ErrorIfSpecialNumeric(const char *input_str);
 
 
 /*----------
@@ -646,82 +643,6 @@ CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist)
 	return attnums;
 }
 
-/*
- * ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits ensures the digits for
- * both precision and scale of the numeric, in string, does not exceed the max
- * allowed digits during COPY TO.
- */
-static void
-ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr)
-{
-	int			totalIntegralDigits = 0;
-	int			totalDecimalDigits = 0;
-	bool		foundDotSeparator = false;
-
-	for (int i = 0; numericStr[i] != '\0'; i++)
-	{
-		if (numericStr[i] == '.')
-		{
-			foundDotSeparator = true;
-			continue;
-		}
-
-		if (!isdigit(numericStr[i]))
-			continue;
-
-		if (foundDotSeparator)
-			totalDecimalDigits++;
-		else
-			totalIntegralDigits++;
-
-		if (totalIntegralDigits > (UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale))
-		{
-			ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
-							errmsg("unbounded numeric type exceeds max allowed digits %d "
-								   "before decimal point",
-								   UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale),
-							errhint("Consider specifying precision and scale for numeric types, "
-									"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
-		}
-
-		if (totalDecimalDigits > UnboundedNumericDefaultScale)
-		{
-			ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
-							errmsg("unbounded numeric type exceeds max allowed digits %d "
-								   "after decimal point", UnboundedNumericDefaultScale),
-							errhint("Consider specifying precision and scale for numeric types, "
-									"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
-		}
-	}
-}
-
-
-/*
-* ErrorIfSpecialNumeric ensures that the input string does not contain
-* special numeric values like NaN, Inf, -Inf.
-*/
-static void
-ErrorIfSpecialNumeric(const char *input_str)
-{
-
-	char	   *num = (char *) input_str;
-
-	/* skip leading whitespace */
-	while (*num != '\0' && isspace((unsigned char) *num))
-		num++;
-
-	if (pg_strncasecmp(num, "NaN", 3) == 0 ||
-		pg_strncasecmp(num, "Infinity", 8) == 0 ||
-		pg_strncasecmp(num, "+Infinity", 9) == 0 ||
-		pg_strncasecmp(num, "-Infinity", 9) == 0 ||
-		pg_strncasecmp(num, "inf", 3) == 0 ||
-		pg_strncasecmp(num, "+inf", 4) == 0 ||
-		pg_strncasecmp(num, "-inf", 4) == 0)
-	{
-		ereport(ERROR, errmsg("Special numeric values like NaN, Inf, -Inf are not allowed for numeric type"),
-				errhint("Use float type instead."));
-	}
-}
 
 
 /*
@@ -795,17 +716,7 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 					string = OutputFunctionCall(&out_functions[attnum - 1],
 												value);
 
-				if (attr->atttypid == NUMERICOID)
-				{
-					if (IsUnboundedNumeric(NUMERICOID, attr->atttypmod))
-						ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(string);
-
-					/* do not allow Nan, Inf etc. */
-					ErrorIfSpecialNumeric(string);
-				}
-
-
-				if (cstate->opts.csv_mode)
+					if (cstate->opts.csv_mode)
 					CopyAttributeOutCSV(cstate, string,
 										cstate->opts.force_quote_flags[attnum - 1],
 										list_length(cstate->attnumlist) == 1);

--- a/pg_lake_engine/src/pgduck/serialize.c
+++ b/pg_lake_engine/src/pgduck/serialize.c
@@ -27,13 +27,97 @@
 #include "pg_lake/pgduck/struct_conversion.h"
 #include "pg_lake/util/timetz.h"
 #include "utils/builtins.h"
-#include "utils/date.h"
 #include "utils/lsyscache.h"
-#include "utils/timestamp.h"
 
 
 static char *ByteAOutForPGDuck(Datum value);
 static char *TimeTzOutForPGDuck(Datum value);
+
+
+/*
+ * ConvertBCToISOYearIfNeeded converts PostgreSQL's BC-era date/timestamp
+ * string to ISO 8601 year numbering.
+ *
+ * If the input ends with " BC", the 1-based BC year is converted:
+ *   1 BC → 0000, 2 BC → -0001, 4712 BC → -4711
+ *
+ * The rest of the string (month-day, time, timezone) is preserved:
+ *   "4712-01-01 BC"            → "-4711-01-01"
+ *   "4712-01-01 00:00:00 BC"   → "-4711-01-01 00:00:00"
+ *   "0001-01-01 00:00:00+00 BC" → "0000-01-01 00:00:00+00"
+ *
+ * AD strings (no " BC" suffix) are returned unchanged.
+ */
+const char *
+ConvertBCToISOYearIfNeeded(const char *str)
+{
+	int			len = strlen(str);
+
+	/* Must end with " BC" */
+	if (len < 3 || strcmp(str + len - 3, " BC") != 0)
+		return str;
+
+	/* Parse PostgreSQL's 1-based BC year */
+	int			pgBcYear;
+
+	if (sscanf(str, "%d-", &pgBcYear) != 1 || pgBcYear <= 0)
+		return str;
+
+	/*
+	 * Convert: 1 BC (pgBcYear=1) → ISO year 0, 2 BC → -1, 4712 BC →
+	 * -4711
+	 */
+	int			isoYear = -(pgBcYear - 1);
+
+	/* Locate first '-' after the year digits to find "-MM-DD..." */
+	const char *afterYear = strchr(str, '-');
+
+	if (afterYear == NULL)
+		return str;
+
+	/* Extract the portion between year and trailing " BC" */
+	int			middleLen = (str + len - 3) - afterYear;
+	char	   *middle = pnstrdup(afterYear, middleLen);
+
+	const char *result;
+
+	if (isoYear == 0)
+		result = psprintf("%04d%s", isoYear, middle);
+	else
+		result = psprintf("-%04d%s", -isoYear, middle);
+
+	pfree(middle);
+	return result;
+}
+
+
+/*
+ * ConvertISOYearToBCIfNeeded converts an ISO 8601 zero/negative year
+ * date/timestamp string to PostgreSQL's "YYYY BC" format.
+ *
+ *   "-4711-01-01"            → "4712-01-01 BC"
+ *   "0000-01-01T00:00:00"    → "0001-01-01T00:00:00 BC"
+ *   "0000-01-01 00:00:00+00" → "0001-01-01 00:00:00+00 BC"
+ *
+ * Positive-year strings pass through unchanged.
+ */
+const char *
+ConvertISOYearToBCIfNeeded(const char *str)
+{
+	int			isoYear;
+	int			consumed = 0;
+
+	if (sscanf(str, "%d%n", &isoYear, &consumed) != 1 || isoYear > 0)
+		return str;
+
+	/* ISO year 0 = 1 BC, -1 = 2 BC, etc. */
+	int			bcYear = 1 - isoYear;
+
+	/* rest points to "-MM-DD..." after the year digits */
+	const char *rest = str + consumed;
+
+	return psprintf("%04d%s BC", bcYear, rest);
+}
 
 
 /*
@@ -89,6 +173,20 @@ PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 		return TextDatumGetCString(geomAsText);
 	}
 
+	/*
+	 * PostgreSQL outputs BC dates/timestamps with a " BC" suffix (e.g.
+	 * "4712-01-01 BC"), but DuckDB expects ISO 8601 negative-year format
+	 * (e.g. "-4711-01-01").  Without this conversion, DuckDB silently drops
+	 * the BC era indicator and treats the value as AD.
+	 */
+	if (columnType == DATEOID || columnType == TIMESTAMPOID ||
+		columnType == TIMESTAMPTZOID)
+	{
+		char	   *result = OutputFunctionCall(flinfo, value);
+
+		return (char *) ConvertBCToISOYearIfNeeded(result);
+	}
+
 	return OutputFunctionCall(flinfo, value);
 }
 
@@ -106,6 +204,14 @@ IsPGDuckSerializeRequired(PGType postgresType)
 		return true;
 
 	if (typeId == TIMETZOID)
+		return true;
+
+	/*
+	 * PostgreSQL outputs BC dates/timestamps with " BC" suffix, but DuckDB
+	 * expects ISO 8601 negative-year format.  We route these types through
+	 * PGDuckSerialize so that ConvertBCToISOYearIfNeeded can convert.
+	 */
+	if (typeId == DATEOID || typeId == TIMESTAMPOID || typeId == TIMESTAMPTZOID)
 		return true;
 
 	/* also covers map */

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -37,8 +37,10 @@
 #include "pg_lake/util/numeric.h"
 #include "nodes/pg_list.h"
 #include "utils/builtins.h"
+#include "pg_lake/pgduck/map.h"
 #include "pg_lake/pgduck/parse_struct.h"
 #include "utils/lsyscache.h"
+#include "utils/typcache.h"
 
 static char *TupleDescToProjectionListForWrite(TupleDesc tupleDesc,
 											   CopyDataFormat destinationFormat);
@@ -46,6 +48,26 @@ static DuckDBTypeInfo ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 													 CopyDataFormat destinationFormat);
 static void AppendFieldIdValue(StringInfo map, Field * field, int fieldId);
 static const char *ParquetVersionToString(ParquetVersion version);
+static char *WrapQueryWithIcebergTemporalValidation(char *query,
+													TupleDesc tupleDesc);
+static const char *GetTemporalMinLiteral(Oid typeOid);
+static const char *GetTemporalMaxLiteral(Oid typeOid);
+static char *WrapQueryWithIcebergNumericValidation(char *query,
+												   TupleDesc tupleDesc);
+static char *NeutralizeNumericCastsInQuery(char *query);
+static const char *GetNumericMaxLiteral(int precision, int scale);
+static void AppendNumericNaNAction(StringInfo buf, const char *expr,
+								   int precision, int scale);
+static void AppendNumericOutOfRangeAction(StringInfo buf, const char *expr,
+										  int precision, int scale,
+										  const char *errMsg);
+static void AppendNumericValidationCaseExpr(StringInfo buf, const char *expr,
+											int typmod);
+static void AppendNumericValidationExpr(StringInfo buf, const char *expr,
+										const char *alias, int typmod);
+static void AppendNumericArrayValidationExpr(StringInfo buf, const char *expr,
+											 const char *alias, int typmod);
+static bool IsNumericArrayType(Oid typeOid);
 
 static DuckDBTypeInfo VARCHAR_TYPE =
 {
@@ -54,6 +76,7 @@ static DuckDBTypeInfo VARCHAR_TYPE =
 
 int			TargetRowGroupSizeMB = DEFAULT_TARGET_ROW_GROUP_SIZE_MB;
 int			DefaultParquetVersion = PARQUET_VERSION_V1;
+int			IcebergOutOfRangeValues = ICEBERG_OUT_OF_RANGE_ERROR;
 
 
 /*
@@ -120,6 +143,19 @@ WriteQueryResultTo(char *query,
 				   TupleDesc queryTupleDesc,
 				   List *leafFields)
 {
+	/*
+	 * For Iceberg, wrap the query with temporal range validation.
+	 *
+	 * All writes (direct INSERT, INSERT..SELECT, COPY FROM) flow through
+	 * here.  This wrapper ensures out-of-range temporal values are rejected
+	 * at the DuckDB level before being written to Parquet files.
+	 */
+	if (destinationFormat == DATA_FORMAT_ICEBERG)
+	{
+		query = WrapQueryWithIcebergTemporalValidation(query, queryTupleDesc);
+		query = WrapQueryWithIcebergNumericValidation(query, queryTupleDesc);
+	}
+
 	StringInfoData command;
 
 	initStringInfo(&command);
@@ -633,7 +669,8 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 
 		GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(postgresTypeMod, &precision, &scale);
 
-		if (CanPushdownNumericToDuckdb(precision, scale))
+		if (CanPushdownNumericToDuckdb(precision, scale) &&
+			destinationFormat != DATA_FORMAT_ICEBERG)
 		{
 			/*
 			 * happy case: we can map to DECIMAL(precision, scale)
@@ -642,7 +679,12 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 		}
 		else
 		{
-			/* explicit precision which is too big for us */
+			/*
+			 * Read numeric as VARCHAR.  For Iceberg, the numeric validation
+			 * wrapper will validate NaN/Inf and digit limits before casting
+			 * to DECIMAL (for both scalars and arrays). For other cases, the
+			 * precision is too big for DuckDB's DECIMAL type.
+			 */
 			duckTypeId = DUCKDB_TYPE_VARCHAR;
 		}
 	}
@@ -721,4 +763,922 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 	};
 
 	return typeInfo;
+}
+
+
+/*
+ * IsTemporalType returns true if the given type OID is a date,
+ * timestamp, or timestamptz type.
+ */
+static bool
+IsTemporalType(Oid typeOid)
+{
+	return typeOid == DATEOID ||
+		typeOid == TIMESTAMPOID ||
+		typeOid == TIMESTAMPTZOID;
+}
+
+
+/*
+ * TypeContainsTemporal recursively checks whether a PostgreSQL type
+ * contains any date/timestamp/timestamptz fields, including fields
+ * nested inside structs, maps, and arrays.
+ */
+static bool
+TypeContainsTemporal(Oid typeOid)
+{
+	if (IsTemporalType(typeOid))
+		return true;
+
+	/* array: check element type */
+	Oid			elemType = get_element_type(typeOid);
+
+	if (OidIsValid(elemType))
+		return TypeContainsTemporal(elemType);
+
+	/* map: check key and value types */
+	if (IsMapTypeOid(typeOid))
+	{
+		PGType		keyType = GetMapKeyType(typeOid);
+		PGType		valueType = GetMapValueType(typeOid);
+
+		return TypeContainsTemporal(keyType.postgresTypeOid) ||
+			TypeContainsTemporal(valueType.postgresTypeOid);
+	}
+
+	/* composite/struct: check each field */
+	if (get_typtype(typeOid) == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
+
+		for (int i = 0; i < tupdesc->natts; i++)
+		{
+			Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+
+			if (att->attisdropped)
+				continue;
+
+			if (TypeContainsTemporal(att->atttypid))
+			{
+				ReleaseTupleDesc(tupdesc);
+				return true;
+			}
+		}
+
+		ReleaseTupleDesc(tupdesc);
+	}
+
+	return false;
+}
+
+
+/*
+ * AppendTemporalRangeCheck appends a DuckDB boolean expression that
+ * checks whether a single scalar temporal expression is out of range
+ * or +-infinity.
+ *
+ * Returns true if the expression is out of range, which callers use
+ * to trigger error() or clamping.  Does NOT include a NULL check —
+ * callers handle NULL propagation.
+ *
+ * The isfinite() check comes first so that year() is never evaluated
+ * on an infinite value, which would be undefined in DuckDB.
+ */
+static void
+AppendTemporalRangeCheck(StringInfo buf, const char *expr, Oid typeOid)
+{
+	Assert(IsTemporalType(typeOid));
+
+	if (typeOid == DATEOID)
+	{
+		appendStringInfo(buf,
+						 "(NOT isfinite(%s) OR year(%s) < -4712 OR year(%s) > 9999)",
+						 expr, expr, expr);
+	}
+	else if (typeOid == TIMESTAMPTZOID)
+	{
+		/*
+		 * DuckDB's ICU-based year() for TIMESTAMPTZ returns the era-based
+		 * year (always positive, e.g. 1 for 1 BC) rather than the ISO year (0
+		 * for 1 BC).  Cast to TIMESTAMP first so the core year() function is
+		 * used, which returns the correct astronomical year.
+		 */
+		appendStringInfo(buf,
+						 "(NOT isfinite(%s) OR year(%s::TIMESTAMP) < 1 OR year(%s::TIMESTAMP) > 9999)",
+						 expr, expr, expr);
+	}
+	else
+	{
+		/* TIMESTAMPOID */
+		appendStringInfo(buf,
+						 "(NOT isfinite(%s) OR year(%s) < 1 OR year(%s) > 9999)",
+						 expr, expr, expr);
+	}
+}
+
+
+/*
+ * AppendTemporalLowerBoundCheck appends a DuckDB boolean expression that
+ * checks whether a scalar temporal expression is below the lower bound
+ * of Iceberg's supported range.
+ *
+ * Uses a direct comparison against the min literal, which correctly
+ * handles +-infinity: -infinity < min is true → clamp to min,
+ * +infinity < min is false → clamp to max.
+ */
+static void
+AppendTemporalLowerBoundCheck(StringInfo buf, const char *expr, Oid typeOid)
+{
+	Assert(IsTemporalType(typeOid));
+
+	appendStringInfo(buf, "%s < %s", expr, GetTemporalMinLiteral(typeOid));
+}
+
+
+/*
+ * GetTemporalMinLiteral returns the DuckDB literal for the minimum
+ * supported temporal value in Iceberg for the given type.
+ */
+static const char *
+GetTemporalMinLiteral(Oid typeOid)
+{
+	if (typeOid == DATEOID)
+		return "DATE '-4712-01-01'";
+	if (typeOid == TIMESTAMPTZOID)
+		return "TIMESTAMPTZ '0001-01-01 00:00:00+00'";
+	return "TIMESTAMP '0001-01-01 00:00:00'";
+}
+
+
+/*
+ * GetTemporalMaxLiteral returns the DuckDB literal for the maximum
+ * supported temporal value in Iceberg for the given type.
+ */
+static const char *
+GetTemporalMaxLiteral(Oid typeOid)
+{
+	if (typeOid == DATEOID)
+		return "DATE '9999-12-31'";
+	if (typeOid == TIMESTAMPTZOID)
+		return "TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'";
+	return "TIMESTAMP '9999-12-31 23:59:59.999999'";
+}
+
+
+/*
+ * AppendTemporalOutOfRangeAction appends the THEN clause for an
+ * out-of-range or infinite temporal value.
+ *
+ * In error mode, emits: error('...')
+ * In clamp mode, emits: CASE WHEN (lower_check) THEN min ELSE max END
+ */
+static void
+AppendTemporalOutOfRangeAction(StringInfo buf, const char *expr, Oid typeOid)
+{
+	if (IcebergOutOfRangeValues == ICEBERG_OUT_OF_RANGE_CLAMP)
+	{
+		appendStringInfoString(buf, "CASE WHEN ");
+		AppendTemporalLowerBoundCheck(buf, expr, typeOid);
+		appendStringInfo(buf, " THEN %s ELSE %s END",
+						 GetTemporalMinLiteral(typeOid),
+						 GetTemporalMaxLiteral(typeOid));
+	}
+	else
+	{
+		const char *errMsg = (typeOid == DATEOID) ?
+			"date out of range for Iceberg" :
+			"timestamp out of range for Iceberg";
+
+		appendStringInfo(buf, "error('%s')", errMsg);
+	}
+}
+
+
+/*
+ * AppendTemporalValidationExpr appends a DuckDB CASE expression that
+ * validates a scalar temporal value against Iceberg's supported range.
+ *
+ * In error mode (default), out-of-range values cause DuckDB's error()
+ * to throw, which propagates back to PostgreSQL as an ereport(ERROR).
+ *
+ * In clamp mode, out-of-range values are clamped to the nearest
+ * valid boundary value.
+ */
+static void
+AppendTemporalValidationExpr(StringInfo buf, const char *expr,
+							 const char *alias, Oid typeOid)
+{
+	appendStringInfo(buf, "CASE WHEN %s IS NOT NULL AND ", expr);
+	AppendTemporalRangeCheck(buf, expr, typeOid);
+	appendStringInfoString(buf, " THEN ");
+	AppendTemporalOutOfRangeAction(buf, expr, typeOid);
+	appendStringInfo(buf, " ELSE %s END AS %s", expr, alias);
+}
+
+
+static void AppendValidatedColumnExpr(StringInfo buf, const char *expr,
+									  Oid typeOid, int depth);
+
+
+/*
+ * AppendValidatedListExpr wraps array/list elements with temporal
+ * validation using DuckDB's list_transform().
+ *
+ * The 'depth' parameter is used to generate unique lambda variable
+ * names (__v0, __v1, ...) to avoid collisions in nested lambdas.
+ */
+static void
+AppendValidatedListExpr(StringInfo buf, const char *expr,
+						Oid elemTypeOid, int depth)
+{
+	char	   *lambdaVar = psprintf("__v%d", depth);
+	StringInfoData lambdaBody;
+
+	initStringInfo(&lambdaBody);
+	AppendValidatedColumnExpr(&lambdaBody, lambdaVar, elemTypeOid, depth + 1);
+
+	appendStringInfo(buf, "list_transform(%s, %s -> %s)",
+					 expr, lambdaVar, lambdaBody.data);
+
+	pfree(lambdaBody.data);
+	pfree(lambdaVar);
+}
+
+
+/*
+ * AppendValidatedColumnExpr recursively appends a DuckDB expression
+ * that validates all temporal fields within a value of the given type.
+ *
+ * Handles:
+ *   - Scalar temporal types (date, timestamp, timestamptz)
+ *   - Arrays of any type containing temporal fields
+ *   - Structs with temporal fields at any nesting depth
+ *   - Maps whose values contain temporal fields
+ *
+ * In error mode, raises an error (via DuckDB's error() function) for
+ * out-of-range temporal values.  In clamp mode, clamps them to the
+ * nearest valid boundary value.
+ */
+static void
+AppendValidatedColumnExpr(StringInfo buf, const char *expr,
+						  Oid typeOid, int depth)
+{
+	if (IsTemporalType(typeOid))
+	{
+		appendStringInfo(buf, "CASE WHEN %s IS NOT NULL AND ", expr);
+		AppendTemporalRangeCheck(buf, expr, typeOid);
+		appendStringInfoString(buf, " THEN ");
+		AppendTemporalOutOfRangeAction(buf, expr, typeOid);
+		appendStringInfo(buf, " ELSE %s END", expr);
+		return;
+	}
+
+	/* array: validate each element */
+	Oid			elemType = get_element_type(typeOid);
+
+	if (OidIsValid(elemType) && TypeContainsTemporal(elemType))
+	{
+		AppendValidatedListExpr(buf, expr, elemType, depth);
+		return;
+	}
+
+	/* map: validate keys and/or values via map_entries + list_transform */
+	if (IsMapTypeOid(typeOid))
+	{
+		PGType		keyType = GetMapKeyType(typeOid);
+		PGType		valType = GetMapValueType(typeOid);
+		bool		keyTemporal = TypeContainsTemporal(keyType.postgresTypeOid);
+		bool		valTemporal = TypeContainsTemporal(valType.postgresTypeOid);
+
+		if (keyTemporal || valTemporal)
+		{
+			char	   *entryVar = psprintf("__v%d", depth);
+			StringInfoData keyBody;
+			StringInfoData valBody;
+
+			initStringInfo(&keyBody);
+			initStringInfo(&valBody);
+
+			if (keyTemporal)
+				AppendValidatedColumnExpr(&keyBody,
+										  psprintf("%s.key", entryVar),
+										  keyType.postgresTypeOid,
+										  depth + 1);
+			else
+				appendStringInfo(&keyBody, "%s.key", entryVar);
+
+			if (valTemporal)
+				AppendValidatedColumnExpr(&valBody,
+										  psprintf("%s.value", entryVar),
+										  valType.postgresTypeOid,
+										  depth + 1);
+			else
+				appendStringInfo(&valBody, "%s.value", entryVar);
+
+			appendStringInfo(buf,
+							 "map_from_entries(list_transform(map_entries(%s), "
+							 "%s -> struct_pack(key := %s, value := %s)))",
+							 expr, entryVar, keyBody.data, valBody.data);
+
+			pfree(keyBody.data);
+			pfree(valBody.data);
+			pfree(entryVar);
+			return;
+		}
+	}
+
+	/* composite/struct: rebuild with validated fields */
+	if (get_typtype(typeOid) == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
+		bool		hasTemporalField = false;
+
+		/* first check if any field needs validation */
+		for (int i = 0; i < tupdesc->natts; i++)
+		{
+			Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+
+			if (att->attisdropped)
+				continue;
+
+			if (TypeContainsTemporal(att->atttypid))
+			{
+				hasTemporalField = true;
+				break;
+			}
+		}
+
+		if (hasTemporalField)
+		{
+			/*
+			 * Rebuild the struct with struct_pack, validating temporal
+			 * fields.
+			 */
+			appendStringInfoString(buf, "struct_pack(");
+
+			bool		first = true;
+
+			for (int i = 0; i < tupdesc->natts; i++)
+			{
+				Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+
+				if (att->attisdropped)
+					continue;
+
+				if (!first)
+					appendStringInfoString(buf, ", ");
+				first = false;
+
+				const char *fieldName = NameStr(att->attname);
+				char	   *fieldExpr = psprintf("%s.%s", expr,
+												 quote_identifier(fieldName));
+
+				appendStringInfo(buf, "%s := ", quote_identifier(fieldName));
+
+				if (TypeContainsTemporal(att->atttypid))
+					AppendValidatedColumnExpr(buf, fieldExpr, att->atttypid,
+											  depth);
+				else
+					appendStringInfoString(buf, fieldExpr);
+
+				pfree(fieldExpr);
+			}
+
+			appendStringInfoChar(buf, ')');
+
+			ReleaseTupleDesc(tupdesc);
+			return;
+		}
+
+		ReleaseTupleDesc(tupdesc);
+	}
+
+	/* no temporal content, pass through */
+	appendStringInfoString(buf, expr);
+}
+
+
+/*
+ * WrapQueryWithIcebergTemporalValidation wraps a DuckDB query with
+ * range-checking expressions for date/timestamp/timestamptz columns
+ * when writing to Iceberg format.
+ *
+ * All writes (direct INSERT, INSERT..SELECT, COPY FROM) flow through
+ * WriteQueryResultTo, which calls this wrapper.  It ensures that
+ * out-of-range temporal values are caught at the DuckDB level before
+ * being written to Parquet data files.
+ *
+ * Handles temporal types at any nesting depth: top-level scalars,
+ * arrays, structs, and maps.
+ *
+ * If no temporal columns are found, the original query is returned as-is.
+ */
+static char *
+WrapQueryWithIcebergTemporalValidation(char *query, TupleDesc tupleDesc)
+{
+	if (tupleDesc == NULL)
+		return query;
+
+	/* quick check: any temporal columns at all? */
+	bool		hasTemporalCol = false;
+
+	for (int i = 0; i < tupleDesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, i);
+
+		if (attr->attisdropped)
+			continue;
+
+		if (TypeContainsTemporal(attr->atttypid))
+		{
+			hasTemporalCol = true;
+			break;
+		}
+	}
+
+	if (!hasTemporalCol)
+		return query;
+
+	StringInfoData wrapped;
+
+	initStringInfo(&wrapped);
+	appendStringInfoString(&wrapped, "SELECT ");
+
+	bool		first = true;
+
+	for (int i = 0; i < tupleDesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, i);
+
+		if (attr->attisdropped)
+			continue;
+
+		if (!first)
+			appendStringInfoString(&wrapped, ", ");
+		first = false;
+
+		const char *colName = quote_identifier(NameStr(attr->attname));
+		Oid			typeId = attr->atttypid;
+
+		if (TypeContainsTemporal(typeId))
+		{
+			if (IsTemporalType(typeId))
+			{
+				/* scalar date/timestamp/timestamptz */
+				AppendTemporalValidationExpr(&wrapped, colName, colName,
+											 typeId);
+			}
+			else
+			{
+				/*
+				 * Complex type containing temporal fields — generate a
+				 * recursive validation expression.
+				 */
+				AppendValidatedColumnExpr(&wrapped, colName, typeId, 0);
+				appendStringInfo(&wrapped, " AS %s", colName);
+			}
+		}
+		else
+		{
+			appendStringInfoString(&wrapped, colName);
+		}
+	}
+
+	appendStringInfo(&wrapped, " FROM (%s) AS __iceberg_temporal_check", query);
+
+	return wrapped.data;
+}
+
+
+/*
+ * GetNumericMaxLiteral returns the maximum positive DECIMAL(p,s) literal.
+ *
+ * For example, DECIMAL(38,9) → "99999999999999999999999999999.999999999"
+ */
+static const char *
+GetNumericMaxLiteral(int precision, int scale)
+{
+	StringInfoData result;
+	int			integralDigits = precision - scale;
+
+	initStringInfo(&result);
+
+	for (int i = 0; i < integralDigits; i++)
+		appendStringInfoChar(&result, '9');
+
+	if (scale > 0)
+	{
+		appendStringInfoChar(&result, '.');
+		for (int i = 0; i < scale; i++)
+			appendStringInfoChar(&result, '9');
+	}
+
+	return result.data;
+}
+
+
+/*
+ * AppendNumericNaNAction appends the THEN clause for a NaN value.
+ *
+ * In error mode (default), emits: error('...')
+ * In clamp mode, emits: NULL::DECIMAL(p,s) (or NULL::VARCHAR)
+ *
+ * NaN has no numeric equivalent, so we clamp to NULL.
+ */
+static void
+AppendNumericNaNAction(StringInfo buf, const char *expr, int precision,
+					   int scale)
+{
+	if (IcebergOutOfRangeValues == ICEBERG_OUT_OF_RANGE_CLAMP)
+	{
+		if (CanPushdownNumericToDuckdb(precision, scale))
+			appendStringInfo(buf, "NULL::DECIMAL(%d,%d)", precision, scale);
+		else
+			appendStringInfoString(buf, "NULL::VARCHAR");
+	}
+	else
+	{
+		appendStringInfo(buf,
+						 "error(CONCAT('NaN is not allowed for numeric type: ', "
+						 "CAST(%s AS VARCHAR)))",
+						 expr);
+	}
+}
+
+
+/*
+ * AppendNumericOutOfRangeAction appends the THEN clause for an
+ * out-of-range numeric value (Infinity or digit overflow).
+ *
+ * In error mode (default), emits: error('...')
+ * In clamp mode, emits a sign-aware expression that returns the
+ * maximum or minimum DECIMAL(p,s) literal (negative max for negative
+ * values, positive max for positive values).
+ */
+static void
+AppendNumericOutOfRangeAction(StringInfo buf, const char *expr,
+							  int precision, int scale,
+							  const char *errMsg)
+{
+	if (IcebergOutOfRangeValues == ICEBERG_OUT_OF_RANGE_CLAMP)
+	{
+		const char *maxLit = GetNumericMaxLiteral(precision, scale);
+
+		if (CanPushdownNumericToDuckdb(precision, scale))
+		{
+			appendStringInfo(buf,
+							 "CASE WHEN STARTS_WITH(LTRIM(CAST(%s AS VARCHAR)), '-') "
+							 "THEN CAST('-%s' AS DECIMAL(%d,%d)) "
+							 "ELSE CAST('%s' AS DECIMAL(%d,%d)) END",
+							 expr, maxLit, precision, scale,
+							 maxLit, precision, scale);
+		}
+		else
+		{
+			appendStringInfo(buf,
+							 "CASE WHEN STARTS_WITH(LTRIM(CAST(%s AS VARCHAR)), '-') "
+							 "THEN '-%s' ELSE '%s' END",
+							 expr, maxLit, maxLit);
+		}
+	}
+	else
+	{
+		appendStringInfo(buf,
+						 "error(CONCAT('%s: ', CAST(%s AS VARCHAR)))",
+						 errMsg, expr);
+	}
+}
+
+
+/*
+ * AppendNumericValidationCaseExpr appends a DuckDB CASE expression
+ * that validates a single numeric value for Iceberg compatibility.
+ *
+ * The generated expression can be used standalone or inside a
+ * list_transform lambda for array elements.
+ *
+ * Checks:
+ *  - NaN → error or NULL (NaN has no numeric equivalent)
+ *  - Infinity → error or clamp to min/max DECIMAL
+ *  - For unbounded numeric: integral and decimal digit limits →
+ *    error or clamp to min/max DECIMAL
+ *  - Otherwise: CAST to DECIMAL(precision, scale) (or keep VARCHAR if
+ *    the precision is too large for DuckDB)
+ *
+ * In error mode (default), invalid values raise error().
+ * In clamp mode, NaN becomes NULL and out-of-range values are clamped
+ * to the min/max DECIMAL(p,s) based on sign.
+ *
+ * Does NOT append an alias — callers add "AS alias" as needed.
+ */
+static void
+AppendNumericValidationCaseExpr(StringInfo buf, const char *expr, int typmod)
+{
+	int			precision;
+	int			scale;
+
+	GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(typmod, &precision, &scale);
+
+	bool		isUnbounded = IsUnboundedNumeric(NUMERICOID, typmod);
+
+	/* check for NaN */
+	appendStringInfo(buf,
+					 "CASE WHEN LOWER(TRIM(CAST(%s AS VARCHAR))) = 'nan' THEN ",
+					 expr);
+	AppendNumericNaNAction(buf, expr, precision, scale);
+
+	/* check for Infinity */
+	appendStringInfo(buf,
+					 " WHEN LOWER(TRIM(CAST(%s AS VARCHAR))) "
+					 "IN ('infinity', '+infinity', '-infinity', "
+					 "'inf', '+inf', '-inf') THEN ",
+					 expr);
+	AppendNumericOutOfRangeAction(buf, expr, precision, scale,
+								  "Infinity values are not allowed for "
+								  "numeric type");
+
+	if (isUnbounded)
+	{
+		int			maxIntegralDigits = precision - scale;
+
+		/* check integral digit count */
+		appendStringInfo(buf,
+						 " WHEN %s IS NOT NULL AND "
+						 "LENGTH(REGEXP_REPLACE(SPLIT_PART("
+						 "LTRIM(CAST(%s AS VARCHAR), '+-'), '.', 1), "
+						 "'[^0-9]', '', 'g')) > %d THEN ",
+						 expr, expr, maxIntegralDigits);
+		AppendNumericOutOfRangeAction(buf, expr, precision, scale,
+									  psprintf("unbounded numeric type exceeds max "
+											   "allowed digits %d before decimal point",
+											   maxIntegralDigits));
+
+		/*
+		 * We intentionally do NOT check the decimal digit count here. When
+		 * the PostgreSQL column is unbounded numeric, values may have more
+		 * fractional digits than the Iceberg scale (e.g. random() produces
+		 * 15+ digits).  The CAST to DECIMAL(p,s) in the ELSE branch will
+		 * round excess fractional digits, which is correct.
+		 */
+	}
+
+	if (CanPushdownNumericToDuckdb(precision, scale))
+	{
+		if (!isUnbounded)
+		{
+			/*
+			 * For bounded numerics, add explicit range checks so that
+			 * out-of-range values are caught before the final CAST. In clamp
+			 * mode this clamps to min/max; in error mode it raises a clear
+			 * error instead of a raw DuckDB conversion error.
+			 *
+			 * TRY_CAST to DECIMAL(38, target_scale) for safe comparison. This
+			 * gives up to (38 - scale) integer digits — always enough —
+			 * while preserving exact fractional precision.
+			 */
+			const char *maxLit = GetNumericMaxLiteral(precision, scale);
+
+			appendStringInfo(buf,
+							 " WHEN %s IS NOT NULL AND "
+							 "TRY_CAST(%s AS DECIMAL(38,%d)) > "
+							 "CAST('%s' AS DECIMAL(38,%d)) THEN ",
+							 expr,
+							 expr, scale,
+							 maxLit, scale);
+			AppendNumericOutOfRangeAction(buf, expr, precision, scale,
+										  psprintf("numeric value exceeds max "
+												   "allowed value for DECIMAL(%d,%d)",
+												   precision, scale));
+
+			appendStringInfo(buf,
+							 " WHEN %s IS NOT NULL AND "
+							 "TRY_CAST(%s AS DECIMAL(38,%d)) < "
+							 "CAST('-%s' AS DECIMAL(38,%d)) THEN ",
+							 expr,
+							 expr, scale,
+							 maxLit, scale);
+			AppendNumericOutOfRangeAction(buf, expr, precision, scale,
+										  psprintf("numeric value exceeds min "
+												   "allowed value for DECIMAL(%d,%d)",
+												   precision, scale));
+		}
+
+		appendStringInfo(buf,
+						 " ELSE CAST(%s AS DECIMAL(%d,%d)) END",
+						 expr, precision, scale);
+	}
+	else
+	{
+		/* precision too big for DuckDB DECIMAL, keep as VARCHAR */
+		appendStringInfo(buf,
+						 " ELSE %s END",
+						 expr);
+	}
+}
+
+
+/*
+ * AppendNumericValidationExpr appends a CASE expression for a scalar
+ * numeric column, including the "AS alias" suffix.
+ */
+static void
+AppendNumericValidationExpr(StringInfo buf, const char *expr,
+							const char *alias, int typmod)
+{
+	AppendNumericValidationCaseExpr(buf, expr, typmod);
+	appendStringInfo(buf, " AS %s", alias);
+}
+
+
+/*
+ * AppendNumericArrayValidationExpr validates each element of a
+ * numeric[] column using DuckDB's list_transform().
+ *
+ * Generates: list_transform(col, __nv -> CASE ... END) AS col
+ */
+static void
+AppendNumericArrayValidationExpr(StringInfo buf, const char *expr,
+								 const char *alias, int typmod)
+{
+	appendStringInfo(buf, "list_transform(%s, __nv -> ", expr);
+	AppendNumericValidationCaseExpr(buf, "__nv", typmod);
+	appendStringInfo(buf, ") AS %s", alias);
+}
+
+
+/*
+ * IsNumericArrayType returns true if the given type OID is an array
+ * whose element type is NUMERICOID.
+ */
+static bool
+IsNumericArrayType(Oid typeOid)
+{
+	Oid			elemType = get_element_type(typeOid);
+
+	return OidIsValid(elemType) && elemType == NUMERICOID;
+}
+
+
+/*
+ * NeutralizeNumericCastsInQuery replaces ::numeric(p,s) casts in the
+ * query string with ::text.
+ *
+ * For INSERT..SELECT pushdown, PostgreSQL's planner adds type coercions
+ * like ::numeric(3,0) to match the target column type.  When DuckDB
+ * executes this cast, it may fail for values that exceed the target
+ * precision (e.g. a large value being cast to DECIMAL(3,0)).
+ *
+ * By replacing these casts with ::text, the value passes through as a
+ * VARCHAR string, and the numeric validation wrapper handles range
+ * checking, clamping, and final casting to the target DECIMAL type.
+ */
+static char *
+NeutralizeNumericCastsInQuery(char *query)
+{
+	StringInfoData result;
+	const char *p = query;
+
+	initStringInfo(&result);
+
+	while (*p != '\0')
+	{
+		/*
+		 * Look for the pattern ::numeric( followed by digits, comma, optional
+		 * space, digits, and closing paren.
+		 */
+		if (strncmp(p, "::numeric(", 10) == 0)
+		{
+			const char *start = p;
+			const char *scan = p + 10;	/* skip "::numeric(" */
+			bool		valid = true;
+
+			/* expect one or more digits */
+			if (!isdigit((unsigned char) *scan))
+				valid = false;
+			while (isdigit((unsigned char) *scan))
+				scan++;
+
+			/* expect comma and optional space */
+			if (valid && *scan == ',')
+				scan++;
+			else
+				valid = false;
+			while (*scan == ' ')
+				scan++;
+
+			/* expect one or more digits */
+			if (valid && !isdigit((unsigned char) *scan))
+				valid = false;
+			while (isdigit((unsigned char) *scan))
+				scan++;
+
+			/* expect closing paren */
+			if (valid && *scan == ')')
+			{
+				scan++;			/* skip ')' */
+				appendStringInfoString(&result, "::text");
+				p = scan;
+				continue;
+			}
+
+			/* not a match, copy the character as-is */
+			(void) start;		/* suppress unused warning */
+		}
+
+		appendStringInfoChar(&result, *p);
+		p++;
+	}
+
+	return result.data;
+}
+
+
+/*
+ * WrapQueryWithIcebergNumericValidation wraps a DuckDB query with
+ * validation expressions for numeric columns when writing to Iceberg.
+ *
+ * All writes (direct INSERT, INSERT..SELECT, COPY FROM) flow through
+ * WriteQueryResultTo, which calls this wrapper.  It ensures that:
+ *  - NaN/Infinity values are rejected or clamped
+ *  - Unbounded numeric digit limits are enforced
+ *  - Bounded numeric values exceeding DECIMAL(p,s) range are clamped
+ *  - Numeric values are cast from VARCHAR to DECIMAL(p,s)
+ *
+ * Handles both scalar numeric and numeric[] columns.
+ *
+ * If no numeric columns are found, the original query is returned as-is.
+ */
+static char *
+WrapQueryWithIcebergNumericValidation(char *query, TupleDesc tupleDesc)
+{
+	if (tupleDesc == NULL)
+		return query;
+
+	/* quick check: any numeric columns (scalar or array)? */
+	bool		hasNumericCol = false;
+
+	for (int i = 0; i < tupleDesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, i);
+
+		if (attr->attisdropped)
+			continue;
+
+		if (attr->atttypid == NUMERICOID || IsNumericArrayType(attr->atttypid))
+		{
+			hasNumericCol = true;
+			break;
+		}
+	}
+
+	if (!hasNumericCol)
+		return query;
+
+	/*
+	 * Replace ::numeric(p,s) casts in the inner query with ::text. This
+	 * prevents DuckDB from failing on bounded numeric casts (e.g.
+	 * ::numeric(3,0)) when the source value exceeds the target precision. The
+	 * validation wrapper handles proper range checking and casting below.
+	 */
+	query = NeutralizeNumericCastsInQuery(query);
+
+	StringInfoData wrapped;
+
+	initStringInfo(&wrapped);
+	appendStringInfoString(&wrapped, "SELECT ");
+
+	bool		first = true;
+
+	for (int i = 0; i < tupleDesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, i);
+
+		if (attr->attisdropped)
+			continue;
+
+		if (!first)
+			appendStringInfoString(&wrapped, ", ");
+		first = false;
+
+		const char *colName = quote_identifier(NameStr(attr->attname));
+
+		if (attr->atttypid == NUMERICOID)
+		{
+			AppendNumericValidationExpr(&wrapped, colName, colName,
+										attr->atttypmod);
+		}
+		else if (IsNumericArrayType(attr->atttypid))
+		{
+			AppendNumericArrayValidationExpr(&wrapped, colName, colName,
+											 attr->atttypmod);
+		}
+		else
+		{
+			appendStringInfoString(&wrapped, colName);
+		}
+	}
+
+	appendStringInfo(&wrapped, " FROM (%s) AS __iceberg_numeric_check", query);
+
+	return wrapped.data;
 }

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_numeric_binary_serde.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_numeric_binary_serde.h
@@ -21,5 +21,5 @@
 
 #include "pg_lake/pgduck/type.h"
 
-extern PGDLLEXPORT unsigned char *PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen);
+extern PGDLLEXPORT unsigned char *PGNumericIcebergBinarySerialize(Datum numericDatum, int icebergScale, size_t *binaryLen);
 extern PGDLLEXPORT Datum PGNumericIcebergBinaryDeserialize(unsigned char *numericBinary, size_t binaryLen, PGType pgType);

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
@@ -26,6 +26,7 @@
 #include "pg_lake/iceberg/iceberg_type_binary_serde.h"
 #include "pg_lake/iceberg/iceberg_type_numeric_binary_serde.h"
 #include "pg_lake/iceberg/utils.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/timetz.h"
 
 #include "port/pg_bswap.h"
@@ -310,8 +311,22 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 	}
 	else if (pgType.postgresTypeOid == NUMERICOID)
 	{
-		/* generate numeric binary in bigendian */
-		binaryValue = PGNumericIcebergBinarySerialize(datum, binaryLen);
+		/*
+		 * Generate numeric binary in big-endian.  The Iceberg spec requires
+		 * the unscaled integer at the schema's scale, so we must pass the
+		 * target scale.  For unbounded numeric (typmod == -1) this falls back
+		 * to the default Iceberg scale via
+		 * GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod.
+		 */
+		int			precision;
+		int			scale;
+
+		GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(
+															 pgType.postgresTypeMod,
+															 &precision, &scale);
+
+		binaryValue = PGNumericIcebergBinarySerialize(datum, scale,
+													  binaryLen);
 	}
 	else if (pgType.postgresTypeOid == UUIDOID)
 	{

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
@@ -27,6 +27,7 @@
 #include "pg_lake/iceberg/iceberg_type_json_serde.h"
 #include "pg_lake/json/json_utils.h"
 #include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/serialize.h"
 #include "pg_extension_base/spi_helpers.h"
 
 #include "access/tupdesc.h"
@@ -137,6 +138,37 @@ PGScalarIcebergJsonSerialize(Datum scalarDatum, Field * field, PGType pgType)
 		 */
 		Assert(strncmp(jsonString, "\"\\\\x", 4) == 0);
 		jsonString = psprintf("\"%s", jsonString + 4);
+	}
+
+	/*
+	 * Convert BC dates to ISO 8601.
+	 *
+	 * PostgreSQL's to_json appends " BC" for BC-era dates/timestamps (e.g.
+	 * "4712-01-01 BC"), but the Iceberg spec requires ISO 8601 format
+	 * ("YYYY-MM-DD") which has no era suffix.  Convert to ISO 8601 year
+	 * numbering (year 0000 = 1 BC, negative years for earlier dates).
+	 * ConvertISOYearToBCIfNeeded reverses this on deserialization.
+	 */
+	if (pgType.postgresTypeOid == DATEOID ||
+		pgType.postgresTypeOid == TIMESTAMPOID ||
+		pgType.postgresTypeOid == TIMESTAMPTZOID)
+	{
+		/*
+		 * to_json wraps the value in JSON quotes (e.g. "\"4712-01-01 BC\"").
+		 * Strip the quotes, apply ISO year conversion, then re-quote.
+		 */
+		int			jsonLen = strlen(jsonString);
+
+		Assert(jsonLen >= 2 && jsonString[0] == '"' && jsonString[jsonLen - 1] == '"');
+
+		char	   *content = pnstrdup(jsonString + 1, jsonLen - 2);
+		const char *converted = ConvertBCToISOYearIfNeeded(content);
+
+		if (converted != content)
+		{
+			jsonString = psprintf("\"%s\"", converted);
+			pfree(content);
+		}
 	}
 
 	return jsonString;
@@ -423,6 +455,18 @@ PGScalarIcebergJsonDeserialize(const char *scalarJson, Field * field, PGType pgT
 		appendStringInfo(hexString, "\\x%s", scalarJson);
 
 		scalarJson = hexString->data;
+	}
+
+	/*
+	 * ISO 8601 year 0000 represents 1 BC, and negative years represent
+	 * earlier BC dates.  Convert back to PostgreSQL's "YYYY BC" format before
+	 * calling the type input function.
+	 */
+	if (pgType.postgresTypeOid == DATEOID ||
+		pgType.postgresTypeOid == TIMESTAMPOID ||
+		pgType.postgresTypeOid == TIMESTAMPTZOID)
+	{
+		scalarJson = ConvertISOYearToBCIfNeeded(scalarJson);
 	}
 
 	Oid			typinput;

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_numeric_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_numeric_binary_serde.c
@@ -20,12 +20,13 @@
 #include "utils/numeric.h"
 
 #include "pg_lake/iceberg/iceberg_type_numeric_binary_serde.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/numeric.h"
 
 
 static unsigned char *NumericStrToBigEndianBinary(const char *numericStr);
 static char *BigEndianBinaryToNumericStr(unsigned char *numericBinary, int scale, bool isNegative);
-static char *NormalizeNumericStr(const char *numericStr);
+static char *NormalizeNumericStr(const char *numericStr, int targetScale);
 static void TwosComplement(unsigned char *numericBinary);
 static unsigned char *StripLeadingBytes(const unsigned char *binaryValue, size_t *binaryLen, bool isNegative);
 static unsigned char *SignExtendNumericBinary(const unsigned char *numericBinary, size_t binaryLen);
@@ -37,7 +38,8 @@ static unsigned char *SignExtendNumericBinary(const unsigned char *numericBinary
  * number of bytes)
  */
 unsigned char *
-PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen)
+PGNumericIcebergBinarySerialize(Datum numericDatum, int icebergScale,
+								size_t *binaryLen)
 {
 	Numeric numeric = DatumGetNumeric(numericDatum);
 
@@ -61,7 +63,8 @@ PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen)
 
 	bool		isNegative = (*numericStr == '-');
 
-	char	   *normalizedNumericStr = NormalizeNumericStr(numericStr);
+	char	   *normalizedNumericStr = NormalizeNumericStr(numericStr,
+														   icebergScale);
 
 	unsigned char *numericBinary = NumericStrToBigEndianBinary(normalizedNumericStr);
 
@@ -81,7 +84,11 @@ PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen)
 Datum
 PGNumericIcebergBinaryDeserialize(unsigned char *numericBinary, size_t binaryLen, PGType pgType)
 {
-	int			scale = numeric_typmod_scale(pgType.postgresTypeMod);
+	int			precision;
+	int			scale;
+
+	GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(pgType.postgresTypeMod,
+														 &precision, &scale);
 
 	bool		isNegative = (numericBinary[0] & 0x80) != 0;
 
@@ -245,10 +252,17 @@ BigEndianBinaryToNumericStr(unsigned char *numericBinary, int scale,
 
 /*
  * NormalizeNumericStr normalizes a Postgres numeric string by removing sign
- * and decimal point.
+ * and decimal point, producing the unscaled integer string for the given
+ * target Iceberg scale.
+ *
+ * The fractional part is padded with trailing zeros (or truncated) to
+ * exactly targetScale digits.  For example:
+ *   "7"         with targetScale=9 → "7000000000"
+ *   "7.5"       with targetScale=9 → "7500000000"
+ *   "7.123456789012" with targetScale=9 → "7123456789"
  */
 static char *
-NormalizeNumericStr(const char *numericStr)
+NormalizeNumericStr(const char *numericStr, int targetScale)
 {
 	const char *p = numericStr;
 
@@ -257,7 +271,7 @@ NormalizeNumericStr(const char *numericStr)
 		p++;
 	}
 
-	/* 2. Remove decimal point if any */
+	/* Find decimal point if any */
 	const char *dot = strchr(p, '.');
 	int			integralLen,
 				fractionLen;
@@ -273,23 +287,27 @@ NormalizeNumericStr(const char *numericStr)
 		fractionLen = 0;
 	}
 
-	/* Build a pure integer string without decimal point */
-	/* For example "123.45" with scale=2 becomes "12345". */
-	int			totalLen = integralLen + fractionLen;
+	/*
+	 * Build a pure integer string representing the unscaled value at the
+	 * target scale.  E.g. "123.45" with targetScale=9 becomes "123450000000".
+	 */
+	int			totalLen = integralLen + targetScale;
 	char	   *normalizedStr = palloc0(totalLen + 1);
 
-	if (dot)
-	{
-		/* copy integral part */
-		memcpy(normalizedStr, p, integralLen);
-		/* copy fractional part */
-		memcpy(normalizedStr + integralLen, dot + 1, fractionLen);
-	}
-	else
-	{
-		/* no decimal point */
-		memcpy(normalizedStr, p, totalLen);
-	}
+	/* Copy integral part */
+	memcpy(normalizedStr, p, integralLen);
+
+	/* Copy fractional digits (up to targetScale) */
+	int			copyFraction = (fractionLen < targetScale) ? fractionLen : targetScale;
+
+	if (dot && copyFraction > 0)
+		memcpy(normalizedStr + integralLen, dot + 1, copyFraction);
+
+	/* Pad remaining fractional positions with zeros */
+	for (int i = copyFraction; i < targetScale; i++)
+		normalizedStr[integralLen + i] = '0';
+
+	normalizedStr[totalLen] = '\0';
 
 	return normalizedStr;
 }

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -33,6 +33,7 @@
 #include "pg_lake/iceberg/operations/manifest_merge.h"
 #include "pg_lake/iceberg/operations/vacuum.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
+#include "pg_lake/pgduck/write_data.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
 
 #define GUC_STANDARD 0
@@ -60,6 +61,13 @@ void		_PG_init(void);
 static const struct config_enum_entry RestCatalogAuthTypeOptions[] = {
 	{"default", REST_CATALOG_AUTH_TYPE_DEFAULT, false},
 	{"horizon", REST_CATALOG_AUTH_TYPE_HORIZON, false},
+	{NULL, 0, false},
+};
+
+/* pg_lake_iceberg.out_of_range_values */
+static const struct config_enum_entry IcebergOutOfRangeOptions[] = {
+	{"error", ICEBERG_OUT_OF_RANGE_ERROR, false},
+	{"clamp", ICEBERG_OUT_OF_RANGE_CLAMP, false},
 	{NULL, 0, false},
 };
 
@@ -314,6 +322,21 @@ _PG_init(void)
 							 true,
 							 PGC_SUSET,
 							 GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
+
+	DefineCustomEnumVariable(
+							 "pg_lake_iceberg.out_of_range_values",
+							 gettext_noop("Determines behavior for out-of-range values "
+										  "during Iceberg writes. 'error' raises an error (default), "
+										  "'clamp' replaces out-of-range temporal values with the "
+										  "nearest valid boundary, and out-of-range numeric values "
+										  "(NaN, Inf, digit overflow) with NULL."),
+							 NULL,
+							 &IcebergOutOfRangeValues,
+							 ICEBERG_OUT_OF_RANGE_ERROR,
+							 IcebergOutOfRangeOptions,
+							 PGC_USERSET,
+							 0,
 							 NULL, NULL, NULL);
 
 	AvroInit();

--- a/pg_lake_iceberg/src/utils/temporal_utils.c
+++ b/pg_lake_iceberg/src/utils/temporal_utils.c
@@ -18,14 +18,15 @@
 #include "postgres.h"
 
 #include "pg_lake/iceberg/utils.h"
+#include "pg_lake/pgduck/write_data.h"
 #include "utils/datetime.h"
 #include "utils/timestamp.h"
 
 static const int32 PostgresToUnixEpochDiffInDays = POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE;
 static const int64 PostgresToUnixEpochDiffInMicrosecs = ((int64) PostgresToUnixEpochDiffInDays) * USECS_PER_DAY;
 
-static void EnsureNotInfinityDate(DateADT date);
-static void EnsureNotInfinityTimestamp(Timestamp ts);
+static void ClampOrErrorIfInfinityDate(DateADT *date);
+static void ClampOrErrorIfInfinityTimestamp(Timestamp *ts);
 
 #define UNIX_EPOCH_YEAR 1970
 
@@ -124,7 +125,7 @@ AdjustTimestampFromPostgresToUnix(Timestamp timestamp)
 int32_t
 DateYearFromUnixEpoch(DateADT date)
 {
-	EnsureNotInfinityDate(date);
+	ClampOrErrorIfInfinityDate(&date);
 
 	int			year;
 	int			month;
@@ -257,7 +258,7 @@ YearsFromEpochToTimestamp(int32 yearsSinceEpoch)
 int32_t
 DateMonthFromUnixEpoch(DateADT date)
 {
-	EnsureNotInfinityDate(date);
+	ClampOrErrorIfInfinityDate(&date);
 
 	int			year;
 	int			month;
@@ -285,7 +286,7 @@ DateMonthFromUnixEpoch(DateADT date)
 int32_t
 DateDayFromUnixEpoch(DateADT date)
 {
-	EnsureNotInfinityDate(date);
+	ClampOrErrorIfInfinityDate(&date);
 
 	return (int32_t) AdjustDateFromPostgresToUnix(date);
 }
@@ -301,7 +302,7 @@ DateDayFromUnixEpoch(DateADT date)
 int32_t
 TimestampYearFromUnixEpoch(Timestamp ts)
 {
-	EnsureNotInfinityTimestamp(ts);
+	ClampOrErrorIfInfinityTimestamp(&ts);
 
 	struct pg_tm tm;
 	fsec_t		fsec;
@@ -325,7 +326,7 @@ TimestampYearFromUnixEpoch(Timestamp ts)
 int32_t
 TimestampMonthFromUnixEpoch(Timestamp ts)
 {
-	EnsureNotInfinityTimestamp(ts);
+	ClampOrErrorIfInfinityTimestamp(&ts);
 
 	struct pg_tm tm;
 	fsec_t		fsec;
@@ -386,7 +387,7 @@ MonthsFromUnixEpochToTimestamp(int32 monthsSinceEpoch)
 int32_t
 TimestampDayFromUnixEpoch(Timestamp ts)
 {
-	EnsureNotInfinityTimestamp(ts);
+	ClampOrErrorIfInfinityTimestamp(&ts);
 
 	Timestamp	unixTs = AdjustTimestampFromPostgresToUnix(ts);
 
@@ -405,7 +406,7 @@ TimestampDayFromUnixEpoch(Timestamp ts)
 int32_t
 TimestampHourFromUnixEpoch(Timestamp ts)
 {
-	EnsureNotInfinityTimestamp(ts);
+	ClampOrErrorIfInfinityTimestamp(&ts);
 
 	Timestamp	unixTs = AdjustTimestampFromPostgresToUnix(ts);
 
@@ -458,31 +459,108 @@ HoursFromUnixEpochToTime(int32 hoursSinceEpoch)
 
 
 /*
- * EnsureNotInfinityDate checks if the given date is +-Infinity.
- * If it is, it raises an error. +-Infinity is not a meaningful value for
- * some query engines.
+ * IcebergMinDate returns the DateADT representing 4713-01-01 BC
+ * (ISO year -4712), the effective lower bound for dates in Iceberg
+ * tables.
+ *
+ * The Iceberg spec allows years down to -9999, but PostgreSQL's
+ * date type only goes back to 4714-11-24 BC.  We use 4713-01-01 BC
+ * as a clean minimum that is safely within PostgreSQL's range.
+ */
+static DateADT
+IcebergMinDate(void)
+{
+	return (DateADT) (date2j(-4712, 1, 1) - POSTGRES_EPOCH_JDATE);
+}
+
+
+/*
+ * IcebergMaxDate returns the DateADT representing 9999-12-31,
+ * the upper bound of Iceberg's supported date range.
+ */
+static DateADT
+IcebergMaxDate(void)
+{
+	return (DateADT) (date2j(9999, 12, 31) - POSTGRES_EPOCH_JDATE);
+}
+
+
+/*
+ * IcebergMinTimestamp returns the Timestamp representing
+ * 0001-01-01 00:00:00, the lower bound of Iceberg's supported
+ * timestamp range.
+ */
+static Timestamp
+IcebergMinTimestamp(void)
+{
+	int64		days = (int64) (date2j(1, 1, 1) - POSTGRES_EPOCH_JDATE);
+
+	return (Timestamp) (days * USECS_PER_DAY);
+}
+
+
+/*
+ * IcebergMaxTimestamp returns the Timestamp representing
+ * 9999-12-31 23:59:59.999999, the upper bound of Iceberg's supported
+ * timestamp range.
+ */
+static Timestamp
+IcebergMaxTimestamp(void)
+{
+	int64		days = (int64) (date2j(9999, 12, 31) - POSTGRES_EPOCH_JDATE);
+
+	return (Timestamp) (days * USECS_PER_DAY + INT64CONST(86399999999));
+}
+
+
+/*
+ * ClampOrErrorIfInfinityDate checks if the given date is +-Infinity.
+ *
+ * In error mode (default), raises ERROR.
+ * In clamp mode, replaces the value with the nearest Iceberg bound.
  */
 static void
-EnsureNotInfinityDate(DateADT date)
+ClampOrErrorIfInfinityDate(DateADT *date)
 {
-	if (DATE_NOT_FINITE(date))
+	if (!DATE_NOT_FINITE(*date))
+		return;
+
+	if (IcebergOutOfRangeValues == ICEBERG_OUT_OF_RANGE_CLAMP)
+	{
+		*date = DATE_IS_NOBEGIN(*date) ? IcebergMinDate() : IcebergMaxDate();
+	}
+	else
+	{
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("+-Infinity dates are not allowed in iceberg tables"),
 				 errhint("Delete or replace +-Infinity values.")));
+	}
 }
 
+
 /*
- * EnsureNotInfinityTimestamp checks if the given timestamp is +-Infinity.
- * If it is, it raises an error. +-Infinity is not a meaningful value for
- * some query engines.
+ * ClampOrErrorIfInfinityTimestamp checks if the given timestamp is
+ * +-Infinity.
+ *
+ * In error mode (default), raises ERROR.
+ * In clamp mode, replaces the value with the nearest Iceberg bound.
  */
 static void
-EnsureNotInfinityTimestamp(Timestamp ts)
+ClampOrErrorIfInfinityTimestamp(Timestamp *ts)
 {
-	if (TIMESTAMP_NOT_FINITE(ts))
+	if (!TIMESTAMP_NOT_FINITE(*ts))
+		return;
+
+	if (IcebergOutOfRangeValues == ICEBERG_OUT_OF_RANGE_CLAMP)
+	{
+		*ts = TIMESTAMP_IS_NOBEGIN(*ts) ? IcebergMinTimestamp() : IcebergMaxTimestamp();
+	}
+	else
+	{
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("+-Infinity timestamps are not allowed in iceberg tables"),
 				 errhint("Delete or replace +-Infinity values.")));
+	}
 }

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
@@ -240,6 +240,19 @@ def test_pg_lake_serde_temporal(
         result = run_query(pg_query, superuser_conn)
         assert str(result[0][0]) == value
 
+    # BC dates — cast to text to work around psycopg2 limitation with BC dates.
+    # Iceberg only supports BC for date type (years -9999..9999 ISO);
+    # timestamps/timestamptz must be AD (years 0001–9999).
+    bc_date_values = [
+        ("date", "date", "4712-01-01 BC"),
+        ("date", "date", "0001-01-01 BC"),
+    ]
+
+    for iceberg_type, pg_type, value in bc_date_values:
+        pg_query = f"SELECT lake_iceberg.serde_value('{value}'::{pg_type}, '{iceberg_type}')::text;"
+        result = run_query(pg_query, superuser_conn)
+        assert result[0][0] == value
+
     timestamptz_values = [
         (
             "timestamptz",
@@ -285,6 +298,33 @@ def test_pg_lake_serde_temporal(
         )
         result = run_query(pg_query, superuser_conn)
         assert str(result[0][0]) == expected
+
+    # Early-AD timestamptz — verifies serde at the boundary of the allowed range
+    run_command("SET TIME ZONE 'UTC';", superuser_conn)
+
+    early_ad_timestamptz_values = [
+        (
+            "timestamptz",
+            "timestamptz",
+            "0001-01-01 00:00:00+00",
+            "0001-01-01 00:00:00+00:00",
+        ),
+        (
+            "timestamptz",
+            "timestamptz",
+            "0001-06-15 12:30:00+00",
+            "0001-06-15 12:30:00+00:00",
+        ),
+    ]
+
+    for iceberg_type, pg_type, value, expected in early_ad_timestamptz_values:
+        pg_query = (
+            f"SELECT lake_iceberg.serde_value('{value}'::{pg_type}, '{iceberg_type}');"
+        )
+        result = run_query(pg_query, superuser_conn)
+        assert str(result[0][0]) == expected
+
+    run_command("RESET TIME ZONE;", superuser_conn)
 
     superuser_conn.rollback()
 

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
@@ -776,6 +776,586 @@ def test_pg_lake_iceberg_table_serial_column(
     pg_conn.commit()
 
 
+def test_pg_lake_iceberg_table_bc_dates(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+):
+    """Verify that BC dates and early-AD timestamps roundtrip correctly through Iceberg write+read.
+
+    Iceberg supports dates from ISO year -9999 to 9999 (BC dates allowed),
+    but timestamps/timestamptz only from 0001-01-01 through 9999-12-31 (AD only).
+    """
+    table_name = "test_pg_lake_iceberg_table_bc_dates"
+    run_command(
+        f"""CREATE TABLE {table_name}(
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command(
+        f"""INSERT INTO {table_name} VALUES
+            ('4712-01-01 BC', '0001-01-01 00:00:00', '0001-01-01 00:00:00+00'),
+            ('0001-01-01 BC', '0001-06-15 12:30:00', '0001-06-15 12:30:00+00'),
+            ('2021-01-01', '2021-01-01 00:00:00', '2021-01-01 00:00:00+00');""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # verify the data roundtrips correctly
+    # cast to text to work around psycopg2 limitation with BC dates
+    # The ::text cast may execute inside DuckDB (query pushdown), which
+    # formats BC as "(BC)".  Normalize to PostgreSQL's " BC" for comparison.
+    result = run_query(
+        f"SELECT col_date::text AS d, col_ts::text AS ts, col_tstz::text AS tstz FROM {table_name} ORDER BY col_date;",
+        pg_conn,
+    )
+
+    assert normalize_bc(result) == [
+        ["4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        ["0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        ["2021-01-01", "2021-01-01 00:00:00", "2021-01-01 00:00:00+00"],
+    ]
+
+    # verify data file stats: BC dates should appear in lower_bounds,
+    # AD dates in upper_bounds
+    for field_id, col_name, col_type in [
+        (1, "col_date", "date"),
+        (2, "col_ts", "timestamp"),
+        (3, "col_tstz", "timestamptz"),
+    ]:
+        result = run_query(
+            f"""SELECT min((lower_bounds->>'{field_id}')::{col_type}) = (SELECT min({col_name}) FROM {table_name}),
+                    max((upper_bounds->>'{field_id}')::{col_type}) = (SELECT max({col_name}) FROM {table_name})
+                FROM lake_iceberg.data_file_stats((SELECT metadata_location FROM iceberg_tables WHERE table_name = '{table_name}'));""",
+            pg_conn,
+        )
+        assert result == [[True, True]], f"stats mismatch for {col_name}"
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_err",
+    [
+        # date: year 10000 AD exceeds Iceberg's 9999 upper bound
+        ("date", "10000-01-01", "date out of range for Iceberg"),
+        # timestamp: BC timestamps are not allowed (min is 0001-01-01 AD)
+        ("timestamp", "0001-01-01 00:00:00 BC", "timestamp out of range for Iceberg"),
+        # timestamptz: BC timestamps are not allowed
+        (
+            "timestamptz",
+            "0001-01-01 00:00:00+00 BC",
+            "timestamp out of range for Iceberg",
+        ),
+    ],
+)
+def test_pg_lake_iceberg_temporal_out_of_range(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+    col_type,
+    value,
+    expected_err,
+):
+    """Verify that out-of-range date/timestamp values are rejected on insert."""
+    table_name = "test_temporal_oor"
+    run_command(
+        f"CREATE TABLE {table_name} (col {col_type}) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    with pytest.raises(Exception, match=expected_err):
+        run_command(
+            f"INSERT INTO {table_name} VALUES ('{value}');",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+def test_pg_lake_iceberg_nested_temporal_out_of_range_struct(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+):
+    """Verify out-of-range date inside a struct is rejected on direct insert."""
+    run_command("CREATE TYPE event_ds AS (id int, happened_at date);", pg_conn)
+    pg_conn.commit()
+
+    run_command(
+        "CREATE TABLE test_nested_oor_struct (col event_ds) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Valid struct should succeed
+    run_command(
+        "INSERT INTO test_nested_oor_struct VALUES (row(1, '2021-01-01')::event_ds);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Out-of-range date inside struct should fail
+    with pytest.raises(Exception, match="date out of range for Iceberg"):
+        run_command(
+            "INSERT INTO test_nested_oor_struct VALUES (row(2, '10000-01-01')::event_ds);",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command("DROP TABLE test_nested_oor_struct;", pg_conn)
+    pg_conn.commit()
+
+
+def test_pg_lake_iceberg_nested_temporal_out_of_range_map(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+):
+    """Verify out-of-range timestamp in map values is rejected on direct insert."""
+    map_type = create_map_type("text", "timestamp")
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    run_command(
+        f"CREATE TABLE test_nested_oor_map (col {map_type}) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Valid map should succeed
+    run_command(
+        f"INSERT INTO test_nested_oor_map VALUES (ARRAY[('key1', '2021-01-01 00:00:00'::timestamp)]::{map_type});",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Out-of-range timestamp in map values should fail
+    with pytest.raises(Exception, match="timestamp out of range for Iceberg"):
+        run_command(
+            f"INSERT INTO test_nested_oor_map VALUES (ARRAY[('key1', '0001-01-01 00:00:00 BC'::timestamp)]::{map_type});",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("DROP TABLE test_nested_oor_map;", pg_conn)
+    pg_conn.commit()
+
+
+def test_pg_lake_iceberg_nested_temporal_out_of_range_array_of_struct(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+):
+    """Verify out-of-range date inside an array of structs is rejected on direct insert."""
+    run_command("CREATE TYPE log_entry_ds AS (msg text, logged_at date);", pg_conn)
+    pg_conn.commit()
+
+    run_command(
+        "CREATE TABLE test_nested_oor_arr (col log_entry_ds[]) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Valid array of structs should succeed
+    run_command(
+        "INSERT INTO test_nested_oor_arr VALUES (ARRAY[row('ok', '2021-01-01')::log_entry_ds]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Out-of-range date in array of structs should fail
+    with pytest.raises(Exception, match="date out of range for Iceberg"):
+        run_command(
+            "INSERT INTO test_nested_oor_arr VALUES "
+            "(ARRAY[row('ok', '2021-01-01')::log_entry_ds, row('bad', '10000-01-01')::log_entry_ds]);",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command("DROP TABLE test_nested_oor_arr;", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_clamped",
+    [
+        # date: year 10000 AD exceeds upper bound → clamped to 9999-12-31
+        ("date", "10000-01-01", "9999-12-31"),
+        # timestamp: BC below lower bound → clamped to 0001-01-01 00:00:00
+        ("timestamp", "0001-01-01 00:00:00 BC", "0001-01-01 00:00:00"),
+        # timestamptz: BC below lower bound → clamped to 0001-01-01 00:00:00+00
+        (
+            "timestamptz",
+            "0001-01-01 00:00:00+00 BC",
+            "0001-01-01 00:00:00+00",
+        ),
+    ],
+)
+def test_pg_lake_iceberg_temporal_out_of_range_clamp(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+    col_type,
+    value,
+    expected_clamped,
+):
+    """Verify that out-of-range date/timestamp values are clamped when GUC is set to 'clamp'."""
+    table_name = "test_temporal_oor_clamp"
+    run_command(
+        f"CREATE TABLE {table_name} (col {col_type}) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    # Insert should succeed (value is clamped, not rejected)
+    run_command(
+        f"INSERT INTO {table_name} VALUES ('{value}');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Read back and verify the clamped value
+    result = run_query(
+        f"SELECT col::text FROM {table_name};",
+        pg_conn,
+    )
+    assert result[0][0] == expected_clamped
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+def test_pg_lake_iceberg_nested_temporal_out_of_range_struct_clamp(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+):
+    """Verify out-of-range date inside a struct is clamped when GUC is set to 'clamp'."""
+    run_command("CREATE TYPE event_ds_clamp AS (id int, happened_at date);", pg_conn)
+    pg_conn.commit()
+
+    run_command(
+        "CREATE TABLE test_nested_oor_struct_clamp (col event_ds_clamp) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    # Out-of-range date inside struct should be clamped, not rejected
+    run_command(
+        "INSERT INTO test_nested_oor_struct_clamp VALUES (row(1, '10000-01-01')::event_ds_clamp);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT (col).id, (col).happened_at::text FROM test_nested_oor_struct_clamp;",
+        pg_conn,
+    )
+    assert result[0][0] == 1
+    assert result[0][1] == "9999-12-31"
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command("DROP TABLE test_nested_oor_struct_clamp;", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_err",
+    [
+        ("date", "infinity", "date out of range for Iceberg"),
+        ("date", "-infinity", "date out of range for Iceberg"),
+        ("timestamp", "infinity", "timestamp out of range for Iceberg"),
+        ("timestamp", "-infinity", "timestamp out of range for Iceberg"),
+        ("timestamptz", "infinity", "timestamp out of range for Iceberg"),
+        ("timestamptz", "-infinity", "timestamp out of range for Iceberg"),
+    ],
+)
+def test_pg_lake_iceberg_infinity_temporal_error(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+    col_type,
+    value,
+    expected_err,
+):
+    """Verify that +-infinity date/timestamp values are rejected on insert."""
+    table_name = "test_inf_temporal_err"
+    run_command(
+        f"CREATE TABLE {table_name} (col {col_type}) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    with pytest.raises(Exception, match=expected_err):
+        run_command(
+            f"INSERT INTO {table_name} VALUES ('{value}');",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_clamped",
+    [
+        # +infinity date → clamped to 9999-12-31
+        ("date", "infinity", "9999-12-31"),
+        # -infinity date → clamped to 4713-01-01 BC (PG's lower date bound)
+        ("date", "-infinity", "4713-01-01 BC"),
+        # +infinity timestamp → clamped to 9999-12-31 23:59:59.999999
+        ("timestamp", "infinity", "9999-12-31 23:59:59.999999"),
+        # -infinity timestamp → clamped to 0001-01-01 00:00:00
+        ("timestamp", "-infinity", "0001-01-01 00:00:00"),
+        # +infinity timestamptz → clamped to 9999-12-31 23:59:59.999999+00
+        ("timestamptz", "infinity", "9999-12-31 23:59:59.999999+00"),
+        # -infinity timestamptz → clamped to 0001-01-01 00:00:00+00
+        ("timestamptz", "-infinity", "0001-01-01 00:00:00+00"),
+    ],
+)
+def test_pg_lake_iceberg_infinity_temporal_clamp(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+    col_type,
+    value,
+    expected_clamped,
+):
+    """Verify that +-infinity temporal values are clamped when GUC is 'clamp'."""
+    table_name = "test_inf_temporal_clamp"
+    run_command(
+        f"CREATE TABLE {table_name} (col {col_type}) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    run_command(
+        f"INSERT INTO {table_name} VALUES ('{value}');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # The ::text cast may execute inside DuckDB (query pushdown), which
+    # formats BC as "(BC)".  Normalize to PostgreSQL's " BC" for comparison.
+    result = run_query(
+        f"SELECT col::text FROM {table_name};",
+        pg_conn,
+    )
+    assert normalize_bc(result)[0][0] == expected_clamped
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "value,expected_err",
+    [
+        ("NaN", "NaN is not allowed for numeric type"),
+        ("Inf", "Infinity values are not allowed for numeric type"),
+        ("-Inf", "Infinity values are not allowed for numeric type"),
+    ],
+)
+def test_pg_lake_iceberg_numeric_special_error(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+    value,
+    expected_err,
+):
+    """Verify NaN/Inf are rejected on insert for iceberg numeric columns."""
+    table_name = "test_numeric_special_err"
+    run_command(
+        f"CREATE TABLE {table_name} (col numeric) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    with pytest.raises(Exception, match=expected_err):
+        run_command(
+            f"INSERT INTO {table_name} VALUES ('{value}');",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # NaN → NULL
+        ("NaN", None),
+        # +Inf → max DECIMAL(38,9)
+        ("Inf", "99999999999999999999999999999.999999999"),
+        # -Inf → min DECIMAL(38,9)
+        ("-Inf", "-99999999999999999999999999999.999999999"),
+    ],
+)
+def test_pg_lake_iceberg_numeric_special_clamp(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+    value,
+    expected,
+):
+    """Verify NaN → NULL and Inf → max/min when GUC is 'clamp'."""
+    table_name = "test_numeric_special_clamp"
+    run_command(
+        f"CREATE TABLE {table_name} (col numeric) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    run_command(
+        f"INSERT INTO {table_name} VALUES ('{value}');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        f"SELECT col::text FROM {table_name};",
+        pg_conn,
+    )
+    assert result[0][0] == expected
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "value,expected_err",
+    [
+        ("NaN", "NaN is not allowed for numeric type"),
+        ("Inf", "Infinity values are not allowed for numeric type"),
+        ("-Inf", "Infinity values are not allowed for numeric type"),
+    ],
+)
+def test_pg_lake_iceberg_numeric_array_special_error(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+    value,
+    expected_err,
+):
+    """Verify NaN/Inf in numeric arrays are rejected on insert."""
+    table_name = "test_numeric_arr_err"
+    run_command(
+        f"CREATE TABLE {table_name} (col numeric[]) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    with pytest.raises(Exception, match=expected_err):
+        run_command(
+            f"INSERT INTO {table_name} VALUES (ARRAY['{value}'::numeric]);",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
+def test_pg_lake_iceberg_numeric_array_special_clamp(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+):
+    """Verify NaN → NULL, Inf → max, -Inf → min in numeric arrays when GUC is 'clamp'."""
+    table_name = "test_numeric_arr_clamp"
+    run_command(
+        f"CREATE TABLE {table_name} (col numeric[]) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    run_command(
+        f"INSERT INTO {table_name} VALUES "
+        "(ARRAY['NaN'::numeric, 'Inf'::numeric, '-Inf'::numeric]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        f"SELECT col[1]::text, col[2]::text, col[3]::text FROM {table_name};",
+        pg_conn,
+    )
+    # NaN → NULL
+    assert result[0][0] is None
+    # Inf → max DECIMAL(38,9)
+    assert result[0][1] == "99999999999999999999999999999.999999999"
+    # -Inf → min DECIMAL(38,9)
+    assert result[0][2] == "-99999999999999999999999999999.999999999"
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
 def test_pg_lake_iceberg_table_random_values(
     pg_conn,
     extension,

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -86,8 +86,6 @@ PgLakeIsReservedColumnNameHookType PgLakeIsReservedColumnNameHook = NULL;
 
 static bool IsCreateLakeTable(CreateForeignTableStmt *createStmt);
 static void AddLakeTableColumnDefinitions(CreateForeignTableStmt *createStmt);
-static bool IsForeignTableStmtWithUnboundedNumericColumns(CreateForeignTableStmt *createStmt);
-static void SetDefaultPrecisionAndScaleForUnboundedNumericColumns(List *columnDefList);
 static bool IsJsonOrCSVBackedTable(PgLakeTableType tableType, List *options);
 static void ErrorIfUnsupportedColumnTypeForJsonOrCSVTables(List *columnDefList);
 static void ErrorIfUsingGeometryWithoutSpatialAnalytics(List *columnDefList);
@@ -594,23 +592,6 @@ ProcessCreateLakeTable(ProcessUtilityParams * params)
 	}
 
 	/*
-	 * If there are unbounded numerics, we assign them a scale and precision.
-	 */
-	if (IsForeignTableStmtWithUnboundedNumericColumns(createStmt))
-	{
-		/* we will adjust numerics in the parse tree */
-		if (params->readOnlyTree)
-			createStmt = (CreateForeignTableStmt *) CopyUtilityStmt(params);
-
-		SetDefaultPrecisionAndScaleForUnboundedNumericColumns(createStmt->base.tableElts);
-
-		/*
-		 * Note: we do not explicitly rerun handlers from the start, since we
-		 * expect the statement to be ready for execution.
-		 */
-	}
-
-	/*
 	 * If there is a filename option, check whether the _filename column is in
 	 * the right place.
 	 */
@@ -812,14 +793,6 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		 * rely on the schema name in PostProcessCreateIcebergTable.
 		 */
 		createStmt->base.relation->schemaname = get_namespace_name(namespaceId);
-	}
-
-	/*
-	 * If there are unbounded numerics, we assign them a scale and precision.
-	 */
-	if (createStmt->base.partbound == NULL && IsForeignTableStmtWithUnboundedNumericColumns(createStmt))
-	{
-		SetDefaultPrecisionAndScaleForUnboundedNumericColumns(createStmt->base.tableElts);
 	}
 
 	DefElem    *locationOption = GetOption(createStmt->options, "location");
@@ -1502,104 +1475,6 @@ ExpandTableLikeClause(TableLikeClause *table_like_clause)
 	table_close(relation, NoLock);
 
 	return newColumns;
-}
-
-
-/*
- * IsForeignTableStmtWithUnboundedNumericColumns checks whether the given
- * CreateForeignTableStmt has unbounded numeric columns.
- */
-static bool
-IsForeignTableStmtWithUnboundedNumericColumns(CreateForeignTableStmt *createStmt)
-{
-	ListCell   *columnDefCell = NULL;
-
-	foreach(columnDefCell, createStmt->base.tableElts)
-	{
-		/* could be LIKE clause or constraint clause */
-		if (!IsA(lfirst(columnDefCell), ColumnDef))
-		{
-			continue;
-		}
-
-		ColumnDef  *columnDef = (ColumnDef *) lfirst(columnDefCell);
-
-		int32		typmod = 0;
-		bool		missingOK = true;
-		Type		typeTuple = LookupTypeName(NULL, columnDef->typeName, &typmod, missingOK);
-
-		if (typeTuple == NULL)
-		{
-			/*
-			 * type not found, could be serial. But we are sure it is not
-			 * numeric
-			 */
-			continue;
-		}
-
-		Oid			typeOid = typeTypeId(typeTuple);
-
-		ReleaseSysCache(typeTuple);
-
-		if (IsUnboundedNumeric(typeOid, typmod))
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
-
-
-/*
- * SetDefaultPrecisionAndScaleForUnboundedNumericColumns sets the default
- * precision and scale for unbounded numeric columns.
- */
-static void
-SetDefaultPrecisionAndScaleForUnboundedNumericColumns(List *columnDefList)
-{
-	ListCell   *columnDefCell = NULL;
-
-	foreach(columnDefCell, columnDefList)
-	{
-		/* could be LIKE clause or constraint clause */
-		if (!IsA(lfirst(columnDefCell), ColumnDef))
-		{
-			continue;
-		}
-
-		ColumnDef  *columnDef = (ColumnDef *) lfirst(columnDefCell);
-
-		int32		typmod = 0;
-		bool		missingOK = true;
-		Type		typeTuple = LookupTypeName(NULL, columnDef->typeName, &typmod, missingOK);
-
-		if (typeTuple == NULL)
-		{
-			/*
-			 * type not found, could be serial. But we are sure it is not
-			 * numeric
-			 */
-			continue;
-		}
-
-		Oid			typeOid = typeTypeId(typeTuple);
-
-		if (IsUnboundedNumeric(typeOid, typmod))
-		{
-			int			newTypMod = make_numeric_typmod(UnboundedNumericDefaultPrecision,
-														UnboundedNumericDefaultScale);
-
-			columnDef->typeName = makeTypeNameFromOid(typeOid, newTypMod);
-
-			ereport(NOTICE, (errmsg("setting default precision and scale for unbounded numeric column \"%s\" to (%d, %d)",
-									columnDef->colname, UnboundedNumericDefaultPrecision,
-									UnboundedNumericDefaultScale),
-							 errdetail("Iceberg tables do not fully support unbounded numeric columns.")));
-		}
-
-		ReleaseSysCache(typeTuple);
-	}
 }
 
 

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -1047,6 +1047,20 @@ PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryT
 int64
 AddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryTupleDesc)
 {
+	/*
+	 * For INSERT..SELECT pushdown, the CustomScan's output slot has 0
+	 * attributes because the scan node doesn't return rows to PostgreSQL. We
+	 * need the target table's tuple descriptor so that
+	 * WrapQueryWithIcebergTemporalValidation can inspect column types.
+	 */
+	if (queryTupleDesc == NULL || queryTupleDesc->natts == 0)
+	{
+		Relation	rel = table_open(relationId, AccessShareLock);
+
+		queryTupleDesc = CreateTupleDescCopy(RelationGetDescr(rel));
+		table_close(rel, AccessShareLock);
+	}
+
 	int64		rowsProcessed = 0;
 	ForeignTable *foreignTable = GetForeignTable(relationId);
 	List	   *options = foreignTable->options;

--- a/pg_lake_table/src/planner/insert_select.c
+++ b/pg_lake_table/src/planner/insert_select.c
@@ -441,21 +441,66 @@ TypeContainsUnsuitableForPushdown(Oid typeId, int32 typmod, CopyDataFormat sourc
 		return true;
 	}
 
+	/*
+	 * For Iceberg, WrapQueryWithIcebergNumericValidation handles all numeric
+	 * types (unbounded, bounded within/exceeding DuckDB limits) in the write
+	 * path.  However, the EXPLAIN path sends the raw deparsed query to DuckDB
+	 * without the wrapper, so a ::numeric(p,s) cast with scale>precision or
+	 * precision>38 would fail in DuckDB's parser.
+	 *
+	 * For Iceberg: allow pushdown for unbounded (typmod=-1, deparsed as
+	 * ::numeric without modifiers) and for bounded numerics whose raw
+	 * precision/scale is valid for DuckDB.
+	 *
+	 * For non-Iceberg: block pushdown for any numeric that DuckDB cannot
+	 * represent, including unbounded.
+	 */
 	if (typeId == NUMERICOID)
 	{
-		/* may fail if unbounded numeric exceeds duckdb limits (38,38) */
-		if (typmod == -1)
-			return false;
-
-		int			precision = numeric_typmod_precision(typmod);
-		int			scale = numeric_typmod_scale(typmod);
-
-		if (!CanPushdownNumericToDuckdb(precision, scale))
+		if (sourceFormat == DATA_FORMAT_ICEBERG)
 		{
-			ereport(DEBUG4,
-					(errmsg("Numeric type with precision(%d) and scale(%d) "
-							"is not pushdownable", precision, scale)));
-			return true;
+			/*
+			 * Unbounded numeric is deparsed as ::numeric (no modifiers),
+			 * which DuckDB handles fine.  The write wrapper takes care of
+			 * validation and casting.
+			 */
+			if (typmod == -1)
+				return false;
+
+			/*
+			 * Bounded numeric: check raw precision/scale.  If DuckDB's
+			 * parser can handle the raw ::numeric(p,s) cast, allow
+			 * pushdown.  Otherwise block, because the EXPLAIN path would
+			 * fail.
+			 */
+			int			precision = numeric_typmod_precision(typmod);
+			int			scale = numeric_typmod_scale(typmod);
+
+			if (!CanPushdownNumericToDuckdb(precision, scale))
+			{
+				ereport(DEBUG4,
+						(errmsg("Numeric type with precision(%d) and scale(%d) "
+								"is not pushdownable (raw type invalid for DuckDB)",
+								precision, scale)));
+				return true;
+			}
+		}
+		else
+		{
+			/* may fail if unbounded numeric exceeds duckdb limits (38,38) */
+			if (typmod == -1)
+				return true;
+
+			int			precision = numeric_typmod_precision(typmod);
+			int			scale = numeric_typmod_scale(typmod);
+
+			if (!CanPushdownNumericToDuckdb(precision, scale))
+			{
+				ereport(DEBUG4,
+						(errmsg("Numeric type with precision(%d) and scale(%d) "
+								"is not pushdownable", precision, scale)));
+				return true;
+			}
 		}
 	}
 

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_date.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_date.py
@@ -28,32 +28,32 @@ test_cases = [
     (
         "date_eq",
         "WHERE col_date = '2024-01-01'",
-        "WHERE (col_date = '2024-01-01'::date)",
+        "WHERE (col_date = ('2024-01-01'::text)::date)",
     ),
     (
         "date_ne",
         "WHERE col_date <> '2023-01-01'",
-        "WHERE (col_date <> '2023-01-01'::date)",
+        "WHERE (col_date <> ('2023-01-01'::text)::date)",
     ),
     (
         "date_lt",
         "WHERE col_date < '2024-01-01'",
-        "WHERE (col_date < '2024-01-01'::date)",
+        "WHERE (col_date < ('2024-01-01'::text)::date)",
     ),
     (
         "date_le",
         "WHERE col_date <= '2022-12-31'",
-        "WHERE (col_date <= '2022-12-31'::date)",
+        "WHERE (col_date <= ('2022-12-31'::text)::date)",
     ),
     (
         "date_gt",
         "WHERE col_date > '2023-01-01'",
-        "WHERE (col_date > '2023-01-01'::date)",
+        "WHERE (col_date > ('2023-01-01'::text)::date)",
     ),
     (
         "date_ge",
         "WHERE col_date >= '2022-12-31'",
-        "WHERE (col_date >= '2022-12-31'::date)",
+        "WHERE (col_date >= ('2022-12-31'::text)::date)",
     ),
     (
         "date_eq_timestamp",
@@ -118,22 +118,22 @@ test_cases = [
     (
         "date_pli",
         "WHERE col_date + 1 = '2024-01-02'::date",
-        "WHERE ((col_date + 1) = '2024-01-02'::date)",
+        "WHERE ((col_date + 1) = ('2024-01-02'::text)::date)",
     ),
     (
         "date_mii",
         "WHERE col_date - 1 = '2023-12-31'::date",
-        "WHERE ((col_date - 1) = '2023-12-31'::date)",
+        "WHERE ((col_date - 1) = ('2023-12-31'::text)::date)",
     ),
     (
         "date_pl_interval",
         "WHERE col_date + interval '1 day' = '2024-01-02'::date",
-        "WHERE ((col_date + '1 day'::interval) = '2024-01-02'::date)",
+        "WHERE ((col_date + '1 day'::interval) = ('2024-01-02'::text)::date)",
     ),
     (
         "date_mi_interval",
         "WHERE col_date - interval '1 day' = '2023-12-31'::date",
-        "WHERE ((col_date - '1 day'::interval) = '2023-12-31'::date)",
+        "WHERE ((col_date - '1 day'::interval) = ('2023-12-31'::text)::date)",
     ),
     (
         "datetime_pl",
@@ -148,17 +148,17 @@ test_cases = [
     (
         "date_mi",
         "WHERE col_date - '2023-12-31' = 1",
-        "WHERE ((col_date - '2023-12-31'::date) = 1)",
+        "WHERE ((col_date - ('2023-12-31'::text)::date) = 1)",
     ),
     (
         "date cast",
         "WHERE col_timestamp::date = '2024-01-01'::date",
-        "WHERE ((col_timestamp)::date = '2024-01-01'::date)",
+        "WHERE ((col_timestamp)::date = ('2024-01-01'::text)::date)",
     ),
     (
         "date cast",
         "WHERE col_timestamptz::date = '2024-01-01'::date",
-        "WHERE ((col_timestamptz)::date = '2024-01-01'::date)",
+        "WHERE ((col_timestamptz)::date = ('2024-01-01'::text)::date)",
     ),
 ]
 

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_timestamp.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_timestamp.py
@@ -28,67 +28,67 @@ test_cases = [
     (
         "timestamp_eq",
         "WHERE col_timestamp = '2024-01-01 12:00:00'::timestamp",
-        "WHERE (col_timestamp = '2024-01-01 12:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp = ('2024-01-01 12:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_ne",
         "WHERE col_timestamp <> '2023-01-01 13:00:00'::timestamp",
-        "WHERE (col_timestamp <> '2023-01-01 13:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp <> ('2023-01-01 13:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_lt",
         "WHERE col_timestamp < '2024-01-01 12:00:00'::timestamp",
-        "WHERE (col_timestamp < '2024-01-01 12:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp < ('2024-01-01 12:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_le",
         "WHERE col_timestamp <= '2022-12-31 23:59:59'::timestamp",
-        "WHERE (col_timestamp <= '2022-12-31 23:59:59'::timestamp without time zone)",
+        "WHERE (col_timestamp <= ('2022-12-31 23:59:59'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_gt",
         "WHERE col_timestamp > '2023-01-01 13:00:00'::timestamp",
-        "WHERE (col_timestamp > '2023-01-01 13:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp > ('2023-01-01 13:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_ge",
         "WHERE col_timestamp >= '2022-12-31 23:59:59'::timestamp",
-        "WHERE (col_timestamp >= '2022-12-31 23:59:59'::timestamp without time zone)",
+        "WHERE (col_timestamp >= ('2022-12-31 23:59:59'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_mi",
         "WHERE col_timestamp - '2022-12-30'::timestamp >= INTERVAL '1 day'",
-        "WHERE ((col_timestamp - '",
+        "WHERE ((col_timestamp - ('",
     ),
     (
         "timestamp_eq_date",
         "WHERE col_timestamp = '2024-01-01'::date",
-        "WHERE (col_timestamp = '2024-01-01'::date)",
+        "WHERE (col_timestamp = ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_ge_date",
         "WHERE col_timestamp >= '2024-01-01'::date",
-        "WHERE (col_timestamp >= '2024-01-01'::date)",
+        "WHERE (col_timestamp >= ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_gt_date",
         "WHERE col_timestamp > '2024-01-01'::date",
-        "WHERE (col_timestamp > '2024-01-01'::date)",
+        "WHERE (col_timestamp > ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_le_date",
         "WHERE col_timestamp <= '2024-01-01'::date",
-        "WHERE (col_timestamp <= '2024-01-01'::date)",
+        "WHERE (col_timestamp <= ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_lt_date",
         "WHERE col_timestamp < '2024-01-01'::date",
-        "WHERE (col_timestamp < '2024-01-01'::date)",
+        "WHERE (col_timestamp < ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_ne_date",
         "WHERE col_timestamp <> '2024-01-01'::date",
-        "WHERE (col_timestamp <> '2024-01-01'::date)",
+        "WHERE (col_timestamp <> ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_eq_timestamptz",
@@ -123,7 +123,7 @@ test_cases = [
     (
         "timestamp_pl_interval",
         "WHERE col_timestamp + INTERVAL '1 day' = '2024-01-02 12:00:00'::timestamp",
-        "WHERE ((col_timestamp + '1 day'::interval) = '2024-01-02 12:00:00'::timestamp without time zone)",
+        "WHERE ((col_timestamp + '1 day'::interval) = ('2024-01-02 12:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_mi_interval",

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_timestamptz.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_timestamptz.py
@@ -58,7 +58,7 @@ test_cases = [
     (
         "timestamptz_mi",
         "WHERE col_timestamptz - '2022-12-30'::timestamptz >= INTERVAL '1 day'",
-        "WHERE ((col_timestamptz - '",
+        "WHERE ((col_timestamptz - ('",
     ),
     (
         "timestamptz_eq_date",

--- a/pg_lake_table/tests/pytests/test_data_file_pruning.py
+++ b/pg_lake_table/tests/pytests/test_data_file_pruning.py
@@ -54,6 +54,40 @@ pruning_data = [
             ("2023-01-02 00:00:00+00", "2023-01-02 00:00:00+00"),
         ],
     ),
+    (
+        True,
+        "date",
+        "prune_date_bc",
+        [
+            ("4712-01-01 BC", "4712-01-01 BC"),
+            ("4712-01-01 BC", "0001-01-01 BC"),
+            ("0001-01-01 BC", "4712-01-01 BC"),
+            ("0001-01-01 BC", "0001-01-01 BC"),
+        ],
+    ),
+    # Iceberg timestamps only support AD years 0001–9999; use early-AD values
+    (
+        True,
+        "timestamp",
+        "prune_timestamp_early_ad",
+        [
+            ("0001-01-01 00:00:00", "0001-01-01 00:00:00"),
+            ("0001-01-01 00:00:00", "0002-06-15 12:30:00"),
+            ("0002-06-15 12:30:00", "0001-01-01 00:00:00"),
+            ("0002-06-15 12:30:00", "0002-06-15 12:30:00"),
+        ],
+    ),
+    (
+        True,
+        "timestamptz",
+        "prune_timestamptz_early_ad",
+        [
+            ("0001-01-01 00:00:00+00", "0001-01-01 00:00:00+00"),
+            ("0001-01-01 00:00:00+00", "0002-06-15 12:30:00+00"),
+            ("0002-06-15 12:30:00+00", "0001-01-01 00:00:00+00"),
+            ("0002-06-15 12:30:00+00", "0002-06-15 12:30:00+00"),
+        ],
+    ),
     # we currently do not store statistics for UUID, once we do, uncomment
     # (True, "uuid", "prune_uuid", [('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000'), ('550e8400-e29b-41d4-a716-446655440000', '123e4567-e89b-12d3-a456-426614174000'), ('123e4567-e89b-12d3-a456-426614174000', '550e8400-e29b-41d4-a716-446655440000'), ('123e4567-e89b-12d3-a456-426614174000', '123e4567-e89b-12d3-a456-426614174000')]),
 ]
@@ -1764,6 +1798,130 @@ def test_pruning_for_inlined_functions(
         assert int(fetch_data_files_used(results)) == 1
 
     run_command("DROP SCHEMA test_pruning_for_inlined_functions CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize("col_type", ["date", "timestamp", "timestamptz"])
+def test_clamped_infinity_data_file_pruning(
+    s3,
+    pg_conn,
+    extension,
+    with_default_location,
+    col_type,
+):
+    """Verify data file pruning works correctly with clamped +-infinity values."""
+
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+
+    run_command(
+        f"""
+        CREATE SCHEMA test_clamp_inf_dfp;
+        CREATE TABLE test_clamp_inf_dfp.tbl (
+            col {col_type}
+        ) USING iceberg WITH (autovacuum_enabled='False');
+        SET TIME ZONE 'UTC';
+        SET pg_lake_iceberg.out_of_range_values = 'clamp';
+    """,
+        pg_conn,
+    )
+
+    # Insert values in separate transactions to create separate data files
+    if col_type == "date":
+        normal_val = "2020-06-15"
+    elif col_type == "timestamp":
+        normal_val = "2020-06-15 10:00:00"
+    else:
+        normal_val = "2020-06-15 10:00:00+00"
+
+    # File 1: normal value
+    run_command(
+        f"INSERT INTO test_clamp_inf_dfp.tbl VALUES ('{normal_val}');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # File 2: +infinity (clamped to upper Iceberg bound)
+    run_command(
+        "INSERT INTO test_clamp_inf_dfp.tbl VALUES ('infinity');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # File 3: -infinity (clamped to lower Iceberg bound)
+    run_command(
+        "INSERT INTO test_clamp_inf_dfp.tbl VALUES ('-infinity');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # 3 data files total
+
+    # Full scan → 3 files
+    results = run_query(
+        f"{explain_prefix} SELECT count(*) FROM test_clamp_inf_dfp.tbl",
+        pg_conn,
+    )
+    assert int(fetch_data_files_used(results)) == 3
+
+    # Exact match on normal value → prune to 1 file
+    if col_type == "date":
+        eq_filter = "col = '2020-06-15'"
+    elif col_type == "timestamp":
+        eq_filter = "col = '2020-06-15 10:00:00'"
+    else:
+        eq_filter = "col = '2020-06-15 10:00:00+00'"
+
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM test_clamp_inf_dfp.tbl WHERE {eq_filter}",
+        pg_conn,
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Year >= 9999 → only the clamped +infinity file
+    if col_type == "date":
+        hi_filter = "col >= '9999-01-01'"
+    elif col_type == "timestamp":
+        hi_filter = "col >= '9999-01-01 00:00:00'"
+    else:
+        hi_filter = "col >= '9999-01-01 00:00:00+00'"
+
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM test_clamp_inf_dfp.tbl WHERE {hi_filter}",
+        pg_conn,
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # Lower bound → only the clamped -infinity file
+    if col_type == "date":
+        lo_filter = "col <= '4000-01-01 BC'"
+    elif col_type == "timestamp":
+        lo_filter = "col <= '0001-12-31 23:59:59'"
+    else:
+        lo_filter = "col <= '0001-12-31 23:59:59+00'"
+
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM test_clamp_inf_dfp.tbl WHERE {lo_filter}",
+        pg_conn,
+    )
+    assert int(fetch_data_files_used(results)) == 1
+
+    # No matching value → 0 files
+    if col_type == "date":
+        no_match = "col = '2025-01-01'"
+    elif col_type == "timestamp":
+        no_match = "col = '2025-01-01 00:00:00'"
+    else:
+        no_match = "col = '2025-01-01 00:00:00+00'"
+
+    results = run_query(
+        f"{explain_prefix} SELECT * FROM test_clamp_inf_dfp.tbl WHERE {no_match}",
+        pg_conn,
+    )
+    assert int(fetch_data_files_used(results)) == 0
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("DROP SCHEMA test_clamp_inf_dfp CASCADE", pg_conn)
     pg_conn.commit()
 
 

--- a/pg_lake_table/tests/pytests/test_iceberg_copy_from_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_copy_from_pushdown.py
@@ -561,3 +561,467 @@ def copy_from_pushdown_setup(superuser_conn):
         superuser_conn,
     )
     superuser_conn.commit()
+
+
+def test_bc_dates_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify BC dates roundtrip correctly through COPY FROM pushdown.
+
+    COPY iceberg_table FROM 'file.parquet' goes through WriteQueryResultTo,
+    bypassing PGDuckSerialize.  This test ensures BC dates in a Parquet file
+    are correctly written to the Iceberg table via the pushed-down path.
+    """
+    parquet_url = f"s3://{TEST_BUCKET}/test_bc_copy_from_pushdown/data.parquet"
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    # Write BC dates to a Parquet file
+    run_command(
+        f"""COPY (
+            SELECT '4712-01-01 BC'::date      AS col_date,
+                   '0001-01-01 00:00:00'::timestamp AS col_ts,
+                   '0001-01-01 00:00:00+00'::timestamptz AS col_tstz
+            UNION ALL
+            SELECT '0001-01-01 BC'::date,
+                   '0001-06-15 12:30:00'::timestamp,
+                   '0001-06-15 12:30:00+00'::timestamptz
+            UNION ALL
+            SELECT '2021-01-01'::date,
+                   '2021-01-01 00:00:00'::timestamp,
+                   '2021-01-01 00:00:00+00'::timestamptz
+        ) TO '{parquet_url}';""",
+        pg_conn,
+    )
+
+    run_command(
+        """CREATE TABLE test_bc_copy_target (
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # COPY FROM pushdown
+    run_command(f"COPY test_bc_copy_target FROM '{parquet_url}';", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT col_date::text AS d, col_ts::text AS ts, col_tstz::text AS tstz "
+        "FROM test_bc_copy_target ORDER BY col_date;",
+        pg_conn,
+    )
+
+    assert normalize_bc(result) == [
+        ["4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        ["0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        ["2021-01-01", "2021-01-01 00:00:00", "2021-01-01 00:00:00+00"],
+    ]
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("DROP TABLE test_bc_copy_target;", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_err",
+    [
+        # date: year 10000 AD exceeds Iceberg's 9999 upper bound
+        ("date", "10000-01-01", "date out of range for Iceberg"),
+        # timestamp: BC timestamps are not allowed (min is 0001-01-01 AD)
+        (
+            "timestamp",
+            "0001-01-01 00:00:00 BC",
+            "timestamp out of range for Iceberg",
+        ),
+        # timestamptz: BC timestamps are not allowed
+        (
+            "timestamptz",
+            "0001-01-01 00:00:00+00 BC",
+            "timestamp out of range for Iceberg",
+        ),
+    ],
+)
+def test_temporal_out_of_range_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_err,
+):
+    """Verify out-of-range temporal values are rejected during COPY FROM pushdown.
+
+    The WrapQueryWithIcebergTemporalValidation wrapper in WriteQueryResultTo
+    adds DuckDB-side range checks that call error() for out-of-range values.
+    """
+    schema = f"test_oor_cf_{col_type.replace(' ', '_')}"
+    parquet_url = (
+        f"s3://{TEST_BUCKET}/test_temporal_oor_copy_pushdown_{col_type}/data.parquet"
+    )
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    try:
+        # Write an out-of-range value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE oor_copy_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # COPY FROM pushdown should reject the out-of-range value
+        with pytest.raises(Exception, match=expected_err):
+            run_command(
+                f"COPY oor_copy_target FROM '{parquet_url}';",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+def test_nested_temporal_out_of_range_struct_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify out-of-range date inside a struct is rejected during COPY FROM pushdown."""
+    schema = "test_nested_oor_cf_struct"
+    parquet_url = f"s3://{TEST_BUCKET}/test_nested_oor_cf_struct/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+
+    try:
+        run_command("CREATE TYPE event_cf AS (id int, happened_at date);", pg_conn)
+        pg_conn.commit()
+
+        # Write a struct with an out-of-range date to a Parquet file
+        run_command(
+            f"COPY (SELECT row(1, '10000-01-01'::date)::event_cf AS col) "
+            f"TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        run_command(
+            "CREATE TABLE oor_copy_target (col event_cf) USING iceberg;", pg_conn
+        )
+        pg_conn.commit()
+
+        # COPY FROM pushdown should reject the out-of-range date inside the struct
+        with pytest.raises(Exception, match="date out of range for Iceberg"):
+            run_command(
+                f"COPY oor_copy_target FROM '{parquet_url}';",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+def test_nested_temporal_out_of_range_map_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify out-of-range timestamp in map values is rejected during COPY FROM pushdown."""
+    schema = "test_nested_oor_cf_map"
+    parquet_url = f"s3://{TEST_BUCKET}/test_nested_oor_cf_map/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    try:
+        map_type = create_map_type("text", "timestamp")
+        pg_conn.commit()
+
+        # Write a map with an out-of-range timestamp value to a Parquet file
+        run_command(
+            f"COPY (SELECT ARRAY[('key1', '0001-01-01 00:00:00 BC'::timestamp)]"
+            f"::{map_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        run_command(
+            f"CREATE TABLE oor_copy_target (col {map_type}) USING iceberg;", pg_conn
+        )
+        pg_conn.commit()
+
+        # COPY FROM pushdown should reject the out-of-range timestamp in the map
+        with pytest.raises(Exception, match="timestamp out of range for Iceberg"):
+            run_command(
+                f"COPY oor_copy_target FROM '{parquet_url}';",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+def test_nested_temporal_out_of_range_array_of_struct_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify out-of-range date inside an array of structs is rejected during COPY FROM pushdown."""
+    schema = "test_nested_oor_cf_arr_struct"
+    parquet_url = f"s3://{TEST_BUCKET}/test_nested_oor_cf_arr_struct/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+
+    try:
+        run_command("CREATE TYPE log_entry_cf AS (msg text, logged_at date);", pg_conn)
+        pg_conn.commit()
+
+        # Write an array of structs with an out-of-range date to a Parquet file
+        run_command(
+            f"COPY (SELECT ARRAY[row('ok', '2021-01-01'::date)::log_entry_cf, "
+            f"row('bad', '10000-01-01'::date)::log_entry_cf] AS col) "
+            f"TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        run_command(
+            "CREATE TABLE oor_copy_target (col log_entry_cf[]) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # COPY FROM pushdown should reject the out-of-range date in the struct array
+        with pytest.raises(Exception, match="date out of range for Iceberg"):
+            run_command(
+                f"COPY oor_copy_target FROM '{parquet_url}';",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_clamped",
+    [
+        # date: year 10000 AD exceeds upper bound → clamped to 9999-12-31
+        ("date", "10000-01-01", "9999-12-31"),
+        # timestamp: BC below lower bound → clamped to 0001-01-01 00:00:00
+        (
+            "timestamp",
+            "0001-01-01 00:00:00 BC",
+            "0001-01-01 00:00:00",
+        ),
+        # timestamptz: BC below lower bound → clamped to 0001-01-01 00:00:00+00
+        (
+            "timestamptz",
+            "0001-01-01 00:00:00+00 BC",
+            "0001-01-01 00:00:00+00",
+        ),
+    ],
+)
+def test_temporal_out_of_range_clamp_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_clamped,
+):
+    """Verify out-of-range temporal values are clamped during COPY FROM pushdown.
+
+    When pg_lake_iceberg.out_of_range_values = 'clamp', the temporal
+    validation wrapper clamps values to the nearest Iceberg boundary instead
+    of raising an error.
+    """
+    schema = f"test_oor_clamp_cf_{col_type.replace(' ', '_')}"
+    parquet_url = f"s3://{TEST_BUCKET}/test_temporal_oor_clamp_copy_pushdown_{col_type}/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    try:
+        # Write an out-of-range value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE oor_copy_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # COPY FROM pushdown should succeed with clamping
+        run_command(
+            f"COPY oor_copy_target FROM '{parquet_url}';",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # Read back and verify the clamped value
+        result = run_query(
+            "SELECT col::text FROM oor_copy_target;",
+            pg_conn,
+        )
+        assert result[0][0] == expected_clamped
+    finally:
+        run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_err",
+    [
+        ("date", "infinity", "date out of range for Iceberg"),
+        ("date", "-infinity", "date out of range for Iceberg"),
+        ("timestamp", "infinity", "timestamp out of range for Iceberg"),
+        ("timestamp", "-infinity", "timestamp out of range for Iceberg"),
+        ("timestamptz", "infinity", "timestamp out of range for Iceberg"),
+        ("timestamptz", "-infinity", "timestamp out of range for Iceberg"),
+    ],
+)
+def test_infinity_temporal_error_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_err,
+):
+    """Verify +-infinity temporal values are rejected during COPY FROM pushdown."""
+    schema = f"test_inf_err_cf_{col_type.replace(' ', '_')}"
+    parquet_url = f"s3://{TEST_BUCKET}/test_inf_temporal_err_copy_pushdown_{col_type}/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    try:
+        # Write an infinity value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE inf_copy_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # COPY FROM pushdown should reject the infinity value
+        with pytest.raises(Exception, match=expected_err):
+            run_command(
+                f"COPY inf_copy_target FROM '{parquet_url}';",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_clamped",
+    [
+        ("date", "infinity", "9999-12-31"),
+        ("date", "-infinity", "4713-01-01 BC"),
+        ("timestamp", "infinity", "9999-12-31 23:59:59.999999"),
+        ("timestamp", "-infinity", "0001-01-01 00:00:00"),
+        ("timestamptz", "infinity", "9999-12-31 23:59:59.999999+00"),
+        ("timestamptz", "-infinity", "0001-01-01 00:00:00+00"),
+    ],
+)
+def test_infinity_temporal_clamp_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_clamped,
+):
+    """Verify +-infinity temporal values are clamped during COPY FROM pushdown."""
+    schema = f"test_inf_clamp_cf_{col_type.replace(' ', '_')}"
+    parquet_url = f"s3://{TEST_BUCKET}/test_inf_temporal_clamp_copy_pushdown_{col_type}/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    try:
+        # Write an infinity value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE inf_copy_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # COPY FROM pushdown should succeed with clamping
+        run_command(
+            f"COPY inf_copy_target FROM '{parquet_url}';",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # Read back and verify the clamped value
+        # The ::text cast may execute inside DuckDB (query pushdown), which
+        # formats BC as "(BC)".  Normalize to PostgreSQL's " BC" for comparison.
+        result = run_query(
+            "SELECT col::text FROM inf_copy_target;",
+            pg_conn,
+        )
+        assert normalize_bc(result)[0][0] == expected_clamped
+    finally:
+        run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_iceberg_ddl.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_ddl.py
@@ -379,6 +379,94 @@ def test_iceberg_add_column_default(pg_conn, s3, extension, with_default_locatio
     pg_conn.rollback()
 
 
+def test_iceberg_add_column_bc_date_default(
+    pg_conn, s3, extension, with_default_location
+):
+    """Verify BC date and early-AD timestamp defaults round-trip through Iceberg JSON serde.
+
+    Iceberg supports dates from ISO year -9999 to 9999 (BC dates allowed),
+    but timestamps/timestamptz only from 0001-01-01 through 9999-12-31 (AD only).
+
+    When a column is added with a BC date default, the value is serialized to
+    Iceberg metadata JSON via PGIcebergJsonSerialize (ConvertBCToISOYear).
+    Old rows that predate the column read the initial-default back via
+    PGIcebergJsonDeserialize (ConvertISOYearToBC).
+    """
+    run_command("CREATE SCHEMA bc_default_test;", pg_conn)
+    run_command(
+        "CREATE TABLE bc_default_test.tbl (a int) USING iceberg",
+        pg_conn,
+    )
+    # row inserted before the default columns exist
+    run_command("INSERT INTO bc_default_test.tbl VALUES (1)", pg_conn)
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    # add columns with defaults — BC for date, early-AD for timestamps
+    run_command(
+        "ALTER TABLE bc_default_test.tbl "
+        "ADD COLUMN d date DEFAULT '4712-01-01 BC', "
+        "ADD COLUMN ts timestamp DEFAULT '0001-01-01 00:00:00', "
+        "ADD COLUMN tstz timestamptz DEFAULT '0001-01-01 00:00:00+00'",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # ── verify Iceberg metadata JSON stores ISO 8601 year numbering ──
+    metadata_location = run_query(
+        "SELECT metadata_location FROM iceberg_tables "
+        "WHERE table_name = 'tbl' AND table_namespace = 'bc_default_test'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    latest_schema = returned_json["schemas"][-1]
+    fields_by_name = {f["name"]: f for f in latest_schema["fields"]}
+
+    # date: "4712-01-01 BC" → ISO "-4711-01-01"
+    assert fields_by_name["d"]["write-default"] == "-4711-01-01"
+    assert fields_by_name["d"]["initial-default"] == "-4711-01-01"
+
+    # timestamp: "0001-01-01 00:00:00" → "0001-01-01T00:00:00" (AD, no BC conversion)
+    assert fields_by_name["ts"]["write-default"] == "0001-01-01T00:00:00"
+    assert fields_by_name["ts"]["initial-default"] == "0001-01-01T00:00:00"
+
+    # timestamptz: "0001-01-01 00:00:00+00" → "0001-01-01T00:00:00+00:00" (AD, no BC conversion)
+    assert fields_by_name["tstz"]["write-default"] == "0001-01-01T00:00:00+00:00"
+    assert fields_by_name["tstz"]["initial-default"] == "0001-01-01T00:00:00+00:00"
+
+    # row with explicit values — BC date, early-AD timestamps
+    run_command(
+        "INSERT INTO bc_default_test.tbl VALUES "
+        "(2, '0001-01-01 BC', '0001-06-15 12:30:00', '0001-06-15 12:30:00+00')",
+        pg_conn,
+    )
+
+    # row relying on defaults (write-default path)
+    run_command("INSERT INTO bc_default_test.tbl(a) VALUES (3)", pg_conn)
+
+    # cast to text to work around psycopg2 limitation with BC dates
+    # The ::text cast may execute inside DuckDB (query pushdown), which
+    # formats BC as "(BC)".  Normalize to PostgreSQL's " BC" for comparison.
+    results = run_query(
+        "SELECT a, d::text AS d, ts::text AS ts, tstz::text AS tstz "
+        "FROM bc_default_test.tbl ORDER BY a",
+        pg_conn,
+    )
+
+    assert normalize_bc(results) == [
+        # row 1: initial-default from Iceberg JSON deserialization
+        [1, "4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        # row 2: explicit values
+        [2, "0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        # row 3: write-default applied at insert time
+        [3, "4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+    ]
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("DROP SCHEMA bc_default_test CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
 def test_iceberg_add_nested_column_default(
     pg_conn, s3, extension, with_default_location
 ):

--- a/pg_lake_table/tests/pytests/test_iceberg_types.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_types.py
@@ -2195,7 +2195,7 @@ def test_field_id_mappings(
     assert top_level_mappings == [
         ["verify_field_id_mapping.test_table", 1, "int_col", "integer", -1],
         ["verify_field_id_mapping.test_table", 2, "array_int_col", "integer[]", -1],
-        ["verify_field_id_mapping.test_table", 4, "numeric_col", "numeric", 2490381],
+        ["verify_field_id_mapping.test_table", 4, "numeric_col", "numeric", -1],
         [
             "verify_field_id_mapping.test_table",
             5,

--- a/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
@@ -256,7 +256,7 @@ def test_insert_select_pushdown_unsupported(
 		CREATE DOMAIN simple_text AS TEXT CHECK (LENGTH(VALUE) <= 50);
 		CREATE TABLE table_with_domain (id INT, description simple_text) USING iceberg;
 
-        -- scale>precision is not safe to pushdown
+        -- scale>precision: raw ::numeric(25,26) is invalid for DuckDB parser, blocks pushdown
 		CREATE TABLE numeric_table (value numeric(25,26)) USING iceberg;
 
         -- plain numeric is safe to pushdown
@@ -723,3 +723,570 @@ def test_insert_select_dropped_cols(s3, pg_conn, extension, with_default_locatio
     assert res == [[22]]
 
     pg_conn.rollback()
+
+
+def test_bc_dates_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify BC dates roundtrip correctly through INSERT SELECT pushdown.
+
+    INSERT INTO iceberg_table SELECT * FROM iceberg_table goes through
+    WriteQueryResultTo (DuckDB-side COPY), bypassing PGDuckSerialize.
+    This test ensures the ISO-year conversion produces correct results
+    in the pushed-down path.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_bc_insert_pushdown;
+        SET search_path TO test_bc_insert_pushdown;
+
+        CREATE TABLE source (
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;
+
+        CREATE TABLE target (
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command(
+        """INSERT INTO source VALUES
+            ('4712-01-01 BC', '0001-01-01 00:00:00', '0001-01-01 00:00:00+00'),
+            ('0001-01-01 BC', '0001-06-15 12:30:00', '0001-06-15 12:30:00+00'),
+            ('2021-01-01', '2021-01-01 00:00:00', '2021-01-01 00:00:00+00');""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # INSERT SELECT pushdown: data flows through DuckDB without PGDuckSerialize
+    results = run_query(
+        "EXPLAIN (VERBOSE) INSERT INTO target SELECT * FROM source",
+        pg_conn,
+    )
+    assert "Custom Scan (Query Pushdown)" in str(results)
+
+    run_command("INSERT INTO target SELECT * FROM source", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT col_date::text AS d, col_ts::text AS ts, col_tstz::text AS tstz "
+        "FROM target ORDER BY col_date;",
+        pg_conn,
+    )
+
+    assert normalize_bc(result) == [
+        ["4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        ["0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        ["2021-01-01", "2021-01-01 00:00:00", "2021-01-01 00:00:00+00"],
+    ]
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("RESET search_path;", pg_conn)
+    run_command("DROP SCHEMA test_bc_insert_pushdown CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_err",
+    [
+        # date: year 10000 AD exceeds Iceberg's 9999 upper bound
+        ("date", "10000-01-01", "date out of range for Iceberg"),
+        # timestamp: BC timestamps are not allowed (min is 0001-01-01 AD)
+        (
+            "timestamp",
+            "0001-01-01 00:00:00 BC",
+            "timestamp out of range for Iceberg",
+        ),
+        # timestamptz: BC timestamps are not allowed
+        (
+            "timestamptz",
+            "0001-01-01 00:00:00+00 BC",
+            "timestamp out of range for Iceberg",
+        ),
+    ],
+)
+def test_temporal_out_of_range_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_err,
+):
+    """Verify out-of-range temporal values are rejected during INSERT SELECT pushdown.
+
+    The WrapQueryWithIcebergTemporalValidation wrapper in WriteQueryResultTo
+    adds DuckDB-side range checks that call error() for out-of-range values.
+    """
+    schema = f"test_oor_is_{col_type.replace(' ', '_')}"
+    parquet_url = (
+        f"s3://{TEST_BUCKET}/test_temporal_oor_pushdown_{col_type}/data.parquet"
+    )
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    try:
+        # Write an out-of-range value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create a pg_lake foreign table pointing to the Parquet file
+        run_command(
+            f"""CREATE FOREIGN TABLE oor_source (col {col_type})
+                SERVER pg_lake OPTIONS (path '{parquet_url}');""",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE oor_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown should reject the out-of-range value
+        with pytest.raises(Exception, match=expected_err):
+            run_command(
+                "INSERT INTO oor_target SELECT * FROM oor_source;",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+def test_nested_temporal_out_of_range_struct_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify out-of-range date inside a struct is rejected during INSERT SELECT pushdown."""
+    schema = "test_nested_oor_struct"
+    parquet_url = f"s3://{TEST_BUCKET}/test_nested_oor_struct/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+
+    try:
+        run_command("CREATE TYPE event AS (id int, happened_at date);", pg_conn)
+        pg_conn.commit()
+
+        # Write a struct with an out-of-range date to a Parquet file
+        run_command(
+            f"COPY (SELECT row(1, '10000-01-01'::date)::event AS col) "
+            f"TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create a pg_lake foreign table pointing to the Parquet file
+        run_command(
+            f"""CREATE FOREIGN TABLE oor_source (col event)
+                SERVER pg_lake OPTIONS (path '{parquet_url}');""",
+            pg_conn,
+        )
+
+        run_command("CREATE TABLE oor_target (col event) USING iceberg;", pg_conn)
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown should reject the out-of-range date inside the struct
+        with pytest.raises(Exception, match="date out of range for Iceberg"):
+            run_command(
+                "INSERT INTO oor_target SELECT * FROM oor_source;",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+def test_nested_temporal_out_of_range_map_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify out-of-range timestamp in map values is rejected during INSERT SELECT pushdown."""
+    schema = "test_nested_oor_map"
+    parquet_url = f"s3://{TEST_BUCKET}/test_nested_oor_map/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    try:
+        map_type = create_map_type("text", "timestamp")
+        pg_conn.commit()
+
+        # Write a map with an out-of-range timestamp value to a Parquet file
+        run_command(
+            f"COPY (SELECT ARRAY[('key1', '0001-01-01 00:00:00 BC'::timestamp)]"
+            f"::{map_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create a pg_lake foreign table pointing to the Parquet file
+        run_command(
+            f"""CREATE FOREIGN TABLE oor_source (col {map_type})
+                SERVER pg_lake OPTIONS (path '{parquet_url}');""",
+            pg_conn,
+        )
+
+        run_command(f"CREATE TABLE oor_target (col {map_type}) USING iceberg;", pg_conn)
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown should reject the out-of-range timestamp in the map
+        with pytest.raises(Exception, match="timestamp out of range for Iceberg"):
+            run_command(
+                "INSERT INTO oor_target SELECT * FROM oor_source;",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+def test_nested_temporal_out_of_range_array_of_struct_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify out-of-range date inside an array of structs is rejected during INSERT SELECT pushdown."""
+    schema = "test_nested_oor_arr_struct"
+    parquet_url = f"s3://{TEST_BUCKET}/test_nested_oor_arr_struct/data.parquet"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+
+    try:
+        run_command("CREATE TYPE log_entry AS (msg text, logged_at date);", pg_conn)
+        pg_conn.commit()
+
+        # Write an array of structs with an out-of-range date to a Parquet file
+        run_command(
+            f"COPY (SELECT ARRAY[row('ok', '2021-01-01'::date)::log_entry, "
+            f"row('bad', '10000-01-01'::date)::log_entry] AS col) "
+            f"TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create a pg_lake foreign table pointing to the Parquet file
+        run_command(
+            f"""CREATE FOREIGN TABLE oor_source (col log_entry[])
+                SERVER pg_lake OPTIONS (path '{parquet_url}');""",
+            pg_conn,
+        )
+
+        run_command("CREATE TABLE oor_target (col log_entry[]) USING iceberg;", pg_conn)
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown should reject the out-of-range date in the struct array
+        with pytest.raises(Exception, match="date out of range for Iceberg"):
+            run_command(
+                "INSERT INTO oor_target SELECT * FROM oor_source;",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+def test_nested_temporal_valid_struct_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify valid dates inside structs pass through INSERT SELECT pushdown correctly."""
+    schema = "test_nested_valid_struct"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+
+    try:
+        run_command("CREATE TYPE event_v AS (id int, happened_at date);", pg_conn)
+        pg_conn.commit()
+
+        run_command("CREATE TABLE source (col event_v) USING iceberg;", pg_conn)
+        run_command("CREATE TABLE target (col event_v) USING iceberg;", pg_conn)
+        pg_conn.commit()
+
+        run_command(
+            "INSERT INTO source VALUES (row(1, '4712-01-01 BC')::event_v), "
+            "(row(2, '2021-06-15')::event_v), "
+            "(row(3, '9999-12-31')::event_v);",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown — valid dates inside struct should work
+        run_command("INSERT INTO target SELECT * FROM source;", pg_conn)
+        pg_conn.commit()
+
+        result = run_query(
+            "SELECT (col).id, (col).happened_at::text FROM target ORDER BY (col).id;",
+            pg_conn,
+        )
+
+        assert normalize_bc(result) == [
+            [1, "4712-01-01 BC"],
+            [2, "2021-06-15"],
+            [3, "9999-12-31"],
+        ]
+    finally:
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_clamped",
+    [
+        # date: year 10000 AD exceeds upper bound → clamped to 9999-12-31
+        ("date", "10000-01-01", "9999-12-31"),
+        # timestamp: BC below lower bound → clamped to 0001-01-01 00:00:00
+        (
+            "timestamp",
+            "0001-01-01 00:00:00 BC",
+            "0001-01-01 00:00:00",
+        ),
+        # timestamptz: BC below lower bound → clamped to 0001-01-01 00:00:00+00
+        (
+            "timestamptz",
+            "0001-01-01 00:00:00+00 BC",
+            "0001-01-01 00:00:00+00",
+        ),
+    ],
+)
+def test_temporal_out_of_range_clamp_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_clamped,
+):
+    """Verify out-of-range temporal values are clamped during INSERT SELECT pushdown.
+
+    When pg_lake_iceberg.out_of_range_values = 'clamp', the temporal
+    validation wrapper clamps values to the nearest Iceberg boundary instead
+    of raising an error.
+    """
+    schema = f"test_oor_clamp_is_{col_type.replace(' ', '_')}"
+    parquet_url = (
+        f"s3://{TEST_BUCKET}/test_temporal_oor_clamp_pushdown_{col_type}/data.parquet"
+    )
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    try:
+        # Write an out-of-range value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create a pg_lake foreign table pointing to the Parquet file
+        run_command(
+            f"""CREATE FOREIGN TABLE oor_source (col {col_type})
+                SERVER pg_lake OPTIONS (path '{parquet_url}');""",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE oor_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown should succeed with clamping
+        run_command(
+            "INSERT INTO oor_target SELECT * FROM oor_source;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # Read back and verify the clamped value
+        result = run_query(
+            "SELECT col::text FROM oor_target;",
+            pg_conn,
+        )
+        assert result[0][0] == expected_clamped
+    finally:
+        run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_err",
+    [
+        ("date", "infinity", "date out of range for Iceberg"),
+        ("date", "-infinity", "date out of range for Iceberg"),
+        ("timestamp", "infinity", "timestamp out of range for Iceberg"),
+        ("timestamp", "-infinity", "timestamp out of range for Iceberg"),
+        ("timestamptz", "infinity", "timestamp out of range for Iceberg"),
+        ("timestamptz", "-infinity", "timestamp out of range for Iceberg"),
+    ],
+)
+def test_infinity_temporal_error_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_err,
+):
+    """Verify +-infinity temporal values are rejected during INSERT SELECT pushdown."""
+    schema = f"test_inf_err_is_{col_type.replace(' ', '_')}"
+    parquet_url = (
+        f"s3://{TEST_BUCKET}/test_inf_temporal_err_pushdown_{col_type}/data.parquet"
+    )
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    try:
+        # Write an infinity value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create a pg_lake foreign table pointing to the Parquet file
+        run_command(
+            f"""CREATE FOREIGN TABLE inf_source (col {col_type})
+                SERVER pg_lake OPTIONS (path '{parquet_url}');""",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE inf_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown should reject the infinity value
+        with pytest.raises(Exception, match=expected_err):
+            run_command(
+                "INSERT INTO inf_target SELECT * FROM inf_source;",
+                pg_conn,
+            )
+        pg_conn.rollback()
+    finally:
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,value,expected_clamped",
+    [
+        ("date", "infinity", "9999-12-31"),
+        ("date", "-infinity", "4713-01-01 BC"),
+        ("timestamp", "infinity", "9999-12-31 23:59:59.999999"),
+        ("timestamp", "-infinity", "0001-01-01 00:00:00"),
+        ("timestamptz", "infinity", "9999-12-31 23:59:59.999999+00"),
+        ("timestamptz", "-infinity", "0001-01-01 00:00:00+00"),
+    ],
+)
+def test_infinity_temporal_clamp_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_clamped,
+):
+    """Verify +-infinity temporal values are clamped during INSERT SELECT pushdown."""
+    schema = f"test_inf_clamp_is_{col_type.replace(' ', '_')}"
+    parquet_url = (
+        f"s3://{TEST_BUCKET}/test_inf_temporal_clamp_pushdown_{col_type}/data.parquet"
+    )
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    try:
+        # Write an infinity value to a Parquet file
+        run_command(
+            f"COPY (SELECT '{value}'::{col_type} AS col) TO '{parquet_url}';",
+            pg_conn,
+        )
+
+        # Create a pg_lake foreign table pointing to the Parquet file
+        run_command(
+            f"""CREATE FOREIGN TABLE inf_source (col {col_type})
+                SERVER pg_lake OPTIONS (path '{parquet_url}');""",
+            pg_conn,
+        )
+
+        # Create the target Iceberg table
+        run_command(
+            f"CREATE TABLE inf_target (col {col_type}) USING iceberg;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # INSERT SELECT pushdown should succeed with clamping
+        run_command(
+            "INSERT INTO inf_target SELECT * FROM inf_source;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # Read back and verify the clamped value
+        # The ::text cast may execute inside DuckDB (query pushdown), which
+        # formats BC as "(BC)".  Normalize to PostgreSQL's " BC" for comparison.
+        result = run_query(
+            "SELECT col::text FROM inf_target;",
+            pg_conn,
+        )
+        assert normalize_bc(result)[0][0] == expected_clamped
+    finally:
+        run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_partition_pruning.py
+++ b/pg_lake_table/tests/pytests/test_partition_pruning.py
@@ -88,6 +88,40 @@ pruning_data = [
     ),
     (
         True,
+        "date",
+        "prune_date_bc",
+        [
+            ("4712-01-01 BC", "4712-01-01 BC"),
+            ("4712-01-01 BC", "0001-01-01 BC"),
+            ("0001-01-01 BC", "4712-01-01 BC"),
+            ("0001-01-01 BC", "0001-01-01 BC"),
+        ],
+    ),
+    # Iceberg timestamps only support AD years 0001–9999; use early-AD values
+    (
+        True,
+        "timestamp",
+        "prune_timestamp_early_ad",
+        [
+            ("0001-01-01 00:00:00", "0001-01-01 00:00:00"),
+            ("0001-01-01 00:00:00", "0002-06-15 12:30:00"),
+            ("0002-06-15 12:30:00", "0001-01-01 00:00:00"),
+            ("0002-06-15 12:30:00", "0002-06-15 12:30:00"),
+        ],
+    ),
+    (
+        True,
+        "timestamptz",
+        "prune_timestamptz_early_ad",
+        [
+            ("0001-01-01 00:00:00+00", "0001-01-01 00:00:00+00"),
+            ("0001-01-01 00:00:00+00", "0002-06-15 12:30:00+00"),
+            ("0002-06-15 12:30:00+00", "0001-01-01 00:00:00+00"),
+            ("0002-06-15 12:30:00+00", "0002-06-15 12:30:00+00"),
+        ],
+    ),
+    (
+        True,
         "time",
         "prune_time",
         [
@@ -572,6 +606,88 @@ def test_datetime_partition_pruning_simple(
             pg_conn,
         )
         assert len(rows) == expected_rows, f"rows: {sql}"
+    run_command("RESET TIME ZONE;", pg_conn)
+    pg_conn.rollback()
+
+
+# Iceberg timestamps only support AD years (0001–9999), so only date
+# columns use BC values for partition pruning tests.
+bc_col_types = ["date"]
+bc_partition_types = ["year", "month", "day"]
+
+
+@pytest.mark.parametrize("partition_by", bc_partition_types)
+@pytest.mark.parametrize("col_type", bc_col_types)
+def test_bc_date_partition_pruning(
+    s3,
+    disable_data_file_pruning,
+    pg_conn,
+    extension,
+    with_default_location,
+    col_type,
+    partition_by,
+):
+    """Verify partition pruning works correctly with BC dates."""
+
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+
+    run_command(
+        f"""
+        CREATE SCHEMA test_bc_partition;
+        CREATE TABLE  test_bc_partition.tbl (
+            col_date {col_type}
+        ) USING iceberg
+        WITH (
+            autovacuum_enabled = 'False',
+            partition_by       = '{partition_by}(col_date)'
+        );
+        SET TIME ZONE 'UTC';
+    """,
+        pg_conn,
+    )
+
+    # insert BC and AD dates into separate data files via separate inserts
+    dates = [
+        "4712-01-01 BC",
+        "1000-01-01 BC",
+        "0001-01-01 BC",
+        "0001-01-01",
+        "1970-01-01",
+        "2021-01-01",
+    ]
+    values_sql = ",".join(f"('{d}')" for d in dates)
+    run_command(
+        f"INSERT INTO test_bc_partition.tbl VALUES {values_sql};",
+        pg_conn,
+    )
+
+    # use count(*) to avoid psycopg2 issues with BC date objects
+    filter_tests = [
+        ("col_date = '4712-01-01 BC'", 1, 1),
+        ("col_date = '0001-01-01 BC'", 1, 1),
+        ("col_date = '2021-01-01'", 1, 1),
+        ("col_date <= '0001-01-01 BC'", 3, 3),
+        ("col_date >= '0001-01-01'", 3, 3),
+        ("col_date BETWEEN '4712-01-01 BC' AND '0001-01-01 BC'", 3, 3),
+        ("col_date BETWEEN '0001-01-01' AND '2021-01-01'", 3, 3),
+        ("col_date BETWEEN '4712-01-01 BC' AND '2021-01-01'", 6, 6),
+        ("col_date = '9999-01-01'", 0, 0),
+        ("col_date > '2021-01-01'", 0, 1),
+    ]
+
+    for sql, expected_rows, expected_files in filter_tests:
+        plan = run_query(
+            f"{explain_prefix} SELECT * FROM test_bc_partition.tbl WHERE {sql}",
+            pg_conn,
+        )
+        assert fetch_data_files_used(plan) == str(expected_files), f"files: {sql}"
+
+        count = run_query(
+            f"SELECT count(*) FROM test_bc_partition.tbl WHERE {sql};",
+            pg_conn,
+        )
+        assert count[0][0] == expected_rows, f"rows: {sql}"
+
     run_command("RESET TIME ZONE;", pg_conn)
     pg_conn.rollback()
 
@@ -1802,6 +1918,126 @@ def test_pruning_for_coercions_temporal(
         )
         assert int(fetch_data_files_used(results)) == 1
 
+    pg_conn.rollback()
+
+
+clamped_inf_col_types = ["date", "timestamp", "timestamptz"]
+clamped_inf_partition_types = ["year", "month", "day"]
+
+
+@pytest.mark.parametrize("partition_by", clamped_inf_partition_types)
+@pytest.mark.parametrize("col_type", clamped_inf_col_types)
+def test_clamped_infinity_partition_pruning(
+    s3,
+    disable_data_file_pruning,
+    pg_conn,
+    extension,
+    with_default_location,
+    col_type,
+    partition_by,
+):
+    """Verify partition pruning works correctly with clamped +-infinity values."""
+
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+
+    run_command(
+        f"""
+        CREATE SCHEMA test_clamp_inf_part;
+        CREATE TABLE test_clamp_inf_part.tbl (
+            col_val {col_type}
+        ) USING iceberg
+        WITH (
+            autovacuum_enabled = 'False',
+            partition_by       = '{partition_by}(col_val)'
+        );
+        SET TIME ZONE 'UTC';
+        SET pg_lake_iceberg.out_of_range_values = 'clamp';
+    """,
+        pg_conn,
+    )
+
+    if col_type == "date":
+        normal_vals = ["2020-01-15", "2021-06-20"]
+    elif col_type == "timestamp":
+        normal_vals = ["2020-01-15 10:00:00", "2021-06-20 12:30:00"]
+    else:
+        normal_vals = ["2020-01-15 10:00:00+00", "2021-06-20 12:30:00+00"]
+
+    all_vals = normal_vals + ["infinity", "-infinity"]
+    values_sql = ",".join(f"('{v}')" for v in all_vals)
+    run_command(
+        f"INSERT INTO test_clamp_inf_part.tbl VALUES {values_sql};",
+        pg_conn,
+    )
+
+    # 4 rows in 4 different partitions → 4 data files
+
+    # Full scan → 4 files
+    plan = run_query(
+        f"{explain_prefix} SELECT count(*) FROM test_clamp_inf_part.tbl",
+        pg_conn,
+    )
+    assert fetch_data_files_used(plan) == "4"
+
+    count = run_query("SELECT count(*) FROM test_clamp_inf_part.tbl;", pg_conn)
+    assert count[0][0] == 4
+
+    # Exact match on a normal value → 1 file
+    if col_type == "date":
+        eq_filter = "col_val = '2020-01-15'"
+    elif col_type == "timestamp":
+        eq_filter = "col_val = '2020-01-15 10:00:00'"
+    else:
+        eq_filter = "col_val = '2020-01-15 10:00:00+00'"
+
+    plan = run_query(
+        f"{explain_prefix} SELECT * FROM test_clamp_inf_part.tbl WHERE {eq_filter}",
+        pg_conn,
+    )
+    assert fetch_data_files_used(plan) == "1", f"eq: {eq_filter}"
+
+    # Year >= 9999 → only the clamped +infinity partition
+    if col_type == "date":
+        hi_filter = "col_val >= '9999-01-01'"
+    elif col_type == "timestamp":
+        hi_filter = "col_val >= '9999-01-01 00:00:00'"
+    else:
+        hi_filter = "col_val >= '9999-01-01 00:00:00+00'"
+
+    plan = run_query(
+        f"{explain_prefix} SELECT * FROM test_clamp_inf_part.tbl WHERE {hi_filter}",
+        pg_conn,
+    )
+    assert fetch_data_files_used(plan) == "1", f"hi: {hi_filter}"
+
+    count = run_query(
+        f"SELECT count(*) FROM test_clamp_inf_part.tbl WHERE {hi_filter};",
+        pg_conn,
+    )
+    assert count[0][0] == 1
+
+    # Lower bound → only the clamped -infinity partition
+    if col_type == "date":
+        lo_filter = "col_val <= '4000-01-01 BC'"
+    elif col_type == "timestamp":
+        lo_filter = "col_val <= '0001-12-31 23:59:59'"
+    else:
+        lo_filter = "col_val <= '0001-12-31 23:59:59+00'"
+
+    plan = run_query(
+        f"{explain_prefix} SELECT * FROM test_clamp_inf_part.tbl WHERE {lo_filter}",
+        pg_conn,
+    )
+    assert fetch_data_files_used(plan) == "1", f"lo: {lo_filter}"
+
+    count = run_query(
+        f"SELECT count(*) FROM test_clamp_inf_part.tbl WHERE {lo_filter};",
+        pg_conn,
+    )
+    assert count[0][0] == 1
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command("RESET TIME ZONE;", pg_conn)
     pg_conn.rollback()
 
 

--- a/pg_lake_table/tests/pytests/test_special_numeric.py
+++ b/pg_lake_table/tests/pytests/test_special_numeric.py
@@ -3,6 +3,7 @@ from utils_pytest import *
 
 
 def test_special_numeric(s3, pg_conn, extension, with_default_location):
+    """Default error mode: NaN, Inf, -Inf are rejected for iceberg numeric columns."""
 
     run_command(
         """
@@ -35,9 +36,10 @@ def test_special_numeric(s3, pg_conn, extension, with_default_location):
                 f"INSERT INTO {table} VALUES ('{value}')", pg_conn, raise_error=False
             )
             assert (
-                "Special numeric values" in str(err)
-                and "are not allowed for numeric type" in str(err)
-            ) or "cannot hold an infinite value" in str(err)
+                "NaN is not allowed for numeric type" in str(err)
+                or "Infinity values are not allowed for numeric type" in str(err)
+                or "cannot hold an infinite value" in str(err)
+            )
 
             pg_conn.rollback()
 
@@ -47,4 +49,105 @@ def test_special_numeric(s3, pg_conn, extension, with_default_location):
                 """,
         pg_conn,
     )
+    pg_conn.commit()
+
+
+def test_special_numeric_array_error(s3, pg_conn, extension, with_default_location):
+    """Default error mode: NaN, Inf, -Inf in numeric arrays are rejected."""
+
+    run_command(
+        "CREATE TABLE test_arr_err (b numeric[]) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    special_values = ["NaN", "Inf", "-Inf"]
+    for value in special_values:
+        err = run_command(
+            f"INSERT INTO test_arr_err VALUES (ARRAY['{value}'::numeric]);",
+            pg_conn,
+            raise_error=False,
+        )
+        assert "NaN is not allowed for numeric type" in str(
+            err
+        ) or "Infinity values are not allowed for numeric type" in str(err)
+        pg_conn.rollback()
+
+    run_command("DROP TABLE test_arr_err;", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_def,value,expected",
+    [
+        # NaN → NULL for unbounded numeric
+        ("numeric", "NaN", None),
+        # +Inf → max DECIMAL(38,9) for unbounded numeric
+        ("numeric", "Inf", "99999999999999999999999999999.999999999"),
+        # -Inf → min DECIMAL(38,9) for unbounded numeric
+        ("numeric", "-Inf", "-99999999999999999999999999999.999999999"),
+        # NaN → NULL for bounded numeric (PG allows NaN for bounded)
+        ("numeric(20,10)", "NaN", None),
+    ],
+)
+def test_special_numeric_clamp(
+    s3, pg_conn, extension, with_default_location, col_def, value, expected
+):
+    """Clamp mode: NaN → NULL, Inf → max/min for iceberg numeric columns."""
+    run_command(
+        f"CREATE TABLE test_clamp_numeric (b {col_def}) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    run_command(
+        f"INSERT INTO test_clamp_numeric VALUES ('{value}');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT b::text FROM test_clamp_numeric;",
+        pg_conn,
+    )
+    assert result[0][0] == expected
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command("DROP TABLE test_clamp_numeric;", pg_conn)
+    pg_conn.commit()
+
+
+def test_special_numeric_array_clamp(s3, pg_conn, extension, with_default_location):
+    """Clamp mode for numeric arrays: NaN → NULL, Inf → max, -Inf → min."""
+    run_command(
+        "CREATE TABLE test_clamp_arr (b numeric[]) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET pg_lake_iceberg.out_of_range_values = 'clamp';", pg_conn)
+
+    run_command(
+        "INSERT INTO test_clamp_arr VALUES "
+        "(ARRAY['NaN'::numeric, 'Inf'::numeric, '-Inf'::numeric]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Verify each array element individually
+    result = run_query(
+        "SELECT b[1]::text, b[2]::text, b[3]::text FROM test_clamp_arr;",
+        pg_conn,
+    )
+    # NaN → NULL
+    assert result[0][0] is None
+    # Inf → max DECIMAL(38,9)
+    assert result[0][1] == "99999999999999999999999999999.999999999"
+    # -Inf → min DECIMAL(38,9)
+    assert result[0][2] == "-99999999999999999999999999999.999999999"
+
+    run_command("RESET pg_lake_iceberg.out_of_range_values;", pg_conn)
+    run_command("DROP TABLE test_clamp_arr;", pg_conn)
     pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_unbounded_numeric.py
+++ b/pg_lake_table/tests/pytests/test_unbounded_numeric.py
@@ -123,18 +123,14 @@ def test_unbounded_numeric_pushdown(s3, pg_conn, extension):
 def test_copy_to_unbounded_numeric_with_default(s3, pg_conn, extension):
     uri = f"s3://{TEST_BUCKET}/unbounded_numeric.parquet"
 
-    error = run_command(
+    # random()::numeric may have more than 9 decimal digits, but DuckDB's
+    # DECIMAL(38,9) rounds the excess fractional digits — this should succeed.
+    run_command(
         f"""
         copy (select random()::numeric)
         to '{uri}'
     """,
         pg_conn,
-        raise_error=False,
-    )
-
-    assert (
-        "unbounded numeric type exceeds max allowed digits 9 after decimal point"
-        in error
     )
 
     pg_conn.rollback()
@@ -143,6 +139,8 @@ def test_copy_to_unbounded_numeric_with_default(s3, pg_conn, extension):
 def test_copy_to_exceeds_unbounded_numeric_max_integral_digits(s3, pg_conn, extension):
     uri = f"s3://{TEST_BUCKET}/numeric_exceeds_max_integral.parquet"
 
+    # 30 integral digits exceed DECIMAL(38,9) capacity (max 29 integral digits).
+    # DuckDB's CSV reader will fail with a conversion error.
     invalid_numeric = "123456789012345678901234567890.56"
 
     error = run_command(
@@ -154,7 +152,7 @@ def test_copy_to_exceeds_unbounded_numeric_max_integral_digits(s3, pg_conn, exte
         raise_error=False,
     )
 
-    assert "numeric type exceeds max allowed digits 29 before decimal point" in error
+    assert "Could not convert string" in error or "Conversion Error" in error
 
     pg_conn.rollback()
 
@@ -162,18 +160,17 @@ def test_copy_to_exceeds_unbounded_numeric_max_integral_digits(s3, pg_conn, exte
 def test_copy_to_exceeds_unbounded_numeric_max_decimal_digits(s3, pg_conn, extension):
     uri = f"s3://{TEST_BUCKET}/numeric_exceeds_max_decimal.parquet"
 
+    # 13 decimal digits exceed scale 9, but DuckDB's DECIMAL(38,9) rounds
+    # the excess fractional digits — this should succeed.
     invalid_numeric = "23.1234567890123"
 
-    error = run_command(
+    run_command(
         f"""
         copy (select 12 as id, {invalid_numeric}::numeric as a)
         to '{uri}'
     """,
         pg_conn,
-        raise_error=False,
     )
-
-    assert "numeric type exceeds max allowed digits 9 after decimal point" in error
 
     pg_conn.rollback()
 
@@ -266,7 +263,7 @@ def test_pg_lake_table_explicit(s3, pg_conn, extension, copy_numeric_to_file):
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'pg_lake_table_explicit' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", 38, 9]]
+    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT numeric_large, numeric_small, numeric_unbounded FROM pg_lake_table_explicit {expected_expression}"
@@ -296,7 +293,7 @@ def test_writable_pg_lake_table(s3, pg_conn, extension, copy_numeric_to_file):
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'writable_pg_lake_table' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", 10, 5]]
+    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT * FROM writable_pg_lake_table {expected_expression}"
@@ -367,7 +364,7 @@ def test_iceberg_table_explicit(s3, pg_conn, extension, with_default_location):
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'iceberg_table' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 5, 3], ["numeric", 10, 5]]
+    assert result == [["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT * FROM iceberg_table {expected_expression}"
@@ -390,7 +387,7 @@ def test_iceberg_create_as_select(s3, pg_conn, extension, with_default_location)
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'iceberg_table' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 5, 3], ["numeric", 38, 9]]
+    assert result == [["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT numeric_small, numeric_unbounded FROM iceberg_table {expected_expression}"

--- a/test_common/helpers/comparisons.py
+++ b/test_common/helpers/comparisons.py
@@ -14,6 +14,7 @@ from .db import (
 # Value / row comparison helpers
 # ---------------------------------------------------------------------------
 
+
 def compare_values(val1, val2, tolerance):
     if isinstance(val1, float) and isinstance(val2, float):
         return abs(val1 - val2) <= tolerance
@@ -129,6 +130,7 @@ def compare_results_with_duckdb(
 # Query-result assertion helpers
 # ---------------------------------------------------------------------------
 
+
 def assert_query_results_on_tables(
     query, pg_conn, first_table_names, second_table_names, tolerance=0.001
 ):
@@ -203,3 +205,25 @@ def assert_query_result_on_duckdb_and_pg(duckdb_conn, pg_conn, duckdb_query, pg_
 def check_table_size(pg_conn, table_name, count):
     result = run_query(f"SELECT count(*) FROM {table_name}", pg_conn)
     assert result[0]["count"] == count
+
+
+def normalize_bc(rows):
+    """Normalize DuckDB's '(BC) between date and time' to PG's 'BC at end'.
+
+    When a ``::text`` cast is pushed down to DuckDB, BC dates are formatted
+    with parentheses and the indicator sits between the date and time parts
+    (e.g. ``"4712-01-01 (BC) 00:00:00"``).  PostgreSQL places ``BC`` at the
+    end without parentheses (``"4712-01-01 00:00:00 BC"``).  This helper
+    normalises query results so assertions can use the PostgreSQL convention.
+    """
+
+    def _fix(v):
+        if not isinstance(v, str):
+            return v
+        v = v.replace(" (BC)", " BC")
+        # DuckDB: "YYYY-MM-DD BC HH:MM:SS" → PG: "YYYY-MM-DD HH:MM:SS BC"
+        if " BC " in v:
+            v = v.replace(" BC ", " ", 1) + " BC"
+        return v
+
+    return [[_fix(v) for v in row] for row in rows]


### PR DESCRIPTION
Error or clamp out of range values (not valid according to iceberg spec).

1. **New GUC:** pg_lake_iceberg.out_of_range_values
File: pg_lake_iceberg/src/init.c (+23)
Enum GUC with values error (default) and clamp
Controls behavior for both temporal and numeric out-of-range values

2. **Temporal validation wrapper (DuckDB query layer)**
WrapQueryWithIcebergTemporalValidation wraps all Iceberg write queries with CASE expressions that validate date/timestamp/timestamptz ranges
Handles infinity values via DuckDB's isfinite() — clamps to DATE '-4712-01-01' / DATE '9999-12-31' etc.
Handles BC date lower bounds and Iceberg's 0001-01-01 to 9999-12-31 range
Works at any nesting depth: scalars, arrays, structs, maps

3. **Numeric validation wrapper (DuckDB query layer)**
WrapQueryWithIcebergNumericValidation wraps queries to validate numeric columns
Reads numeric columns as VARCHAR from the inner query; casts to DECIMAL(p,s) after validation
Handles: NaN → NULL (clamp) or error; Inf/-Inf → min/max DECIMAL (clamp) or error; digit overflow → min/max DECIMAL (clamp) or error
NeutralizeNumericCastsInQuery replaces ::numeric(p,s) casts with ::text in inner queries to prevent premature DuckDB cast failures
Handles both scalar numeric and numeric[] (via list_transform)

4. We no longer convert postgres table schema for unbounded numeric to numeric(38,9). But we still write it to (38,9) to iceberg.