### PR TITLE
Fix BC date/timestamp via PGDuckSerialize + ISO write to Iceberg

### DIFF
--- a/.cursor/rules/prefer-postgres-apis.mdc
+++ b/.cursor/rules/prefer-postgres-apis.mdc
@@ -1,0 +1,27 @@
+---
+description: Prefer PostgreSQL utility functions over C standard library equivalents in extension C code
+globs: "**/*.c"
+alwaysApply: false
+---
+
+# Prefer PostgreSQL utility functions
+
+When writing C code for PostgreSQL extensions, prefer PostgreSQL's own utility
+functions over C standard library equivalents.
+
+## String functions (`common/string.h`)
+
+- `pg_str_endswith(str, suffix)` instead of manual `strlen` + `strcmp` suffix checks
+- `strtoint(str, &endptr, base)` instead of `sscanf(str, "%d", ...)` or `atoi`
+
+## Memory and string allocation (`utils/palloc.h`, `utils/builtins.h`, `lib/stringinfo.h`)
+
+- `palloc` / `pfree` instead of `malloc` / `free`
+- `pstrdup` / `pnstrdup` instead of `strdup` / `strndup`
+- `psprintf` instead of `snprintf` into a manually-sized buffer
+- `StringInfo` (`appendStringInfo`, etc.) instead of repeated `strcat` or manual buffer management
+
+## Output and formatting
+
+- `elog` / `ereport` instead of `fprintf(stderr, ...)`
+- `OutputFunctionCall` for datum-to-string conversions instead of hand-rolled formatting

--- a/pg_lake_engine/include/pg_lake/pgduck/serialize.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/serialize.h
@@ -31,6 +31,8 @@ extern PGDLLEXPORT char *PGDuckOnlySerialize(Oid typeOid, Datum value);
 extern PGDLLEXPORT bool IsPGDuckSerializeRequired(PGType postgresType);
 extern PGDLLEXPORT char *IntervalOutForPGDuck(Datum value);
 extern bool IsContainerType(Oid postgresType);
+extern PGDLLEXPORT const char *ConvertBCToISOYearIfNeeded(const char *dateTimestampString);
+extern PGDLLEXPORT const char *ConvertISOYearToBCIfNeeded(const char *dateTimestampString);
 
 /*
  * IsSerializedAsContainer returns whether a type will be serialized as a

--- a/pg_lake_engine/src/pgduck/serialize.c
+++ b/pg_lake_engine/src/pgduck/serialize.c
@@ -19,6 +19,7 @@
 
 #include "fmgr.h"
 #include "catalog/pg_type_d.h"
+#include "common/string.h"
 #include "pg_lake/extensions/postgis.h"
 #include "pg_lake/pgduck/array_conversion.h"
 #include "pg_lake/pgduck/map.h"
@@ -27,13 +28,90 @@
 #include "pg_lake/pgduck/struct_conversion.h"
 #include "pg_lake/util/timetz.h"
 #include "utils/builtins.h"
-#include "utils/date.h"
 #include "utils/lsyscache.h"
-#include "utils/timestamp.h"
 
 
 static char *ByteAOutForPGDuck(Datum value);
 static char *TimeTzOutForPGDuck(Datum value);
+
+
+/*
+ * ConvertBCToISOYearIfNeeded converts PostgreSQL's BC-era date/timestamp
+ * string to ISO 8601 year numbering.
+ *
+ * If the input ends with " BC", the 1-based BC year is converted:
+ *   1 BC → 0000, 2 BC → -0001, 4712 BC → -4711
+ *
+ * The rest of the string (month-day, time, timezone) is preserved:
+ *   "4712-01-01 BC"            → "-4711-01-01"
+ *   "4712-01-01 00:00:00 BC"   → "-4711-01-01 00:00:00"
+ *   "0001-01-01 00:00:00+00 BC" → "0000-01-01 00:00:00+00"
+ *
+ * AD strings (no " BC" suffix) are returned unchanged.
+ */
+const char *
+ConvertBCToISOYearIfNeeded(const char *dateTimestampString)
+{
+	if (!pg_str_endswith(dateTimestampString, " BC"))
+		return dateTimestampString;
+
+	char	   *endptr;
+	int			pgBcYear = strtoint(dateTimestampString, &endptr, 10);
+
+	if (endptr == dateTimestampString || pgBcYear <= 0 || *endptr != '-')
+		return dateTimestampString;
+
+	/*
+	 * Convert: 1 BC (pgBcYear=1) → ISO year 0, 2 BC → -1, 4712 BC →
+	 * -4711
+	 */
+	int			isoYear = -(pgBcYear - 1);
+
+	/*
+	 * copy the part after the year. endptr points to "-MM-DD...", strip
+	 * trailing " BC"
+	 */
+	char	   *dateTimeRemainder = pstrdup(endptr);
+
+	/* strip the " BC" */
+	dateTimeRemainder[strlen(dateTimeRemainder) - 3] = '\0';
+
+	const char *result;
+
+	if (isoYear == 0)
+		result = psprintf("%04d%s", isoYear, dateTimeRemainder);
+	else
+		result = psprintf("-%04d%s", -isoYear, dateTimeRemainder);
+
+	pfree(dateTimeRemainder);
+	return result;
+}
+
+
+/*
+ * ConvertISOYearToBCIfNeeded converts an ISO 8601 zero/negative year
+ * date/timestamp string to PostgreSQL's "YYYY BC" format.
+ *
+ *   "-4711-01-01"            → "4712-01-01 BC"
+ *   "0000-01-01T00:00:00"    → "0001-01-01T00:00:00 BC"
+ *   "0000-01-01 00:00:00+00" → "0001-01-01 00:00:00+00 BC"
+ *
+ * Positive-year strings pass through unchanged.
+ */
+const char *
+ConvertISOYearToBCIfNeeded(const char *dateTimestampString)
+{
+	char	   *endptr;
+	int			isoYear = strtoint(dateTimestampString, &endptr, 10);
+
+	if (endptr == dateTimestampString || isoYear > 0)
+		return dateTimestampString;
+
+	/* ISO year 0 = 1 BC, -1 = 2 BC, etc. */
+	int			bcYear = 1 - isoYear;
+
+	return psprintf("%04d%s BC", bcYear, endptr);
+}
 
 
 /*
@@ -89,6 +167,20 @@ PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 		return TextDatumGetCString(geomAsText);
 	}
 
+	/*
+	 * PostgreSQL outputs BC dates/timestamps with a " BC" suffix (e.g.
+	 * "4712-01-01 BC"), but DuckDB expects ISO 8601 negative-year format
+	 * (e.g. "-4711-01-01").  Without this conversion, DuckDB silently drops
+	 * the BC era indicator and treats the value as AD.
+	 */
+	if (columnType == DATEOID || columnType == TIMESTAMPOID ||
+		columnType == TIMESTAMPTZOID)
+	{
+		char	   *result = OutputFunctionCall(flinfo, value);
+
+		return (char *) ConvertBCToISOYearIfNeeded(result);
+	}
+
 	return OutputFunctionCall(flinfo, value);
 }
 
