### PR TITLE
Fix CI check-indent and pin pg18 version + Fix repo formatting

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Check formatting
       shell: bash
       run: |
-        make check-indent
+        make check-indent PG_INDENT=/home/postgres/pgsql-${PG_INDENT_VERSION}/bin/pgindent
 
     - name: Check for typos # ;)
       uses: ./.github/actions/check-typos

--- a/.github/workflows/pytest_all.yml
+++ b/.github/workflows/pytest_all.yml
@@ -14,6 +14,7 @@ env:
   CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
   ORG: snowflake-labs
   PG_LAKE_DELTA_SUPPORT: 1
+  PG_INDENT_VERSION: 18
 
 jobs:
   build-image-almalinux:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ UNAME_S := $(shell uname -s)
 
 # List of targets for indent checks
 INDENT_TARGETS = pgduck_server $(EXTENSION_TARGETS)
-TYPEDEFS = /tmp/typedefs-$(PG_MAJOR_VERSION).list
+PG_INDENT_VERSION = 18
+PG_INDENT ?= pgindent
+TYPEDEFS = /tmp/typedefs-$(PG_INDENT_VERSION).list
 
 CMAKE_AVRO_ARGS = -DCMAKE_INSTALL_PREFIX=avrolib -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
@@ -63,7 +65,7 @@ endif
 
 # style/indent-related changes
 
-# This target ensures that we download the latest major version's typedefs.list
+# This target ensures that we download the PG_INDENT_VERSION's typedefs.list
 # from buildfarm if we don't have a local copy.  Since we currently do not
 # override the typedefs.list, this should be equivalent to what we were
 # previously doing by pulling from the postgres source tree.
@@ -71,16 +73,14 @@ endif
 typedefs: $(TYPEDEFS)
 
 $(TYPEDEFS):
-	curl -o $(TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PG_MAJOR_VERSION)_STABLE
+	curl -o $(TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PG_INDENT_VERSION)_STABLE
 
 check-indent: typedefs
-	for dir in $(INDENT_TARGETS); do \
-		pgindent --typedefs=$(TYPEDEFS) $(INDENT_TARGETS); \
-	done
+	$(PG_INDENT) --typedefs=$(TYPEDEFS) --check --diff $(INDENT_TARGETS)
 	pipenv run black --check --diff $(INDENT_TARGETS)
 
 reindent: typedefs
-	pgindent --typedefs=$(TYPEDEFS) $(INDENT_TARGETS)
+	$(PG_INDENT) --typedefs=$(TYPEDEFS) $(INDENT_TARGETS)
 	pipenv run black $(INDENT_TARGETS)
 
 submodules:

--- a/pg_lake_engine/include/pg_lake/json/json_reader.h
+++ b/pg_lake_engine/include/pg_lake/json/json_reader.h
@@ -31,7 +31,7 @@ typedef enum FieldRequired
 }			FieldRequired;
 
 extern PGDLLEXPORT bool JsonExtractInt32Field(JsonbContainer *json, char *fieldName, FieldRequired required, int32_t *intPointer);
-extern PGDLLEXPORT bool JsonExtractInt64Field(JsonbContainer *json, char *fieldName, FieldRequired required, int64_t * longPointer);
+extern PGDLLEXPORT bool JsonExtractInt64Field(JsonbContainer *json, char *fieldName, FieldRequired required, int64_t *longPointer);
 extern PGDLLEXPORT bool JsonExtractBoolField(JsonbContainer *json, char *fieldName, FieldRequired required, bool *boolPointer);
 extern PGDLLEXPORT bool JsonExtractStringField(JsonbContainer *json, char *fieldName, FieldRequired required,
 											   const char **stringPointer, size_t *lengthPointer);

