### PR TITLE
Use index scan in CheckObjectCreatedByLakeInternal

### DIFF
--- a/pg_lake_table/src/test/hide_lake_objects.c
+++ b/pg_lake_table/src/test/hide_lake_objects.c
@@ -356,7 +356,7 @@ CheckObjectCreatedByLakeInternal(HTAB *referencedObjectsMap, ObjectAddress refer
 				BTEqualStrategyNumber, F_OIDEQ,
 				ObjectIdGetDatum(referencingAddress.objectId));
 
-	scanDesc = systable_beginscan(pgDependRel, InvalidOid, false,
+	scanDesc = systable_beginscan(pgDependRel, DependDependerIndexId, true,
 								  NULL, 2, scanKey);
 
 	bool		createdByLake = false;


### PR DESCRIPTION
## Description

In `installcheck-postgres-with_extensions_created` test suite, we `SET pg_lake_table.hide_objects_created_by_lake=true`. This GUC checks for objects created by `pg_lake` by scanning `pg_depend` sequentially.

By using an index scan, each `pg_depend` lookup goes from O(N) to O(log N) index lookup, speeding up the test to the normal speed of `installcheck-postgres` test without extensions created.

[test-installcheck-postgres (18, installcheck-postgres)](https://github.com/Snowflake-Labs/pg_lake/actions/runs/23043279911/job/66926697499?pr=261#logs) succeeded in 2m 46s
[test-installcheck-postgres (18, installcheck-postgres-with_extensions_created)](https://github.com/Snowflake-Labs/pg_lake/actions/runs/23043279911/job/66926697466?pr=261#logs) succeeded in 2m 44s

Fixes #19 

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**