### PR TITLE
Unbounded numeric stays as numeric in PG schema, still writes as DECIMAL(38,9) to Iceberg

### DIFF
--- a/pg_lake_benchmark/tests/pytests/test_tpch.py
+++ b/pg_lake_benchmark/tests/pytests/test_tpch.py
@@ -114,12 +114,19 @@ def test_tpch_answers(
             pgduck_conn,
         )
 
+        # Load CSV into a temp heap table, then create the answer as an iceberg
+        # table so both sides go through the same DECIMAL(38,9) truncation path.
         run_command(
             f"""
-                    CREATE TABLE answer_{query_nr} (LIKE result_{query_nr});
-                    COPY answer_{query_nr} FROM '{answer_location}' (format 'csv', delimiter '|',
+                    CREATE TEMP TABLE _load_answer_{query_nr} (LIKE result_{query_nr});
+                    COPY _load_answer_{query_nr} FROM '{answer_location}' (format 'csv', delimiter '|',
                                                                      header 'true', quote '');
                     """,
+            pg_conn,
+        )
+
+        run_command(
+            f"CREATE TABLE answer_{query_nr} USING iceberg AS SELECT * FROM _load_answer_{query_nr}",
             pg_conn,
         )
 
@@ -184,12 +191,19 @@ def test_tpch_partitioned_answers(
             pgduck_conn,
         )
 
+        # Load CSV into a temp heap table, then create the answer as an iceberg
+        # table so both sides go through the same DECIMAL(38,9) truncation path.
         run_command(
             f"""
-                    CREATE TABLE answer_{query_nr} (LIKE result_{query_nr});
-                    COPY answer_{query_nr} FROM '{answer_location}' (format 'csv', delimiter '|',
+                    CREATE TEMP TABLE _load_answer_{query_nr} (LIKE result_{query_nr});
+                    COPY _load_answer_{query_nr} FROM '{answer_location}' (format 'csv', delimiter '|',
                                                                      header 'true', quote '');
                     """,
+            pg_conn,
+        )
+
+        run_command(
+            f"CREATE TABLE answer_{query_nr} USING iceberg AS SELECT * FROM _load_answer_{query_nr}",
             pg_conn,
         )
 

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -647,15 +647,17 @@ CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist)
 }
 
 /*
- * ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits ensures the digits for
- * both precision and scale of the numeric, in string, does not exceed the max
- * allowed digits during COPY TO.
+ * ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits ensures the integral
+ * digits of the numeric string do not exceed the max allowed digits during
+ * COPY TO.
+ *
+ * Excess fractional (decimal) digits are intentionally allowed here because
+ * DuckDB's DECIMAL(P,S) will round them during the CSV-to-Parquet conversion.
  */
 static void
 ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr)
 {
 	int			totalIntegralDigits = 0;
-	int			totalDecimalDigits = 0;
 	bool		foundDotSeparator = false;
 
 	for (int i = 0; numericStr[i] != '\0'; i++)
@@ -669,9 +671,7 @@ ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr)
 		if (!isdigit(numericStr[i]))
 			continue;
 
-		if (foundDotSeparator)
-			totalDecimalDigits++;
-		else
+		if (!foundDotSeparator)
 			totalIntegralDigits++;
 
 		if (totalIntegralDigits > (UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale))
@@ -680,15 +680,6 @@ ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr)
 							errmsg("unbounded numeric type exceeds max allowed digits %d "
 								   "before decimal point",
 								   UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale),
-							errhint("Consider specifying precision and scale for numeric types, "
-									"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
-		}
-
-		if (totalDecimalDigits > UnboundedNumericDefaultScale)
-		{
-			ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
-							errmsg("unbounded numeric type exceeds max allowed digits %d "
-								   "after decimal point", UnboundedNumericDefaultScale),
 							errhint("Consider specifying precision and scale for numeric types, "
 									"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
 		}

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_numeric_binary_serde.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_numeric_binary_serde.h
@@ -21,5 +21,5 @@
 
 #include "pg_lake/pgduck/type.h"
 
-extern PGDLLEXPORT unsigned char *PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen);
+extern PGDLLEXPORT unsigned char *PGNumericIcebergBinarySerialize(Datum numericDatum, int icebergScale, size_t *binaryLen);
 extern PGDLLEXPORT Datum PGNumericIcebergBinaryDeserialize(unsigned char *numericBinary, size_t binaryLen, PGType pgType);

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
@@ -26,6 +26,7 @@
 #include "pg_lake/iceberg/iceberg_type_binary_serde.h"
 #include "pg_lake/iceberg/iceberg_type_numeric_binary_serde.h"
 #include "pg_lake/iceberg/utils.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/timetz.h"
 
 #include "port/pg_bswap.h"