--- a/pg_lake_engine/include/pg_lake/pgduck/map.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/map.h
@@ -21,7 +21,7 @@
 
 Oid			GetOrCreatePGMapType(const char *name);
 char	   *GetDuckDBMapDefinitionForPGType(Oid postgresTypeId,
-										CopyDataFormat format);
+											CopyDataFormat format);
 
 extern PGDLLEXPORT bool IsMapTypeOid(Oid typeId);
 extern PGDLLEXPORT PGType GetMapKeyType(Oid mapOid);

--- a/pg_lake_engine/src/copy/copy_format.c
+++ b/pg_lake_engine/src/copy/copy_format.c
@@ -391,7 +391,10 @@ OptionsToCopyDataCompression(List *copyOptions)
 const char *
 FormatToFileExtension(CopyDataFormat format, CopyDataCompression compression)
 {
-	/* Parquet files use a single extension (Iceberg data files are also Parquet) */
+	/*
+	 * Parquet files use a single extension (Iceberg data files are also
+	 * Parquet)
+	 */
 	if (FormatUsesParquet(format))
 		return ".parquet";
 

--- a/pg_lake_engine/src/json/json_reader.c
+++ b/pg_lake_engine/src/json/json_reader.c
@@ -58,7 +58,7 @@ JsonExtractInt32Field(JsonbContainer *json, char *fieldName, FieldRequired requi
 
 
 bool
-JsonExtractInt64Field(JsonbContainer *json, char *fieldName, FieldRequired required, int64_t * longPointer)
+JsonExtractInt64Field(JsonbContainer *json, char *fieldName, FieldRequired required, int64_t *longPointer)
 {
 	JsonbValue *fieldValueJson;
 

--- a/pg_lake_engine/src/pgduck/map_conversion.c
+++ b/pg_lake_engine/src/pgduck/map_conversion.c
@@ -127,7 +127,7 @@ MapOutForPGDuck(Datum myMap, CopyDataFormat format)
 			ereport(ERROR, (errmsg("cannot have NULL for map key entry")));;
 
 		serializedKey = PGDuckSerialize(&keysExtra->proc, keysElementType, pairValues[0],
-								format);
+										format);
 		if (!keyIsContainer)
 			serializedKey = (char *) quote_literal_cstr(serializedKey);
 

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -610,8 +610,8 @@ RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext * context)
 		 * DuckDB's binder compares the GROUPING() children against the GROUP
 		 * BY expressions using parsed expression equality. When the GROUP BY
 		 * has "true::boolean" but GROUPING has just "true", DuckDB sees them
-		 * as different expressions and raises:
-		 * "GROUPING child must be a grouping column".
+		 * as different expressions and raises: "GROUPING child must be a
+		 * grouping column".
 		 *
 		 * To fix this, we wrap any Const args in the GroupingFunc with an
 		 * explicit RelabelType cast so that ruleutils deparses them with the
@@ -789,7 +789,7 @@ RewriteConst(Const *constExpr)
 
 	/* serialize Const in the DuckDB format */
 	char	   *pgduckText = PGDuckSerialize(&outFunc, constTypeId, constExpr->constvalue,
-											  DATA_FORMAT_INVALID);
+											 DATA_FORMAT_INVALID);
 
 	/* construct a text constant with the rewritten text */
 	Const	   *textConst = makeNode(Const);
@@ -2295,7 +2295,8 @@ RewriteFuncExprInitcap(Node *node, void *context)
 	if (list_length(funcExpr->args) != 1)
 		return node;
 
-	Oid	collation = funcExpr->inputcollid;
+	Oid			collation = funcExpr->inputcollid;
+
 	if (collation != InvalidOid &&
 		!(collation == DEFAULT_COLLATION_OID || collation == C_COLLATION_OID))
 		return node;