@@ -106,6 +198,14 @@ IsPGDuckSerializeRequired(PGType postgresType)
 		return true;
 
 	if (typeId == TIMETZOID)
+		return true;
+
+	/*
+	 * PostgreSQL outputs BC dates/timestamps with " BC" suffix, but DuckDB
+	 * expects ISO 8601 negative-year format.  We route these types through
+	 * PGDuckSerialize so that ConvertBCToISOYearIfNeeded can convert.
+	 */
+	if (typeId == DATEOID || typeId == TIMESTAMPOID || typeId == TIMESTAMPTZOID)
 		return true;
 
 	/* also covers map */

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
@@ -27,6 +27,7 @@
 #include "pg_lake/iceberg/iceberg_type_json_serde.h"
 #include "pg_lake/json/json_utils.h"
 #include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/serialize.h"
 #include "pg_extension_base/spi_helpers.h"
 
 #include "access/tupdesc.h"
@@ -137,6 +138,37 @@ PGScalarIcebergJsonSerialize(Datum scalarDatum, Field * field, PGType pgType)
 		 */
 		Assert(strncmp(jsonString, "\"\\\\x", 4) == 0);
 		jsonString = psprintf("\"%s", jsonString + 4);
+	}
+
+	/*
+	 * Convert BC dates to ISO 8601.
+	 *
+	 * PostgreSQL's to_json appends " BC" for BC-era dates/timestamps (e.g.
+	 * "4712-01-01 BC"), but the Iceberg spec requires ISO 8601 format
+	 * ("YYYY-MM-DD") which has no era suffix.  Convert to ISO 8601 year
+	 * numbering (year 0000 = 1 BC, negative years for earlier dates).
+	 * ConvertISOYearToBCIfNeeded reverses this on deserialization.
+	 */
+	if (pgType.postgresTypeOid == DATEOID ||
+		pgType.postgresTypeOid == TIMESTAMPOID ||
+		pgType.postgresTypeOid == TIMESTAMPTZOID)
+	{
+		/*
+		 * to_json wraps the value in JSON quotes (e.g. "\"4712-01-01 BC\"").
+		 * Strip the quotes, apply ISO year conversion, then re-quote.
+		 */
+		int			jsonLen = strlen(jsonString);
+
+		Assert(jsonLen >= 2 && jsonString[0] == '"' && jsonString[jsonLen - 1] == '"');
+
+		char	   *content = pnstrdup(jsonString + 1, jsonLen - 2);
+		const char *converted = ConvertBCToISOYearIfNeeded(content);
+
+		if (converted != content)
+		{
+			jsonString = psprintf("\"%s\"", converted);
+			pfree(content);
+		}
 	}
 
 	return jsonString;
