### PR TITLE
Clamp only bounded numerics in iceberg tables

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/iceberg_datum_validation.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/iceberg_datum_validation.h
@@ -27,6 +27,10 @@
  * (composites, maps, domains).  For types that need no validation the
  * value is returned unchanged.
  *
+ * typmod is used to distinguish bounded numerics (Iceberg decimal) from
+ * unbounded ones (mapped to float8).  Only bounded numerics have NaN
+ * clamped; unbounded numerics pass through unchanged.
+ *
  * *isNull is set to true when a top-level unsupported value is clamped:
  * numeric NaN or a multidimensional array.  The caller should write NULL
  * instead of the original value.  NaN values and multidimensional arrays
@@ -34,5 +38,6 @@
  * container.
  */
 extern PGDLLEXPORT Datum IcebergErrorOrClampDatum(Datum value, Oid typeOid,
+												  int32 typmod,
 												  IcebergOutOfRangePolicy policy,
 												  bool *isNull);

--- a/pg_lake_engine/include/pg_lake/pgduck/iceberg_validation.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/iceberg_validation.h
@@ -57,11 +57,16 @@ extern PGDLLEXPORT bool IsTemporalType(Oid typeOid);
  * any component that needs Iceberg write validation, including inside
  * arrays, composites, maps, and domains.
  *
+ * typmod is used to distinguish bounded numerics (Iceberg decimal) from
+ * unbounded ones (mapped to float8).  Only bounded numerics need NaN
+ * validation.
+ *
  * Validation covers: temporal boundaries (date/timestamp/timestamptz),
  * multidimensional array rejection (any array type), and bounded
  * numeric NaN (non-pushdown only, since numeric blocks pushdown).
  */
-extern PGDLLEXPORT bool TypeNeedsIcebergValidation(Oid typeOid, bool isPushdown);
+extern PGDLLEXPORT bool TypeNeedsIcebergValidation(Oid typeOid, int32 typmod,
+												   bool isPushdown);
 
 /* Temporal boundary year constants shared by datum and query-level validation */
 #define TEMPORAL_DATE_MIN_YEAR		(-4712)

--- a/pg_lake_engine/src/pgduck/iceberg_datum_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_datum_validation.c
@@ -45,6 +45,7 @@
 #include "datatype/timestamp.h"
 #include "pg_lake/pgduck/iceberg_datum_validation.h"
 #include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/temporal_utils.h"
 #include "utils/array.h"
 #include "utils/date.h"
@@ -58,7 +59,7 @@ static Datum ErrorOrClampTemporal(Datum value, Oid typeOid, int year,
 								  IcebergOutOfRangePolicy policy);
 static Datum IcebergErrorOrClampTemporalDatum(Datum value, Oid typeOid,
 											  IcebergOutOfRangePolicy policy);