@@ -310,8 +311,22 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 	}
 	else if (pgType.postgresTypeOid == NUMERICOID)
 	{
-		/* generate numeric binary in bigendian */
-		binaryValue = PGNumericIcebergBinarySerialize(datum, binaryLen);
+		/*
+		 * Generate numeric binary in big-endian.  The Iceberg spec requires
+		 * the unscaled integer at the schema's scale, so we must pass the
+		 * target scale.  For unbounded numeric (typmod == -1) this falls back
+		 * to the default Iceberg scale via
+		 * GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod.
+		 */
+		int			precision;
+		int			scale;
+
+		GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(
+															 pgType.postgresTypeMod,
+															 &precision, &scale);
+
+		binaryValue = PGNumericIcebergBinarySerialize(datum, scale,
+													  binaryLen);
 	}
 	else if (pgType.postgresTypeOid == UUIDOID)
 	{

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_numeric_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_numeric_binary_serde.c
@@ -20,12 +20,13 @@
 #include "utils/numeric.h"
 
 #include "pg_lake/iceberg/iceberg_type_numeric_binary_serde.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/numeric.h"
 
 
 static unsigned char *NumericStrToBigEndianBinary(const char *numericStr);
 static char *BigEndianBinaryToNumericStr(unsigned char *numericBinary, int scale, bool isNegative);
-static char *NormalizeNumericStr(const char *numericStr);
+static char *NormalizeNumericStr(const char *numericStr, int targetScale);
 static void TwosComplement(unsigned char *numericBinary);
 static unsigned char *StripLeadingBytes(const unsigned char *binaryValue, size_t *binaryLen, bool isNegative);
 static unsigned char *SignExtendNumericBinary(const unsigned char *numericBinary, size_t binaryLen);
@@ -37,7 +38,8 @@ static unsigned char *SignExtendNumericBinary(const unsigned char *numericBinary
  * number of bytes)
  */
 unsigned char *
-PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen)
+PGNumericIcebergBinarySerialize(Datum numericDatum, int icebergScale,
+								size_t *binaryLen)
 {
 	Numeric numeric = DatumGetNumeric(numericDatum);
 
@@ -61,7 +63,8 @@ PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen)
 
 	bool		isNegative = (*numericStr == '-');
 
-	char	   *normalizedNumericStr = NormalizeNumericStr(numericStr);
+	char	   *normalizedNumericStr = NormalizeNumericStr(numericStr,
+														   icebergScale);
 
 	unsigned char *numericBinary = NumericStrToBigEndianBinary(normalizedNumericStr);
 