@@ -423,6 +455,18 @@ PGScalarIcebergJsonDeserialize(const char *scalarJson, Field * field, PGType pgT
 		appendStringInfo(hexString, "\\x%s", scalarJson);
 
 		scalarJson = hexString->data;
+	}
+
+	/*
+	 * ISO 8601 year 0000 represents 1 BC, and negative years represent
+	 * earlier BC dates.  Convert back to PostgreSQL's "YYYY BC" format before
+	 * calling the type input function.
+	 */
+	if (pgType.postgresTypeOid == DATEOID ||
+		pgType.postgresTypeOid == TIMESTAMPOID ||
+		pgType.postgresTypeOid == TIMESTAMPTZOID)
+	{
+		scalarJson = ConvertISOYearToBCIfNeeded(scalarJson);
 	}
 
 	Oid			typinput;

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
@@ -240,6 +240,19 @@ def test_pg_lake_serde_temporal(
         result = run_query(pg_query, superuser_conn)
         assert str(result[0][0]) == value
 
+    # BC dates — cast to text to work around psycopg2 limitation with BC dates.
+    # Iceberg only supports BC for date type (years -9999..9999 ISO);
+    # timestamps/timestamptz must be AD (years 0001–9999).
+    bc_date_values = [
+        ("date", "date", "4712-01-01 BC"),
+        ("date", "date", "0001-01-01 BC"),
+    ]
+
+    for iceberg_type, pg_type, value in bc_date_values:
+        pg_query = f"SELECT lake_iceberg.serde_value('{value}'::{pg_type}, '{iceberg_type}')::text;"
+        result = run_query(pg_query, superuser_conn)
+        assert result[0][0] == value
+
     timestamptz_values = [
         (
             "timestamptz",
@@ -285,6 +298,33 @@ def test_pg_lake_serde_temporal(
         )
         result = run_query(pg_query, superuser_conn)
         assert str(result[0][0]) == expected
+
+    # Early-AD timestamptz — verifies serde at the boundary of the allowed range
+    run_command("SET TIME ZONE 'UTC';", superuser_conn)
+
+    early_ad_timestamptz_values = [
+        (
+            "timestamptz",
+            "timestamptz",
+            "0001-01-01 00:00:00+00",
+            "0001-01-01 00:00:00+00:00",
+        ),
+        (
+            "timestamptz",
+            "timestamptz",
+            "0001-06-15 12:30:00+00",
+            "0001-06-15 12:30:00+00:00",
+        ),
+    ]
+
+    for iceberg_type, pg_type, value, expected in early_ad_timestamptz_values:
+        pg_query = (
+            f"SELECT lake_iceberg.serde_value('{value}'::{pg_type}, '{iceberg_type}');"
+        )
+        result = run_query(pg_query, superuser_conn)
+        assert str(result[0][0]) == expected
+
+    run_command("RESET TIME ZONE;", superuser_conn)
 
     superuser_conn.rollback()
 

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
@@ -776,6 +776,74 @@ def test_pg_lake_iceberg_table_serial_column(
     pg_conn.commit()
 
 
+def test_pg_lake_iceberg_table_bc_dates(
+    pg_conn,
+    extension,
+    s3,
+    create_helper_functions,
+    with_default_location,
+):
+    """Verify that BC dates and early-AD timestamps roundtrip correctly through Iceberg write+read.
+
+    Iceberg supports dates from ISO year -9999 to 9999 (BC dates allowed),
+    but timestamps/timestamptz only from 0001-01-01 through 9999-12-31 (AD only).
+    """
+    table_name = "test_pg_lake_iceberg_table_bc_dates"
+    run_command(
+        f"""CREATE TABLE {table_name}(
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command(
+        f"""INSERT INTO {table_name} VALUES
+            ('4712-01-01 BC', '0001-01-01 00:00:00', '0001-01-01 00:00:00+00'),
+            ('0001-01-01 BC', '0001-06-15 12:30:00', '0001-06-15 12:30:00+00'),
+            ('2021-01-01', '2021-01-01 00:00:00', '2021-01-01 00:00:00+00');""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # verify the data roundtrips correctly
+    # cast to text to work around psycopg2 limitation with BC dates
+    # The ::text cast may execute inside DuckDB (query pushdown), which
+    # formats BC as "(BC)".  Normalize to PostgreSQL's " BC" for comparison.
+    result = run_query(
+        f"SELECT col_date::text AS d, col_ts::text AS ts, col_tstz::text AS tstz FROM {table_name} ORDER BY col_date;",
+        pg_conn,
+    )
+
+    assert normalize_bc(result) == [
+        ["4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        ["0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        ["2021-01-01", "2021-01-01 00:00:00", "2021-01-01 00:00:00+00"],
+    ]
+
+    # verify data file stats: BC dates should appear in lower_bounds,
+    # AD dates in upper_bounds
+    for field_id, col_name, col_type in [
+        (1, "col_date", "date"),
+        (2, "col_ts", "timestamp"),
+        (3, "col_tstz", "timestamptz"),
+    ]:
+        result = run_query(
+            f"""SELECT min((lower_bounds->>'{field_id}')::{col_type}) = (SELECT min({col_name}) FROM {table_name}),
+                    max((upper_bounds->>'{field_id}')::{col_type}) = (SELECT max({col_name}) FROM {table_name})
+                FROM lake_iceberg.data_file_stats((SELECT metadata_location FROM iceberg_tables WHERE table_name = '{table_name}'));""",
+            pg_conn,
+        )
+        assert result == [[True, True]], f"stats mismatch for {col_name}"
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command(f"DROP TABLE {table_name}", pg_conn)
+    pg_conn.commit()
+
+
 def test_pg_lake_iceberg_table_random_values(
     pg_conn,
     extension,

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_date.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_date.py
@@ -28,32 +28,32 @@ test_cases = [
     (
         "date_eq",
         "WHERE col_date = '2024-01-01'",
-        "WHERE (col_date = '2024-01-01'::date)",
+        "WHERE (col_date = ('2024-01-01'::text)::date)",
     ),
     (
         "date_ne",
         "WHERE col_date <> '2023-01-01'",
-        "WHERE (col_date <> '2023-01-01'::date)",
+        "WHERE (col_date <> ('2023-01-01'::text)::date)",
     ),
     (
         "date_lt",
         "WHERE col_date < '2024-01-01'",
-        "WHERE (col_date < '2024-01-01'::date)",
+        "WHERE (col_date < ('2024-01-01'::text)::date)",
     ),
     (
         "date_le",
         "WHERE col_date <= '2022-12-31'",
-        "WHERE (col_date <= '2022-12-31'::date)",
+        "WHERE (col_date <= ('2022-12-31'::text)::date)",
     ),
     (
         "date_gt",
         "WHERE col_date > '2023-01-01'",
-        "WHERE (col_date > '2023-01-01'::date)",
+        "WHERE (col_date > ('2023-01-01'::text)::date)",
     ),
     (
         "date_ge",
         "WHERE col_date >= '2022-12-31'",
-        "WHERE (col_date >= '2022-12-31'::date)",
+        "WHERE (col_date >= ('2022-12-31'::text)::date)",
     ),
     (
         "date_eq_timestamp",
@@ -118,22 +118,22 @@ test_cases = [
     (
         "date_pli",
         "WHERE col_date + 1 = '2024-01-02'::date",
-        "WHERE ((col_date + 1) = '2024-01-02'::date)",
+        "WHERE ((col_date + 1) = ('2024-01-02'::text)::date)",
     ),
     (
         "date_mii",
         "WHERE col_date - 1 = '2023-12-31'::date",
-        "WHERE ((col_date - 1) = '2023-12-31'::date)",
+        "WHERE ((col_date - 1) = ('2023-12-31'::text)::date)",
     ),
     (
         "date_pl_interval",
         "WHERE col_date + interval '1 day' = '2024-01-02'::date",
-        "WHERE ((col_date + '1 day'::interval) = '2024-01-02'::date)",
+        "WHERE ((col_date + '1 day'::interval) = ('2024-01-02'::text)::date)",
     ),
     (
         "date_mi_interval",
         "WHERE col_date - interval '1 day' = '2023-12-31'::date",
-        "WHERE ((col_date - '1 day'::interval) = '2023-12-31'::date)",
+        "WHERE ((col_date - '1 day'::interval) = ('2023-12-31'::text)::date)",
     ),
     (
         "datetime_pl",
@@ -148,17 +148,17 @@ test_cases = [
     (
         "date_mi",
         "WHERE col_date - '2023-12-31' = 1",
-        "WHERE ((col_date - '2023-12-31'::date) = 1)",
+        "WHERE ((col_date - ('2023-12-31'::text)::date) = 1)",
     ),
     (
         "date cast",
         "WHERE col_timestamp::date = '2024-01-01'::date",
-        "WHERE ((col_timestamp)::date = '2024-01-01'::date)",
+        "WHERE ((col_timestamp)::date = ('2024-01-01'::text)::date)",
     ),
     (
         "date cast",
         "WHERE col_timestamptz::date = '2024-01-01'::date",
-        "WHERE ((col_timestamptz)::date = '2024-01-01'::date)",
+        "WHERE ((col_timestamptz)::date = ('2024-01-01'::text)::date)",
     ),
 ]
 

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_timestamp.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_timestamp.py
@@ -28,67 +28,67 @@ test_cases = [
     (
         "timestamp_eq",
         "WHERE col_timestamp = '2024-01-01 12:00:00'::timestamp",
-        "WHERE (col_timestamp = '2024-01-01 12:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp = ('2024-01-01 12:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_ne",
         "WHERE col_timestamp <> '2023-01-01 13:00:00'::timestamp",
-        "WHERE (col_timestamp <> '2023-01-01 13:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp <> ('2023-01-01 13:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_lt",
         "WHERE col_timestamp < '2024-01-01 12:00:00'::timestamp",
-        "WHERE (col_timestamp < '2024-01-01 12:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp < ('2024-01-01 12:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_le",
         "WHERE col_timestamp <= '2022-12-31 23:59:59'::timestamp",
-        "WHERE (col_timestamp <= '2022-12-31 23:59:59'::timestamp without time zone)",
+        "WHERE (col_timestamp <= ('2022-12-31 23:59:59'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_gt",
         "WHERE col_timestamp > '2023-01-01 13:00:00'::timestamp",
-        "WHERE (col_timestamp > '2023-01-01 13:00:00'::timestamp without time zone)",
+        "WHERE (col_timestamp > ('2023-01-01 13:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_ge",
         "WHERE col_timestamp >= '2022-12-31 23:59:59'::timestamp",
-        "WHERE (col_timestamp >= '2022-12-31 23:59:59'::timestamp without time zone)",
+        "WHERE (col_timestamp >= ('2022-12-31 23:59:59'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_mi",
         "WHERE col_timestamp - '2022-12-30'::timestamp >= INTERVAL '1 day'",
-        "WHERE ((col_timestamp - '",
+        "WHERE ((col_timestamp - ('",
     ),
     (
         "timestamp_eq_date",
         "WHERE col_timestamp = '2024-01-01'::date",
-        "WHERE (col_timestamp = '2024-01-01'::date)",
+        "WHERE (col_timestamp = ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_ge_date",
         "WHERE col_timestamp >= '2024-01-01'::date",
-        "WHERE (col_timestamp >= '2024-01-01'::date)",
+        "WHERE (col_timestamp >= ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_gt_date",
         "WHERE col_timestamp > '2024-01-01'::date",
-        "WHERE (col_timestamp > '2024-01-01'::date)",
+        "WHERE (col_timestamp > ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_le_date",
         "WHERE col_timestamp <= '2024-01-01'::date",
-        "WHERE (col_timestamp <= '2024-01-01'::date)",
+        "WHERE (col_timestamp <= ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_lt_date",
         "WHERE col_timestamp < '2024-01-01'::date",
-        "WHERE (col_timestamp < '2024-01-01'::date)",
+        "WHERE (col_timestamp < ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_ne_date",
         "WHERE col_timestamp <> '2024-01-01'::date",
-        "WHERE (col_timestamp <> '2024-01-01'::date)",
+        "WHERE (col_timestamp <> ('2024-01-01'::text)::date)",
     ),
     (
         "timestamp_eq_timestamptz",
@@ -123,7 +123,7 @@ test_cases = [
     (
         "timestamp_pl_interval",
         "WHERE col_timestamp + INTERVAL '1 day' = '2024-01-02 12:00:00'::timestamp",
-        "WHERE ((col_timestamp + '1 day'::interval) = '2024-01-02 12:00:00'::timestamp without time zone)",
+        "WHERE ((col_timestamp + '1 day'::interval) = ('2024-01-02 12:00:00'::text)::timestamp without time zone)",
     ),
     (
         "timestamp_mi_interval",

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_timestamptz.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_timestamptz.py
@@ -58,7 +58,7 @@ test_cases = [
     (
         "timestamptz_mi",
         "WHERE col_timestamptz - '2022-12-30'::timestamptz >= INTERVAL '1 day'",
-        "WHERE ((col_timestamptz - '",
+        "WHERE ((col_timestamptz - ('",
     ),
     (
         "timestamptz_eq_date",

--- a/pg_lake_table/tests/pytests/test_iceberg_copy_from_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_copy_from_pushdown.py
@@ -561,3 +561,68 @@ def copy_from_pushdown_setup(superuser_conn):
         superuser_conn,
     )
     superuser_conn.commit()
+
+
+def test_bc_dates_copy_from_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify BC dates roundtrip correctly through COPY FROM pushdown.
+
+    COPY iceberg_table FROM 'file.parquet' goes through WriteQueryResultTo,
+    bypassing PGDuckSerialize.  This test ensures BC dates in a Parquet file
+    are correctly written to the Iceberg table via the pushed-down path.
+    """
+    parquet_url = f"s3://{TEST_BUCKET}/test_bc_copy_from_pushdown/data.parquet"
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    # Write BC dates to a Parquet file
+    run_command(
+        f"""COPY (
+            SELECT '4712-01-01 BC'::date      AS col_date,
+                   '0001-01-01 00:00:00'::timestamp AS col_ts,
+                   '0001-01-01 00:00:00+00'::timestamptz AS col_tstz
+            UNION ALL
+            SELECT '0001-01-01 BC'::date,
+                   '0001-06-15 12:30:00'::timestamp,
+                   '0001-06-15 12:30:00+00'::timestamptz
+            UNION ALL
+            SELECT '2021-01-01'::date,
+                   '2021-01-01 00:00:00'::timestamp,
+                   '2021-01-01 00:00:00+00'::timestamptz
+        ) TO '{parquet_url}';""",
+        pg_conn,
+    )
+
+    run_command(
+        """CREATE TABLE test_bc_copy_target (
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # COPY FROM pushdown
+    run_command(f"COPY test_bc_copy_target FROM '{parquet_url}';", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT col_date::text AS d, col_ts::text AS ts, col_tstz::text AS tstz "
+        "FROM test_bc_copy_target ORDER BY col_date;",
+        pg_conn,
+    )
+
+    assert normalize_bc(result) == [
+        ["4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        ["0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        ["2021-01-01", "2021-01-01 00:00:00", "2021-01-01 00:00:00+00"],
+    ]
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("DROP TABLE test_bc_copy_target;", pg_conn)
+    pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_iceberg_ddl.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_ddl.py
@@ -379,6 +379,94 @@ def test_iceberg_add_column_default(pg_conn, s3, extension, with_default_locatio
     pg_conn.rollback()
 
 
+def test_iceberg_add_column_bc_date_default(
+    pg_conn, s3, extension, with_default_location
+):
+    """Verify BC date and early-AD timestamp defaults round-trip through Iceberg JSON serde.
+
+    Iceberg supports dates from ISO year -9999 to 9999 (BC dates allowed),
+    but timestamps/timestamptz only from 0001-01-01 through 9999-12-31 (AD only).
+
+    When a column is added with a BC date default, the value is serialized to
+    Iceberg metadata JSON via PGIcebergJsonSerialize (ConvertBCToISOYear).
+    Old rows that predate the column read the initial-default back via
+    PGIcebergJsonDeserialize (ConvertISOYearToBC).
+    """
+    run_command("CREATE SCHEMA bc_default_test;", pg_conn)
+    run_command(
+        "CREATE TABLE bc_default_test.tbl (a int) USING iceberg",
+        pg_conn,
+    )
+    # row inserted before the default columns exist
+    run_command("INSERT INTO bc_default_test.tbl VALUES (1)", pg_conn)
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    # add columns with defaults — BC for date, early-AD for timestamps
+    run_command(
+        "ALTER TABLE bc_default_test.tbl "
+        "ADD COLUMN d date DEFAULT '4712-01-01 BC', "
+        "ADD COLUMN ts timestamp DEFAULT '0001-01-01 00:00:00', "
+        "ADD COLUMN tstz timestamptz DEFAULT '0001-01-01 00:00:00+00'",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # ── verify Iceberg metadata JSON stores ISO 8601 year numbering ──
+    metadata_location = run_query(
+        "SELECT metadata_location FROM iceberg_tables "
+        "WHERE table_name = 'tbl' AND table_namespace = 'bc_default_test'",
+        pg_conn,
+    )[0][0]
+    returned_json = normalize_json(read_s3_operations(s3, metadata_location))
+    latest_schema = returned_json["schemas"][-1]
+    fields_by_name = {f["name"]: f for f in latest_schema["fields"]}
+
+    # date: "4712-01-01 BC" → ISO "-4711-01-01"
+    assert fields_by_name["d"]["write-default"] == "-4711-01-01"
+    assert fields_by_name["d"]["initial-default"] == "-4711-01-01"
+
+    # timestamp: "0001-01-01 00:00:00" → "0001-01-01T00:00:00" (AD, no BC conversion)
+    assert fields_by_name["ts"]["write-default"] == "0001-01-01T00:00:00"
+    assert fields_by_name["ts"]["initial-default"] == "0001-01-01T00:00:00"
+
+    # timestamptz: "0001-01-01 00:00:00+00" → "0001-01-01T00:00:00+00:00" (AD, no BC conversion)
+    assert fields_by_name["tstz"]["write-default"] == "0001-01-01T00:00:00+00:00"
+    assert fields_by_name["tstz"]["initial-default"] == "0001-01-01T00:00:00+00:00"
+
+    # row with explicit values — BC date, early-AD timestamps
+    run_command(
+        "INSERT INTO bc_default_test.tbl VALUES "
+        "(2, '0001-01-01 BC', '0001-06-15 12:30:00', '0001-06-15 12:30:00+00')",
+        pg_conn,
+    )
+
+    # row relying on defaults (write-default path)
+    run_command("INSERT INTO bc_default_test.tbl(a) VALUES (3)", pg_conn)
+
+    # cast to text to work around psycopg2 limitation with BC dates
+    # The ::text cast may execute inside DuckDB (query pushdown), which
+    # formats BC as "(BC)".  Normalize to PostgreSQL's " BC" for comparison.
+    results = run_query(
+        "SELECT a, d::text AS d, ts::text AS ts, tstz::text AS tstz "
+        "FROM bc_default_test.tbl ORDER BY a",
+        pg_conn,
+    )
+
+    assert normalize_bc(results) == [
+        # row 1: initial-default from Iceberg JSON deserialization
+        [1, "4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        # row 2: explicit values
+        [2, "0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        # row 3: write-default applied at insert time
+        [3, "4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+    ]
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("DROP SCHEMA bc_default_test CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
 def test_iceberg_add_nested_column_default(
     pg_conn, s3, extension, with_default_location
 ):

--- a/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
@@ -723,3 +723,75 @@ def test_insert_select_dropped_cols(s3, pg_conn, extension, with_default_locatio
     assert res == [[22]]
 
     pg_conn.rollback()
+
+
+def test_bc_dates_insert_select_pushdown(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+):
+    """Verify BC dates roundtrip correctly through INSERT SELECT pushdown.
+
+    INSERT INTO iceberg_table SELECT * FROM iceberg_table goes through
+    WriteQueryResultTo (DuckDB-side COPY), bypassing PGDuckSerialize.
+    This test ensures the ISO-year conversion produces correct results
+    in the pushed-down path.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_bc_insert_pushdown;
+        SET search_path TO test_bc_insert_pushdown;
+
+        CREATE TABLE source (
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;
+
+        CREATE TABLE target (
+            col_date date,
+            col_ts timestamp,
+            col_tstz timestamptz
+        ) USING iceberg;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+    run_command(
+        """INSERT INTO source VALUES
+            ('4712-01-01 BC', '0001-01-01 00:00:00', '0001-01-01 00:00:00+00'),
+            ('0001-01-01 BC', '0001-06-15 12:30:00', '0001-06-15 12:30:00+00'),
+            ('2021-01-01', '2021-01-01 00:00:00', '2021-01-01 00:00:00+00');""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # INSERT SELECT pushdown: data flows through DuckDB without PGDuckSerialize
+    results = run_query(
+        "EXPLAIN (VERBOSE) INSERT INTO target SELECT * FROM source",
+        pg_conn,
+    )
+    assert "Custom Scan (Query Pushdown)" in str(results)
+
+    run_command("INSERT INTO target SELECT * FROM source", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT col_date::text AS d, col_ts::text AS ts, col_tstz::text AS tstz "
+        "FROM target ORDER BY col_date;",
+        pg_conn,
+    )
+
+    assert normalize_bc(result) == [
+        ["4712-01-01 BC", "0001-01-01 00:00:00", "0001-01-01 00:00:00+00"],
+        ["0001-01-01 BC", "0001-06-15 12:30:00", "0001-06-15 12:30:00+00"],
+        ["2021-01-01", "2021-01-01 00:00:00", "2021-01-01 00:00:00+00"],
+    ]
+
+    run_command("RESET TIME ZONE;", pg_conn)
+    run_command("RESET search_path;", pg_conn)
+    run_command("DROP SCHEMA test_bc_insert_pushdown CASCADE;", pg_conn)
+    pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_partition_pruning.py
+++ b/pg_lake_table/tests/pytests/test_partition_pruning.py
@@ -88,6 +88,40 @@ pruning_data = [
     ),
     (
         True,
+        "date",
+        "prune_date_bc",
+        [
+            ("4712-01-01 BC", "4712-01-01 BC"),
+            ("4712-01-01 BC", "0001-01-01 BC"),
+            ("0001-01-01 BC", "4712-01-01 BC"),
+            ("0001-01-01 BC", "0001-01-01 BC"),
+        ],
+    ),
+    # Iceberg timestamps only support AD years 0001–9999; use early-AD values
+    (
+        True,
+        "timestamp",
+        "prune_timestamp_early_ad",
+        [
+            ("0001-01-01 00:00:00", "0001-01-01 00:00:00"),
+            ("0001-01-01 00:00:00", "0002-06-15 12:30:00"),
+            ("0002-06-15 12:30:00", "0001-01-01 00:00:00"),
+            ("0002-06-15 12:30:00", "0002-06-15 12:30:00"),
+        ],
+    ),
+    (
+        True,
+        "timestamptz",
+        "prune_timestamptz_early_ad",
+        [
+            ("0001-01-01 00:00:00+00", "0001-01-01 00:00:00+00"),
+            ("0001-01-01 00:00:00+00", "0002-06-15 12:30:00+00"),
+            ("0002-06-15 12:30:00+00", "0001-01-01 00:00:00+00"),
+            ("0002-06-15 12:30:00+00", "0002-06-15 12:30:00+00"),
+        ],
+    ),
+    (
+        True,
         "time",
         "prune_time",
         [
@@ -572,6 +606,88 @@ def test_datetime_partition_pruning_simple(
             pg_conn,
         )
         assert len(rows) == expected_rows, f"rows: {sql}"
+    run_command("RESET TIME ZONE;", pg_conn)
+    pg_conn.rollback()
+
+
+# Iceberg timestamps only support AD years (0001–9999), so only date
+# columns use BC values for partition pruning tests.
+bc_col_types = ["date"]
+bc_partition_types = ["year", "month", "day"]
+
+
+@pytest.mark.parametrize("partition_by", bc_partition_types)
+@pytest.mark.parametrize("col_type", bc_col_types)
+def test_bc_date_partition_pruning(
+    s3,
+    disable_data_file_pruning,
+    pg_conn,
+    extension,
+    with_default_location,
+    col_type,
+    partition_by,
+):
+    """Verify partition pruning works correctly with BC dates."""
+
+    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
+
+    run_command(
+        f"""
+        CREATE SCHEMA test_bc_partition;
+        CREATE TABLE  test_bc_partition.tbl (
+            col_date {col_type}
+        ) USING iceberg
+        WITH (
+            autovacuum_enabled = 'False',
+            partition_by       = '{partition_by}(col_date)'
+        );
+        SET TIME ZONE 'UTC';
+    """,
+        pg_conn,
+    )
+
+    # insert BC and AD dates into separate data files via separate inserts
+    dates = [
+        "4712-01-01 BC",
+        "1000-01-01 BC",
+        "0001-01-01 BC",
+        "0001-01-01",
+        "1970-01-01",
+        "2021-01-01",
+    ]
+    values_sql = ",".join(f"('{d}')" for d in dates)
+    run_command(
+        f"INSERT INTO test_bc_partition.tbl VALUES {values_sql};",
+        pg_conn,
+    )
+
+    # use count(*) to avoid psycopg2 issues with BC date objects
+    filter_tests = [
+        ("col_date = '4712-01-01 BC'", 1, 1),
+        ("col_date = '0001-01-01 BC'", 1, 1),
+        ("col_date = '2021-01-01'", 1, 1),
+        ("col_date <= '0001-01-01 BC'", 3, 3),
+        ("col_date >= '0001-01-01'", 3, 3),
+        ("col_date BETWEEN '4712-01-01 BC' AND '0001-01-01 BC'", 3, 3),
+        ("col_date BETWEEN '0001-01-01' AND '2021-01-01'", 3, 3),
+        ("col_date BETWEEN '4712-01-01 BC' AND '2021-01-01'", 6, 6),
+        ("col_date = '9999-01-01'", 0, 0),
+        ("col_date > '2021-01-01'", 0, 1),
+    ]
+
+    for sql, expected_rows, expected_files in filter_tests:
+        plan = run_query(
+            f"{explain_prefix} SELECT * FROM test_bc_partition.tbl WHERE {sql}",
+            pg_conn,
+        )
+        assert fetch_data_files_used(plan) == str(expected_files), f"files: {sql}"
+
+        count = run_query(
+            f"SELECT count(*) FROM test_bc_partition.tbl WHERE {sql};",
+            pg_conn,
+        )
+        assert count[0][0] == expected_rows, f"rows: {sql}"
+
     run_command("RESET TIME ZONE;", pg_conn)
     pg_conn.rollback()
 

--- a/test_common/helpers/comparisons.py
+++ b/test_common/helpers/comparisons.py
@@ -14,6 +14,7 @@ from .db import (
 # Value / row comparison helpers
 # ---------------------------------------------------------------------------
 
+
 def compare_values(val1, val2, tolerance):
     if isinstance(val1, float) and isinstance(val2, float):
         return abs(val1 - val2) <= tolerance
@@ -129,6 +130,7 @@ def compare_results_with_duckdb(
 # Query-result assertion helpers
 # ---------------------------------------------------------------------------
 
+
 def assert_query_results_on_tables(
     query, pg_conn, first_table_names, second_table_names, tolerance=0.001
 ):
@@ -203,3 +205,25 @@ def assert_query_result_on_duckdb_and_pg(duckdb_conn, pg_conn, duckdb_query, pg_
 def check_table_size(pg_conn, table_name, count):
     result = run_query(f"SELECT count(*) FROM {table_name}", pg_conn)
     assert result[0]["count"] == count
+
+
+def normalize_bc(rows):
+    """Normalize DuckDB's '(BC) between date and time' to PG's 'BC at end'.
+
+    When a ``::text`` cast is pushed down to DuckDB, BC dates are formatted
+    with parentheses and the indicator sits between the date and time parts
+    (e.g. ``"4712-01-01 (BC) 00:00:00"``).  PostgreSQL places ``BC`` at the
+    end without parentheses (``"4712-01-01 00:00:00 BC"``).  This helper
+    normalises query results so assertions can use the PostgreSQL convention.
+    """
+
+    def _fix(v):
+        if not isinstance(v, str):
+            return v
+        v = v.replace(" (BC)", " BC")
+        # DuckDB: "YYYY-MM-DD BC HH:MM:SS" → PG: "YYYY-MM-DD HH:MM:SS BC"
+        if " BC " in v:
+            v = v.replace(" BC ", " ", 1) + " BC"
+        return v
+
+    return [[_fix(v) for v in row] for row in rows]


### PR DESCRIPTION
- [x] BC-era dates/timestamps are serialized to ISO 8601 negative-year format when sent to DuckDB
- [x] Iceberg JSON/binary serde round-trips them correctly.
- [x] IsPGDuckSerializeRequired returning true for date/ts/tstz causes RewriteConst to rewrite date constants as ('...'::text)::date, which explains the operator_pushdown test changes.
