### PR TITLE
Add support for ALTER TABLE path changes on external Iceberg tables

### DIFF
--- a/docs/file-formats-reference.md
+++ b/docs/file-formats-reference.md
@@ -157,7 +157,11 @@ server pg_lake
 options (path 's3://mybucket/table/v14.metadata.json');
 ```
 
-Note that changes to the external Iceberg table will **not** be reflected in the foreign table unless you update the path to point to the new metadata file.
+Note that changes to the external Iceberg table will **not** be reflected in the foreign table unless you update the path to point to the new metadata file. You can do this without dropping and recreating the table:
+
+```sql
+ALTER FOREIGN TABLE external_iceberg OPTIONS (SET path 's3://mybucket/table/v15.metadata.json');
+```
 
 ## Hugging Face
 

--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -694,6 +694,17 @@ There are a few additional limitations regarding `ALTER TABLE` compared to regul
 
 Some advanced table management features such as declarative partitioning and inheritance are supported. Do be careful with those features, since the PostgreSQL planner does not always know how to efficiently perform aggregations across Iceberg (read: foreign) partitions.
 
+### Altering external Iceberg tables
+
+External read-only Iceberg foreign tables (created via `SERVER pg_lake OPTIONS (path '...metadata.json')`) support one `ALTER` operation: updating the `path` option to redirect the table to a different snapshot. All other `ALTER` operations are unsupported on external tables.
+
+```sql
+-- Redirect an external Iceberg table to a newer snapshot
+ALTER FOREIGN TABLE external_iceberg OPTIONS (SET path 's3://mybucket/table/v15.metadata.json');
+```
+
+This avoids having to `DROP` and re-`CREATE` the table when a new snapshot is available, preserving any dependent views, permissions, or references.
+
 ## Vacuuming an Iceberg table
 
 Each insert/update/delete operation on an Iceberg table results in additional data files being written. Quite often, this can result in the table being made up of many small files. The solution to that is to vacuum the table, similar to (auto)vacuum for regular heap tables. VACUUM on Iceberg tables does the following tasks:

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -59,6 +59,7 @@
 #include "pg_lake/rest_catalog/rest_catalog.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
 #include "pg_lake/util/rel_utils.h"
+#include "pg_lake/util/table_type.h"
 
 
 typedef enum PgLakeDDLType
@@ -275,6 +276,20 @@ ProcessAlterTable(ProcessUtilityParams * processUtilityParams, void *arg)
 			 * read-only rest catalog iceberg tables.
 			 */
 			List	   *allowedOptions = list_make3("catalog_table_name", "catalog_namespace", "catalog_name");
+
+			ErrorIfUnsupportedTableOptionChange(alterStmt, allowedOptions);
+
+			return false;
+		}
+		else if (icebergCatalogType == NONE_CATALOG && IsExternalIcebergTable(relationId))
+		{
+			/*
+			 * For external read-only Iceberg foreign tables created via
+			 * SERVER pg_lake OPTIONS (path '...metadata.json'), allow
+			 * updating the path option so callers can redirect the table to a
+			 * newer snapshot without DROP + CREATE.
+			 */
+			List	   *allowedOptions = list_make1("path");
 
 			ErrorIfUnsupportedTableOptionChange(alterStmt, allowedOptions);
 


### PR DESCRIPTION
## Description
External Iceberg foreign tables (created via SERVER pg_lake OPTIONS (path '...metadata.json')) were previously immutable — to point to a newer snapshot you had to DROP and re-CREATE the table, losing any dependent views, permissions, or references.

This change adds a narrow ALTER TABLE ... OPTIONS (SET path '...') path for these read-only external tables, allowing callers to redirect to a different metadata snapshot in-place.

Changes
pg_lake_table/src/ddl/alter_table.c: Added a branch in ProcessAlterTable() that detects NONE_CATALOG external Iceberg tables and permits only the path option to be changed, rejecting all other option modifications via ErrorIfUnsupportedTableOptionChange.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