@@ -81,7 +84,11 @@ PGNumericIcebergBinarySerialize(Datum numericDatum, size_t *binaryLen)
 Datum
 PGNumericIcebergBinaryDeserialize(unsigned char *numericBinary, size_t binaryLen, PGType pgType)
 {
-	int			scale = numeric_typmod_scale(pgType.postgresTypeMod);
+	int			precision;
+	int			scale;
+
+	GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(pgType.postgresTypeMod,
+														 &precision, &scale);
 
 	bool		isNegative = (numericBinary[0] & 0x80) != 0;
 
@@ -245,10 +252,17 @@ BigEndianBinaryToNumericStr(unsigned char *numericBinary, int scale,
 
 /*
  * NormalizeNumericStr normalizes a Postgres numeric string by removing sign
- * and decimal point.
+ * and decimal point, producing the unscaled integer string for the given
+ * target Iceberg scale.
+ *
+ * The fractional part is padded with trailing zeros (or truncated) to
+ * exactly targetScale digits.  For example:
+ *   "7"         with targetScale=9 → "7000000000"
+ *   "7.5"       with targetScale=9 → "7500000000"
+ *   "7.123456789012" with targetScale=9 → "7123456789"
  */
 static char *
-NormalizeNumericStr(const char *numericStr)
+NormalizeNumericStr(const char *numericStr, int targetScale)
 {
 	const char *p = numericStr;
 
@@ -257,7 +271,7 @@ NormalizeNumericStr(const char *numericStr)
 		p++;
 	}
 
-	/* 2. Remove decimal point if any */
+	/* Find decimal point if any */
 	const char *dot = strchr(p, '.');
 	int			integralLen,
 				fractionLen;
@@ -273,23 +287,27 @@ NormalizeNumericStr(const char *numericStr)
 		fractionLen = 0;
 	}
 
-	/* Build a pure integer string without decimal point */
-	/* For example "123.45" with scale=2 becomes "12345". */
-	int			totalLen = integralLen + fractionLen;
+	/*
+	 * Build a pure integer string representing the unscaled value at the
+	 * target scale.  E.g. "123.45" with targetScale=9 becomes "123450000000".
+	 */
+	int			totalLen = integralLen + targetScale;
 	char	   *normalizedStr = palloc0(totalLen + 1);
 
-	if (dot)
-	{
-		/* copy integral part */
-		memcpy(normalizedStr, p, integralLen);
-		/* copy fractional part */
-		memcpy(normalizedStr + integralLen, dot + 1, fractionLen);
-	}
-	else
-	{
-		/* no decimal point */
-		memcpy(normalizedStr, p, totalLen);
-	}
+	/* Copy integral part */
+	memcpy(normalizedStr, p, integralLen);
+
+	/* Copy fractional digits (up to targetScale) */
+	int			copyFraction = (fractionLen < targetScale) ? fractionLen : targetScale;
+
+	if (dot && copyFraction > 0)
+		memcpy(normalizedStr + integralLen, dot + 1, copyFraction);
+
+	/* Pad remaining fractional positions with zeros */
+	for (int i = copyFraction; i < targetScale; i++)
+		normalizedStr[integralLen + i] = '0';
+
+	normalizedStr[totalLen] = '\0';
 
 	return normalizedStr;
 }

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -86,8 +86,6 @@ PgLakeIsReservedColumnNameHookType PgLakeIsReservedColumnNameHook = NULL;
 
 static bool IsCreateLakeTable(CreateForeignTableStmt *createStmt);
 static void AddLakeTableColumnDefinitions(CreateForeignTableStmt *createStmt);
-static bool IsForeignTableStmtWithUnboundedNumericColumns(CreateForeignTableStmt *createStmt);
-static void SetDefaultPrecisionAndScaleForUnboundedNumericColumns(List *columnDefList);
 static bool IsJsonOrCSVBackedTable(PgLakeTableType tableType, List *options);
 static void ErrorIfUnsupportedColumnTypeForJsonOrCSVTables(List *columnDefList);
 static void ErrorIfUsingGeometryWithoutSpatialAnalytics(List *columnDefList);
@@ -594,23 +592,6 @@ ProcessCreateLakeTable(ProcessUtilityParams * params)
 	}
 
 	/*
-	 * If there are unbounded numerics, we assign them a scale and precision.
-	 */
-	if (IsForeignTableStmtWithUnboundedNumericColumns(createStmt))
-	{
-		/* we will adjust numerics in the parse tree */
-		if (params->readOnlyTree)
-			createStmt = (CreateForeignTableStmt *) CopyUtilityStmt(params);
-
-		SetDefaultPrecisionAndScaleForUnboundedNumericColumns(createStmt->base.tableElts);
-
-		/*
-		 * Note: we do not explicitly rerun handlers from the start, since we
-		 * expect the statement to be ready for execution.
-		 */
-	}
-
-	/*
 	 * If there is a filename option, check whether the _filename column is in
 	 * the right place.
 	 */
@@ -812,14 +793,6 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		 * rely on the schema name in PostProcessCreateIcebergTable.
 		 */
 		createStmt->base.relation->schemaname = get_namespace_name(namespaceId);
