### PR TITLE
Fix crash in hide_lake_objects for MERGE on catalog tables

### DIFF
--- a/pg_lake_table/src/test/hide_lake_objects.c
+++ b/pg_lake_table/src/test/hide_lake_objects.c
@@ -278,8 +278,25 @@ HideObjectsCreatedByLakeFromCatalogTables(Node *node, void *context)
 					CreateObjectCreatedByLakeExpr(catalogTableOid, varno);
 
 				/*
-				 * we add the new expr to the existing quals
+				 * In PG17+, transform_MERGE_to_join() moves jointree->quals
+				 * into a FromExpr scoped to only mergeTargetRelation, and
+				 * uses mergeJoinCondition as the JoinExpr->quals that can
+				 * see both sides. So source RTE quals must go in
+				 * mergeJoinCondition to avoid referencing a varno outside
+				 * the target-only scope (see prepjointree.c).
 				 */
+#if PG_VERSION_NUM >= 170000
+				if (query->commandType == CMD_MERGE &&
+					varno != query->mergeTargetRelation)
+				{
+					query->mergeJoinCondition =
+						make_and_qual(query->mergeJoinCondition,
+									  createdByLakeExpr);
+					MemoryContextSwitchTo(originalContext);
+					continue;
+				}
+#endif
+
 				query->jointree->quals = make_and_qual(query->jointree->quals, createdByLakeExpr);
 
 				MemoryContextSwitchTo(originalContext);


### PR DESCRIPTION
## Description

In PG17+, `transform_MERGE_to_join()` moves `jointree->quals` into a `FromExpr` scoped to only the target relation. Place source RTE quals in `mergeJoinCondition` instead to keep them in scope.

Relevant PG commit: https://github.com/postgres/postgres/commit/0294df2f1

Note to reviewer: PG built with assertions enabled, can verify by running
`make installcheck-postgres-with_extensions_created PG_REGRESS_DIR=$PG_REGRESS_DIR`

Fixes #263 

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**