--- a/pg_lake_iceberg/include/pg_lake/avro/avro_reader.h
+++ b/pg_lake_iceberg/include/pg_lake/avro/avro_reader.h
@@ -58,8 +58,8 @@ bool		AvroFieldExists(avro_value_t * record, char *fieldName);
 void		AvroGetBoolField(avro_value_t * record, char *fieldName, AvroFieldRequired required, bool *boolPointer);
 void		AvroGetInt32Field(avro_value_t * record, char *fieldName, AvroFieldRequired required, int32_t *valPointer);
 void		AvroGetNullableInt32Field(avro_value_t * record, char *fieldName, int32_t *intPointer, bool *isSet);
-void		AvroGetInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired required, int64_t * valPointer);
-void		AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, int64_t * longPointer, bool *isSet);
+void		AvroGetInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired required, int64_t *valPointer);
+void		AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, int64_t *longPointer, bool *isSet);
 void		AvroGetStringField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 							   const char **stringPointer, size_t *lengthPointer);
 void		AvroGetNullableStringField(avro_value_t * record, char *fieldName, const char **stringPointer, size_t *lengthPointer, bool *isSet);
@@ -74,7 +74,7 @@ void		AvroGetObjectArrayField(avro_value_t * record, char *fieldName, AvroFieldR
 void		AvroGetInt32ArrayField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 								   int32_t **arrayPointer, size_t *lengthPointer);
 void		AvroGetInt64ArrayField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
-								   int64_t * *arrayPointer, size_t *lengthPointer);
+								   int64_t **arrayPointer, size_t *lengthPointer);
 void		AvroGetMapField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 							AvroParseMapEntryFunction parseFn, size_t entrySize,
 							void **arrayPointer, size_t *lengthPointer, void *context);

