### PR TITLE
Make linting its own workflow

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -33,11 +33,6 @@ runs:
       run: |
         python3.11 -m pipenv install --dev
 
-    - name: Check formatting
-      shell: bash
-      run: |
-        make check-indent PG_INDENT=/home/postgres/pgsql-${PG_INDENT_VERSION}/bin/pgindent
-
     - name: Check for typos # ;)
       uses: ./.github/actions/check-typos
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Check formatting for pg_lake repos
+
+on:
+  workflow_call:
+    inputs:
+      pg_version:
+        required: true
+        type: string
+      image_tag:
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/snowflake-labs/pg-lake-ci-pg-almalinux:${{ inputs.image_tag }}
+      options: --user 1001 --shm-size=128MB
+      volumes:
+        - /usr/local:/host/usr/local
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Check out repository code
+        with:
+          fetch-depth: 0
+
+      - name: Export PGDIR, PATH and PG_REGRESS_DIR
+        run: |
+          echo "PGDIR=/home/postgres/pgsql-${{ inputs.pg_version }}" >> $GITHUB_ENV
+          echo "PATH=/home/postgres/pgsql-${{ inputs.pg_version }}/bin:$PATH" >> $GITHUB_ENV
+          echo "PG_REGRESS_DIR=/home/postgres/pgsql-${{ inputs.pg_version }}/regress" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        id: cache_pipenv
+        name: Cache pipenv
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-python-3.11-pipenv-${{ hashFiles('Pipfile.lock') }}
+
+      - name: Install pipenv dependencies
+        if: steps.cache_pipenv.outputs.cache-hit != 'true'
+        run: |
+          python3.11 -m pipenv install --dev
+
+      - name: Check formatting
+        run: |
+          make check-indent

--- a/.github/workflows/pytest_all.yml
+++ b/.github/workflows/pytest_all.yml
@@ -14,7 +14,6 @@ env:
   CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
   ORG: snowflake-labs
   PG_LAKE_DELTA_SUPPORT: 1
-  PG_INDENT_VERSION: 18
 
 jobs:
   build-image-almalinux:
@@ -130,6 +129,14 @@ jobs:
         with:
           container_os: 'debian'
           pg_version: ${{ matrix.pg_version }}
+
+  # Formatting checks only on one postgres version
+  lint-check-18:
+    needs: [build-image-almalinux]
+    uses: ./.github/workflows/lint.yml
+    with:
+      pg_version: "18"
+      image_tag: ${{ needs.build-image-almalinux.outputs.tag }}
 
   test-check:
     needs: [build-image-almalinux, build-and-install-almalinux]

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 
 # style/indent-related changes
 
-# This target ensures that we download the latest major version's typedefs.list
+# This target ensures that we download the target major version's typedefs.list
 # from buildfarm if we don't have a local copy.  Since we currently do not
 # override the typedefs.list, this should be equivalent to what we were
 # previously doing by pulling from the postgres source tree.

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,7 @@ UNAME_S := $(shell uname -s)
 
 # List of targets for indent checks
 INDENT_TARGETS = pgduck_server $(EXTENSION_TARGETS)
-PG_INDENT_VERSION = 18
-PG_INDENT ?= pgindent
-TYPEDEFS = /tmp/typedefs-$(PG_INDENT_VERSION).list
+TYPEDEFS = /tmp/typedefs-$(PG_MAJOR_VERSION).list
 
 CMAKE_AVRO_ARGS = -DCMAKE_INSTALL_PREFIX=avrolib -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
@@ -65,7 +63,7 @@ endif
 
 # style/indent-related changes
 
-# This target ensures that we download the PG_INDENT_VERSION's typedefs.list
+# This target ensures that we download the latest major version's typedefs.list
 # from buildfarm if we don't have a local copy.  Since we currently do not
 # override the typedefs.list, this should be equivalent to what we were
 # previously doing by pulling from the postgres source tree.
@@ -73,14 +71,14 @@ endif
 typedefs: $(TYPEDEFS)
 
 $(TYPEDEFS):
-	curl -o $(TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PG_INDENT_VERSION)_STABLE
+	curl -o $(TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PG_MAJOR_VERSION)_STABLE
 
 check-indent: typedefs
-	$(PG_INDENT) --typedefs=$(TYPEDEFS) --check --diff $(INDENT_TARGETS)
+	pgindent --typedefs=$(TYPEDEFS) --check --diff $(INDENT_TARGETS)
 	pipenv run black --check --diff $(INDENT_TARGETS)
 
 reindent: typedefs
-	$(PG_INDENT) --typedefs=$(TYPEDEFS) $(INDENT_TARGETS)
+	pgindent --typedefs=$(TYPEDEFS) $(INDENT_TARGETS)
 	pipenv run black $(INDENT_TARGETS)
 
 submodules:


### PR DESCRIPTION
### Description
`lint-check-18` will error so we cannot merge a PR, but will allow the rest of the tests to run without needing to immediately fix a simple formatting bug.

Idea from @sfc-gh-dachristensen 

---

### Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**