### PR TITLE
postgres_scanner fix +-inf

### DIFF
--- a/duckdb_pglake/patches/duckdb-postgres/numeric-nan.patch
+++ b/duckdb_pglake/patches/duckdb-postgres/numeric-nan.patch
@@ -1,46 +1,58 @@
 diff --git a/src/include/postgres_binary_reader.hpp b/src/include/postgres_binary_reader.hpp
-index f4bc336..d9e92f1 100644
+index f4bc336..79ab24e 100644
 --- a/src/include/postgres_binary_reader.hpp
 +++ b/src/include/postgres_binary_reader.hpp
-@@ -136,9 +136,11 @@ protected:
+@@ -136,9 +136,17 @@ protected:
  	PostgresDecimalConfig ReadDecimalConfig();
  
  	template <class T, class OP = DecimalConversionInteger>
 -	T ReadDecimal() {
 -		// this is wild
-+	T ReadDecimal(bool *out_is_nan = nullptr) {
++	T ReadDecimal(bool *out_is_nan = nullptr, bool *out_is_pinf = nullptr, bool *out_is_ninf = nullptr) {
  		auto config = ReadDecimalConfig();
 +		if (out_is_nan) {
 +			*out_is_nan = config.is_nan;
++		}
++		if (out_is_pinf) {
++			*out_is_pinf = config.is_pinf;
++		}
++		if (out_is_ninf) {
++			*out_is_ninf = config.is_ninf;
 +		}
  		auto scale_POWER = OP::GetPowerOfTen(config.scale);
  
  		if (config.ndigits == 0) {
 diff --git a/src/include/postgres_conversion.hpp b/src/include/postgres_conversion.hpp
-index 391429e..ba4162b 100644
+index 391429e..f9049eb 100644
 --- a/src/include/postgres_conversion.hpp
 +++ b/src/include/postgres_conversion.hpp
-@@ -96,6 +96,7 @@ struct PostgresDecimalConfig {
+@@ -96,6 +96,9 @@ struct PostgresDecimalConfig {
  	uint16_t ndigits;
  	int16_t weight;
  	bool is_negative;
 +	bool is_nan;
++	bool is_pinf;
++	bool is_ninf;
  };
  
  struct PostgresConversion {
 diff --git a/src/postgres_binary_reader.cpp b/src/postgres_binary_reader.cpp
-index 86ebe30..9a49f8c 100644
+index 86ebe30..4dbccc2 100644
 --- a/src/postgres_binary_reader.cpp
 +++ b/src/postgres_binary_reader.cpp
-@@ -137,6 +137,7 @@ PostgresDecimalConfig PostgresBinaryReader::ReadDecimalConfig() {
+@@ -136,7 +136,10 @@ PostgresDecimalConfig PostgresBinaryReader::ReadDecimalConfig() {
+ 	      sign == NUMERIC_NEG)) {
  		throw NotImplementedException("Postgres numeric NA/Inf");
  	}
- 	config.is_negative = sign == NUMERIC_NEG;
+-	config.is_negative = sign == NUMERIC_NEG;
++	config.is_negative = sign == NUMERIC_NEG || sign == NUMERIC_NINF;
 +	config.is_nan = sign == NUMERIC_NAN;
++	config.is_pinf = sign == NUMERIC_PINF;
++	config.is_ninf = sign == NUMERIC_NINF;
  	config.scale = ReadInteger<uint16_t>();
  
  	return config;
-@@ -247,9 +248,12 @@ void PostgresBinaryReader::ReadValue(const LogicalType &type, const PostgresType
+@@ -247,9 +250,19 @@ void PostgresBinaryReader::ReadValue(const LogicalType &type, const PostgresType
  		FlatVector::GetData<float>(out_vec)[output_offset] = ReadFloat();
  		break;
  	case LogicalTypeId::DOUBLE: {
@@ -48,39 +60,48 @@ index 86ebe30..9a49f8c 100644
  		if (postgres_type.info == PostgresTypeAnnotation::NUMERIC_AS_DOUBLE) {
 -			FlatVector::GetData<double>(out_vec)[output_offset] = ReadDecimal<double, DecimalConversionDouble>();
 +			bool is_nan = false;
-+			FlatVector::GetData<double>(out_vec)[output_offset] = ReadDecimal<double, DecimalConversionDouble>(&is_nan);
++			bool is_pinf = false;
++			bool is_ninf = false;
++			FlatVector::GetData<double>(out_vec)[output_offset] =
++			    ReadDecimal<double, DecimalConversionDouble>(&is_nan, &is_pinf, &is_ninf);
 +			if (is_nan) {
 +				FlatVector::GetData<double>(out_vec)[output_offset] = NAN;
++			} else if (is_pinf) {
++				FlatVector::GetData<double>(out_vec)[output_offset] = INFINITY;
++			} else if (is_ninf) {
++				FlatVector::GetData<double>(out_vec)[output_offset] = -INFINITY;
 +			}
  			break;
  		}
  		D_ASSERT(value_len == sizeof(double));
-@@ -284,22 +288,26 @@ void PostgresBinaryReader::ReadValue(const LogicalType &type, const PostgresType
+@@ -284,22 +297,28 @@ void PostgresBinaryReader::ReadValue(const LogicalType &type, const PostgresType
  		if (value_len < sizeof(uint16_t) * 4) {
  			throw InvalidInputException("Need at least 8 bytes to read a Postgres decimal. Got %d", value_len);
  		}
 +		bool is_nan = false;
++		bool is_pinf = false;
++		bool is_ninf = false;
  		switch (type.InternalType()) {
  		case PhysicalType::INT16:
 -			FlatVector::GetData<int16_t>(out_vec)[output_offset] = ReadDecimal<int16_t>();
-+			FlatVector::GetData<int16_t>(out_vec)[output_offset] = ReadDecimal<int16_t>(&is_nan);
++			FlatVector::GetData<int16_t>(out_vec)[output_offset] = ReadDecimal<int16_t>(&is_nan, &is_pinf, &is_ninf);
  			break;
  		case PhysicalType::INT32:
 -			FlatVector::GetData<int32_t>(out_vec)[output_offset] = ReadDecimal<int32_t>();
-+			FlatVector::GetData<int32_t>(out_vec)[output_offset] = ReadDecimal<int32_t>(&is_nan);
++			FlatVector::GetData<int32_t>(out_vec)[output_offset] = ReadDecimal<int32_t>(&is_nan, &is_pinf, &is_ninf);
  			break;
  		case PhysicalType::INT64:
 -			FlatVector::GetData<int64_t>(out_vec)[output_offset] = ReadDecimal<int64_t>();
-+			FlatVector::GetData<int64_t>(out_vec)[output_offset] = ReadDecimal<int64_t>(&is_nan);
++			FlatVector::GetData<int64_t>(out_vec)[output_offset] = ReadDecimal<int64_t>(&is_nan, &is_pinf, &is_ninf);
  			break;
  		case PhysicalType::INT128:
 -			FlatVector::GetData<hugeint_t>(out_vec)[output_offset] = ReadDecimal<hugeint_t, DecimalConversionHugeint>();
-+			FlatVector::GetData<hugeint_t>(out_vec)[output_offset] = ReadDecimal<hugeint_t, DecimalConversionHugeint>(&is_nan);
++			FlatVector::GetData<hugeint_t>(out_vec)[output_offset] = ReadDecimal<hugeint_t, DecimalConversionHugeint>(&is_nan, &is_pinf, &is_ninf);
  			break;
  		default:
  			throw InvalidInputException("Unsupported decimal storage type");
  		}
-+		if (is_nan) {
++		if (is_nan || is_pinf || is_ninf) {
 +			FlatVector::SetNull(out_vec, output_offset, true);
 +		}
  		break;
@@ -90,7 +111,7 @@ diff --git a/src/postgres_text_reader.cpp b/src/postgres_text_reader.cpp
 index 066e072..e3cfa67 100644
 --- a/src/postgres_text_reader.cpp
 +++ b/src/postgres_text_reader.cpp
-@@ -321,6 +321,19 @@ void PostgresTextReader::ConvertVector(Vector &source, Vector &target, const Pos
+@@ -321,6 +321,23 @@ void PostgresTextReader::ConvertVector(Vector &source, Vector &target, const Pos
  	case LogicalTypeId::BLOB:
  		ConvertBlob(source, target, count);
  		break;
@@ -99,7 +120,11 @@ index 066e072..e3cfa67 100644
 +		for (idx_t i = 0; i < count; i++) {
 +			if (!FlatVector::IsNull(source, i)) {
 +				auto str = strings[i];
-+				if (str.GetSize() == 3 && memcmp(str.GetData(), "NaN", 3) == 0) {
++				auto sz = str.GetSize();
++				auto ptr = str.GetData();
++				if ((sz == 3 && memcmp(ptr, "NaN", 3) == 0) ||
++				    (sz == 8 && memcmp(ptr, "Infinity", 8) == 0) ||
++				    (sz == 9 && memcmp(ptr, "-Infinity", 9) == 0)) {
 +					FlatVector::SetNull(source, i, true);
 +				}
 +			}

--- a/pg_lake_iceberg/src/iceberg/data_file_stats.c
+++ b/pg_lake_iceberg/src/iceberg/data_file_stats.c
@@ -84,16 +84,11 @@ SetColumnBoundsFromDataFileStats(const DataFileStats * dataFileStats,
 
 		char	   *upperBoundText = columnStat->upperBoundText;
 
-		if (lowerBoundText != NULL)
-		{
-			ColumnBound *lowerBound = CreateColumnBoundForLeafField(leafField, lowerBoundText);
+		ColumnBound *lowerBound = NULL;
+		ColumnBound *upperBound = NULL;
 
-			if (lowerBound)
-			{
-				lBounds[totalLowerBounds] = *lowerBound;
-				totalLowerBounds++;
-			}
-		}
+		if (lowerBoundText != NULL)
+			lowerBound = CreateColumnBoundForLeafField(leafField, lowerBoundText);
 
 		if (upperBoundText != NULL)
 		{
@@ -104,13 +99,23 @@ SetColumnBoundsFromDataFileStats(const DataFileStats * dataFileStats,
 			 */
 			Assert(lowerBoundText != NULL);
 
-			ColumnBound *upperBound = CreateColumnBoundForLeafField(leafField, upperBoundText);
+			upperBound = CreateColumnBoundForLeafField(leafField, upperBoundText);
+		}
 
-			if (upperBound)
-			{
-				uBounds[totalUpperBounds] = *upperBound;
-				totalUpperBounds++;
-			}
+		/*
+		 * Add bounds only when both serialize successfully.  Special values
+		 * like NaN/Infinity can cause one bound to serialize while the other
+		 * cannot (e.g. min=0.0 serializes but max=NaN does not).  Truncation
+		 * overflow can also set upperBoundText to NULL.  In both cases we
+		 * skip the column to keep lower_bounds and upper_bounds in sync.
+		 */
+		if (lowerBound != NULL && upperBound != NULL)
+		{
+			lBounds[totalLowerBounds] = *lowerBound;
+			totalLowerBounds++;
+
+			uBounds[totalUpperBounds] = *upperBound;
+			totalUpperBounds++;
 		}
 	}
 

--- a/pg_lake_table/src/transaction/external_heavy_asserts.c
+++ b/pg_lake_table/src/transaction/external_heavy_asserts.c
@@ -390,10 +390,10 @@ AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relationId, bool d
 
 		/*
 		 * Filter out internal column stats whose bounds were not written to
-		 * the Iceberg metadata.  Columns with NULL bounds (all-NULL data) or
-		 * non-serializable bounds (NaN/Inf floats) are skipped by
-		 * CreateColumnBoundForLeafField during metadata writes, so they won't
-		 * appear in the external bounds.
+		 * the Iceberg metadata.  The write path
+		 * (SetColumnBoundsFromDataFileStats) only emits a column's bounds
+		 * when BOTH lower and upper serialize successfully, so we must apply
+		 * the same predicate here.
 		 */
 		List	   *internalColumnStatsList = NIL;
 		ListCell   *statsCell;
@@ -406,6 +406,10 @@ AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relationId, bool d
 				Assert(colStats->upperBoundText == NULL);
 
 			if (!CanSerializeColumnBound(colStats->lowerBoundText,
+										 colStats->leafField.field))
+				continue;
+
+			if (!CanSerializeColumnBound(colStats->upperBoundText,
 										 colStats->leafField.field))
 				continue;
 

--- a/pg_lake_table/tests/pytests/test_special_numeric.py
+++ b/pg_lake_table/tests/pytests/test_special_numeric.py
@@ -1,5 +1,6 @@
 import pytest
 import math
+from decimal import Decimal
 from utils_pytest import *
 
 
@@ -84,4 +85,113 @@ def test_special_numeric_unbounded_as_double(
             f"DROP SCHEMA {schema} CASCADE;",
             pg_conn,
         )
+        pg_conn.commit()
+
+
+def test_special_values_across_float_and_numeric_types(
+    s3, pg_conn, extension, with_default_location
+):
+    """±Inf, NaN, and NULL across float4, float8, and three numeric flavors.
+
+    Column types and their Iceberg storage:
+
+      f4            float4         → REAL   (IEEE 754 float)
+      f8            float8         → DOUBLE (IEEE 754 double)
+      num_unbounded numeric        → DOUBLE (unsupported numeric → double)
+      num_large     numeric(50,2)  → DOUBLE (precision > 38 → double)
+      num_bounded   numeric(10,2)  → DECIMAL(10,2)
+
+    PostgreSQL rejects ±Infinity for any bounded numeric (including
+    large-precision), so Infinity rows use NULL for num_large and
+    num_bounded.  Bounded DECIMAL cannot represent NaN; with
+    out_of_range_values = 'clamp' it is replaced with NULL.
+    Large numeric(50,2) maps to DOUBLE, so NaN is preserved there.
+
+    +----+------+------+--------+-------+---------+
+    | id | f4   | f8   | num_u  | num_l | num_b   |
+    +----+------+------+--------+-------+---------+
+    | 1  | NaN  | NaN  | NaN    | NaN   | NaN→NULL|
+    | 2  | +Inf | +Inf | +Inf   | NULL  | NULL    |
+    | 3  | -Inf | -Inf | -Inf   | NULL  | NULL    |
+    | 4  | NULL | NULL | NULL   | NULL  | NULL    |
+    | 5  | 1.5  | 1.5  | 1.5    | 1.50  | 1.50    |
+    +----+------+------+--------+-------+---------+
+    """
+    schema = "test_special_all_types"
+
+    run_command(
+        f"""
+        CREATE SCHEMA {schema};
+        CREATE TABLE {schema}.t (
+            id int,
+            f4 float4,
+            f8 float8,
+            num_unbounded numeric,
+            num_large numeric(50, 2),
+            num_bounded numeric(10, 2)
+        ) USING iceberg WITH (out_of_range_values = 'clamp');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        run_command(
+            f"""INSERT INTO {schema}.t VALUES
+                (1, 'NaN'::float4,      'NaN'::float8,      'NaN'::numeric,   'NaN'::numeric(50,2),   'NaN'::numeric(10,2)),
+                (2, 'Infinity'::float4,  'Infinity'::float8,  'Infinity'::numeric, NULL, NULL),
+                (3, '-Infinity'::float4, '-Infinity'::float8, '-Infinity'::numeric, NULL, NULL),
+                (4, NULL,                NULL,                 NULL,               NULL,                 NULL),
+                (5, 1.5::float4,         1.5::float8,         1.5::numeric,       1.50::numeric(50,2),  1.50::numeric(10,2))""",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        rows = run_query(
+            f"SELECT id, f4, f8, num_unbounded, num_large, num_bounded "
+            f"FROM {schema}.t ORDER BY id",
+            pg_conn,
+        )
+        assert len(rows) == 5
+        r = {row[0]: row for row in rows}
+
+        # --- Row 1: NaN ---
+        assert math.isnan(r[1][1]), f"f4 NaN failed: {r[1][1]}"
+        assert math.isnan(r[1][2]), f"f8 NaN failed: {r[1][2]}"
+        assert math.isnan(r[1][3]), f"num_unbounded NaN failed: {r[1][3]}"
+        assert math.isnan(r[1][4]), f"num_large NaN failed: {r[1][4]}"
+        assert r[1][5] is None, f"num_bounded NaN should be clamped to NULL: {r[1][5]}"
+
+        # --- Row 2: +Infinity ---
+        assert r[2][1] == float("inf"), f"f4 +Inf failed: {r[2][1]}"
+        assert r[2][2] == float("inf"), f"f8 +Inf failed: {r[2][2]}"
+        assert r[2][3] == float("inf"), f"num_unbounded +Inf failed: {r[2][3]}"
+        assert (
+            r[2][4] is None
+        ), "num_large +Inf row should be NULL (PG rejects Inf for bounded numeric)"
+        assert r[2][5] is None, "num_bounded +Inf row should be NULL"
+
+        # --- Row 3: -Infinity ---
+        assert r[3][1] == float("-inf"), f"f4 -Inf failed: {r[3][1]}"
+        assert r[3][2] == float("-inf"), f"f8 -Inf failed: {r[3][2]}"
+        assert r[3][3] == float("-inf"), f"num_unbounded -Inf failed: {r[3][3]}"
+        assert (
+            r[3][4] is None
+        ), "num_large -Inf row should be NULL (PG rejects Inf for bounded numeric)"
+        assert r[3][5] is None, "num_bounded -Inf row should be NULL"
+
+        # --- Row 4: NULL ---
+        for col in range(1, 6):
+            assert r[4][col] is None, f"column {col} NULL failed: {r[4][col]}"
+
+        # --- Row 5: normal value 1.5 ---
+        assert r[5][1] == pytest.approx(1.5)
+        assert r[5][2] == pytest.approx(1.5)
+        assert r[5][3] == pytest.approx(1.5)
+        assert r[5][4] == pytest.approx(1.5)
+        assert r[5][5] == Decimal("1.50")
+
+    finally:
+        pg_conn.rollback()
+        run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
         pg_conn.commit()

--- a/pgduck_server/tests/pytests/test_postgres_scanner.py
+++ b/pgduck_server/tests/pytests/test_postgres_scanner.py
@@ -4,8 +4,10 @@ via postgres_scan().
 
 Scenarios covered:
 - Composite types read as structs with correct field values
-- Bounded numeric(p,s) NaN clamped to NULL
-- Unbounded / large-precision numerics converted to double (NaN preserved)
+- Bounded numeric(p,s) NaN clamped to NULL (binary & text protocol)
+- Unbounded / large-precision numerics converted to double (NaN and ±Inf preserved)
+- Special values (±Inf, NaN, NULL) across float4, float8, and numeric flavors
+  (binary & text protocol)
 - Multidimensional array values in int[] column clamped to NULL
 """
 
@@ -147,7 +149,30 @@ def pg_tables(postgres):
         "(123.456, 999.99), "
         "('NaN'::numeric, 'NaN'::numeric), "
         "(NULL, NULL), "
-        "(1e30, 1e30)"
+        "(1e30, 1e30), "
+        "('Infinity'::numeric, NULL), "
+        "('-Infinity'::numeric, NULL)"
+    )
+
+    # -- special values across float and numeric types -------------------
+    cur.execute("DROP TABLE IF EXISTS scanner_special_values_tbl")
+    cur.execute(
+        "CREATE TABLE scanner_special_values_tbl ("
+        "  id int PRIMARY KEY,"
+        "  f4 float4,"
+        "  f8 float8,"
+        "  num_unbounded numeric,"
+        "  num_large numeric(50, 2),"
+        "  num_bounded numeric(10, 2)"
+        ")"
+    )
+    cur.execute(
+        "INSERT INTO scanner_special_values_tbl VALUES "
+        "(1, 'NaN'::float4, 'NaN'::float8, 'NaN'::numeric, 'NaN'::numeric, 'NaN'::numeric),"
+        "(2, 'Infinity'::float4, 'Infinity'::float8, 'Infinity'::numeric, NULL, NULL),"
+        "(3, '-Infinity'::float4, '-Infinity'::float8, '-Infinity'::numeric, NULL, NULL),"
+        "(4, NULL, NULL, NULL, NULL, NULL),"
+        "(5, 1.5::float4, 1.5::float8, 1.5::numeric, 1.50::numeric(50,2), 1.50::numeric(10,2))"
     )
 
     # -- multidimensional arrays ----------------------------------------
@@ -187,6 +212,7 @@ def pg_tables(postgres):
     cur.execute("DROP TYPE IF EXISTS scanner_color CASCADE")
     cur.execute("DROP TABLE IF EXISTS scanner_bounded_numeric_tbl")
     cur.execute("DROP TABLE IF EXISTS scanner_unbounded_numeric_tbl")
+    cur.execute("DROP TABLE IF EXISTS scanner_special_values_tbl")
     cur.execute("DROP TABLE IF EXISTS scanner_multidim_array_tbl")
     cur.close()
     conn.close()
@@ -285,16 +311,23 @@ def test_enum_type(pg_tables, pgduck_conn):
 # -------------------------------------------------------------------
 
 
-def test_bounded_numeric_nan_to_null(pg_tables, pgduck_conn):
+@pytest.mark.parametrize("use_text_protocol", [False, True], ids=["binary", "text"])
+def test_bounded_numeric_nan_to_null(pg_tables, pgduck_conn, use_text_protocol):
     """NaN in numeric(10,2) is scanned as NULL (DuckDB DECIMAL can't hold NaN)."""
-    scan = _scan("scanner_bounded_numeric_tbl")
-    rows = perform_query_on_cursor(
-        f"SELECT v FROM {scan} ORDER BY v NULLS LAST",
-        pgduck_conn,
-    )
-    # Source: 123.45, NaN, NULL, 0.00
-    # After:  0.00, 123.45, NULL (NaN→NULL), NULL (original)
-    assert rows == [("0.00",), ("123.45",), (None,), (None,)]
+    if use_text_protocol:
+        perform_query_on_cursor("SET pg_use_text_protocol = true", pgduck_conn)
+    try:
+        scan = _scan("scanner_bounded_numeric_tbl")
+        rows = perform_query_on_cursor(
+            f"SELECT v FROM {scan} ORDER BY v NULLS LAST",
+            pgduck_conn,
+        )
+        # Source: 123.45, NaN, NULL, 0.00
+        # After:  0.00, 123.45, NULL (NaN→NULL), NULL (original)
+        assert rows == [("0.00",), ("123.45",), (None,), (None,)]
+    finally:
+        if use_text_protocol:
+            perform_query_on_cursor("SET pg_use_text_protocol = false", pgduck_conn)
 
 
 # -------------------------------------------------------------------
@@ -303,41 +336,122 @@ def test_bounded_numeric_nan_to_null(pg_tables, pgduck_conn):
 
 
 def test_unbounded_numeric_as_double(pg_tables, pgduck_conn):
-    """Unbounded numeric maps to DOUBLE; NaN preserved, NULL preserved."""
+    """Unbounded numeric maps to DOUBLE; NaN and ±Infinity preserved, NULL preserved."""
     scan = _scan("scanner_unbounded_numeric_tbl")
     rows = perform_query_on_cursor(
         f"SELECT typeof(unbounded), "
         f"  CASE WHEN unbounded IS NULL THEN 'null' "
         f"       WHEN isnan(unbounded) THEN 'nan' "
+        f"       WHEN isinf(unbounded) AND unbounded > 0 THEN '+inf' "
+        f"       WHEN isinf(unbounded) AND unbounded < 0 THEN '-inf' "
         f"       ELSE 'value' END "
         f"FROM {scan} ORDER BY unbounded NULLS LAST",
         pgduck_conn,
     )
     assert rows == [
+        ("DOUBLE", "-inf"),  # -Infinity preserved
         ("DOUBLE", "value"),  # 123.456
         ("DOUBLE", "value"),  # 1e30
+        ("DOUBLE", "+inf"),  # +Infinity preserved
         ("DOUBLE", "nan"),  # NaN preserved as double NaN
         ("DOUBLE", "null"),  # original NULL
     ]
 
 
 def test_large_precision_numeric_as_double(pg_tables, pgduck_conn):
-    """numeric(40,2) (precision > 38) maps to DOUBLE; NaN preserved, NULL preserved."""
+    """numeric(40,2) (precision > 38) maps to DOUBLE; NaN preserved, NULL preserved.
+
+    PostgreSQL rejects ±Infinity for bounded numeric types (including
+    large-precision), so the Infinity rows in the source table have NULL
+    for this column.
+    """
     scan = _scan("scanner_unbounded_numeric_tbl")
     rows = perform_query_on_cursor(
         f"SELECT typeof(large_precision), "
         f"  CASE WHEN large_precision IS NULL THEN 'null' "
         f"       WHEN isnan(large_precision) THEN 'nan' "
         f"       ELSE 'value' END "
-        f"FROM {scan} ORDER BY large_precision NULLS LAST",
+        f"FROM {scan} "
+        f"WHERE large_precision IS NOT NULL "
+        f"ORDER BY large_precision NULLS LAST",
         pgduck_conn,
     )
     assert rows == [
         ("DOUBLE", "value"),  # 999.99
         ("DOUBLE", "value"),  # 1e30
         ("DOUBLE", "nan"),  # NaN preserved as double NaN
-        ("DOUBLE", "null"),  # original NULL
     ]
+
+
+# -------------------------------------------------------------------
+# Special values (±Inf, NaN, NULL) across float & numeric types
+# -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_text_protocol", [False, True], ids=["binary", "text"])
+def test_special_values_across_types(pg_tables, pgduck_conn, use_text_protocol):
+    """±Inf, NaN, and NULL across float4, float8, and three numeric flavors.
+
+    Column types and their DuckDB mapping via postgres_scan:
+
+      f4            float4         → FLOAT
+      f8            float8         → DOUBLE
+      num_unbounded numeric        → DOUBLE (NUMERIC_AS_DOUBLE)
+      num_large     numeric(50,2)  → DOUBLE (precision > 38)
+      num_bounded   numeric(10,2)  → DECIMAL(10,2)
+
+    PostgreSQL rejects ±Infinity for bounded numeric types, so Infinity
+    rows use NULL for num_large and num_bounded.  NaN is accepted by all
+    PostgreSQL numeric types, but DuckDB DECIMAL cannot represent NaN, so
+    bounded numeric NaN is scanned as NULL.
+    """
+    if use_text_protocol:
+        perform_query_on_cursor("SET pg_use_text_protocol = true", pgduck_conn)
+    try:
+        scan = _scan("scanner_special_values_tbl")
+
+        def classify(col):
+            return (
+                f"CASE WHEN {col} IS NULL THEN 'null' "
+                f"WHEN isnan({col}) THEN 'nan' "
+                f"WHEN isinf({col}) AND {col} > 0 THEN '+inf' "
+                f"WHEN isinf({col}) AND {col} < 0 THEN '-inf' "
+                f"ELSE 'value' END"
+            )
+
+        rows = perform_query_on_cursor(
+            f"SELECT id, "
+            f"  {classify('f4')}, {classify('f8')}, "
+            f"  {classify('num_unbounded')}, {classify('num_large')}, "
+            f"  CASE WHEN num_bounded IS NULL THEN 'null' ELSE 'value' END "
+            f"FROM {scan} ORDER BY id",
+            pgduck_conn,
+        )
+
+        assert rows == [
+            ("1", "nan", "nan", "nan", "nan", "null"),  # NaN (bounded → NULL)
+            (
+                "2",
+                "+inf",
+                "+inf",
+                "+inf",
+                "null",
+                "null",
+            ),  # +Inf (large/bounded NULL in PG)
+            (
+                "3",
+                "-inf",
+                "-inf",
+                "-inf",
+                "null",
+                "null",
+            ),  # -Inf (large/bounded NULL in PG)
+            ("4", "null", "null", "null", "null", "null"),  # NULL
+            ("5", "value", "value", "value", "value", "value"),  # 1.5
+        ]
+    finally:
+        if use_text_protocol:
+            perform_query_on_cursor("SET pg_use_text_protocol = false", pgduck_conn)
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
- [x] preserve it for double instead of reading as 0.
- [x] clamp to null for decimal