--- a/pg_lake_iceberg/include/pg_lake/avro/avro_writer.h
+++ b/pg_lake_iceberg/include/pg_lake/avro/avro_writer.h
@@ -70,4 +70,4 @@ void		AvroSetBinaryField(avro_value_t * record, char *fieldName, const void *byt
 void		AvroSetNullableBinaryField(avro_value_t * record, char *fieldName, const void *bytes, size_t length, bool isSet);
 void		AvroSetRecordArrayField(avro_value_t * record, char *fieldName, AvroSerializeFunction serializeFn, size_t entrySize, void *entryArray, size_t entryCount);
 void		AvroSetInt32ArrayField(avro_value_t * record, char *fieldName, int32_t *values, size_t valueCount);
-void		AvroSetInt64ArrayField(avro_value_t * record, char *fieldName, int64_t * values, size_t valueCount);
+void		AvroSetInt64ArrayField(avro_value_t * record, char *fieldName, int64_t *values, size_t valueCount);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/data_file_stats.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/data_file_stats.h
@@ -23,8 +23,8 @@
 #include "pg_lake/iceberg/api.h"
 
 extern PGDLLEXPORT void SetIcebergDataFileStats(const DataFileStats * dataFileStats,
-												int64_t * recordCount,
-												int64_t * fileSizeInBytes,
+												int64_t *recordCount,
+												int64_t *fileSizeInBytes,
 												ColumnBound * *lowerBounds,
 												size_t *nLowerBounds,
 												ColumnBound * *upperBounds,

--- a/pg_lake_iceberg/src/avro/avro_reader.c
+++ b/pg_lake_iceberg/src/avro/avro_reader.c
@@ -203,7 +203,7 @@ AvroGetNullableInt32Field(avro_value_t * record, char *fieldName, int32_t *intPo
 
 
 void
-AvroGetInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired required, int64_t * longPointer)
+AvroGetInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired required, int64_t *longPointer)
 {
 	avro_value_t fieldValue;
 
@@ -221,7 +221,7 @@ AvroGetInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired requ
 
 
 void
-AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, int64_t * longPointer, bool *isSet)
+AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, int64_t *longPointer, bool *isSet)
 {
 	avro_value_t fieldValue;
 
@@ -399,7 +399,7 @@ AvroGetInt32ArrayField(avro_value_t * record, char *fieldName, AvroFieldRequired
 
 void
 AvroGetInt64ArrayField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
-					   int64_t * *arrayPointer, size_t *lengthPointer)
+					   int64_t **arrayPointer, size_t *lengthPointer)
 {
 	avro_value_t fieldValue;
 	size_t		itemCount;
@@ -557,7 +557,7 @@ AvroExtractNullableFieldFromRecordByIndex(avro_value_t * record, int index,
 	{
 		*value = palloc0(sizeof(int64_t));
 		*valueLength = sizeof(int64_t);
-		rc = avro_value_get_long(&fieldValue, (int64_t *) * value);
+		rc = avro_value_get_long(&fieldValue, (int64_t *) *value);
 	}
 	else if (fieldType == AVRO_STRING)
 	{

--- a/pg_lake_iceberg/src/avro/avro_writer.c
+++ b/pg_lake_iceberg/src/avro/avro_writer.c
@@ -618,7 +618,7 @@ AvroSetInt32ArrayField(avro_value_t * record, char *fieldName, int32_t *values, 
 
 
 void
-AvroSetInt64ArrayField(avro_value_t * record, char *fieldName, int64_t * values, size_t valueCount)
+AvroSetInt64ArrayField(avro_value_t * record, char *fieldName, int64_t *values, size_t valueCount)
 {
 	avro_value_t arrayValue;
 	bool		isSet = valueCount > 0;

--- a/pg_lake_iceberg/src/http/http_client.c
+++ b/pg_lake_iceberg/src/http/http_client.c
@@ -45,7 +45,7 @@
 
 static HttpResult HttpCommonNoThrows(HttpMethod method, const char *url, const char *postData,
 									 const List *headers);
-static bool CheckMinCurlVersion(const curl_version_info_data * versionInfo);
+static bool CheckMinCurlVersion(const curl_version_info_data *versionInfo);
 static size_t CurlResponseBodyWriteCallback(void *ptr, size_t size, size_t nmemb, void *userdata);
 static size_t CurlResponseHeaderWriteCallback(void *ptr, size_t size, size_t nmemb, void *userdata);
 static void GrowResponseData(char **data, size_t *dataLength, void *newData, size_t newDataBytes);
@@ -55,13 +55,13 @@ static int	CurlProgressCallback(void *clientp, curl_off_t dltotal, curl_off_t dl
 #endif
 static void CurlLogError(CURLcode curlCode, const char *error_buffer);
 static CURLcode CurlGloballyInitIfNotInitialized(void);
-static CURLcode CurlSetErrorBuffer(CURL * curl, char **errorBuffer);
-static CURLcode CurlSetOptions(CURL * curl, const char *url, HttpMethod method,
+static CURLcode CurlSetErrorBuffer(CURL *curl, char **errorBuffer);
+static CURLcode CurlSetOptions(CURL *curl, const char *url, HttpMethod method,
 							   const char *postData, HttpResult * httpResult);
-static CURLcode CurlSetHeaders(CURL * curl, const List *headers, struct curl_slist **headerList);
+static CURLcode CurlSetHeaders(CURL *curl, const List *headers, struct curl_slist **headerList);
 static void CurlGlobalCleanup(int code, Datum arg);
-static void CurlCleanup(CURL * curl, struct curl_slist *headerList);
-static HttpResult CurlReturnError(CURL * curl, struct curl_slist *headerList,
+static void CurlCleanup(CURL *curl, struct curl_slist *headerList);
+static HttpResult CurlReturnError(CURL *curl, struct curl_slist *headerList,
 								  CURLcode curlCode, const char *errorMsg);
 static const char *HttpRequestMethodToString(HttpMethod method);
 static char *RedactSensitiveJson(char *s);
@@ -110,7 +110,7 @@ CurlGloballyInitIfNotInitialized(void)
  * CurlSetErrorBuffer sets up the error buffer for a given CURL handle.
  */
 static CURLcode
-CurlSetErrorBuffer(CURL * curl, char **errorBuffer)
+CurlSetErrorBuffer(CURL *curl, char **errorBuffer)
 {
 	ereport(DEBUG4, (errmsg("setting libcurl error buffer")));
 
@@ -132,7 +132,7 @@ CurlSetErrorBuffer(CURL * curl, char **errorBuffer)
  * CurlSetOptions sets the options for a given CURL handle.
  */
 static CURLcode
-CurlSetOptions(CURL * curl, const char *url, HttpMethod method,
+CurlSetOptions(CURL *curl, const char *url, HttpMethod method,
 			   const char *postData, HttpResult * res)
 {
 	ereport(DEBUG4, (errmsg("setting libcurl options")));
@@ -198,7 +198,7 @@ CurlSetOptions(CURL * curl, const char *url, HttpMethod method,
  * CurlSetHeaders sets the headers for a given CURL handle.
  */
 static CURLcode
-CurlSetHeaders(CURL * curl, const List *headers, struct curl_slist **headerList)
+CurlSetHeaders(CURL *curl, const List *headers, struct curl_slist **headerList)
 {
 	ereport(DEBUG4, (errmsg("setting libcurl headers")));
 
@@ -238,7 +238,7 @@ CurlGlobalCleanup(int code, Datum arg)
  * CurlCleanup cleans up given curl handle and headers.
  */
 static void
-CurlCleanup(CURL * curl, struct curl_slist *headerList)
+CurlCleanup(CURL *curl, struct curl_slist *headerList)
 {
 	ereport(DEBUG4, (errmsg("cleaning up libcurl")));
 
@@ -255,7 +255,7 @@ CurlCleanup(CURL * curl, struct curl_slist *headerList)
  * with the error message.
  */
 static HttpResult
-CurlReturnError(CURL * curl, struct curl_slist *headerList,
+CurlReturnError(CURL *curl, struct curl_slist *headerList,
 				CURLcode curlCode, const char *errorMsg)
 {
 	CurlLogError(curlCode, errorMsg);
@@ -496,7 +496,7 @@ CurlLogError(CURLcode curlCode, const char *error_buffer)
  * CheckMinCurlVersion checks if curl version >= the minimum required version.
  */
 static bool
-CheckMinCurlVersion(const curl_version_info_data * versionInfo)
+CheckMinCurlVersion(const curl_version_info_data *versionInfo)
 {
 	elog(DEBUG4, "curl version %s", versionInfo->version);
 	elog(DEBUG4, "curl version number 0x%x", versionInfo->version_num);

--- a/pg_lake_iceberg/src/iceberg/data_file_stats.c
+++ b/pg_lake_iceberg/src/iceberg/data_file_stats.c
@@ -38,8 +38,8 @@ static ColumnBound * CreateColumnBoundForLeafField(LeafField * leafField, char *
  */
 void
 SetIcebergDataFileStats(const DataFileStats * dataFileStats,
-						int64_t * recordCount,
-						int64_t * fileSizeInBytes,
+						int64_t *recordCount,
+						int64_t *fileSizeInBytes,
 						ColumnBound * *lowerBounds,
 						size_t *nLowerBounds,
 						ColumnBound * *upperBounds,

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -234,8 +234,8 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 		/*
 		 * Iceberg does not have a native interval type. We represent it as a
 		 * struct with months, days, and microseconds fields, matching the
-		 * internal PostgreSQL interval representation. This is self-describing
-		 * and readable by any Iceberg-compatible engine.
+		 * internal PostgreSQL interval representation. This is
+		 * self-describing and readable by any Iceberg-compatible engine.
 		 */
 		const char *names[] = {"months", "days", "microseconds"};
 

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -76,7 +76,7 @@ typedef enum RestCatalogRequestRetryAction
 	REST_CATALOG_RETRY_STOP,
 	REST_CATALOG_RETRY_BACKOFF_SHORT,	/* 429 Too Many Requests */
 	REST_CATALOG_RETRY_BACKOFF_LONG,	/* 503 Service Unavailable */
-	REST_CATALOG_RETRY_REFRESH_AUTH		/* 419 Token Expired */
+	REST_CATALOG_RETRY_REFRESH_AUTH /* 419 Token Expired */
 }			RestCatalogRequestRetryAction;
 
 /*
@@ -1160,8 +1160,9 @@ SendRequestToRestCatalog(HttpMethod method, const char *url, const char *body, L
 			case REST_CATALOG_RETRY_REFRESH_AUTH:
 				{
 					/*
-					 * Force-refresh the cached token and update the Authorization
-					 * header so the retried request carries the new token.
+					 * Force-refresh the cached token and update the
+					 * Authorization header so the retried request carries the
+					 * new token.
 					 */
 					bool		forceRefreshToken = true;
 					char	   *freshToken = GetRestCatalogAccessToken(forceRefreshToken);

--- a/pg_lake_table/src/test/hide_lake_objects.c
+++ b/pg_lake_table/src/test/hide_lake_objects.c
@@ -280,10 +280,10 @@ HideObjectsCreatedByLakeFromCatalogTables(Node *node, void *context)
 				/*
 				 * In PG17+, transform_MERGE_to_join() moves jointree->quals
 				 * into a FromExpr scoped to only mergeTargetRelation, and
-				 * uses mergeJoinCondition as the JoinExpr->quals that can
-				 * see both sides. So source RTE quals must go in
-				 * mergeJoinCondition to avoid referencing a varno outside
-				 * the target-only scope (see prepjointree.c).
+				 * uses mergeJoinCondition as the JoinExpr->quals that can see
+				 * both sides. So source RTE quals must go in
+				 * mergeJoinCondition to avoid referencing a varno outside the
+				 * target-only scope (see prepjointree.c).
 				 */
 #if PG_VERSION_NUM >= 170000
 				if (query->commandType == CMD_MERGE &&

--- a/pg_lake_table/src/transaction/external_heavy_asserts.c
+++ b/pg_lake_table/src/transaction/external_heavy_asserts.c
@@ -389,11 +389,11 @@ AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relationId, bool d
 		Assert(list_length(externalLowerBounds) == list_length(externalUpperBounds));
 
 		/*
-		 * Filter out internal column stats whose bounds were not written
-		 * to the Iceberg metadata.  Columns with NULL bounds (all-NULL
-		 * data) or non-serializable bounds (NaN/Inf floats) are skipped
-		 * by CreateColumnBoundForLeafField during metadata writes, so
-		 * they won't appear in the external bounds.
+		 * Filter out internal column stats whose bounds were not written to
+		 * the Iceberg metadata.  Columns with NULL bounds (all-NULL data) or
+		 * non-serializable bounds (NaN/Inf floats) are skipped by
+		 * CreateColumnBoundForLeafField during metadata writes, so they won't
+		 * appear in the external bounds.
 		 */
 		List	   *internalColumnStatsList = NIL;
 		ListCell   *statsCell;

--- a/pgduck_server/src/pidfile.c
+++ b/pgduck_server/src/pidfile.c
@@ -29,7 +29,7 @@
 #define MAXPGPATH 1024
 
 static int	my_pidfile;
-static char	pidfile_path[MAXPGPATH];
+static char pidfile_path[MAXPGPATH];
 
 /**
  * @brief Creates and locks a PID file.


### PR DESCRIPTION
### Description
There's already a `make check-indent` step in the CI, but it has a problem: `pgindent` silently reformats C code without failing if there were differences. This PR fixes that and pins pgindent and typedefs to PG18. It also fixes all leftover indent issues in the repo.

Verify that the check now works: https://github.com/Snowflake-Labs/pg_lake/actions/runs/24236423143/job/70760072486?pr=307

Thanks to @sfc-gh-vparakh for noticing the issue.

---

### Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**