### PR TITLE
Fix: add --break-system-packages for pipenv install on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -678,9 +678,9 @@ install_test_deps() {
     if ! command -v pipenv &>/dev/null; then
         print_info "Installing pipenv..."
         if command -v pip3 &>/dev/null; then
-            pip3 install --user pipenv
+            pip3 install --user pipenv || pip3 install --user --break-system-packages pipenv
         elif command -v python3 &>/dev/null; then
-            python3 -m pip install --user pipenv
+            python3 -m pip install --user pipenv || python3 -m pip install --user --break-system-packages pipenv
         else
             print_warning "pip3 or python3 not found. Please install pipenv manually:"
             print_warning "  Debian/Ubuntu: sudo apt-get install pipenv"


### PR DESCRIPTION
## Description

Use --break-system-packages flag as a fallback to bypass PEP 668 restrictions on macOS.

Fixes the following installation error on macOS:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
```