-	}
-
-	/*
-	 * If there are unbounded numerics, we assign them a scale and precision.
-	 */
-	if (createStmt->base.partbound == NULL && IsForeignTableStmtWithUnboundedNumericColumns(createStmt))
-	{
-		SetDefaultPrecisionAndScaleForUnboundedNumericColumns(createStmt->base.tableElts);
 	}
 
 	DefElem    *locationOption = GetOption(createStmt->options, "location");
@@ -1502,104 +1475,6 @@ ExpandTableLikeClause(TableLikeClause *table_like_clause)
 	table_close(relation, NoLock);
 
 	return newColumns;
-}
-
-
-/*
- * IsForeignTableStmtWithUnboundedNumericColumns checks whether the given
- * CreateForeignTableStmt has unbounded numeric columns.
- */
-static bool
-IsForeignTableStmtWithUnboundedNumericColumns(CreateForeignTableStmt *createStmt)
-{
-	ListCell   *columnDefCell = NULL;
-
-	foreach(columnDefCell, createStmt->base.tableElts)
-	{
-		/* could be LIKE clause or constraint clause */
-		if (!IsA(lfirst(columnDefCell), ColumnDef))
-		{
-			continue;
-		}
-
-		ColumnDef  *columnDef = (ColumnDef *) lfirst(columnDefCell);
-
-		int32		typmod = 0;
-		bool		missingOK = true;
-		Type		typeTuple = LookupTypeName(NULL, columnDef->typeName, &typmod, missingOK);
-
-		if (typeTuple == NULL)
-		{
-			/*
-			 * type not found, could be serial. But we are sure it is not
-			 * numeric
-			 */
-			continue;
-		}
-
-		Oid			typeOid = typeTypeId(typeTuple);
-
-		ReleaseSysCache(typeTuple);
-
-		if (IsUnboundedNumeric(typeOid, typmod))
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
-
-
-/*
- * SetDefaultPrecisionAndScaleForUnboundedNumericColumns sets the default
- * precision and scale for unbounded numeric columns.
- */
-static void
-SetDefaultPrecisionAndScaleForUnboundedNumericColumns(List *columnDefList)
-{
-	ListCell   *columnDefCell = NULL;
-
-	foreach(columnDefCell, columnDefList)
-	{
-		/* could be LIKE clause or constraint clause */
-		if (!IsA(lfirst(columnDefCell), ColumnDef))
-		{
-			continue;
-		}
-
-		ColumnDef  *columnDef = (ColumnDef *) lfirst(columnDefCell);
-
-		int32		typmod = 0;
-		bool		missingOK = true;
-		Type		typeTuple = LookupTypeName(NULL, columnDef->typeName, &typmod, missingOK);
-
-		if (typeTuple == NULL)
-		{
-			/*
-			 * type not found, could be serial. But we are sure it is not
-			 * numeric
-			 */
-			continue;
-		}
-
-		Oid			typeOid = typeTypeId(typeTuple);
-
-		if (IsUnboundedNumeric(typeOid, typmod))
-		{
-			int			newTypMod = make_numeric_typmod(UnboundedNumericDefaultPrecision,
-														UnboundedNumericDefaultScale);
-
-			columnDef->typeName = makeTypeNameFromOid(typeOid, newTypMod);
-
-			ereport(NOTICE, (errmsg("setting default precision and scale for unbounded numeric column \"%s\" to (%d, %d)",
-									columnDef->colname, UnboundedNumericDefaultPrecision,
-									UnboundedNumericDefaultScale),
-							 errdetail("Iceberg tables do not fully support unbounded numeric columns.")));
-		}
-
-		ReleaseSysCache(typeTuple);
-	}
 }
 
 

--- a/pg_lake_table/tests/pytests/test_iceberg_types.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_types.py
@@ -2195,7 +2195,7 @@ def test_field_id_mappings(
     assert top_level_mappings == [
         ["verify_field_id_mapping.test_table", 1, "int_col", "integer", -1],
         ["verify_field_id_mapping.test_table", 2, "array_int_col", "integer[]", -1],
-        ["verify_field_id_mapping.test_table", 4, "numeric_col", "numeric", 2490381],
+        ["verify_field_id_mapping.test_table", 4, "numeric_col", "numeric", -1],
         [
             "verify_field_id_mapping.test_table",
             5,

--- a/pg_lake_table/tests/pytests/test_unbounded_numeric.py
+++ b/pg_lake_table/tests/pytests/test_unbounded_numeric.py
@@ -123,18 +123,14 @@ def test_unbounded_numeric_pushdown(s3, pg_conn, extension):
 def test_copy_to_unbounded_numeric_with_default(s3, pg_conn, extension):
     uri = f"s3://{TEST_BUCKET}/unbounded_numeric.parquet"
 
-    error = run_command(
+    # random()::numeric may have more than 9 decimal digits, but DuckDB's
+    # DECIMAL(38,9) rounds the excess fractional digits — this should succeed.
+    run_command(
         f"""
         copy (select random()::numeric)
         to '{uri}'
     """,
         pg_conn,
-        raise_error=False,
-    )
-
-    assert (
-        "unbounded numeric type exceeds max allowed digits 9 after decimal point"
-        in error
     )
 
     pg_conn.rollback()
@@ -162,18 +158,17 @@ def test_copy_to_exceeds_unbounded_numeric_max_integral_digits(s3, pg_conn, exte
 def test_copy_to_exceeds_unbounded_numeric_max_decimal_digits(s3, pg_conn, extension):
     uri = f"s3://{TEST_BUCKET}/numeric_exceeds_max_decimal.parquet"
 
-    invalid_numeric = "23.1234567890123"
+    # 13 decimal digits exceed scale 9, but DuckDB's DECIMAL(38,9) rounds
+    # the excess fractional digits — this should succeed.
+    numeric_val = "23.1234567890123"
 
-    error = run_command(
+    run_command(
         f"""
-        copy (select 12 as id, {invalid_numeric}::numeric as a)
+        copy (select 12 as id, {numeric_val}::numeric as a)
         to '{uri}'
     """,
         pg_conn,
-        raise_error=False,
     )
-
-    assert "numeric type exceeds max allowed digits 9 after decimal point" in error
 
     pg_conn.rollback()
 
@@ -266,7 +261,7 @@ def test_pg_lake_table_explicit(s3, pg_conn, extension, copy_numeric_to_file):
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'pg_lake_table_explicit' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", 38, 9]]
+    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT numeric_large, numeric_small, numeric_unbounded FROM pg_lake_table_explicit {expected_expression}"
@@ -296,7 +291,7 @@ def test_writable_pg_lake_table(s3, pg_conn, extension, copy_numeric_to_file):
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'writable_pg_lake_table' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", 10, 5]]
+    assert result == [["numeric", 39, 10], ["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT * FROM writable_pg_lake_table {expected_expression}"
@@ -367,7 +362,7 @@ def test_iceberg_table_explicit(s3, pg_conn, extension, with_default_location):
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'iceberg_table' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 5, 3], ["numeric", 10, 5]]
+    assert result == [["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT * FROM iceberg_table {expected_expression}"
@@ -390,7 +385,7 @@ def test_iceberg_create_as_select(s3, pg_conn, extension, with_default_location)
         "select data_type, numeric_precision, numeric_scale from information_schema.columns where table_name = 'iceberg_table' order by column_name",
         pg_conn,
     )
-    assert result == [["numeric", 5, 3], ["numeric", 38, 9]]
+    assert result == [["numeric", 5, 3], ["numeric", None, None]]
 
     expected_expression = "WHERE (abs(numeric_unbounded) > (1)::numeric)"
     query = f"SELECT numeric_small, numeric_unbounded FROM iceberg_table {expected_expression}"


### PR DESCRIPTION
- [x] Remove SetDefaultPrecisionAndScaleForUnboundedNumericColumns from create_table.c so that unbounded numeric columns keep their native PG type (numeric without precision/scale) in the foreign table schema.
- [x] Update Iceberg binary serde to pass the target Iceberg scale (from GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod) to PGNumericIcebergBinarySerialize and NormalizeNumericStr, ensuring values are still written as DECIMAL(38,9) in Iceberg data files.


