### PR TITLE
feat: add ALTER TABLE SET SCHEMA hook support

### DIFF
--- a/pg_lake_table/include/pg_lake/ddl/alter_table.h
+++ b/pg_lake_table/include/pg_lake/ddl/alter_table.h
@@ -29,6 +29,10 @@ void		PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams * params, v
 /* allow other hooks */
 typedef void (*PgLakeAlterTableHookType) (Oid relationOid, AlterTableStmt *stmt);
 typedef void (*PgLakeAlterTableRenameColumnHookType) (Oid relationOid, RenameStmt *stmt);
+typedef void (*PgLakeAlterTableSetSchemaHookType) (Oid relationOid, AlterObjectSchemaStmt *stmt);
+typedef bool (*PgLakeIsReplicationTargetHookType) (Oid relationOid);
 
 extern PGDLLEXPORT PgLakeAlterTableHookType PgLakeAlterTableHook;
 extern PGDLLEXPORT PgLakeAlterTableRenameColumnHookType PgLakeAlterTableRenameColumnHook;
+extern PGDLLEXPORT PgLakeAlterTableSetSchemaHookType PgLakeAlterTableSetSchemaHook;
+extern PGDLLEXPORT PgLakeIsReplicationTargetHookType PgLakeIsReplicationTargetHook;

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -124,6 +124,8 @@ static bool DisallowedForWritableRestSetSchema(Node *arg, Oid relationId);
 
 PgLakeAlterTableHookType PgLakeAlterTableHook = NULL;
 PgLakeAlterTableRenameColumnHookType PgLakeAlterTableRenameColumnHook = NULL;
+PgLakeAlterTableSetSchemaHookType PgLakeAlterTableSetSchemaHook = NULL;
+PgLakeIsReplicationTargetHookType PgLakeIsReplicationTargetHook = NULL;
 
 /*
  * Below is the support matrix for ALTER TABLE commands, which pg_lake
@@ -742,13 +744,18 @@ PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams * params, void *a
 		return;
 	}
 
-	ErrorIfReadOnlyIcebergTable(relationId);
+	bool isReplicationTarget = PgLakeIsReplicationTargetHook && PgLakeIsReplicationTargetHook(relationId);
+	if (!isReplicationTarget)
+		ErrorIfReadOnlyIcebergTable(relationId);
 
 	PgLakeTableType tableType = GetPgLakeTableType(relationId);
 
 	ErrorIfUnsupportedAlterWritablePgLakeTableSchemaStmt(alterSchemaStmt, tableType);
 
 	TriggerCatalogExportIfObjectStoreTable(relationId);
+
+	if (PgLakeAlterTableSetSchemaHook)
+		PgLakeAlterTableSetSchemaHook(relationId, alterSchemaStmt);
 
 	return;
 }

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -744,7 +744,8 @@ PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams * params, void *a
 		return;
 	}
 
-	bool isReplicationTarget = PgLakeIsReplicationTargetHook && PgLakeIsReplicationTargetHook(relationId);
+	bool		isReplicationTarget = PgLakeIsReplicationTargetHook && PgLakeIsReplicationTargetHook(relationId);
+
 	if (!isReplicationTarget)
 		ErrorIfReadOnlyIcebergTable(relationId);
 


### PR DESCRIPTION
## Summary
- Add `PgLakeAlterTableSetSchemaHook` to allow replication extensions to handle `ALTER TABLE SET SCHEMA`
- Add `PgLakeIsReplicationTargetHook` to skip read-only check for replication targets
- Export both hooks via `PGDLLEXPORT` for shared library access

## Context
This enables both extensions to properly track table schema changes when tables are moved between schemas via `ALTER TABLE SET SCHEMA`.

## Test plan
- Tested with the second extension's test suite: all 8 `test_set_schema` tests pass