### PR TITLE
Fix type mismatch in TimestampDifference and off-by-1 in GUC check

### DIFF
--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -1313,7 +1313,7 @@ ComputeNextWakeTimeMs(void)
 
 		TimestampDifference(now, workerEntry->restartAfter, &secDiff, &microsecDiff);
 
-		long		msUntilRestart = secDiff * 1000 + microsecDiff / 1000;
+		int64		msUntilRestart = secDiff * 1000 + microsecDiff / 1000;
 
 		if (msUntilRestart <= 0)
 		{

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -1308,12 +1308,12 @@ ComputeNextWakeTimeMs(void)
 			break;
 		}
 
-		int64		secDiff;
+		long		secDiff;
 		int			microsecDiff;
 
 		TimestampDifference(now, workerEntry->restartAfter, &secDiff, &microsecDiff);
 
-		int64		msUntilRestart = secDiff * 1000 + microsecDiff / 1000;
+		long		msUntilRestart = secDiff * 1000 + microsecDiff / 1000;
 
 		if (msUntilRestart <= 0)
 		{

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -922,7 +922,7 @@ GetAddSnapshotCatalogRequest(IcebergSnapshot * newSnapshot, Oid relationId)
 	appendStringInfo(body, ",\"schema-id\":%d", newSnapshot->schema_id);
 	appendStringInfoString(body, "}}, ");	/* end add-snapshot */
 
-	appendStringInfo(body, "{\"action\":\"set-snapshot-ref\", \"type\":\"branch\", \"ref-name\":\"main\", \"snapshot-id\":" INT64_FORMAT "}", newSnapshot->snapshot_id);
+	appendStringInfo(body, "{\"action\":\"set-snapshot-ref\", \"type\":\"branch\", \"ref-name\":\"main\", \"snapshot-id\":%" PRId64 "}", newSnapshot->snapshot_id);
 
 	RestCatalogRequest *request = palloc0(sizeof(RestCatalogRequest));
 

--- a/pg_lake_table/src/init.c
+++ b/pg_lake_table/src/init.c
@@ -402,6 +402,6 @@ _PG_init(void)
 static bool
 CheckTargetFileSizeMB(int *newval, void **extra, GucSource source)
 {
-	return *newval <= 0 || *newval > MIN_TARGET_FILE_SIZE_MB ||
+	return *newval <= 0 || *newval >= MIN_TARGET_FILE_SIZE_MB ||
 		(IsTransactionState() && superuser());
 }


### PR DESCRIPTION
Use `long` instead of `int64` for secDiff/msUntilRestart to match the `TimestampDifference` API, fixing an `-Wincompatible-pointer-types` warning.

Fix `CheckTargetFileSizeMB` to use >= instead of > so that the documented minimum of 16 MB is actually accepted for non-superusers.

Fix `-Wformat` warning for `snapshot_id` in REST catalog

---

### Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**