### PR TITLE
Export GetNotShippableDescription and CollectNotShippableObjects

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/shippable.h
+++ b/pg_lake_table/include/pg_lake/fdw/shippable.h
@@ -55,5 +55,5 @@ typedef struct NotShippableObject
 extern bool is_builtin(Oid objectId);
 extern bool is_shippable(Oid objectId, Oid classId, Node *expr);
 extern bool is_non_shippable_udt_context(Node *node);
-extern const char *GetNotShippableDescription(NotShippableReason reason, Oid classId, Oid objectId);
-extern HTAB *CollectNotShippableObjects(Node *node);
+extern PGDLLEXPORT const char *GetNotShippableDescription(NotShippableReason reason, Oid classId, Oid objectId);
+extern PGDLLEXPORT HTAB *CollectNotShippableObjects(Node *node);


### PR DESCRIPTION
Mark these two as PGDLLEXPORT so external extensions can reuse the shippability walker and the associated description helper. The pg_lake codebase builds with -fvisibility=hidden, so the declarations would otherwise be unreachable from another dylib loaded into the same backend.

Made-with: Cursor
