### PR TITLE
Tolerate catalog failure during DROP TABLE

### DIFF
--- a/pg_lake_table/src/ddl/drop_table.c
+++ b/pg_lake_table/src/ddl/drop_table.c
@@ -468,7 +468,6 @@ static bool
 MarkAllReferencedFilesForDeletion(Oid relationId)
 {
 	TimestampTz orphanedAt = GetCurrentTransactionStartTimestamp();
-	char	   *metadataLocation = GetIcebergMetadataLocation(relationId, true);
 	MemoryContext savedContext = CurrentMemoryContext;
 
 	List	   *allFiles = NIL;
@@ -476,6 +475,8 @@ MarkAllReferencedFilesForDeletion(Oid relationId)
 
 	PG_TRY();
 	{
+		char	   *metadataLocation = GetIcebergMetadataLocation(relationId, true);
+
 		allFiles = IcebergFindAllReferencedFiles(metadataLocation);
 	}
 	PG_CATCH();


### PR DESCRIPTION
I've observed tests where `MarkAllReferencedFilesForDeletion` would hard error because of an issue in the catalog, while the intent was for it to soft error to ensure that network/storage failure does not prevent you from dropping the table. Even `PostAllRestCatalogRequests` swallows the error.

This is mainly a REST issue, so not marking it as backport. 

