### PR TITLE
Fix: Support writing domain types

### DIFF
--- a/pg_lake_engine/src/pgduck/parse_struct.c
+++ b/pg_lake_engine/src/pgduck/parse_struct.c
@@ -41,6 +41,7 @@
 #include "executor/spi.h"
 #include "nodes/makefuncs.h"
 #include "utils/builtins.h"
+#include "utils/lsyscache.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
 
@@ -1280,10 +1281,15 @@ GetCompositeTypeForPGType(Oid postgresType)
 
 		/*
 		 * Our internal representation wants to track the base type of any
-		 * array type and to carry a flag instead atttypid directly.
+		 * array type and to carry a flag instead of atttypid directly. Unwrap
+		 * domains so downstream code sees the base type, but preserve map
+		 * types which are domains with special semantics.
 		 */
 
 		Oid			rawTypid = attr->atttypid;
+
+		if (!IsMapTypeOid(rawTypid))
+			rawTypid = getBaseType(rawTypid);
 
 		col->colType = GetRelatedTypeOid(rawTypid, false);
 		col->isArray = rawTypid != col->colType;

--- a/pg_lake_table/tests/pytests/test_create_as_select.py
+++ b/pg_lake_table/tests/pytests/test_create_as_select.py
@@ -568,6 +568,52 @@ def test_default_table_access_method_iceberg(
     pg_conn.commit()
 
 
+@pytest.mark.parametrize("access_method", ["iceberg", "heap"])
+def test_ctas_domain_in_nested_types(
+    s3, pg_conn, extension, with_default_location, access_method
+):
+    """CREATE TABLE AS must handle domains inside composites, arrays of
+    composites, and domain-over-domain through the DESCRIBE path for
+    both iceberg and heap access methods.
+    """
+    schema = "test_ctas_domain_nested"
+    run_command(
+        f"""
+        CREATE SCHEMA {schema};
+        SET search_path TO {schema};
+
+        CREATE DOMAIN d_int AS int;
+        CREATE DOMAIN d_text AS text;
+        CREATE DOMAIN dd_text AS d_text;
+
+        CREATE TYPE comp AS (a d_int, b dd_text);
+        """,
+        pg_conn,
+    )
+
+    using_clause = "USING iceberg" if access_method == "iceberg" else ""
+    run_command(
+        f"""
+        SET search_path TO {schema};
+        CREATE TABLE tgt {using_clause} AS
+            SELECT 1 AS id,
+                   ROW(42, 'hello')::comp AS c,
+                   ARRAY[ROW(1, 'a'), ROW(2, 'b')]::comp[] AS ca,
+                   'world'::dd_text AS plain_d;
+        """,
+        pg_conn,
+    )
+
+    result = run_query(f"SELECT id, c, ca, plain_d FROM {schema}.tgt", pg_conn)
+    assert len(result) == 1
+    assert result[0][0] == 1
+    assert result[0][1] == "(42,hello)"
+    assert result[0][2] == '{"(1,a)","(2,b)"}'
+    assert result[0][3] == "world"
+
+    pg_conn.rollback()
+
+
 # create the table on both Postgres
 @pytest.fixture(scope="module")
 def create_heap_table(pg_conn, s3, request, create_types):

--- a/pg_lake_table/tests/pytests/test_iceberg_types.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_types.py
@@ -2715,6 +2715,157 @@ def test_iceberg_interval_type(pg_conn, s3, extension, with_default_location):
     pg_conn.commit()
 
 
+def test_iceberg_domain_in_nested_types(pg_conn, s3, extension, with_default_location):
+    """Domains inside composites, arrays, maps, and domain-over-domain must
+    round-trip through every write path: INSERT VALUES, COPY TO parquet,
+    COPY FROM parquet, and INSERT ... SELECT pushdown.
+    """
+    schema = "test_domain_nested"
+    parquet_url = f"s3://{TEST_BUCKET}/{schema}/export.parquet"
+
+    run_command(
+        f"""
+        CREATE SCHEMA {schema};
+        SET search_path TO {schema};
+
+        CREATE DOMAIN d_int AS int;
+        CREATE DOMAIN d_text AS text;
+        CREATE DOMAIN dd_text AS d_text;
+
+        CREATE TYPE comp AS (a d_int, b dd_text);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    map_type_name = create_map_type("int", f"{schema}.dd_text")
+
+    run_command(
+        f"""
+        SET search_path TO {schema};
+
+        CREATE TABLE src (
+            id int,
+            c comp,
+            ca comp[],
+            plain_d dd_text,
+            m {map_type_name}
+        ) USING iceberg;
+
+        INSERT INTO src VALUES
+            (1,
+             ROW(42, 'hello')::comp,
+             ARRAY[ROW(1, 'a'), ROW(2, 'b')]::comp[],
+             'world',
+             ARRAY[(10, 'x'), (20, 'y')]::{map_type_name}),
+            (2,
+             ROW(99, NULL)::comp,
+             ARRAY[ROW(3, 'c')]::comp[],
+             NULL,
+             NULL),
+            (3,
+             NULL,
+             NULL,
+             'zz',
+             ARRAY[(30, NULL)]::{map_type_name});
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # -- verify INSERT VALUES round-trip --
+    result = run_query(
+        f"SELECT id, c, ca, plain_d, m FROM {schema}.src ORDER BY id", pg_conn
+    )
+    assert len(result) == 3
+    assert result[0][0] == 1
+    assert result[0][1] == "(42,hello)"
+    assert result[0][2] == '{"(1,a)","(2,b)"}'
+    assert result[0][3] == "world"
+    assert result[1][0] == 2
+    assert result[1][1] == "(99,)"
+    assert result[1][2] == '{"(3,c)"}'
+    assert result[1][3] is None
+    assert result[1][4] is None
+    assert result[2][0] == 3
+    assert result[2][1] is None
+    assert result[2][2] is None
+    assert result[2][3] == "zz"
+
+    # -- COPY TO parquet --
+    run_command(
+        f"COPY (SELECT * FROM {schema}.src ORDER BY id) TO '{parquet_url}'", pg_conn
+    )
+
+    # -- COPY FROM parquet --
+    run_command(
+        f"""
+        SET search_path TO {schema};
+
+        CREATE TABLE tgt_copy (
+            id int,
+            c comp,
+            ca comp[],
+            plain_d dd_text,
+            m {map_type_name}
+        ) USING iceberg;
+
+        COPY tgt_copy FROM '{parquet_url}';
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        f"SELECT id, c, ca, plain_d FROM {schema}.tgt_copy ORDER BY id", pg_conn
+    )
+    assert len(result) == 3
+    assert result[0] == [1, "(42,hello)", '{"(1,a)","(2,b)"}', "world"]
+    assert result[1] == [2, "(99,)", '{"(3,c)"}', None]
+    assert result[2] == [3, None, None, "zz"]
+
+    # -- INSERT ... SELECT --
+    run_command(
+        f"""
+        SET search_path TO {schema};
+
+        CREATE TABLE tgt_pushdown (
+            id int,
+            c comp,
+            ca comp[],
+            plain_d dd_text,
+            m {map_type_name}
+        ) USING iceberg;
+
+        INSERT INTO tgt_pushdown SELECT * FROM src;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        f"SELECT id, c, ca, plain_d FROM {schema}.tgt_pushdown ORDER BY id", pg_conn
+    )
+    assert len(result) == 3
+    assert result[0] == [1, "(42,hello)", '{"(1,a)","(2,b)"}', "world"]
+    assert result[1] == [2, "(99,)", '{"(3,c)"}', None]
+    assert result[2] == [3, None, None, "zz"]
+
+    # cleanup: drop iceberg tables first to avoid cross-schema cascade issues
+    # with map internal types
+    run_command(
+        f"""
+        DROP TABLE {schema}.tgt_pushdown;
+        DROP TABLE {schema}.tgt_copy;
+        DROP TABLE {schema}.src;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 @pytest.fixture(scope="module")
 def create_helper_functions(superuser_conn, app_user):
 

--- a/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
@@ -1,4 +1,3 @@
-import psycopg2
 import pytest
 
 from utils_pytest import *
@@ -484,9 +483,8 @@ def test_insert_select_domain_in_map_key(s3, pg_conn, superuser_conn, extension)
 
 
 def test_insert_select_domain_in_struct(s3, pg_conn, extension):
-    """Domain inside a composite: even EXPLAIN fails because the FDW
-    planning path cannot resolve domain types in DuckDB struct
-    definitions.  The error itself proves the query cannot be pushed down.
+    """Domain inside a composite is not pushed down but is supported via
+    the non-pushdown path.
     """
     loc = f"s3://{TEST_BUCKET}/test_unsuitable/domain_in_struct"
     run_command(
@@ -502,18 +500,15 @@ def test_insert_select_domain_in_struct(s3, pg_conn, extension):
         """,
         pg_conn,
     )
-    with pytest.raises(psycopg2.errors.IndeterminateDatatype):
-        run_query(
-            "EXPLAIN INSERT INTO domain_tgt SELECT * FROM domain_src",
-            pg_conn,
-        )
+    assert_query_not_pushdownable(
+        "INSERT INTO domain_tgt SELECT * FROM domain_src", pg_conn
+    )
     pg_conn.rollback()
 
 
 def test_insert_select_domain_in_struct_in_array(s3, pg_conn, extension):
-    """Domain inside a composite inside an array: EXPLAIN fails because
-    the FDW planning path cannot resolve domain types in DuckDB struct
-    definitions.  The error itself proves the query cannot be pushed down.
+    """Domain inside a composite inside an array is not pushed down but
+    is supported via the non-pushdown path.
     """
     loc = f"s3://{TEST_BUCKET}/test_unsuitable/domain_in_struct_in_array"
     run_command(
@@ -529,11 +524,7 @@ def test_insert_select_domain_in_struct_in_array(s3, pg_conn, extension):
         """,
         pg_conn,
     )
-    with pytest.raises(psycopg2.errors.IndeterminateDatatype):
-        run_query(
-            "EXPLAIN INSERT INTO tgt SELECT * FROM src",
-            pg_conn,
-        )
+    assert_query_not_pushdownable("INSERT INTO tgt SELECT * FROM src", pg_conn)
     pg_conn.rollback()
 
 


### PR DESCRIPTION
We need to recurse into domains to support writing them. Otherwise, we get errors.