-static Datum IcebergErrorOrClampNumericDatum(Datum value,
+static Datum IcebergErrorOrClampNumericDatum(Datum value, int32 typmod,
 											 IcebergOutOfRangePolicy policy,
 											 bool *isNull);
 static Datum IcebergErrorOrClampMultiDimArrayDatum(ArrayType *array,
@@ -220,16 +221,24 @@ IcebergErrorOrClampTemporalDatum(Datum value, Oid typeOid,
 
 
 /*
- * IcebergErrorOrClampNumericDatum validates a numeric Datum for NaN.
+ * IcebergErrorOrClampNumericDatum validates a bounded numeric Datum for NaN.
+ *
+ * Unbounded numerics (and those with precision/scale beyond Iceberg limits)
+ * are mapped to float8, which supports NaN natively, so they are returned
+ * unchanged.  Only bounded numerics that map to Iceberg decimal are checked.
  *
  * In clamp mode: sets *isNull to true and returns 0 (caller writes NULL).
  * In error mode: raises an error.
  * For non-NaN values the datum is returned unchanged.
  */
 static Datum
-IcebergErrorOrClampNumericDatum(Datum value, IcebergOutOfRangePolicy policy,
+IcebergErrorOrClampNumericDatum(Datum value, int32 typmod,
+								IcebergOutOfRangePolicy policy,
 								bool *isNull)
 {
+	if (IsUnsupportedNumericForIceberg(NUMERICOID, typmod))
+		return value;
+
 	if (!numeric_is_nan(DatumGetNumeric(value)))
 		return value;
 
@@ -311,8 +320,8 @@ IcebergErrorOrClampNestedDatum(Datum value, Oid typeOid, int32 typmod,
 
 	if (typeOid == NUMERICOID)
 	{
-		Datum		result = IcebergErrorOrClampNumericDatum(value, policy,
-															 isNull);
+		Datum		result = IcebergErrorOrClampNumericDatum(value, typmod,
+															 policy, isNull);
 
 		*modified = *isNull;
 		return result;
@@ -368,7 +377,7 @@ IcebergErrorOrClampNestedDatum(Datum value, Oid typeOid, int32 typmod,
 			bool		elemModified = false;
 			Datum		clamped = IcebergErrorOrClampNestedDatum(elems[i],
 																 elemType,
-																 -1,
+																 typmod,
 																 policy,
 																 &elemIsNull,
 																 &elemModified);
@@ -489,19 +498,23 @@ IcebergErrorOrClampNestedDatum(Datum value, Oid typeOid, int32 typmod,
  * as well as nested containers (arrays, composites, maps, domains).
  * For types that need no validation the value is returned unchanged.
  *
+ * typmod is used to distinguish bounded numerics (Iceberg decimal) from
+ * unbounded ones (mapped to float8).  Only bounded numerics have NaN
+ * clamped; unbounded numerics pass through unchanged.
+ *
  * *isNull is set to true when a top-level unsupported value is clamped:
  * numeric NaN or a multidimensional array.  The caller should write NULL
  * instead of the original value.  Unsupported values nested inside
  * containers are absorbed as NULL within the reconstructed container.
  */
 Datum
-IcebergErrorOrClampDatum(Datum value, Oid typeOid,
+IcebergErrorOrClampDatum(Datum value, Oid typeOid, int32 typmod,
 						 IcebergOutOfRangePolicy policy, bool *isNull)
 {
 	*isNull = false;
 
 	bool		modified = false;
 
-	return IcebergErrorOrClampNestedDatum(value, typeOid, -1, policy,
+	return IcebergErrorOrClampNestedDatum(value, typeOid, typmod, policy,
 										  isNull, &modified);
 }

--- a/pg_lake_engine/src/pgduck/iceberg_datum_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_datum_validation.c
@@ -338,7 +338,7 @@ IcebergErrorOrClampNestedDatum(Datum value, Oid typeOid, int32 typmod,
 		ArrayType  *array = DatumGetArrayTypeP(value);
 		bool		needsMultidimClamp = ARR_NDIM(array) > 1;
 		bool		needsElementValidation =
-			TypeNeedsIcebergValidation(elemType, false);
+			TypeNeedsIcebergValidation(elemType, typmod, false);
 
 		if (!needsMultidimClamp && !needsElementValidation)
 			return value;
@@ -450,7 +450,8 @@ IcebergErrorOrClampNestedDatum(Datum value, Oid typeOid, int32 typmod,
 			if (attr->attisdropped || attrNulls[i])
 				continue;
 
-			if (!TypeNeedsIcebergValidation(attr->atttypid, false))
+			if (!TypeNeedsIcebergValidation(attr->atttypid, attr->atttypmod,
+											false))
 				continue;
 
 			bool		attrIsNull = false;

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -103,7 +103,7 @@ TupleDescNeedsValidation(TupleDesc tupleDesc)
 		if (attr->attisdropped)
 			continue;
 
-		if (TypeNeedsIcebergValidation(attr->atttypid, true))
+		if (TypeNeedsIcebergValidation(attr->atttypid, attr->atttypmod, true))
 			return true;
 	}
 
@@ -241,7 +241,7 @@ AppendIcebergValidationExpression(StringInfo buf, const char *expr,
 			? "pg_nullify_nested_list"
 			: "pg_error_nested_list";
 
-		if (TypeNeedsIcebergValidation(elemType, true))
+		if (TypeNeedsIcebergValidation(elemType, typmod, true))
 		{
 			char	   *lambdaVar = psprintf("_x%d", depth);
 
@@ -264,8 +264,10 @@ AppendIcebergValidationExpression(StringInfo buf, const char *expr,
 	{
 		PGType		keyType = GetMapKeyType(typeOid);
 		PGType		valType = GetMapValueType(typeOid);
-		bool		keyNeedsValidation = TypeNeedsIcebergValidation(keyType.postgresTypeOid, true);
-		bool		valNeedsValidation = TypeNeedsIcebergValidation(valType.postgresTypeOid, true);
+		bool		keyNeedsValidation = TypeNeedsIcebergValidation(keyType.postgresTypeOid,
+																	keyType.postgresTypeMod, true);
+		bool		valNeedsValidation = TypeNeedsIcebergValidation(valType.postgresTypeOid,
+																	valType.postgresTypeMod, true);
 
 		if (!keyNeedsValidation && !valNeedsValidation)
 			return false;
@@ -326,7 +328,8 @@ AppendIcebergValidationExpression(StringInfo buf, const char *expr,
 			if (attr->attisdropped)
 				continue;
 
-			if (TypeNeedsIcebergValidation(attr->atttypid, true))
+			if (TypeNeedsIcebergValidation(attr->atttypid, attr->atttypmod,
+										   true))
 			{
 				anyFieldNeedsTransform = true;
 				break;

--- a/pg_lake_engine/src/pgduck/iceberg_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_validation.c
@@ -30,6 +30,7 @@
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/pgduck/iceberg_validation.h"
 #include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/table_type.h"
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
@@ -93,14 +94,17 @@ IsTemporalType(Oid typeOid)
  * Validation covers: temporal boundaries (date/timestamp/timestamptz),
  * multidimensional array rejection (any array type), and bounded
  * numeric NaN (non-pushdown only, since numeric blocks pushdown).
+ * Unbounded and large-precision numerics are mapped to float8 on
+ * Iceberg tables, so NaN is valid for those and no validation is needed.
  */
 bool
-TypeNeedsIcebergValidation(Oid typeOid, bool isPushdown)
+TypeNeedsIcebergValidation(Oid typeOid, int32 typmod, bool isPushdown)
 {
 	if (IsTemporalType(typeOid))
 		return true;
 
-	if (!isPushdown && typeOid == NUMERICOID)
+	if (!isPushdown && typeOid == NUMERICOID &&
+		!IsUnsupportedNumericForIceberg(typeOid, typmod))
 		return true;
 
 	Oid			elemType = get_element_type(typeOid);
@@ -124,14 +128,21 @@ TypeNeedsIcebergValidation(Oid typeOid, bool isPushdown)
 		PGType		keyType = GetMapKeyType(typeOid);
 		PGType		valType = GetMapValueType(typeOid);
 
-		return TypeNeedsIcebergValidation(keyType.postgresTypeOid, isPushdown) ||
-			TypeNeedsIcebergValidation(valType.postgresTypeOid, isPushdown);
+		return TypeNeedsIcebergValidation(keyType.postgresTypeOid,
+										  keyType.postgresTypeMod, isPushdown) ||
+			TypeNeedsIcebergValidation(valType.postgresTypeOid,
+									   valType.postgresTypeMod, isPushdown);
 	}
 
 	char		typtype = get_typtype(typeOid);
 
 	if (typtype == TYPTYPE_DOMAIN)
-		return TypeNeedsIcebergValidation(getBaseType(typeOid), isPushdown);
+	{
+		int32		baseTypmod = typmod;
+		Oid			baseType = getBaseTypeAndTypmod(typeOid, &baseTypmod);
+
+		return TypeNeedsIcebergValidation(baseType, baseTypmod, isPushdown);
+	}
 
 	if (typtype == TYPTYPE_COMPOSITE)
 	{
@@ -145,7 +156,8 @@ TypeNeedsIcebergValidation(Oid typeOid, bool isPushdown)
 			if (attr->attisdropped)
 				continue;
 
-			if (TypeNeedsIcebergValidation(attr->atttypid, isPushdown))
+			if (TypeNeedsIcebergValidation(attr->atttypid, attr->atttypmod,
+										   isPushdown))
 			{
 				found = true;
 				break;

--- a/pg_lake_table/src/fdw/pg_lake_table.c
+++ b/pg_lake_table/src/fdw/pg_lake_table.c
@@ -2624,6 +2624,7 @@ IcebergErrorOrClampSlotInPlace(TupleTableSlot *slot, TupleDesc tupleDesc,
 		bool		isNull = false;
 		Datum		clamped = IcebergErrorOrClampDatum(slot->tts_values[i],
 													   attr->atttypid,
+													   attr->atttypmod,
 													   policy,
 													   &isNull);
 

--- a/pg_lake_table/src/fdw/pg_lake_table.c
+++ b/pg_lake_table/src/fdw/pg_lake_table.c
@@ -2590,7 +2590,7 @@ TupleDescNeedsIcebergValidation(TupleDesc tupleDesc)
 		if (attr->attisdropped)
 			continue;
 
-		if (TypeNeedsIcebergValidation(attr->atttypid, false))
+		if (TypeNeedsIcebergValidation(attr->atttypid, attr->atttypmod, false))
 			return true;
 	}
 
@@ -2618,7 +2618,7 @@ IcebergErrorOrClampSlotInPlace(TupleTableSlot *slot, TupleDesc tupleDesc,
 		if (attr->attisdropped || slot->tts_isnull[i])
 			continue;
 
-		if (!TypeNeedsIcebergValidation(attr->atttypid, false))
+		if (!TypeNeedsIcebergValidation(attr->atttypid, attr->atttypmod, false))
 			continue;
 
 		bool		isNull = false;


### PR DESCRIPTION
Unbounded (numeric) and large numerics (numeric(p,s) where p > 38) are mapped to float8 in iceberg table columns. We do not need to validate those datums. Only bounded numeric datums (e.g. numeric(10,2)) need to be validated.