### PR TITLE
Get pg_lake's custom types in the typedefs list for pgindent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ INDENT_TARGETS = pgduck_server $(EXTENSION_TARGETS)
 # Pinned PG version for formatting (pgindent/typedefs). Must match CI
 # (lint-check-18 in pytest_all.yml).
 PGINDENT_PG_VERSION := 18
-TYPEDEFS = /tmp/typedefs-$(PGINDENT_PG_VERSION).list
+PG_TYPEDEFS = /tmp/typedefs-pg-$(PGINDENT_PG_VERSION).list
+PGLAKE_TYPEDEFS = /tmp/typedefs-pglake.list
+TYPEDEFS = /tmp/typedefs-combined-$(PGINDENT_PG_VERSION).list
 
 CMAKE_AVRO_ARGS = -DCMAKE_INSTALL_PREFIX=avrolib -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
@@ -67,15 +69,18 @@ endif
 
 # style/indent-related changes
 
-# This target ensures that we download the target major version's typedefs.list
+# This target ensures that we download the PGINDENT_PG_VERSION's typedefs.list
 # from buildfarm if we don't have a local copy.  Since we currently do not
 # override the typedefs.list, this should be equivalent to what we were
 # previously doing by pulling from the postgres source tree.
+$(PG_TYPEDEFS):
+	curl -o $(PG_TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PGINDENT_PG_VERSION)_STABLE
 
-typedefs: $(TYPEDEFS)
+$(PGLAKE_TYPEDEFS): $(shell find $(INDENT_TARGETS) -name '*.c' -o -name '*.h' 2>/dev/null)
+	tools/extract_typedefs.sh $(INDENT_TARGETS) > $(PGLAKE_TYPEDEFS)
 
-$(TYPEDEFS):
-	curl -o $(TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PGINDENT_PG_VERSION)_STABLE
+typedefs: $(PG_TYPEDEFS) $(PGLAKE_TYPEDEFS)
+	cat $(PG_TYPEDEFS) $(PGLAKE_TYPEDEFS) | sort -u > $(TYPEDEFS)
 
 check-indent: typedefs
 	pgindent --typedefs=$(TYPEDEFS) --check --diff $(INDENT_TARGETS)

--- a/pg_extension_base/include/pg_extension_base/attached_worker.h
+++ b/pg_extension_base/include/pg_extension_base/attached_worker.h
@@ -38,19 +38,19 @@ typedef struct AttachedWorker
 	/* background worker handle */
 	pid_t		workerPid;
 	BackgroundWorkerHandle *workerHandle;
-}			AttachedWorker;
+} AttachedWorker;
 
-extern PGDLLEXPORT AttachedWorker * StartAttachedWorker(char *command);
-extern PGDLLEXPORT AttachedWorker * StartAttachedWorkerInDatabase(char *command,
-																  char *databaseName,
-																  char *userName);
-extern PGDLLEXPORT AttachedWorker * StartAttachedWorkerReturning(char *command);
-extern PGDLLEXPORT AttachedWorker * StartAttachedWorkerInDatabaseReturning(char *command,
-																		   char *databaseName,
-																		   char *userName);
-extern PGDLLEXPORT char *ReadFromAttachedWorker(AttachedWorker * worker, bool wait);
-extern PGDLLEXPORT void ReadResultsFromAttachedWorker(AttachedWorker * worker,
+extern PGDLLEXPORT AttachedWorker *StartAttachedWorker(char *command);
+extern PGDLLEXPORT AttachedWorker *StartAttachedWorkerInDatabase(char *command,
+																 char *databaseName,
+																 char *userName);
+extern PGDLLEXPORT AttachedWorker *StartAttachedWorkerReturning(char *command);
+extern PGDLLEXPORT AttachedWorker *StartAttachedWorkerInDatabaseReturning(char *command,
+																		  char *databaseName,
+																		  char *userName);
+extern PGDLLEXPORT char *ReadFromAttachedWorker(AttachedWorker *worker, bool wait);
+extern PGDLLEXPORT void ReadResultsFromAttachedWorker(AttachedWorker *worker,
 													  Tuplestorestate *store,
 													  TupleDesc *resultDesc);
-extern PGDLLEXPORT bool IsAttachedWorkerRunning(AttachedWorker * worker);
-extern PGDLLEXPORT void EndAttachedWorker(AttachedWorker * worker);
+extern PGDLLEXPORT bool IsAttachedWorkerRunning(AttachedWorker *worker);
+extern PGDLLEXPORT void EndAttachedWorker(AttachedWorker *worker);

--- a/pg_extension_base/include/pg_extension_base/extension_ids.h
+++ b/pg_extension_base/include/pg_extension_base/extension_ids.h
@@ -56,11 +56,11 @@ typedef void (*ClearFunction) (void *clearContext);
 struct CachedExtensionIdsData;
 typedef struct CachedExtensionIdsData CachedExtensionIds;
 
-extern PGDLLEXPORT CachedExtensionIds * CreateExtensionIdsCache(char *extensionName,
-																ClearFunction clearFn,
-																void *clearContext);
-extern PGDLLEXPORT bool IsExtensionCreated(CachedExtensionIds * extension);
-extern PGDLLEXPORT Oid ExtensionId(CachedExtensionIds * extension);
-extern PGDLLEXPORT Oid ExtensionSchemaId(CachedExtensionIds * extension);
-extern PGDLLEXPORT Oid ExtensionOwnerId(CachedExtensionIds * extension);
-extern PGDLLEXPORT void EnsureExtensionExists(CachedExtensionIds * extension);
+extern PGDLLEXPORT CachedExtensionIds *CreateExtensionIdsCache(char *extensionName,
+															   ClearFunction clearFn,
+															   void *clearContext);
+extern PGDLLEXPORT bool IsExtensionCreated(CachedExtensionIds *extension);
+extern PGDLLEXPORT Oid ExtensionId(CachedExtensionIds *extension);
+extern PGDLLEXPORT Oid ExtensionSchemaId(CachedExtensionIds *extension);
+extern PGDLLEXPORT Oid ExtensionOwnerId(CachedExtensionIds *extension);
+extern PGDLLEXPORT void EnsureExtensionExists(CachedExtensionIds *extension);

--- a/pg_extension_base/include/pg_extension_base/pg_extension_base_ids.h
+++ b/pg_extension_base/include/pg_extension_base/pg_extension_base_ids.h
@@ -22,6 +22,6 @@
 #define PG_EXTENSION_BASE_NAME "pg_extension_base"
 
 /* cached extension IDs for pg_extension_base */
-extern PGDLLEXPORT CachedExtensionIds * PgExtensionBase;
+extern PGDLLEXPORT CachedExtensionIds *PgExtensionBase;
 
 extern PGDLLEXPORT void InitializePgExtensionBaseCache(void);

--- a/pg_extension_base/src/attached_worker.c
+++ b/pg_extension_base/src/attached_worker.c
@@ -82,8 +82,8 @@ PG_FUNCTION_INFO_V1(pg_extension_base_run_attached_worker_returning);
 extern PGDLLEXPORT void AttachedWorkerMain(Datum mainArg);
 
 /* internal functions */
-static AttachedWorker * StartAttachedWorkerInternal(char *command, char *databaseName,
-													char *userName, uint32 flags);
+static AttachedWorker *StartAttachedWorkerInternal(char *command, char *databaseName,
+												   char *userName, uint32 flags);
 static void RunAttachedWorker(char *command, char *databaseName, char *userName, ReturnSetInfo *rsinfo);
 static void RunAttachedWorkerReturning(char *command, char *databaseName,
 									   char *userName, ReturnSetInfo *rsinfo);
@@ -543,7 +543,7 @@ ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
  * worker until reaching query completion or error.
  */
 char *
-ReadFromAttachedWorker(AttachedWorker * worker, bool wait)
+ReadFromAttachedWorker(AttachedWorker *worker, bool wait)
 {
 	return ProcessProtocolMessages(worker->outputQueue, !wait, NULL);
 }
@@ -594,7 +594,7 @@ ValidateWorkerTupleDesc(TupleDesc workerDesc, TupleDesc expectedDesc)
  * On return, *resultDesc is set to the TupleDesc that was used.
  */
 void
-ReadResultsFromAttachedWorker(AttachedWorker * worker, Tuplestorestate *store,
+ReadResultsFromAttachedWorker(AttachedWorker *worker, Tuplestorestate *store,
 							  TupleDesc *resultDesc)
 {
 	TupleDesc	tupleDesc = *resultDesc;
@@ -661,7 +661,7 @@ ReadResultsFromAttachedWorker(AttachedWorker * worker, Tuplestorestate *store,
  * still running.
  */
 bool
-IsAttachedWorkerRunning(AttachedWorker * worker)
+IsAttachedWorkerRunning(AttachedWorker *worker)
 {
 	pid_t		pid;
 
@@ -674,7 +674,7 @@ IsAttachedWorkerRunning(AttachedWorker * worker)
  * worker to clean up the resources.
  */
 void
-EndAttachedWorker(AttachedWorker * worker)
+EndAttachedWorker(AttachedWorker *worker)
 {
 	if (worker->sharedMemorySegment == NULL)
 		return;

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -152,7 +152,7 @@ typedef struct BaseWorkerControlData
 	/* current PID of the server starter */
 	pid_t		serverStarterPid;
 	int			serverStarterProcno;
-}			BaseWorkerControlData;
+} BaseWorkerControlData;
 
 
 typedef enum WorkerState
@@ -162,7 +162,7 @@ typedef enum WorkerState
 	WORKER_RUNNING,
 	WORKER_STOPPED,
 	WORKER_RESTARTING
-}			WorkerState;
+} WorkerState;
 
 
 /*
@@ -184,7 +184,7 @@ typedef struct DatabaseStarterEntry
 
 	/* process number for signaling via ProcSendSignal */
 	int			procno;
-}			DatabaseStarterEntry;
+} DatabaseStarterEntry;
 
 
 /*
@@ -197,7 +197,7 @@ typedef struct BaseWorkerKey
 
 	/* worker ID */
 	int32		workerId;
-}			BaseWorkerKey;
+} BaseWorkerKey;
 
 
 /*
@@ -225,7 +225,7 @@ typedef struct BaseWorkerEntry
 
 	/* when to restart the base worker (delayed after failure) */
 	TimestampTz restartAfter;
-}			BaseWorkerEntry;
+} BaseWorkerEntry;
 
 
 /*
@@ -241,7 +241,7 @@ typedef struct DatabaseEntry
 
 	/* whether this is a template database */
 	bool		isTemplate;
-}			DatabaseEntry;
+} DatabaseEntry;
 
 
 /*
@@ -261,7 +261,7 @@ typedef struct BaseWorkerRegistration
 
 	/* entry point function */
 	Oid			entryPointFunctionId;
-}			BaseWorkerRegistration;
+} BaseWorkerRegistration;
 
 /*
  * StartDatabaseStarterResult indicates whether a database starter was
@@ -273,7 +273,7 @@ typedef enum StartDatabaseStarterResult
 	DATABASE_STARTER_EXISTS,
 	DATABASE_STARTER_DONE,
 	DATABASE_STARTER_FAILED
-}			StartDatabaseStarterResult;
+} StartDatabaseStarterResult;
 
 /*
  * StartBaseWorkerResult indicates whether a base worker was
@@ -286,7 +286,7 @@ typedef enum StartBaseWorkerResult
 	BASE_WORKER_DONE,
 	BASE_WORKER_START_FAILED,
 	BASE_WORKER_START_BLOCKED
-}			StartBaseWorkerResult;
+} StartBaseWorkerResult;
 
 
 
@@ -308,10 +308,10 @@ static StartDatabaseStarterResult StartDatabaseStarter(Oid databaseId,
 													   char *databaseName);
 
 /* shared memory bookkeeping */
-static DatabaseStarterEntry * GetDatabaseStarterEntry(Oid databaseId, bool *isFound);
-static DatabaseStarterEntry * GetOrCreateDatabaseStarterEntry(Oid databaseId, bool *isFound);
-static BaseWorkerEntry * GetBaseWorkerEntry(Oid databaseId, int32 workerId, bool *isFound);
-static BaseWorkerEntry * GetOrCreateBaseWorkerEntry(int32 workerId, bool *isFound);
+static DatabaseStarterEntry *GetDatabaseStarterEntry(Oid databaseId, bool *isFound);
+static DatabaseStarterEntry *GetOrCreateDatabaseStarterEntry(Oid databaseId, bool *isFound);
+static BaseWorkerEntry *GetBaseWorkerEntry(Oid databaseId, int32 workerId, bool *isFound);
+static BaseWorkerEntry *GetOrCreateBaseWorkerEntry(int32 workerId, bool *isFound);
 static void RemoveBaseWorkerEntry(Oid databaseId, int32 workerId);
 static void RemoveBaseWorkerEntriesForDatabase(Oid databaseId);
 static void RemoveBaseWorkerEntriesNotInRegistrationList(List *workerRegistrationList);
@@ -377,7 +377,7 @@ PGDLLEXPORT void PgExtensionBaseDatabaseStarterMain(Datum arg);
 PGDLLEXPORT void PgExtensionBaseWorkerMain(Datum arg);
 
 /* shared memory state */
-static BaseWorkerControlData * BaseWorkerControl = NULL;
+static BaseWorkerControlData *BaseWorkerControl = NULL;
 static HTAB *DatabaseStarterHash = NULL;
 static HTAB *BaseWorkerHash = NULL;
 

--- a/pg_extension_base/src/extension_ids.c
+++ b/pg_extension_base/src/extension_ids.c
@@ -208,7 +208,7 @@ InvalidateExtensionIdCache(Datum argument, Oid relationId)
  * IsExtensionCreated returns whether exists.
  */
 bool
-IsExtensionCreated(CachedExtensionIds * extension)
+IsExtensionCreated(CachedExtensionIds *extension)
 {
 	if (extension->existsStatus == EXTENSION_STATUS_EXISTS)
 		return true;
@@ -235,7 +235,7 @@ IsExtensionCreated(CachedExtensionIds * extension)
  * ExtensionId returns the OID of the extension.
  */
 Oid
-ExtensionId(CachedExtensionIds * extension)
+ExtensionId(CachedExtensionIds *extension)
 {
 	if (extension->extensionId == InvalidOid)
 	{
@@ -250,7 +250,7 @@ ExtensionId(CachedExtensionIds * extension)
  * ExtensionSchemaId returns the OID of the extension schema.
  */
 Oid
-ExtensionSchemaId(CachedExtensionIds * extension)
+ExtensionSchemaId(CachedExtensionIds *extension)
 {
 	if (extension->schemaId == InvalidOid)
 		extension->schemaId = get_extension_schema(ExtensionId(extension));
@@ -263,7 +263,7 @@ ExtensionSchemaId(CachedExtensionIds * extension)
  * ExtensionOwnerId returns the OID of the extension owner.
  */
 Oid
-ExtensionOwnerId(CachedExtensionIds * extension)
+ExtensionOwnerId(CachedExtensionIds *extension)
 {
 	if (extension->ownerId == InvalidOid)
 	{
@@ -300,7 +300,7 @@ ExtensionOwnerId(CachedExtensionIds * extension)
  * in the current database.
  */
 void
-EnsureExtensionExists(CachedExtensionIds * extension)
+EnsureExtensionExists(CachedExtensionIds *extension)
 {
 	if (IsExtensionCreated(extension))
 		return;

--- a/pg_extension_base/src/extension_ids.c
+++ b/pg_extension_base/src/extension_ids.c
@@ -45,7 +45,7 @@ typedef enum ExtensionStatus
 	EXTENSION_STATUS_UNKNOWN,
 	EXTENSION_STATUS_EXISTS,
 	EXTENSION_STATUS_NOT_EXISTS
-}			ExtensionStatus;
+} ExtensionStatus;
 
 
 /*

--- a/pg_extension_base/src/library_preloader.c
+++ b/pg_extension_base/src/library_preloader.c
@@ -45,12 +45,12 @@ typedef struct PreloadLibrary
 
 	/* name of the library */
 	char	   *libraryName;
-}			PreloadLibrary;
+} PreloadLibrary;
 
 /* internal functions */
 static List *FindAllPreloadLibraries(void);
 static List *FindExtensionPreloadLibraryNames(char *extensionName);
-static List *AddPreloadLibrary(List *libraries, PreloadLibrary * preloadLibrary);
+static List *AddPreloadLibrary(List *libraries, PreloadLibrary *preloadLibrary);
 
 /* SQL-callable functions */
 PG_FUNCTION_INFO_V1(pg_extension_base_list_preload_libraries);
@@ -309,7 +309,7 @@ FindExtensionPreloadLibraryNames(char *extensionName)
  * unless the library already appears.
  */
 static List *
-AddPreloadLibrary(List *libraries, PreloadLibrary * preloadLibrary)
+AddPreloadLibrary(List *libraries, PreloadLibrary *preloadLibrary)
 {
 	ListCell   *libraryCell = NULL;
 

--- a/pg_extension_updater/src/pg_extension_updater.c
+++ b/pg_extension_updater/src/pg_extension_updater.c
@@ -45,7 +45,7 @@ typedef struct UpdatableExtension
 
 	/* default version (usually the latest installed version) */
 	char	   *defaultVersion;
-}			UpdatableExtension;
+} UpdatableExtension;
 
 
 /* function declarations */

--- a/pg_lake_benchmark/include/pg_lake/benchmark.h
+++ b/pg_lake_benchmark/include/pg_lake/benchmark.h
@@ -36,13 +36,13 @@ typedef struct BenchQuery
 {
 	const char *query;
 	int			query_nr;
-}			BenchQuery;
+} BenchQuery;
 
 extern void PgDuckInstallBenchExtension(BenchmarkType benchType);
 extern void PgDuckDropBenchTables(const char *tableNames[], int length);
 extern void PgDuckGenerateBenchTables(BenchmarkType benchType, float4 scaleFactor, int iterationCount);
 extern void PgDuckCopyBenchTablesToRemoteParquet(const char *tableNames[], int length, char *location);
-extern void PgDuckGetQueries(BenchmarkType benchType, BenchQuery * queries, int queryCount);
+extern void PgDuckGetQueries(BenchmarkType benchType, BenchQuery *queries, int queryCount);
 extern void PgLakeDropBenchTables(const char *tableNames[], int length, char *location);
 extern void PgLakeCreateBenchTables(const char *tableNames[], char **partitionBys, int length, BenchmarkTableType tableType, char *location);
 extern BenchmarkTableType GetBenchTableType(Oid tableTypeId);

--- a/pg_lake_benchmark/src/benchmark.c
+++ b/pg_lake_benchmark/src/benchmark.c
@@ -119,7 +119,7 @@ PgDuckCopyBenchTablesToRemoteParquet(const char *tableNames[], int length, char 
  * PgDuckGetQueries returns the benchmark queries via pgduck server.
  */
 void
-PgDuckGetQueries(BenchmarkType benchType, BenchQuery * queries, int queryCount)
+PgDuckGetQueries(BenchmarkType benchType, BenchQuery *queries, int queryCount)
 {
 	char	   *query;
 

--- a/pg_lake_copy/include/pg_lake/copy/copy.h
+++ b/pg_lake_copy/include/pg_lake/copy/copy.h
@@ -28,7 +28,7 @@
 extern bool EnablePgLakeCopy;
 extern bool EnablePgLakeCopyJson;
 
-bool		PgLakeCopyHandler(ProcessUtilityParams * params, void *arg);
+bool		PgLakeCopyHandler(ProcessUtilityParams *params, void *arg);
 void		ProcessPgLakeCopy(ParseState *pstate, PlannedStmt *plannedStmt,
 							  const char *queryString, uint64 *rowsProcessed);
 

--- a/pg_lake_copy/include/pg_lake/copy/create_table.h
+++ b/pg_lake_copy/include/pg_lake/copy/create_table.h
@@ -20,6 +20,6 @@
 
 #include "pg_lake/ddl/utility_hook.h"
 
-bool		CreateTableFromFileHandler(ProcessUtilityParams * params, void *arg);
+bool		CreateTableFromFileHandler(ProcessUtilityParams *params, void *arg);
 
 #endif

--- a/pg_lake_copy/src/copy/copy.c
+++ b/pg_lake_copy/src/copy/copy.c
@@ -106,7 +106,7 @@ static char *GenerateReadDataSourceQuery(char *sourcePath,
 										 CopyDataCompression sourceCompression,
 										 TupleDesc tupleDesc,
 										 List *options,
-										 DataFileSchema * schema,
+										 DataFileSchema *schema,
 										 int readFlags);
 static List *FindCopyFromWriteOptions(CopyDataFormat format, List *options);
 static void ProcessPgLakeCopyTo(CopyStmt *copyStmt, ParseState *pstate,
@@ -129,7 +129,7 @@ static TupleDesc BuildTupleDescriptorForRelation(Relation relation, List *attrib
 static TupleDesc RemoveDroppedColumnsFromTupleDesc(TupleDesc tupleDesc);
 static void VerifyNoDuplicateNames(TupleDesc tupleDesc);
 static int	CopyReceivedTransmitDataToBuffer(void *outbuf, int minread, int maxread);
-static bool ReceiveCopyData(PGDuckConnection * pgDuckConn, StringInfo buffer);
+static bool ReceiveCopyData(PGDuckConnection *pgDuckConn, StringInfo buffer);
 
 PG_FUNCTION_INFO_V1(pg_lake_last_copy_pushed_down_test);
 
@@ -145,7 +145,7 @@ bool		EnablePgLakeCopyJson = true;
  * The connection is closed automatically via PGDuckClientTransactionCallback.
  * The old pointers may remain in place and should always be reset before use.
  */
-static PGDuckConnection * CurrentCopyFromConnection = NULL;
+static PGDuckConnection *CurrentCopyFromConnection = NULL;
 static StringInfoData CopyFromBuffer;
 
 
@@ -164,7 +164,7 @@ static bool LastCopyPushedDownTest = false;
  * - COPY (SELECT ... ) TO 's3://...';
  */
 bool
-PgLakeCopyHandler(ProcessUtilityParams * params, void *arg)
+PgLakeCopyHandler(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -668,7 +668,7 @@ static char *
 GenerateReadDataSourceQuery(char *sourcePath, CopyDataFormat sourceFormat,
 							CopyDataCompression sourceCompression,
 							TupleDesc tupleDesc, List *options,
-							DataFileSchema * schema, int readFlags)
+							DataFileSchema *schema, int readFlags)
 {
 
 	List	   *dataFileList = NIL;
@@ -1497,7 +1497,7 @@ CopyReceivedTransmitDataToBuffer(void *outbuf, int minread, int maxread)
  * them to the buffer.
  */
 static bool
-ReceiveCopyData(PGDuckConnection * pgDuckConnection, StringInfo buffer)
+ReceiveCopyData(PGDuckConnection *pgDuckConnection, StringInfo buffer)
 {
 	PGconn	   *conn = pgDuckConnection->conn;
 	int			async = 0;

--- a/pg_lake_copy/src/copy/copy_io.c
+++ b/pg_lake_copy/src/copy/copy_io.c
@@ -46,10 +46,10 @@ typedef struct CopyFromStdinState
 
 	/* whether we reached the end-of-file */
 	bool		raw_reached_eof;
-}			CopyFromStdinState;
+} CopyFromStdinState;
 
 static void SendCopyInResponseToClient(int16 columnCount, bool isBinary);
-static int	ReceiveDataFromClient(CopyFromStdinState * cstate, char *databuf);
+static int	ReceiveDataFromClient(CopyFromStdinState *cstate, char *databuf);
 static void SendCopyBegin(int columnCount, bool isBinary);
 static void SendCopyEnd(void);
 static void SendCopyData(char *sendBuffer, int sendBufferLength);
@@ -161,7 +161,7 @@ SendCopyInResponseToClient(int16 columnCount, bool isBinary)
  * This code is copied ad verbatim from CopyGetData in PostgreSQL.
  */
 static int
-ReceiveDataFromClient(CopyFromStdinState * cstate, char *databuf)
+ReceiveDataFromClient(CopyFromStdinState *cstate, char *databuf)
 {
 	int			minread = 1;
 	int			maxread = MAX_READ_SIZE;

--- a/pg_lake_copy/src/ddl/create_table.c
+++ b/pg_lake_copy/src/ddl/create_table.c
@@ -43,7 +43,7 @@
 
 static bool IsCreateFromFile(CreateStmt *createStmt);
 static void ProcessCreateFromFile(CreateStmt *createStmt,
-								  ProcessUtilityParams * params);
+								  ProcessUtilityParams *params);
 static void ErrorIfTableExists(CreateStmt *createStmt);
 static List *ExtractDataImportOptions(CopyDataFormat format, List *options);
 
@@ -55,7 +55,7 @@ static List *ExtractDataImportOptions(CopyDataFormat format, List *options);
  * - CREATE TABLE name () WITH (definition_from = 's3://...')
  */
 bool
-CreateTableFromFileHandler(ProcessUtilityParams * params, void *arg)
+CreateTableFromFileHandler(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -116,7 +116,7 @@ IsCreateFromFile(CreateStmt *createStmt)
  */
 static void
 ProcessCreateFromFile(CreateStmt *createStmt,
-					  ProcessUtilityParams * utilityParams)
+					  ProcessUtilityParams *utilityParams)
 {
 	char	   *definitionFromURL = NULL;
 	char	   *loadFromURL = NULL;

--- a/pg_lake_copy/src/test/types.c
+++ b/pg_lake_copy/src/test/types.c
@@ -32,7 +32,7 @@ PG_FUNCTION_INFO_V1(duckdb_type_by_name);
 PG_FUNCTION_INFO_V1(duckdb_name_by_type);
 PG_FUNCTION_INFO_V1(duckdb_parse_struct);
 
-static void output_composite_type_rows(ReturnSetInfo *rsinfo, CompositeType * parsedType, int level);
+static void output_composite_type_rows(ReturnSetInfo *rsinfo, CompositeType *parsedType, int level);
 
 /*
  * lookup pgduck type by pgduck name
@@ -92,7 +92,7 @@ duckdb_parse_struct(PG_FUNCTION_ARGS)
 
 /* recursive helper for above */
 static void
-output_composite_type_rows(ReturnSetInfo *rsinfo, CompositeType * parsedType, int level)
+output_composite_type_rows(ReturnSetInfo *rsinfo, CompositeType *parsedType, int level)
 {
 	if (parsedType->cols)
 	{

--- a/pg_lake_engine/include/pg_lake/copy/copy_format.h
+++ b/pg_lake_engine/include/pg_lake/copy/copy_format.h
@@ -44,7 +44,7 @@ typedef enum CopyDataFormat
 	DATA_FORMAT_DELTA,
 	DATA_FORMAT_GDAL,
 	DATA_FORMAT_LOG
-}			CopyDataFormat;
+} CopyDataFormat;
 
 /* possible values of the COPY .. WITH (compression ..) option */
 typedef enum CopyDataCompression
@@ -55,7 +55,7 @@ typedef enum CopyDataCompression
 	DATA_COMPRESSION_ZSTD,
 	DATA_COMPRESSION_SNAPPY,
 	DATA_COMPRESSION_ZIP
-}			CopyDataCompression;
+} CopyDataCompression;
 
 /*
  * PgLakeTableProperties describes the main properties of an Iceberg and
@@ -67,7 +67,7 @@ typedef struct PgLakeTableProperties
 	CopyDataFormat format;
 	CopyDataCompression compression;
 	List	   *options;
-}			PgLakeTableProperties;
+} PgLakeTableProperties;
 
 
 /*
@@ -100,7 +100,7 @@ extern PGDLLEXPORT char *ResolveStageURL(const char *path);
 
 extern PGDLLEXPORT void FindDataFormatAndCompression(PgLakeTableType tableType,
 													 char *path, List *copyOptions,
-													 CopyDataFormat * format,
-													 CopyDataCompression * compression);
+													 CopyDataFormat *format,
+													 CopyDataCompression *compression);
 
 #endif

--- a/pg_lake_engine/include/pg_lake/data_file/data_file_stats.h
+++ b/pg_lake_engine/include/pg_lake/data_file/data_file_stats.h
@@ -35,7 +35,7 @@ typedef enum ColumnStatsMode
 {
 	COLUMN_STATS_MODE_TRUNCATE = 0,
 	COLUMN_STATS_MODE_NONE = 1,
-}			ColumnStatsMode;
+} ColumnStatsMode;
 
 /*
  * ColumnStatsConfig describes the configuration for column stats.
@@ -48,7 +48,7 @@ typedef struct ColumnStatsConfig
 
 	/* used for truncate mode */
 	size_t		truncateLen;
-}			ColumnStatsConfig;
+} ColumnStatsConfig;
 
 
 
@@ -66,7 +66,7 @@ typedef struct DataFileColumnStats
 
 	/* upper bound of the column in text representation of the field's type */
 	char	   *upperBoundText;
-}			DataFileColumnStats;
+} DataFileColumnStats;
 
  /*
   * DataFileStats stores all statistics for a data file.
@@ -92,26 +92,26 @@ typedef struct DataFileStats
 
 	/* for a new data file with row IDs, the start of the range */
 	int64		rowIdStart;
-}			DataFileStats;
+} DataFileStats;
 
 typedef struct StatsCollector
 {
 	int64		totalRowCount;
 	List	   *dataFileStats;
-}			StatsCollector;
+} StatsCollector;
 
-extern PGDLLEXPORT DataFileStats * DeepCopyDataFileStats(const DataFileStats * stats);
-extern PGDLLEXPORT StatsCollector * GetDataFileStatsListFromPGResult(PGresult *result,
-																	 List *leafFields,
-																	 DataFileSchema * schema);
-extern PGDLLEXPORT StatsCollector * ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
-																		   List *leafFields,
-																		   DataFileSchema * schema,
-																		   char *destinationPath,
-																		   CopyDataFormat destinationFormat);
-extern PGDLLEXPORT bool ShouldSkipStatistics(LeafField * leafField);
-extern PGDLLEXPORT DataFileStats * CreateDataFileStatsForDataFile(char *dataFilePath,
-																  int64 rowCount, int64 deletedRowCount,
-																  List *leafFields);
+extern PGDLLEXPORT DataFileStats *DeepCopyDataFileStats(const DataFileStats *stats);
+extern PGDLLEXPORT StatsCollector *GetDataFileStatsListFromPGResult(PGresult *result,
+																	List *leafFields,
+																	DataFileSchema *schema);
+extern PGDLLEXPORT StatsCollector *ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
+																		  List *leafFields,
+																		  DataFileSchema *schema,
+																		  char *destinationPath,
+																		  CopyDataFormat destinationFormat);
+extern PGDLLEXPORT bool ShouldSkipStatistics(LeafField *leafField);
+extern PGDLLEXPORT DataFileStats *CreateDataFileStatsForDataFile(char *dataFilePath,
+																 int64 rowCount, int64 deletedRowCount,
+																 List *leafFields);
 extern PGDLLEXPORT void ApplyColumnStatsModeForAllFileStats(Oid relationId, List *dataFileStats);
 extern PGDLLEXPORT List *GetRemoteParquetColumnStats(char *path, List *leafFields);

--- a/pg_lake_engine/include/pg_lake/data_file/data_files.h
+++ b/pg_lake_engine/include/pg_lake/data_file/data_files.h
@@ -38,7 +38,7 @@ typedef struct RowIdRangeMapping
 	int64		rowStartId;		/* starting row id for this range */
 	int64		rowStartNum;	/* starting row number for this range */
 	int64		numRows;		/* how many rows in this chunk */
-}			RowIdRangeMapping;
+} RowIdRangeMapping;
 
 
 /*
@@ -54,7 +54,7 @@ typedef enum DataFileContent
 	 * to match the Iceberg spec.
 	 */
 	CONTENT_EQUALITY_DELETES = 2,
-}			DataFileContent;
+} DataFileContent;
 
 /*
  * TableDataFile represents a single data file in a writable table.
@@ -76,7 +76,7 @@ typedef struct TableDataFile
 	/* partition info for the data file */
 	int32_t		partitionSpecId;
 	struct Partition *partition;
-}			TableDataFile;
+} TableDataFile;
 
 
 /*
@@ -97,7 +97,7 @@ typedef enum TableMetadataOperationType
 	DATA_FILE_ADD_ROW_ID_MAPPING = 9,
 	TABLE_PARTITION_BY = 10,
 	TABLE_CREATE = 11,
-}			TableMetadataOperationType;
+} TableMetadataOperationType;
 
 struct IcebergPartitionSpec;
 struct Partition;
@@ -118,7 +118,7 @@ typedef enum DDLSchemaEffect
 	DDL_EFFECT_NONE = 0,
 	DDL_EFFECT_ADD_SCHEMA = 1,
 	DDL_EFFECT_SET_EXISTING_SCHEMA = 2,
-}			DDLSchemaEffect;
+} DDLSchemaEffect;
 
 /*
  * TableMetadataOperation represents an operation on table metadata.
@@ -160,17 +160,17 @@ typedef struct TableMetadataOperation
 	/* for partition specs */
 	List	   *partitionSpecs;
 	int			defaultSpecId;
-}			TableMetadataOperation;
+} TableMetadataOperation;
 
 
-extern PGDLLEXPORT TableMetadataOperation * AddDataFileOperation(const char *path,
-																 DataFileContent content,
-																 DataFileStats * dataFileStats,
-																 struct Partition *partition,
-																 int32 partitionSpecId);
-extern PGDLLEXPORT TableMetadataOperation * RemoveDataFileOperation(const char *path);
-extern PGDLLEXPORT TableMetadataOperation * UpdateDeletedRowCountOperation(const char *path, int64 deletedRowCount);
-extern PGDLLEXPORT TableMetadataOperation * AddDeleteMappingOperation(const char *deleteFilePath,
-																	  const char *dataFilePath);
-extern PGDLLEXPORT TableMetadataOperation * AddRowIdMappingOperation(const char *dataFilePath,
-																	 List *rowIdRanges);
+extern PGDLLEXPORT TableMetadataOperation *AddDataFileOperation(const char *path,
+																DataFileContent content,
+																DataFileStats *dataFileStats,
+																struct Partition *partition,
+																int32 partitionSpecId);
+extern PGDLLEXPORT TableMetadataOperation *RemoveDataFileOperation(const char *path);
+extern PGDLLEXPORT TableMetadataOperation *UpdateDeletedRowCountOperation(const char *path, int64 deletedRowCount);
+extern PGDLLEXPORT TableMetadataOperation *AddDeleteMappingOperation(const char *deleteFilePath,
+																	 const char *dataFilePath);
+extern PGDLLEXPORT TableMetadataOperation *AddRowIdMappingOperation(const char *dataFilePath,
+																	List *rowIdRanges);

--- a/pg_lake_engine/include/pg_lake/ddl/utility_hook.h
+++ b/pg_lake_engine/include/pg_lake/ddl/utility_hook.h
@@ -33,25 +33,25 @@ typedef struct ProcessUtilityParams
 	struct QueryEnvironment *queryEnv;
 	DestReceiver *dest;
 	QueryCompletion *completionTag;
-}			ProcessUtilityParams;
+} ProcessUtilityParams;
 
 /*
  * UtilityStatementHandler implementations can handle a utility statement end-to-end,
  * and may internally call PgLakeCommonProcessUtility (with handlers) or
  * PgLakeCommonParentProcessUtility (skip handlers).
  */
-typedef bool (*UtilityStatementHandler) (ProcessUtilityParams * processUtilityParams, void *arg);
+typedef bool (*UtilityStatementHandler) (ProcessUtilityParams *processUtilityParams, void *arg);
 
 /*
  * UtilityStatementPostHandler implementations can handle a utility statement after
  * it is handled by UtilityStatementHandlers.
  */
-typedef void (*UtilityStatementPostHandler) (ProcessUtilityParams * processUtilityParams, void *arg);
+typedef void (*UtilityStatementPostHandler) (ProcessUtilityParams *processUtilityParams, void *arg);
 
 void		InitializeUtilityHook(void);
 
-extern PGDLLEXPORT void PgLakeCommonProcessUtility(ProcessUtilityParams * processUtilityParams);
-extern PGDLLEXPORT void PgLakeCommonParentProcessUtility(ProcessUtilityParams * processUtilityParams);
+extern PGDLLEXPORT void PgLakeCommonProcessUtility(ProcessUtilityParams *processUtilityParams);
+extern PGDLLEXPORT void PgLakeCommonParentProcessUtility(ProcessUtilityParams *processUtilityParams);
 extern PGDLLEXPORT void RegisterUtilityStatementHandler(UtilityStatementHandler callback, void *arg);
 extern PGDLLEXPORT void RegisterPostUtilityStatementHandler(UtilityStatementPostHandler callback, void *arg);
-extern PGDLLEXPORT Node *CopyUtilityStmt(ProcessUtilityParams * processUtilityParams);
+extern PGDLLEXPORT Node *CopyUtilityStmt(ProcessUtilityParams *processUtilityParams);

--- a/pg_lake_engine/include/pg_lake/extensions/btree_gist.h
+++ b/pg_lake_engine/include/pg_lake/extensions/btree_gist.h
@@ -22,6 +22,6 @@
 #define BTREE_GIST "btree_gist"
 
 /* cached extension IDs for btree_gist */
-extern PGDLLEXPORT CachedExtensionIds * BtreeGist;
+extern PGDLLEXPORT CachedExtensionIds *BtreeGist;
 
 void		InitializeBtreeGistIdCache(void);

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake.h
@@ -22,6 +22,6 @@
 #define PG_LAKE "pg_lake"
 
 /* cached extension IDs for pg_lake */
-extern PGDLLEXPORT CachedExtensionIds * PgLake;
+extern PGDLLEXPORT CachedExtensionIds *PgLake;
 
 void		InitializePgLakeIdCache(void);

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_benchmark.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_benchmark.h
@@ -22,6 +22,6 @@
 #define PG_LAKE_BENCHMARK "pg_lake_benchmark"
 
 /* cached extension IDs for pg_lake_benchmark */
-extern PGDLLEXPORT CachedExtensionIds * PgLakeBenchmark;
+extern PGDLLEXPORT CachedExtensionIds *PgLakeBenchmark;
 
 void		InitializePgLakeBenchmarkIdCache(void);

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_copy.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_copy.h
@@ -22,6 +22,6 @@
 #define PG_LAKE_COPY "pg_lake_copy"
 
 /* cached extension IDs for pg_lake_copy */
-extern PGDLLEXPORT CachedExtensionIds * PgLakeCopy;
+extern PGDLLEXPORT CachedExtensionIds *PgLakeCopy;
 
 void		InitializePgLakeCopyIdCache(void);

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_engine.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_engine.h
@@ -30,7 +30,7 @@ extern PGDLLEXPORT bool EnableHeavyAsserts;
 extern PGDLLEXPORT char *PgLakeStageLocation;
 
 /* cached extension IDs for pg_lake_engine */
-extern PGDLLEXPORT CachedExtensionIds * PgLakeEngine;
+extern PGDLLEXPORT CachedExtensionIds *PgLakeEngine;
 
 void		InitializePgLakeEngineIdCache(void);
 

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_iceberg.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_iceberg.h
@@ -24,7 +24,7 @@
 #define ICEBERG_INTERNAL_CATALOG_TABLE_NAME "tables_internal"
 
 /* cached extension IDs for pg_lake_iceberg */
-extern PGDLLEXPORT CachedExtensionIds * PgLakeIceberg;
+extern PGDLLEXPORT CachedExtensionIds *PgLakeIceberg;
 
 extern PGDLLEXPORT void InitializePgLakeIcebergIdCache(void);
 extern PGDLLEXPORT Oid IcebergTablesInternalTableId(void);

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_replication.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_replication.h
@@ -22,6 +22,6 @@
 #define PG_LAKE_REPLICATION "pg_lake_replication"
 
 /* cached extension IDs for pg_lake_replication */
-extern PGDLLEXPORT CachedExtensionIds * PgLakeReplication;
+extern PGDLLEXPORT CachedExtensionIds *PgLakeReplication;
 
 void		InitializePgLakeReplicationIdCache(void);

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_spatial.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_spatial.h
@@ -19,7 +19,7 @@
 
 #include "pg_extension_base/extension_ids.h"
 
-extern PGDLLEXPORT CachedExtensionIds * PgLakeSpatial;
+extern PGDLLEXPORT CachedExtensionIds *PgLakeSpatial;
 
 void		InitializePgLakeSpatialIdCache(void);
 

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_table.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_table.h
@@ -28,7 +28,7 @@
 #define PG_LAKE_TABLE_DATA_FILE_PARTITION_VALUES_TABLE_NAME "data_file_partition_values"
 #define REPLICATION_WRITES_SCHEMA "__pg_lake_table_writes"
 
-extern PGDLLEXPORT CachedExtensionIds * PgLakeTable;
+extern PGDLLEXPORT CachedExtensionIds *PgLakeTable;
 
 extern PGDLLEXPORT void InitializePgLakeTableIdCache(void);
 

--- a/pg_lake_engine/include/pg_lake/extensions/pg_map.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_map.h
@@ -22,7 +22,7 @@
 #define MAP_TYPES_SCHEMA "map_type"
 
 /* cached extension IDs for pg_map */
-extern PGDLLEXPORT CachedExtensionIds * PgMap;
+extern PGDLLEXPORT CachedExtensionIds *PgMap;
 
 void		InitializePgMapIdCache(void);
 Oid			PgMapSchemaId(void);

--- a/pg_lake_engine/include/pg_lake/extensions/pg_parquet.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_parquet.h
@@ -22,6 +22,6 @@
 #define PG_PARQUET "pg_parquet"
 
 /* cached extension IDs for pg_parquet */
-extern PGDLLEXPORT CachedExtensionIds * PgParquet;
+extern PGDLLEXPORT CachedExtensionIds *PgParquet;
 
 void		InitializePgParquetIdCache(void);

--- a/pg_lake_engine/include/pg_lake/extensions/postgis.h
+++ b/pg_lake_engine/include/pg_lake/extensions/postgis.h
@@ -34,7 +34,7 @@
 #define GEOMETRY_GET_TYPE(typmod) ((typmod & 0x000000FC)>>2)
 #define GEOMETRY_GET_SRID(typmod) ((((typmod) & 0x0FFFFF00) - ((typmod) & 0x10000000)) >> 8)
 
-extern PGDLLEXPORT CachedExtensionIds * Postgis;
+extern PGDLLEXPORT CachedExtensionIds *Postgis;
 
 void		InitializePostgisIdCache(void);
 

--- a/pg_lake_engine/include/pg_lake/json/json_reader.h
+++ b/pg_lake_engine/include/pg_lake/json/json_reader.h
@@ -28,7 +28,7 @@ typedef enum FieldRequired
 {
 	FIELD_REQUIRED,
 	FIELD_OPTIONAL
-}			FieldRequired;
+} FieldRequired;
 
 extern PGDLLEXPORT bool JsonExtractInt32Field(JsonbContainer *json, char *fieldName, FieldRequired required, int32_t *intPointer);
 extern PGDLLEXPORT bool JsonExtractInt64Field(JsonbContainer *json, char *fieldName, FieldRequired required, int64_t *longPointer);

--- a/pg_lake_engine/include/pg_lake/parquet/field.h
+++ b/pg_lake_engine/include/pg_lake/parquet/field.h
@@ -51,7 +51,7 @@ typedef enum FieldType
 	FIELD_TYPE_LIST,
 	FIELD_TYPE_MAP,
 	FIELD_TYPE_STRUCT
-}			FieldType;
+} FieldType;
 
 /* forward declaration */
 struct Field;
@@ -64,7 +64,7 @@ struct Field;
 typedef struct FieldScalar
 {
 	const char *typeName;
-}			FieldScalar;
+} FieldScalar;
 
 /*
  * FieldList represents a list is a collection of values with some element type.
@@ -77,7 +77,7 @@ typedef struct FieldList
 	int			elementId;
 	bool		elementRequired;
 	struct Field *element;
-}			FieldList;
+} FieldList;
 
 /*
  * FieldStructElement represents an element of a struct field.
@@ -96,7 +96,7 @@ typedef struct FieldStructElement
 	const char *initialDefault;
 	const char *duckSerializedInitialDefault;
 	struct Field *type;
-}			FieldStructElement;
+} FieldStructElement;
 
 /*
  * FieldStruct is a tuple of typed values. Each field in the tuple is named
@@ -111,7 +111,7 @@ typedef struct FieldStruct
 {
 	FieldStructElement *fields;
 	size_t		nfields;
-}			FieldStruct;
+} FieldStruct;
 
 /*
  * FieldMap represents is a collection of key-value pairs with a key type and a value type.
@@ -128,7 +128,7 @@ typedef struct FieldMap
 	int			valueId;
 	bool		valueRequired;
 	struct Field *value;
-}			FieldMap;
+} FieldMap;
 
 /*
  * Field represents a field.
@@ -145,7 +145,7 @@ typedef struct Field
 		FieldMap	map;
 		FieldStruct structType;
 	}			field;
-}			Field;
+} Field;
 
 /*
  * A data file schema is represented by FieldStruct. To make the context
@@ -154,6 +154,6 @@ typedef struct Field
 typedef FieldStruct DataFileSchema;
 typedef FieldStructElement DataFileSchemaField;
 
-extern PGDLLEXPORT DataFileSchema * DeepCopyDataFileSchema(const DataFileSchema * schema);
-extern PGDLLEXPORT Field * DeepCopyField(const Field * field);
-extern PGDLLEXPORT bool PGTypeRequiresConversionToIcebergString(Field * field, PGType pgType);
+extern PGDLLEXPORT DataFileSchema *DeepCopyDataFileSchema(const DataFileSchema *schema);
+extern PGDLLEXPORT Field *DeepCopyField(const Field *field);
+extern PGDLLEXPORT bool PGTypeRequiresConversionToIcebergString(Field *field, PGType pgType);

--- a/pg_lake_engine/include/pg_lake/parquet/leaf_field.h
+++ b/pg_lake_engine/include/pg_lake/parquet/leaf_field.h
@@ -47,12 +47,12 @@ typedef struct LeafField
 	 * fields.
 	 */
 	int			level;
-}			LeafField;
+} LeafField;
 
 extern PGDLLEXPORT int LeafFieldCompare(const ListCell *a, const ListCell *b);
-extern PGDLLEXPORT bool SchemaFieldsEquivalent(DataFileSchemaField * fieldA, DataFileSchemaField * fieldB);
-extern PGDLLEXPORT LeafField DeepCopyLeafField(const LeafField * leafField);
-extern PGDLLEXPORT LeafField * FindLeafField(List *leafFieldList, int fieldId);
+extern PGDLLEXPORT bool SchemaFieldsEquivalent(DataFileSchemaField *fieldA, DataFileSchemaField *fieldB);
+extern PGDLLEXPORT LeafField DeepCopyLeafField(const LeafField *leafField);
+extern PGDLLEXPORT LeafField *FindLeafField(List *leafFieldList, int fieldId);
 #if PG_VERSION_NUM < 170000
 extern PGDLLEXPORT int pg_cmp_s32(int32 a, int32 b);
 #endif

--- a/pg_lake_engine/include/pg_lake/pgduck/cache_control.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/cache_control.h
@@ -27,7 +27,7 @@ typedef struct FileInCache
 	char	   *url;
 	size_t		fileSize;
 	Timestamp	lastAccessTime;
-}			FileInCache;
+} FileInCache;
 
 
 extern PGDLLEXPORT int64 AddFileToCache(char *url, bool refresh);

--- a/pg_lake_engine/include/pg_lake/pgduck/client.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/client.h
@@ -34,22 +34,22 @@ typedef struct PGDuckConnection
 	uint32		connectionId;
 	PGconn	   *conn;
 
-}			PGDuckConnection;
+} PGDuckConnection;
 
-extern PGDLLEXPORT PGDuckConnection * GetPGDuckConnection(void);
-extern PGDLLEXPORT void ReleasePGDuckConnection(PGDuckConnection * pgDuckConnection);
+extern PGDLLEXPORT PGDuckConnection *GetPGDuckConnection(void);
+extern PGDLLEXPORT void ReleasePGDuckConnection(PGDuckConnection *pgDuckConnection);
 extern PGDLLEXPORT int64 ExecuteCommandInPGDuck(char *query);
 extern PGDLLEXPORT List *ExecuteCommandsInPGDuck(List *commands);
 extern PGDLLEXPORT bool ExecuteOptionalCommandInPGDuck(char *command);
-extern PGDLLEXPORT PGresult *ExecuteQueryOnPGDuckConnection(PGDuckConnection * pgDuckConnection,
+extern PGDLLEXPORT PGresult *ExecuteQueryOnPGDuckConnection(PGDuckConnection *pgDuckConnection,
 															const char *query);
-extern PGDLLEXPORT PGresult *WaitForResult(PGDuckConnection * conn);
-extern PGDLLEXPORT PGresult *WaitForLastResult(PGDuckConnection * conn);
-extern PGDLLEXPORT void SendQueryToPGDuck(PGDuckConnection * conn, char *query);
-extern PGDLLEXPORT void CheckPGDuckResult(PGDuckConnection * conn, PGresult *result);
-extern PGDLLEXPORT void ThrowIfPGDuckResultHasError(PGDuckConnection * conn, PGresult *result);
+extern PGDLLEXPORT PGresult *WaitForResult(PGDuckConnection *conn);
+extern PGDLLEXPORT PGresult *WaitForLastResult(PGDuckConnection *conn);
+extern PGDLLEXPORT void SendQueryToPGDuck(PGDuckConnection *conn, char *query);
+extern PGDLLEXPORT void CheckPGDuckResult(PGDuckConnection *conn, PGresult *result);
+extern PGDLLEXPORT void ThrowIfPGDuckResultHasError(PGDuckConnection *conn, PGresult *result);
 extern PGDLLEXPORT char *GetSingleValueFromPGDuck(char *query);
-extern PGDLLEXPORT void SendQueryWithParams(PGDuckConnection * pgduckConn, char *queryString,
+extern PGDLLEXPORT void SendQueryWithParams(PGDuckConnection *pgduckConn, char *queryString,
 											int numParams, const char **parameterValues);
 
 #endif

--- a/pg_lake_engine/include/pg_lake/pgduck/delete_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/delete_data.h
@@ -24,11 +24,11 @@
 #include "pg_lake/pgduck/read_data.h"
 #include "pg_lake/data_file/data_file_stats.h"
 
-extern PGDLLEXPORT StatsCollector * PerformDeleteFromParquet(char *sourceDataFilePath,
-															 List *positionDeleteFiles,
-															 char *deletionFilePath,
-															 char *destinationPath,
-															 CopyDataCompression destinationCompression,
-															 DataFileSchema * schema,
-															 ReadDataStats * stats,
-															 List *leafFields);
+extern PGDLLEXPORT StatsCollector *PerformDeleteFromParquet(char *sourceDataFilePath,
+															List *positionDeleteFiles,
+															char *deletionFilePath,
+															char *destinationPath,
+															CopyDataCompression destinationCompression,
+															DataFileSchema *schema,
+															ReadDataStats *stats,
+															List *leafFields);

--- a/pg_lake_engine/include/pg_lake/pgduck/iceberg_validation.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/iceberg_validation.h
@@ -43,7 +43,7 @@ typedef enum IcebergOutOfRangePolicy
 	ICEBERG_OOR_NONE = 0,
 	ICEBERG_OOR_ERROR = 1,
 	ICEBERG_OOR_CLAMP = 2,
-}			IcebergOutOfRangePolicy;
+} IcebergOutOfRangePolicy;
 
 /*
  * GetIcebergOutOfRangePolicyForTable returns the IcebergOutOfRangePolicy

--- a/pg_lake_engine/include/pg_lake/pgduck/parse_struct.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/parse_struct.h
@@ -36,7 +36,7 @@ typedef struct CompositeType
 	bool		isArray;		/* the top-level type can be an array */
 	bool		isFinalized;	/* if true, then we know all component parts
 								 * exist */
-}			CompositeType;
+} CompositeType;
 
 typedef struct CompositeCol
 {
@@ -46,16 +46,16 @@ typedef struct CompositeCol
 	CompositeType *subStruct;	/* for a non-composite type, NULL; for
 								 * composite, pointer to that type's struct */
 	bool		isArray;		/* whether we are an array type or not */
-}			CompositeCol;
+} CompositeCol;
 
 
 /* Composite Type functions - convert to/from postgres composite types and
  * STRUCT strings */
-extern PGDLLEXPORT CompositeType * GetCompositeTypeForPGType(Oid postgresType);
-extern PGDLLEXPORT char *GetDuckDBStructDefinitionForCompositeType(CompositeType * type,
+extern PGDLLEXPORT CompositeType *GetCompositeTypeForPGType(Oid postgresType);
+extern PGDLLEXPORT char *GetDuckDBStructDefinitionForCompositeType(CompositeType *type,
 																   CopyDataFormat format);
 
 /* simple string to parse tree */
-extern PGDLLEXPORT CompositeType * ParseStructString(char *parse);
+extern PGDLLEXPORT CompositeType *ParseStructString(char *parse);
 
 #endif

--- a/pg_lake_engine/include/pg_lake/pgduck/read_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/read_data.h
@@ -44,7 +44,7 @@ typedef struct ReadDataStats
 {
 	uint64		sourceRowCount;
 	uint64		positionDeleteRowCount;
-}			ReadDataStats;
+} ReadDataStats;
 
 /*
  * ReadRowLocationMode reflects how we want to read filename and file_row_number.
@@ -59,7 +59,7 @@ typedef enum ReadRowLocationMode
 	NO_ROW_LOCATION,
 	READ_ROW_LOCATION,
 	EMIT_ROW_LOCATION
-}			ReadRowLocationMode;
+} ReadRowLocationMode;
 
 
 extern PGDLLEXPORT char *ReadDataSourceQuery(List *dataFilePaths,
@@ -68,8 +68,8 @@ extern PGDLLEXPORT char *ReadDataSourceQuery(List *dataFilePaths,
 											 CopyDataCompression sourceCompression,
 											 TupleDesc expectedDesc,
 											 List *formatOptions,
-											 DataFileSchema * schema,
-											 ReadDataStats * stats,
+											 DataFileSchema *schema,
+											 ReadDataStats *stats,
 											 int flags);
 extern PGDLLEXPORT char *TupleDescToProjectionList(TupleDesc tupleDesc,
 												   CopyDataFormat sourceFormat,

--- a/pg_lake_engine/include/pg_lake/pgduck/remote_storage.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/remote_storage.h
@@ -34,7 +34,7 @@ typedef struct RemoteFileDesc
 	TimestampTz lastModifiedTime;
 
 	char	   *etag;
-}			RemoteFileDesc;
+} RemoteFileDesc;
 
 extern PGDLLEXPORT int64 GetRemoteFileSize(char *path);
 extern PGDLLEXPORT int64 GetRemoteParquetFileRowCount(char *path);

--- a/pg_lake_engine/include/pg_lake/pgduck/shippable_builtin_functions.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/shippable_builtin_functions.h
@@ -41,7 +41,7 @@ typedef struct
 	int			proargcount;
 	char	   *proargtypes[10];
 	IsShippableFunction isShippable;
-}			PGDuckShippableFunction;
+} PGDuckShippableFunction;
 
 
 extern PGDLLEXPORT const PGDuckShippableFunction *GetShippableBuiltinFunctions(int *sizePointer);

--- a/pg_lake_engine/include/pg_lake/pgduck/shippable_builtin_operators.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/shippable_builtin_operators.h
@@ -39,14 +39,14 @@ typedef struct
 	int			oprcodeargcount;
 	char	   *oprcodeargtypes[2];
 	IsShippableFunction isShippable;
-}			PGDuckShippableOperator;
+} PGDuckShippableOperator;
 
 typedef struct
 {
 	char	   *typename;
 	int			oprsLen;
-	const		PGDuckShippableOperator *oprs;
-}			PGDuckShippableOperatorsByType;
+	const PGDuckShippableOperator *oprs;
+} PGDuckShippableOperatorsByType;
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 

--- a/pg_lake_engine/include/pg_lake/pgduck/type.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/type.h
@@ -90,7 +90,7 @@ typedef enum DuckDBType
 	DUCKDB_TYPE_JSON,
 	/* spatial extension */
 	DUCKDB_TYPE_GEOMETRY
-}			DuckDBType;
+} DuckDBType;
 
 /*
  * DuckDBTypeInfo holds a DuckDB type with its full name in string form.
@@ -100,14 +100,14 @@ typedef struct DuckDBTypeInfo
 	DuckDBType	typeId;
 	bool		isArrayType;
 	char	   *typeName;
-}			DuckDBTypeInfo;
+} DuckDBTypeInfo;
 
 /* Store information about a given postgres type */
 typedef struct PGType
 {
 	Oid			postgresTypeOid;
 	int32		postgresTypeMod;
-}			PGType;
+} PGType;
 
 #define MakePGTypeOid(oid) ((PGType){.postgresTypeOid = oid, .postgresTypeMod = -1})
 #define MakePGType(oid,mod) ((PGType){.postgresTypeOid = oid, .postgresTypeMod = mod})

--- a/pg_lake_engine/include/pg_lake/pgduck/write_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/write_data.h
@@ -37,27 +37,27 @@ typedef enum ParquetVersion
 /* pg_lake_table.default_parquet_version */
 extern PGDLLEXPORT int DefaultParquetVersion;
 
-extern PGDLLEXPORT StatsCollector * ConvertCSVFileTo(char *csvFilePath,
-													 TupleDesc tupleDesc,
-													 int maxLineSize,
-													 char *destinationPath,
-													 CopyDataFormat destinationFormat,
-													 CopyDataCompression destinationCompression,
-													 List *formatOptions,
-													 DataFileSchema * schema,
-													 List *leafFields);
-extern PGDLLEXPORT StatsCollector * WriteQueryResultTo(char *query,
-													   char *destinationPath,
-													   CopyDataFormat destinationFormat,
-													   CopyDataCompression destinationCompression,
-													   List *formatOptions,
-													   bool queryHasRowId,
-													   DataFileSchema * schema,
-													   TupleDesc queryTupleDesc,
-													   List *leafFields,
-													   IcebergOutOfRangePolicy outOfRangePolicy,
-													   bool wrapNativeIntervals);
-extern PGDLLEXPORT void AppendFields(StringInfo map, DataFileSchema * schema);
+extern PGDLLEXPORT StatsCollector *ConvertCSVFileTo(char *csvFilePath,
+													TupleDesc tupleDesc,
+													int maxLineSize,
+													char *destinationPath,
+													CopyDataFormat destinationFormat,
+													CopyDataCompression destinationCompression,
+													List *formatOptions,
+													DataFileSchema *schema,
+													List *leafFields);
+extern PGDLLEXPORT StatsCollector *WriteQueryResultTo(char *query,
+													  char *destinationPath,
+													  CopyDataFormat destinationFormat,
+													  CopyDataCompression destinationCompression,
+													  List *formatOptions,
+													  bool queryHasRowId,
+													  DataFileSchema *schema,
+													  TupleDesc queryTupleDesc,
+													  List *leafFields,
+													  IcebergOutOfRangePolicy outOfRangePolicy,
+													  bool wrapNativeIntervals);
+extern PGDLLEXPORT void AppendFields(StringInfo map, DataFileSchema *schema);
 extern PGDLLEXPORT char *TupleDescToColumnMapForWrite(TupleDesc tupleDesc, CopyDataFormat destinationFormat);
 extern PGDLLEXPORT char *TupleDescToProjectionListForWrite(TupleDesc tupleDesc,
 														   CopyDataFormat destinationFormat);

--- a/pg_lake_engine/include/pg_lake/util/table_type.h
+++ b/pg_lake_engine/include/pg_lake/util/table_type.h
@@ -24,7 +24,7 @@ typedef enum PgLakeTableType
 	PG_LAKE_INVALID_TABLE_TYPE,
 	PG_LAKE_TABLE_TYPE,
 	PG_LAKE_ICEBERG_TABLE_TYPE
-}			PgLakeTableType;
+} PgLakeTableType;
 
 
 extern PGDLLEXPORT const char *PgLakeTableTypeToName(PgLakeTableType tableType);

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -50,7 +50,7 @@ typedef struct DeletionQueueEntry
 	TimestampTz orphanedAt;
 	int			retryCount;
 	bool		isPrefix;
-}			DeletionQueueEntry;
+} DeletionQueueEntry;
 
 static void RemoveDeletionQueuePathsFromCatalog(List *filePaths);
 static void IncrementDeletionQueueRetryCount(List *failedRemovalPaths);

--- a/pg_lake_engine/src/cleanup/in_progress_files.c
+++ b/pg_lake_engine/src/cleanup/in_progress_files.c
@@ -96,7 +96,7 @@ typedef struct InProgressFiles
 	char	   *path;
 	int64_t		operationId;
 	bool		isPrefix;
-}			InProgressFiles;
+} InProgressFiles;
 
 static bool GetInProgressFileRecords(char *location, bool isFull, List **fileRecords);
 static int64 GetTransactionOperationId(void);

--- a/pg_lake_engine/src/copy/copy_format.c
+++ b/pg_lake_engine/src/copy/copy_format.c
@@ -34,7 +34,7 @@ typedef struct CopyDataFormatName
 {
 	char	   *name;
 	CopyDataFormat format;
-}			CopyDataFormatName;
+} CopyDataFormatName;
 
 static CopyDataFormatName DataFormatNames[] =
 {
@@ -71,7 +71,7 @@ typedef struct CopyDataCompressionName
 {
 	char	   *name;
 	CopyDataCompression compression;
-}			CopyDataCompressionName;
+} CopyDataCompressionName;
 
 static CopyDataCompressionName DataCompressionNames[] =
 {
@@ -102,7 +102,7 @@ typedef struct CopyDataFormatExtension
 
 	CopyDataFormat format;
 	CopyDataCompression compression;
-}			CopyDataFormatExtension;
+} CopyDataFormatExtension;
 
 static CopyDataFormatExtension DataFormatExtensions[] =
 {
@@ -508,8 +508,8 @@ ResolveStageURL(const char *path)
 void
 FindDataFormatAndCompression(PgLakeTableType tableType,
 							 char *path, List *copyOptions,
-							 CopyDataFormat * format,
-							 CopyDataCompression * compression)
+							 CopyDataFormat *format,
+							 CopyDataCompression *compression)
 {
 	*format = DATA_FORMAT_INVALID;
 	*compression = DATA_COMPRESSION_INVALID;

--- a/pg_lake_engine/src/data_file/data_file_stats.c
+++ b/pg_lake_engine/src/data_file/data_file_stats.c
@@ -38,13 +38,13 @@ static void ParseDuckdbColumnMinMaxFromText(char *input, List **names, List **mi
 static void ExtractMinMaxForAllColumns(Datum returnStatsMap, List **names, List **mins, List **maxs);
 static void ExtractMinMaxForColumn(Datum map, char *colName, List **names, List **mins, List **maxs);
 static char *UnescapeDoubleQuotes(char *s);
-static List *GetDataFileColumnStatsList(List *names, List *mins, List *maxs, List *leafFields, DataFileSchema * schema);
+static List *GetDataFileColumnStatsList(List *names, List *mins, List *maxs, List *leafFields, DataFileSchema *schema);
 static int	FindIndexInStringList(List *names, const char *targetName);
-static List *FetchRowGroupStats(PGDuckConnection * pgDuckConn, List *fieldIdList, char *path);
+static List *FetchRowGroupStats(PGDuckConnection *pgDuckConn, List *fieldIdList, char *path);
 static char *PrepareRowGroupStatsMinMaxQuery(List *rowGroupStatList);
 static char *SerializeTextArrayTypeToPgDuck(ArrayType *array);
 static ArrayType *ReadArrayFromText(char *arrayText);
-static List *GetFieldMinMaxStats(PGDuckConnection * pgDuckConn, List *rowGroupStatsList);
+static List *GetFieldMinMaxStats(PGDuckConnection *pgDuckConn, List *rowGroupStatsList);
 static ColumnStatsConfig GetColumnStatsConfig(Oid relationId);
 static void ApplyColumnStatsModeForType(ColumnStatsConfig columnStatsConfig,
 										PGType pgType, char **lowerBoundText,
@@ -72,7 +72,7 @@ typedef struct RowGroupStats
 {
 	LeafField  *leafField;
 	ArrayType  *minMaxArray;
-}			RowGroupStats;
+} RowGroupStats;
 
 
 /*
@@ -82,7 +82,7 @@ typedef struct RowGroupStats
 StatsCollector *
 ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 									   List *leafFields,
-									   DataFileSchema * schema,
+									   DataFileSchema *schema,
 									   char *destinationPath,
 									   CopyDataFormat destinationFormat)
 {
@@ -153,7 +153,7 @@ ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
  * It returns the collector object that contains the total row count and data file statistics.
  */
 StatsCollector *
-GetDataFileStatsListFromPGResult(PGresult *result, List *leafFields, DataFileSchema * schema)
+GetDataFileStatsListFromPGResult(PGresult *result, List *leafFields, DataFileSchema *schema)
 {
 	List	   *statsList = NIL;
 
@@ -408,7 +408,7 @@ ParseDuckdbColumnMinMaxFromText(char *input, List **names, List **mins, List **m
  * names, mins, maxs lists and schema.
  */
 static List *
-GetDataFileColumnStatsList(List *names, List *mins, List *maxs, List *leafFields, DataFileSchema * schema)
+GetDataFileColumnStatsList(List *names, List *mins, List *maxs, List *leafFields, DataFileSchema *schema)
 {
 	List	   *columnStatsList = NIL;
 
@@ -479,7 +479,7 @@ FindIndexInStringList(List *names, const char *targetName)
 * given leaf field.
 */
 bool
-ShouldSkipStatistics(LeafField * leafField)
+ShouldSkipStatistics(LeafField *leafField)
 {
 	Field	   *field = leafField->field;
 	PGType		pgType = leafField->pgType;
@@ -598,7 +598,7 @@ GetRemoteParquetColumnStats(char *path, List *leafFields)
 * The output is sorted by the input fieldIdList.
 */
 static List *
-FetchRowGroupStats(PGDuckConnection * pgDuckConn, List *fieldIdList, char *path)
+FetchRowGroupStats(PGDuckConnection *pgDuckConn, List *fieldIdList, char *path)
 {
 	List	   *rowGroupStatsList = NIL;
 
@@ -825,7 +825,7 @@ ReadArrayFromText(char *arrayText)
 * and then aggregate the min and max values for each field.
 */
 static List *
-GetFieldMinMaxStats(PGDuckConnection * pgDuckConn, List *rowGroupStatList)
+GetFieldMinMaxStats(PGDuckConnection *pgDuckConn, List *rowGroupStatList)
 {
 	char	   *query = PrepareRowGroupStatsMinMaxQuery(rowGroupStatList);
 

--- a/pg_lake_engine/src/data_file/data_files.c
+++ b/pg_lake_engine/src/data_file/data_files.c
@@ -25,7 +25,7 @@
  * file.
  */
 TableMetadataOperation *
-AddDataFileOperation(const char *path, DataFileContent content, DataFileStats * dataFileStats,
+AddDataFileOperation(const char *path, DataFileContent content, DataFileStats *dataFileStats,
 					 struct Partition *partition, int32 partitionSpecId)
 {
 	TableMetadataOperation *operation = palloc0(sizeof(TableMetadataOperation));
@@ -116,7 +116,7 @@ AddRowIdMappingOperation(const char *dataFilePath, List *rowIdRanges)
  * DeepCopyDataFileStats deep copies a DataFileSchema.
  */
 DataFileStats *
-DeepCopyDataFileStats(const DataFileStats * stats)
+DeepCopyDataFileStats(const DataFileStats *stats)
 {
 	DataFileStats *copiedStats = palloc0(sizeof(DataFileStats));
 

--- a/pg_lake_engine/src/ddl/utility_hook.c
+++ b/pg_lake_engine/src/ddl/utility_hook.c
@@ -41,7 +41,7 @@ typedef struct UtilityStatementHandlerItem
 
 	/* optional argument to the handler */
 	void	   *arg;
-}			UtilityStatementHandlerItem;
+} UtilityStatementHandlerItem;
 
 /*
  * Linked list of post utility statement handlers, based on XactCallback.
@@ -56,7 +56,7 @@ typedef struct UtilityStatementPostHandlerItem
 
 	/* optional argument to the handler */
 	void	   *arg;
-}			UtilityStatementPostHandlerItem;
+} UtilityStatementPostHandlerItem;
 
 static void PgLakeCommonProcessUtilityHook(PlannedStmt *plannedStmt,
 										   const char *queryString,
@@ -71,8 +71,8 @@ static void PgLakeCommonProcessUtilityHook(PlannedStmt *plannedStmt,
 static ProcessUtility_hook_type PrevProcessUtility = NULL;
 
 /* registered handlers */
-static UtilityStatementHandlerItem * UtilityStatementHandlers = NULL;
-static UtilityStatementPostHandlerItem * UtilityStatementPostHandlers = NULL;
+static UtilityStatementHandlerItem *UtilityStatementHandlers = NULL;
+static UtilityStatementPostHandlerItem *UtilityStatementPostHandlers = NULL;
 
 
 /*
@@ -122,7 +122,7 @@ PgLakeCommonProcessUtilityHook(PlannedStmt *plannedStmt,
  * logic otherwise.
  */
 void
-PgLakeCommonProcessUtility(ProcessUtilityParams * processUtilityParams)
+PgLakeCommonProcessUtility(ProcessUtilityParams *processUtilityParams)
 {
 	Node	   *parsetree = processUtilityParams->plannedStmt->utilityStmt;
 
@@ -182,7 +182,7 @@ PgLakeCommonProcessUtility(ProcessUtilityParams * processUtilityParams)
  * (or standard_ProcessUtility), skipping any registered handlers.
  */
 void
-PgLakeCommonParentProcessUtility(ProcessUtilityParams * processUtilityParams)
+PgLakeCommonParentProcessUtility(ProcessUtilityParams *processUtilityParams)
 {
 	PlannedStmt *plannedStmt = processUtilityParams->plannedStmt;
 	const char *queryString = processUtilityParams->queryString;
@@ -239,7 +239,7 @@ RegisterPostUtilityStatementHandler(UtilityStatementPostHandler handler, void *a
  * and returns the utility statement it contains.
  */
 Node *
-CopyUtilityStmt(ProcessUtilityParams * processUtilityParams)
+CopyUtilityStmt(ProcessUtilityParams *processUtilityParams)
 {
 	processUtilityParams->plannedStmt = copyObject(processUtilityParams->plannedStmt);
 	processUtilityParams->readOnlyTree = false;

--- a/pg_lake_engine/src/extensions/pg_lake_engine.c
+++ b/pg_lake_engine/src/extensions/pg_lake_engine.c
@@ -37,7 +37,7 @@ typedef struct PgLakeEngineIds
 	Oid			inProgressTableId;
 
 	Oid			inProgressTablePkeyId;
-}			PgLakeEngineIds;
+} PgLakeEngineIds;
 
 static void ClearIds(void *queryEngineIds);
 

--- a/pg_lake_engine/src/extensions/pg_lake_iceberg.c
+++ b/pg_lake_engine/src/extensions/pg_lake_iceberg.c
@@ -38,7 +38,7 @@ typedef struct PgLakeIcebergIds
 	 * pg_lake_iceberg.tables_internal relation OID
 	 */
 	Oid			tablesInternalTableId;
-}			PgLakeIcebergIds;
+} PgLakeIcebergIds;
 
 static void ClearIds(void *pgLakeIcebergIds);
 

--- a/pg_lake_engine/src/extensions/pg_lake_spatial.c
+++ b/pg_lake_engine/src/extensions/pg_lake_spatial.c
@@ -49,7 +49,7 @@ typedef struct PgLakeSpatialExtensionIds
 
 	/* internal ST_GeometryType(geometry) function */
 	Oid			internalGeometryTypeFunctionId;
-}			PgLakeSpatialExtensionIds;
+} PgLakeSpatialExtensionIds;
 
 /*
  * Generic extension state.

--- a/pg_lake_engine/src/extensions/pg_lake_table.c
+++ b/pg_lake_engine/src/extensions/pg_lake_table.c
@@ -49,7 +49,7 @@ typedef struct PgLakeTableIds
 	 * __pg_lake_table_writes schema ID
 	 */
 	Oid			pgLakeWritesSchemaId;
-}			PgLakeTableIds;
+} PgLakeTableIds;
 
 static void ClearIds(void *lakeTableIds);
 

--- a/pg_lake_engine/src/extensions/pg_map.c
+++ b/pg_lake_engine/src/extensions/pg_map.c
@@ -31,7 +31,7 @@
 typedef struct PgMapIds
 {
 	Oid			schemaId;
-}			PgMapIds;
+} PgMapIds;
 
 static void ClearIds(void *queryEngineIds);
 

--- a/pg_lake_engine/src/extensions/postgis.c
+++ b/pg_lake_engine/src/extensions/postgis.c
@@ -71,7 +71,7 @@ typedef struct PostgisExtensionIds
 	/* ST_Union_Agg aggregate function */
 	Oid			stUnionAggAggregateId;
 
-}			PostgisExtensionIds;
+} PostgisExtensionIds;
 
 
 static void ClearIds(void *postgisIds);

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -24,13 +24,13 @@
 #include "pg_lake/parquet/leaf_field.h"
 #include "pg_lake/util/string_utils.h"
 
-static FieldStructElement * DeepCopyFieldStructElement(FieldStructElement * structElementField);
+static FieldStructElement *DeepCopyFieldStructElement(FieldStructElement *structElementField);
 
 /*
  * DeepCopyField deep copies a Field.
  */
 Field *
-DeepCopyField(const Field * field)
+DeepCopyField(const Field *field)
 {
 	Field	   *fieldCopy = palloc0(sizeof(Field));
 
@@ -90,7 +90,7 @@ DeepCopyField(const Field * field)
  * DeepCopyFieldStructElement deep copies a FieldStructElement.
  */
 static FieldStructElement *
-DeepCopyFieldStructElement(FieldStructElement * structElementField)
+DeepCopyFieldStructElement(FieldStructElement *structElementField)
 {
 	FieldStructElement *copiedStructElementField = palloc0(sizeof(FieldStructElement));
 
@@ -111,7 +111,7 @@ DeepCopyFieldStructElement(FieldStructElement * structElementField)
  * DeepCopyDataFileSchema deep copies a DataFileSchema.
  */
 DataFileSchema *
-DeepCopyDataFileSchema(const DataFileSchema * schema)
+DeepCopyDataFileSchema(const DataFileSchema *schema)
 {
 	DataFileSchema *copiedSchema = palloc0(sizeof(DataFileSchema));
 
@@ -156,7 +156,7 @@ pg_cmp_s32(int32 a, int32 b)
 * the type of any field in the schema, including nested types.
 */
 bool
-SchemaFieldsEquivalent(DataFileSchemaField * fieldA, DataFileSchemaField * fieldB)
+SchemaFieldsEquivalent(DataFileSchemaField *fieldA, DataFileSchemaField *fieldB)
 {
 	if (fieldA->id != fieldB->id)
 		return false;
@@ -192,7 +192,7 @@ SchemaFieldsEquivalent(DataFileSchemaField * fieldA, DataFileSchemaField * field
  * e.g. custom types like hstore
  */
 bool
-PGTypeRequiresConversionToIcebergString(Field * field, PGType pgType)
+PGTypeRequiresConversionToIcebergString(Field *field, PGType pgType)
 {
 	/*
 	 * We treat geometry as binary within the Iceberg schema, which is encoded

--- a/pg_lake_engine/src/parquet/geoparquet.c
+++ b/pg_lake_engine/src/parquet/geoparquet.c
@@ -35,7 +35,7 @@ typedef struct GeometryColumn
 	/* geometry type (point, linestring, ...), see postgis.h */
 	int			geometryType;
 
-}			GeometryColumn;
+} GeometryColumn;
 
 
 static List *GetGeometryColumns(TupleDesc tupleDesc);

--- a/pg_lake_engine/src/parquet/leaf_field.c
+++ b/pg_lake_engine/src/parquet/leaf_field.c
@@ -27,7 +27,7 @@
  * DeepCopyLeafField deep copies a LeafField.
  */
 LeafField
-DeepCopyLeafField(const LeafField * leafField)
+DeepCopyLeafField(const LeafField *leafField)
 {
 	LeafField  *copiedLeafField = palloc0(sizeof(LeafField));
 

--- a/pg_lake_engine/src/pgduck/cache_worker.c
+++ b/pg_lake_engine/src/pgduck/cache_worker.c
@@ -44,7 +44,7 @@ typedef enum ManageCacheResult
 	MANAGE_CACHE_SUCCESS,
 	MANAGE_CACHE_ERROR,
 	MANAGE_CACHE_DISABLED
-}			ManageCacheResult;
+} ManageCacheResult;
 
 
 /* background worker entry point */
@@ -200,7 +200,7 @@ ManageCache(void)
 					 "CALL pg_lake_manage_cache(" INT64_FORMAT ")",
 					 maxCacheSizeBytes);
 
-	volatile	ManageCacheResult manageCacheResult;
+	volatile ManageCacheResult manageCacheResult;
 
 	/*
 	 * We start a transaction primarily to go through the transaction

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -69,7 +69,7 @@ typedef struct PgDuckServerConnectionHashEntry
 	SubTransactionId subTransactionId;
 	PGDuckConnection pgDuckConnection;
 
-}			PgDuckServerConnectionHashEntry;
+} PgDuckServerConnectionHashEntry;
 
 /*
  * InitializePGDuckClient is called the first time we get a PGDuck connection
@@ -171,7 +171,7 @@ GetPGDuckConnection(void)
  * pgduck_server, if any.
  */
 void
-ReleasePGDuckConnection(PGDuckConnection * pgDuckConnection)
+ReleasePGDuckConnection(PGDuckConnection *pgDuckConnection)
 {
 	uint32		connectionId = pgDuckConnection->connectionId;
 	bool		found = false;
@@ -199,7 +199,7 @@ ReleasePGDuckConnection(PGDuckConnection * pgDuckConnection)
  * SendQueryToPGDuck sends the given query over the connection.
  */
 void
-SendQueryToPGDuck(PGDuckConnection * pgDuckConnection, char *query)
+SendQueryToPGDuck(PGDuckConnection *pgDuckConnection, char *query)
 {
 	PGconn	   *conn = pgDuckConnection->conn;
 
@@ -349,7 +349,7 @@ ExecuteOptionalCommandInPGDuck(char *command)
  * connection.
  */
 PGresult *
-ExecuteQueryOnPGDuckConnection(PGDuckConnection * pgDuckConnection,
+ExecuteQueryOnPGDuckConnection(PGDuckConnection *pgDuckConnection,
 							   const char *query)
 {
 	PGconn	   *conn = pgDuckConnection->conn;
@@ -384,7 +384,7 @@ ExecuteQueryOnPGDuckConnection(PGDuckConnection * pgDuckConnection,
  * while also checking for signals and postmaster death.
  */
 PGresult *
-WaitForResult(PGDuckConnection * pgDuckConnection)
+WaitForResult(PGDuckConnection *pgDuckConnection)
 {
 	PGconn	   *conn = pgDuckConnection->conn;
 
@@ -430,7 +430,7 @@ WaitForResult(PGDuckConnection * pgDuckConnection)
  * Derived from pgfdw_get_result
  */
 PGresult *
-WaitForLastResult(PGDuckConnection * pgDuckConnection)
+WaitForLastResult(PGDuckConnection *pgDuckConnection)
 {
 	PGresult   *volatile last_res = NULL;
 
@@ -465,7 +465,7 @@ WaitForLastResult(PGDuckConnection * pgDuckConnection)
  * PQclear is called on the result in case of error.
  */
 void
-CheckPGDuckResult(PGDuckConnection * pgDuckConnection, PGresult *result)
+CheckPGDuckResult(PGDuckConnection *pgDuckConnection, PGresult *result)
 {
 	PG_TRY();
 	{
@@ -485,7 +485,7 @@ CheckPGDuckResult(PGDuckConnection * pgDuckConnection, PGresult *result)
  * ThrowIfPGDuckResultHasError throws the error received over a connection, if any.
  */
 void
-ThrowIfPGDuckResultHasError(PGDuckConnection * pgDuckConnection, PGresult *result)
+ThrowIfPGDuckResultHasError(PGDuckConnection *pgDuckConnection, PGresult *result)
 {
 	ExecStatusType resultStatus = PQresultStatus(result);
 
@@ -922,7 +922,7 @@ GetSingleValueFromPGDuck(char *query)
 * It is a wrapper around PQsendQueryParams() followed by PQsetSingleRowMode().
 */
 void
-SendQueryWithParams(PGDuckConnection * pgduckConn, char *queryString,
+SendQueryWithParams(PGDuckConnection *pgduckConn, char *queryString,
 					int numParams, const char **parameterValues)
 {
 	PGconn	   *conn = pgduckConn->conn;

--- a/pg_lake_engine/src/pgduck/delete_data.c
+++ b/pg_lake_engine/src/pgduck/delete_data.c
@@ -39,8 +39,8 @@
 static char *DeleteFromParquetQuery(char *sourceDataFilePath,
 									List *positionDeleteFiles,
 									char *deletionFilePath,
-									DataFileSchema * schema,
-									ReadDataStats * stats);
+									DataFileSchema *schema,
+									ReadDataStats *stats);
 
 
 /*
@@ -53,8 +53,8 @@ PerformDeleteFromParquet(char *sourcePath,
 						 char *deletionFilePath,
 						 char *destinationPath,
 						 CopyDataCompression destinationCompression,
-						 DataFileSchema * schema,
-						 ReadDataStats * stats,
+						 DataFileSchema *schema,
+						 ReadDataStats *stats,
 						 List *leafFields)
 {
 	const char *remainderQuery =
@@ -111,8 +111,8 @@ PerformDeleteFromParquet(char *sourcePath,
  */
 static char *
 DeleteFromParquetQuery(char *sourceDataFilePath, List *positionDeleteFiles,
-					   char *deletionFilePath, DataFileSchema * schema,
-					   ReadDataStats * stats)
+					   char *deletionFilePath, DataFileSchema *schema,
+					   ReadDataStats *stats)
 {
 	StringInfoData command;
 

--- a/pg_lake_engine/src/pgduck/explain.c
+++ b/pg_lake_engine/src/pgduck/explain.c
@@ -37,7 +37,7 @@ typedef struct ExtraInfo
 {
 	const char *key;
 	const char *value;
-}			ExtraInfo;
+} ExtraInfo;
 
 /*
  * Physical operator object in DuckDB explain output.
@@ -52,13 +52,13 @@ typedef struct PhysicalOperator
 
 	ExtraInfo  *extraInfo;
 	size_t		extraInfoLength;
-}			PhysicalOperator;
+} PhysicalOperator;
 
 
 static char *GetExplainJson(char *query, int numParams, const char **parameterValues);
-static void ExplainPhysicalOperator(PhysicalOperator * operator, ExplainState *es);
-static void ReadPhysicalOperator(JsonbContainer *json, PhysicalOperator * operator);
-static void ReadExtraInfo(const char *key, JsonbValue *jsonValue, ExtraInfo * property);
+static void ExplainPhysicalOperator(PhysicalOperator *operator, ExplainState *es);
+static void ReadPhysicalOperator(JsonbContainer *json, PhysicalOperator *operator);
+static void ReadExtraInfo(const char *key, JsonbValue *jsonValue, ExtraInfo *property);
 
 
 /*
@@ -102,7 +102,7 @@ ExplainPGDuckQuery(char *query, int numParams, const char **parameterValues,
  * functions.
  */
 static void
-ExplainPhysicalOperator(PhysicalOperator * operator, ExplainState *es)
+ExplainPhysicalOperator(PhysicalOperator *operator, ExplainState *es)
 {
 	/* { in JSON, <Physical-Operator> in XML */
 	ExplainOpenGroup("Physical Operator", NULL, true, es);
@@ -163,7 +163,7 @@ ExplainPhysicalOperator(PhysicalOperator * operator, ExplainState *es)
  * ReadPhysicalOperator parses a DuckDB physical operator from explain output.
  */
 static void
-ReadPhysicalOperator(JsonbContainer *json, PhysicalOperator * operator)
+ReadPhysicalOperator(JsonbContainer *json, PhysicalOperator *operator)
 {
 	memset(operator, '\0', sizeof(PhysicalOperator));
 
@@ -184,7 +184,7 @@ ReadPhysicalOperator(JsonbContainer *json, PhysicalOperator * operator)
  * ReadExtraInfo reads the extra_info properties.
  */
 static void
-ReadExtraInfo(const char *key, JsonbValue *jsonValue, ExtraInfo * property)
+ReadExtraInfo(const char *key, JsonbValue *jsonValue, ExtraInfo *property)
 {
 	memset(property, '\0', sizeof(ExtraInfo));
 

--- a/pg_lake_engine/src/pgduck/keywords.c
+++ b/pg_lake_engine/src/pgduck/keywords.c
@@ -41,7 +41,7 @@ typedef struct DuckDBKeyword
 {
 	char	   *keywordName;
 	int			keywordCategory;
-}			DuckDBKeyword;
+} DuckDBKeyword;
 
 /* we only care about the name and the category here */
 #define PG_KEYWORD(name,value,cat,is_bare_label) {(name), (cat)},

--- a/pg_lake_engine/src/pgduck/parallel_command.c
+++ b/pg_lake_engine/src/pgduck/parallel_command.c
@@ -53,7 +53,7 @@ typedef enum CommandExecutionStateMachineState
 	COMMAND_EXECUTION_STATE_FAILING,	/* cleaning up after failure */
 	COMMAND_EXECUTION_STATE_COMPLETED,	/* query completed successfully */
 	COMMAND_EXECUTION_STATE_FAILED	/* query failed (terminal state) */
-}			CommandExecutionStateMachineState;
+} CommandExecutionStateMachineState;
 
 /*
  * CommandExecutionState tracks the state of an in-progress upload.
@@ -64,7 +64,7 @@ typedef struct CommandExecutionState
 	PGDuckConnection *pgDuckConnection;
 	CommandExecutionStateMachineState state;
 	char	   *errorMessage;
-}			CommandExecutionState;
+} CommandExecutionState;
 
 /*
  * MultiCommandExecutionState tracks the state of a set of uploads.
@@ -74,18 +74,18 @@ typedef struct MultiCommandExecutionState
 	CommandExecutionState *states;
 	int32		executionCount;
 	int32		busyConnectionsCount;
-}			MultiCommandExecutionState;
+} MultiCommandExecutionState;
 
 
-static void RunNonBlockingCommandExecutions(MultiCommandExecutionState * multiState,
+static void RunNonBlockingCommandExecutions(MultiCommandExecutionState *multiState,
 											int32 maxRunningExecutions);
-static void WaitForSocketEvents(MultiCommandExecutionState * multiState);
-static void RunCommandExecutionStateMachine(MultiCommandExecutionState * multiState,
-											CommandExecutionState * state);
-static bool AdvanceCommandExecutionStateMachine(MultiCommandExecutionState * multiState,
-												CommandExecutionState * state);
-static int	CountActiveExecutions(MultiCommandExecutionState * multiState);
-static int	CountWaitingExecutions(MultiCommandExecutionState * multiState);
+static void WaitForSocketEvents(MultiCommandExecutionState *multiState);
+static void RunCommandExecutionStateMachine(MultiCommandExecutionState *multiState,
+											CommandExecutionState *state);
+static bool AdvanceCommandExecutionStateMachine(MultiCommandExecutionState *multiState,
+												CommandExecutionState *state);
+static int	CountActiveExecutions(MultiCommandExecutionState *multiState);
+static int	CountWaitingExecutions(MultiCommandExecutionState *multiState);
 
 
 
@@ -151,7 +151,7 @@ ExecuteCommandsInParallelInPGDuck(List *commandList, int32 maxActiveExecutions)
  * progress without waiting for I/O.
  */
 static void
-RunNonBlockingCommandExecutions(MultiCommandExecutionState * multiState,
+RunNonBlockingCommandExecutions(MultiCommandExecutionState *multiState,
 								int32 maxActiveExecutions)
 {
 	CommandExecutionState *execStates = multiState->states;
@@ -190,7 +190,7 @@ RunNonBlockingCommandExecutions(MultiCommandExecutionState * multiState,
  * For WAITING state: waits for read-ready
  */
 static void
-WaitForSocketEvents(MultiCommandExecutionState * multiState)
+WaitForSocketEvents(MultiCommandExecutionState *multiState)
 {
 	int			waitingExecutionsCount = CountWaitingExecutions(multiState);
 
@@ -298,8 +298,8 @@ WaitForSocketEvents(MultiCommandExecutionState * multiState)
  * until it reaches a state that requires waiting for IO or a terminal state.
  */
 static void
-RunCommandExecutionStateMachine(MultiCommandExecutionState * multiState,
-								CommandExecutionState * state)
+RunCommandExecutionStateMachine(MultiCommandExecutionState *multiState,
+								CommandExecutionState *state)
 {
 	/* iterate until a blocking or terminal state is reached */
 	while (AdvanceCommandExecutionStateMachine(multiState, state))
@@ -317,8 +317,8 @@ RunCommandExecutionStateMachine(MultiCommandExecutionState * multiState,
  * wait for IO.
  */
 static bool
-AdvanceCommandExecutionStateMachine(MultiCommandExecutionState * multiState,
-									CommandExecutionState * state)
+AdvanceCommandExecutionStateMachine(MultiCommandExecutionState *multiState,
+									CommandExecutionState *state)
 {
 	switch (state->state)
 	{
@@ -473,7 +473,7 @@ AdvanceCommandExecutionStateMachine(MultiCommandExecutionState * multiState,
  * CountActiveExecutions returns the number of executions that are not yet completed or failed.
  */
 static int
-CountActiveExecutions(MultiCommandExecutionState * multiState)
+CountActiveExecutions(MultiCommandExecutionState *multiState)
 {
 	int			activeCount = 0;
 
@@ -497,7 +497,7 @@ CountActiveExecutions(MultiCommandExecutionState * multiState)
  * for IO.
  */
 static int32
-CountWaitingExecutions(MultiCommandExecutionState * multiState)
+CountWaitingExecutions(MultiCommandExecutionState *multiState)
 {
 	int			waitingExecutionsCount = 0;
 

--- a/pg_lake_engine/src/pgduck/parse_struct.c
+++ b/pg_lake_engine/src/pgduck/parse_struct.c
@@ -59,24 +59,24 @@ typedef struct StructParserState
 	const char *sourceString;
 	char	   *position;
 	List	   *uncreatedTypes;
-}			StructParserState;
+} StructParserState;
 
 
 /* pulling from type.c without general include */
 extern Oid	GetPGTypeForDuckDBTypeNameBuiltin(const char *name, int *typeMod, bool arrayOid);
 
 /* prototypes */
-static Oid	FindOrCreatePGCompositeType(CompositeType * type);
-static Oid	CreatePGCompositeType(CompositeType * type);
+static Oid	FindOrCreatePGCompositeType(CompositeType *type);
+static Oid	CreatePGCompositeType(CompositeType *type);
 static void CreateUncreatedTypes(List *uncreatedTypes);
 static Oid	GetRelatedTypeOid(Oid inputType, bool getArray);
-static void EnsureColumnTypesArePopulated(CompositeType * myType);
+static void EnsureColumnTypesArePopulated(CompositeType *myType);
 
 /* parser-related returns */
 /* not exposed, but importable via extern */
-CompositeType *ParseStructType(StructParserState * parse);
-static CompositeCol * ParseStructColumn(StructParserState * parse);
-static bool ParseSkipToNextField(StructParserState * parse);
+CompositeType *ParseStructType(StructParserState *parse);
+static CompositeCol *ParseStructColumn(StructParserState *parse);
+static bool ParseSkipToNextField(StructParserState *parse);
 static char *ParseSkipCasePrefix(const char *string, const char *prefix);
 
 /* exposed for map parsing as well */
@@ -84,8 +84,8 @@ char	   *ParseDuckDBFieldType(char **sourceStringPtr, bool *isArray);
 
 /* helper functions for parsing */
 static char *ParseDuckDBFieldName(char **sourceStringPtr);
-static void AssignBaseStructTypeName(CompositeType * type);
-static void FinalizeCompositeTypeName(CompositeType * type);
+static void AssignBaseStructTypeName(CompositeType *type);
+static void FinalizeCompositeTypeName(CompositeType *type);
 
 /* simple wrapper for easily parsing a single type */
 CompositeType *
@@ -169,7 +169,7 @@ GetOrCreatePGStructType(const char *name)
  * order in one pass.
  */
 CompositeType *
-ParseStructType(StructParserState * parse)
+ParseStructType(StructParserState *parse)
 {
 	/* we should only be running this if we are a struct type */
 	Assert(IsStructType(parse->sourceString));
@@ -260,7 +260,7 @@ ParseSkipCasePrefix(const char *string, const char *prefix)
  * itself could be a struct, which will also recursively be parsed).
  */
 static CompositeCol *
-ParseStructColumn(StructParserState * parse)
+ParseStructColumn(StructParserState *parse)
 {
 	CompositeCol *myCol = palloc0(sizeof(CompositeCol));
 
@@ -678,7 +678,7 @@ ParseDuckDBFieldType(char **sourceString, bool *isArray)
  * false if there was an error.
  */
 static bool
-ParseSkipToNextField(StructParserState * parse)
+ParseSkipToNextField(StructParserState *parse)
 {
 	/* skip leading whitespace */
 	while (isspace(*parse->position))
@@ -730,7 +730,7 @@ ParseSkipToNextField(StructParserState * parse)
  * type instead of the elem composite type.
  */
 static Oid
-FindOrCreatePGCompositeType(CompositeType * type)
+FindOrCreatePGCompositeType(CompositeType *type)
 {
 	elog(DEBUG1, "Looking up existing composite postgres type for: %s", GetDuckDBStructDefinitionForCompositeType(type, DATA_FORMAT_INVALID));
 
@@ -845,7 +845,7 @@ FindOrCreatePGCompositeType(CompositeType * type)
  * of the columns match.
  */
 static Oid
-CreatePGCompositeType(CompositeType * type)
+CreatePGCompositeType(CompositeType *type)
 {
 	RangeVar   *typevar;
 	List	   *coldeflist = NIL;
@@ -917,7 +917,7 @@ CreatePGCompositeType(CompositeType * type)
  * finalizes the name.
  */
 static void
-AssignBaseStructTypeName(CompositeType * type)
+AssignBaseStructTypeName(CompositeType *type)
 {
 	/* get column names */
 
@@ -949,7 +949,7 @@ AssignBaseStructTypeName(CompositeType * type)
  * generated name.  It also changes spaces to underscores in the output.
  */
 static void
-FinalizeCompositeTypeName(CompositeType * type)
+FinalizeCompositeTypeName(CompositeType *type)
 {
 	if (type->isFinalized)
 		return;
@@ -1059,7 +1059,7 @@ FinalizeCompositeTypeName(CompositeType * type)
  * basically the inverse of the ParseStructType() routine.
  */
 char *
-GetDuckDBStructDefinitionForCompositeType(CompositeType * type,
+GetDuckDBStructDefinitionForCompositeType(CompositeType *type,
 										  CopyDataFormat format)
 {
 	ListCell   *lc;
@@ -1368,7 +1368,7 @@ GetRelatedTypeOid(Oid inputType, bool getArray)
  * This routine populates any unpopulated column type fields from the subStruct.
  */
 static void
-EnsureColumnTypesArePopulated(CompositeType * myType)
+EnsureColumnTypesArePopulated(CompositeType *myType)
 {
 	ListCell   *lc;
 

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -49,12 +49,12 @@ static char *ReadDataSourceFunction(List *sourcePaths,
 									CopyDataCompression sourceCompression,
 									TupleDesc expectedDesc,
 									List *formatOptions,
-									DataFileSchema * schema,
+									DataFileSchema *schema,
 									bool preferVarchar,
 									ReadRowLocationMode emitRowLocation,
 									bool emitRowId);
-static char *BuildParquetSchema(DataFileSchema * schema, bool emitRowId);
-static char *GetSchemaType(Field * mapping);
+static char *BuildParquetSchema(DataFileSchema *schema, bool emitRowId);
+static char *GetSchemaType(Field *mapping);
 static char *ReadEmptyDataSource(TupleDesc tupleDesc, CopyDataFormat format,
 								 bool preferVarchar,
 								 ReadRowLocationMode emitRowLocation);
@@ -92,8 +92,8 @@ ReadDataSourceQuery(List *sourcePaths,
 					CopyDataCompression sourceCompression,
 					TupleDesc expectedDesc,
 					List *formatOptions,
-					DataFileSchema * schema,
-					ReadDataStats * stats,
+					DataFileSchema *schema,
+					ReadDataStats *stats,
 					int flags)
 {
 	/* whether to prepare output for TRANSMIT */
@@ -229,7 +229,7 @@ ReadDataSourceFunction(List *sourcePaths,
 					   CopyDataCompression sourceCompression,
 					   TupleDesc expectedDesc,
 					   List *formatOptions,
-					   DataFileSchema * schema,
+					   DataFileSchema *schema,
 					   bool preferVarchar,
 					   ReadRowLocationMode readRowLocationMode,
 					   bool emitRowId)
@@ -566,7 +566,7 @@ ReadDataSourceFunction(List *sourcePaths,
 * read them all. The
 */
 static char *
-BuildParquetSchema(DataFileSchema * schema, bool emitRowId)
+BuildParquetSchema(DataFileSchema *schema, bool emitRowId)
 {
 	StringInfoData schemaString;
 
@@ -618,7 +618,7 @@ BuildParquetSchema(DataFileSchema * schema, bool emitRowId)
 * GetSchemaType returns the schema type for a given field.
 */
 static char *
-GetSchemaType(Field * field)
+GetSchemaType(Field *field)
 {
 	StringInfoData str;
 

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -58,7 +58,7 @@ typedef struct RewriteQueryTreeContext
 	int			level;
 	/* our extra arg from rewrite rule */
 	int			funcIntArg;
-}			RewriteQueryTreeContext;
+} RewriteQueryTreeContext;
 
 
 /*
@@ -94,7 +94,7 @@ typedef struct FunctionCallRewriteRuleByName
 	const char *functionName;
 	ExpressionRewriter rewriteFunction;
 	int			limitArgs;
-}			FunctionCallRewriteRuleByName;
+} FunctionCallRewriteRuleByName;
 
 
 /*
@@ -107,7 +107,7 @@ typedef struct AggregateRewriteRuleByName
 	const char *schemaName;
 	const char *aggregateName;
 	ExpressionRewriter rewriteAggregate;
-}			AggregateRewriteRuleByName;
+} AggregateRewriteRuleByName;
 
 
 /*
@@ -120,11 +120,11 @@ typedef struct OperatorRewriteRuleByName
 	const char *operatorName;
 	char	   *replacementFunctionName;
 	ExpressionRewriter rewriteOperator;
-}			OperatorRewriteRuleByName;
+} OperatorRewriteRuleByName;
 
 
 static void InitRewriteRules(void);
-static Node *RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext * context);
+static Node *RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext *context);
 static Node *ReplaceJsonbWithPgLakeInternalJsonbFunction(Node *inputNode, void *context);
 static bool IsJsonbCast(Node *node);
 static Node *WrapPgLakeInternalJsonbFunction(Node *data);
@@ -521,7 +521,7 @@ RewriteQueryTreeForPGDuck(Query *query)
  * for use in pgduck.
  */
 static Node *
-RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext * context)
+RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext *context)
 {
 	if (node == NULL)
 	{

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -452,7 +452,7 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
  * GetShippableBuiltinFunctionCount
  *		Returns the number of shippable functions
  */
-const		PGDuckShippableFunction *
+const PGDuckShippableFunction *
 GetShippableBuiltinFunctions(int *sizePointer)
 {
 	*sizePointer = ARRAY_SIZE(ShippableBuiltinProcs);

--- a/pg_lake_engine/src/pgduck/shippable_builtin_operators.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_operators.c
@@ -519,7 +519,7 @@ static const PGDuckShippableOperatorsByType PGDuckShippableOperatorsByTypes[] = 
  * GetPGDuckShippableOperatorsByType returns all shippable built-in operators,
  * group by type.
  */
-const		PGDuckShippableOperatorsByType *
+const PGDuckShippableOperatorsByType *
 GetPGDuckShippableOperatorsByType(int *sizePointer)
 {
 	*sizePointer = ARRAY_SIZE(PGDuckShippableOperatorsByTypes);

--- a/pg_lake_engine/src/pgduck/shippable_spatial_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_spatial_functions.c
@@ -216,7 +216,7 @@ static const PGDuckShippableFunction ShippableSpatialProcs[] =
 /*
  * GetShippableSpatialFunctionCount returns the number of shippable spatial functions.
  */
-const		PGDuckShippableFunction *
+const PGDuckShippableFunction *
 GetShippableSpatialFunctions(int *sizePointer)
 {
 	*sizePointer = ARRAY_SIZE(ShippableSpatialProcs);

--- a/pg_lake_engine/src/pgduck/shippable_spatial_operators.c
+++ b/pg_lake_engine/src/pgduck/shippable_spatial_operators.c
@@ -39,7 +39,7 @@ static const PGDuckShippableOperator ShippableSpatialOperators[] = {
  * GetShippableSpatialOperatorCount
  *		Returns the number of shippable functions
  */
-const		PGDuckShippableOperator *
+const PGDuckShippableOperator *
 GetShippableSpatialOperators(int *sizePointer)
 {
 	*sizePointer = ARRAY_SIZE(ShippableSpatialOperators);

--- a/pg_lake_engine/src/pgduck/to_char.c
+++ b/pg_lake_engine/src/pgduck/to_char.c
@@ -93,7 +93,7 @@ typedef struct FormatSpecifierMapping
 	 */
 	int			padLength;
 	char	   *padString;
-}			FormatSpecifierMapping;
+} FormatSpecifierMapping;
 
 static Node *MakeStrftimeExpr(Node *timeArg, char *strftimeFormat);
 static Node *MakeSSSSExpr(Node *timeArg, char *tocharSpecifier);
@@ -121,150 +121,150 @@ static FormatSpecifierMapping SpecifierMappings[] =
 	{
 		/* seconds since midnight */
 		.toCharSpecifier = "SSSSS",
-			.createCustomExpr = MakeSSSSExpr
+		.createCustomExpr = MakeSSSSExpr
 	},
 	{
 		/* seconds since midnight */
 		.toCharSpecifier = "SSSS",
-			.createCustomExpr = MakeSSSSExpr
+		.createCustomExpr = MakeSSSSExpr
 	},
 
 	{
 		/* Hours 24-hour format (0-padded) */
 		.toCharSpecifier = "HH24",
-			.strftimeSpecifier = "%-H",
-			.strftimeSpecifierPadded = "%H"
+		.strftimeSpecifier = "%-H",
+		.strftimeSpecifierPadded = "%H"
 	},
 	{
 		/* Hours 12-hour format (0-padded) */
 		.toCharSpecifier = "HH12",
-			.strftimeSpecifier = "%-I",
-			.strftimeSpecifierPadded = "%I"
+		.strftimeSpecifier = "%-I",
+		.strftimeSpecifierPadded = "%I"
 	},
 	{
 		/* Hours 12-hour format (0-padded) */
 		.toCharSpecifier = "HH",
-			.strftimeSpecifier = "%I"
+		.strftimeSpecifier = "%I"
 	},
 	{
 		/* Minutes (0-padded) */
 		.toCharSpecifier = "MI",
-			.strftimeSpecifier = "%-M",
-			.strftimeSpecifierPadded = "%M"
+		.strftimeSpecifier = "%-M",
+		.strftimeSpecifierPadded = "%M"
 	},
 	{
 		/* Seconds (0-padded) */
 		.toCharSpecifier = "SS",
-			.strftimeSpecifier = "%-S",
-			.strftimeSpecifierPadded = "%S"
+		.strftimeSpecifier = "%-S",
+		.strftimeSpecifierPadded = "%S"
 	},
 	{
 		/* Milliseconds */
 		.toCharSpecifier = "MS",
-			.strftimeSpecifier = "%g"
+		.strftimeSpecifier = "%g"
 	},
 	{
 		/* Microseconds */
 		.toCharSpecifier = "US",
-			.strftimeSpecifier = "%f"
+		.strftimeSpecifier = "%f"
 	},
 	{
 		/* Tenth of seconds */
 		.toCharSpecifier = "FF1",
-			.createCustomExpr = MakeFFExpr
+		.createCustomExpr = MakeFFExpr
 	},
 	{
 		/* Hundredth of seconds */
 		.toCharSpecifier = "FF2",
-			.createCustomExpr = MakeFFExpr,
-			.padLength = -2,
-			.padString = "0"
+		.createCustomExpr = MakeFFExpr,
+		.padLength = -2,
+		.padString = "0"
 	},
 	{
 		/* Tenth of a millisecond */
 		.toCharSpecifier = "FF3",
-			.createCustomExpr = MakeFFExpr,
-			.padLength = -3,
-			.padString = "0"
+		.createCustomExpr = MakeFFExpr,
+		.padLength = -3,
+		.padString = "0"
 	},
 	{
 		/* Hundredth of a millisecond */
 		.toCharSpecifier = "FF4",
-			.createCustomExpr = MakeFFExpr,
-			.padLength = -4,
-			.padString = "0"
+		.createCustomExpr = MakeFFExpr,
+		.padLength = -4,
+		.padString = "0"
 	},
 	{
 		/* Tenth of a microsecond */
 		.toCharSpecifier = "FF5",
-			.createCustomExpr = MakeFFExpr,
-			.padLength = -5,
-			.padString = "0"
+		.createCustomExpr = MakeFFExpr,
+		.padLength = -5,
+		.padString = "0"
 	},
 	{
 		/* Hundredth of a microsecond */
 		.toCharSpecifier = "FF6",
-			.createCustomExpr = MakeFFExpr,
-			.padLength = -6,
-			.padString = "0"
+		.createCustomExpr = MakeFFExpr,
+		.padLength = -6,
+		.padString = "0"
 	},
 	{
 		/* AM / PM */
 		.toCharSpecifier = "AM",
-			.strftimeSpecifier = "%p",
-			.isCaseSensitive = true,
-			.isTextual = true
+		.strftimeSpecifier = "%p",
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* am / pm */
 		.toCharSpecifier = "am",
-			.createCustomExpr = MakeAmPmExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeAmPmExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 
 	},
 	{
 		/* AM / PM */
 		.toCharSpecifier = "PM",
-			.strftimeSpecifier = "%p",
-			.isCaseSensitive = true,
-			.isTextual = true
+		.strftimeSpecifier = "%p",
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* am / pm */
 		.toCharSpecifier = "pm",
-			.createCustomExpr = MakeAmPmExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeAmPmExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* A.M. / P.M. */
 		.toCharSpecifier = "A.M.",
-			.createCustomExpr = MakeAmPmExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeAmPmExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* a.m. / p.m. */
 		.toCharSpecifier = "a.m.",
-			.createCustomExpr = MakeAmPmExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeAmPmExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 
 	},
 	{
 		/* A.M. / P.M. */
 		.toCharSpecifier = "P.M.",
-			.createCustomExpr = MakeAmPmExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeAmPmExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* a.m. / p.m. */
 		.toCharSpecifier = "p.m.",
-			.createCustomExpr = MakeAmPmExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeAmPmExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* Year (always 0-padded to 4 digits) */
@@ -273,7 +273,7 @@ static FormatSpecifierMapping SpecifierMappings[] =
 		 * common case
 		 */
 		.toCharSpecifier = "YYYY",
-			.strftimeSpecifier = "%Y"
+		.strftimeSpecifier = "%Y"
 	},
 	{
 		/* Year formatted as 2,025  */
@@ -283,25 +283,25 @@ static FormatSpecifierMapping SpecifierMappings[] =
 		 * would be quite complicated.
 		 */
 		.toCharSpecifier = "Y,YYY",
-			.createCustomExpr = MakeYCommaYYYExpr,
+		.createCustomExpr = MakeYCommaYYYExpr,
 	},
 	{
 		/* Last 3 digits of the year */
 		.toCharSpecifier = "YYY",
-			.createCustomExpr = MakeYExpr,
-			.padLength = -3,
-			.padString = "0"
+		.createCustomExpr = MakeYExpr,
+		.padLength = -3,
+		.padString = "0"
 	},
 	{
 		/* Last 2 digits of year */
 		.toCharSpecifier = "YY",
-			.strftimeSpecifier = "%-y",
-			.strftimeSpecifierPadded = "%y"
+		.strftimeSpecifier = "%-y",
+		.strftimeSpecifierPadded = "%y"
 	},
 	{
 		/* Last digit of the year */
 		.toCharSpecifier = "Y",
-			.createCustomExpr = MakeYExpr
+		.createCustomExpr = MakeYExpr
 	},
 	{
 		/* ISO 8601 week aligned year (always 0-padded to 4 digits) */
@@ -310,180 +310,180 @@ static FormatSpecifierMapping SpecifierMappings[] =
 		 * common case
 		 */
 		.toCharSpecifier = "IYYY",
-			.strftimeSpecifier = "%G"
+		.strftimeSpecifier = "%G"
 	},
 	{
 		/* last 3 digits of ISO 8601 week aligned year */
 		.toCharSpecifier = "IYY",
-			.createCustomExpr = MakeIYExpr,
-			.padLength = -3,
-			.padString = "0"
+		.createCustomExpr = MakeIYExpr,
+		.padLength = -3,
+		.padString = "0"
 	},
 	{
 		/* last 2 digits of ISO 8601 week aligned year */
 		.toCharSpecifier = "IY",
-			.createCustomExpr = MakeIYExpr,
-			.padLength = -2,
-			.padString = "0"
+		.createCustomExpr = MakeIYExpr,
+		.padLength = -2,
+		.padString = "0"
 	},
 	{
 		/* AD / BC */
 		.toCharSpecifier = "BC",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* ad / bc */
 		.toCharSpecifier = "bc",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* AD / BC */
 		.toCharSpecifier = "AD",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* ad / bc */
 		.toCharSpecifier = "ad",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* A.D. / B.C. */
 		.toCharSpecifier = "B.C.",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* a.d. / b.c. */
 		.toCharSpecifier = "b.c.",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* A.D. / B.C. */
 		.toCharSpecifier = "A.D.",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* a.d. / b.c. */
 		.toCharSpecifier = "a.d.",
-			.createCustomExpr = MakeEraExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeEraExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* month name uppercase */
 		.toCharSpecifier = "MONTH",
-			.createCustomExpr = MakeMonthNameExpr,
-			.padLength = MAX_MONTH_LENGTH,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeMonthNameExpr,
+		.padLength = MAX_MONTH_LENGTH,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* month name */
 		.toCharSpecifier = "Month",
-			.strftimeSpecifier = "%B",
-			.padLength = MAX_MONTH_LENGTH,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.strftimeSpecifier = "%B",
+		.padLength = MAX_MONTH_LENGTH,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* month name lowercase */
 		.toCharSpecifier = "month",
-			.createCustomExpr = MakeMonthNameExpr,
-			.padLength = MAX_MONTH_LENGTH,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeMonthNameExpr,
+		.padLength = MAX_MONTH_LENGTH,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* abbreviated month name uppercase */
 		.toCharSpecifier = "MON",
-			.createCustomExpr = MakeMonthNameExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeMonthNameExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* abbreviated month name */
 		.toCharSpecifier = "Mon",
-			.strftimeSpecifier = "%b",
-			.isCaseSensitive = true,
-			.isTextual = true
+		.strftimeSpecifier = "%b",
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* abbreviated month name lowercase */
 		.toCharSpecifier = "mon",
-			.createCustomExpr = MakeMonthNameExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeMonthNameExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* month number (0-padded) */
 		.toCharSpecifier = "MM",
-			.strftimeSpecifier = "%-m",
-			.strftimeSpecifierPadded = "%m",
-			.isTextual = true
+		.strftimeSpecifier = "%-m",
+		.strftimeSpecifierPadded = "%m",
+		.isTextual = true
 	},
 	{
 		/* day name uppercase */
 		.toCharSpecifier = "DAY",
-			.createCustomExpr = MakeDayNameExpr,
-			.padLength = MAX_DAY_LENGTH,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeDayNameExpr,
+		.padLength = MAX_DAY_LENGTH,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* day name */
 		.toCharSpecifier = "Day",
-			.strftimeSpecifier = "%A",
-			.isCaseSensitive = true,
-			.padLength = MAX_DAY_LENGTH,
-			.isTextual = true
+		.strftimeSpecifier = "%A",
+		.isCaseSensitive = true,
+		.padLength = MAX_DAY_LENGTH,
+		.isTextual = true
 	},
 	{
 		/* day name lowercase */
 		.toCharSpecifier = "day",
-			.createCustomExpr = MakeDayNameExpr,
-			.padLength = MAX_DAY_LENGTH,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeDayNameExpr,
+		.padLength = MAX_DAY_LENGTH,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* abbreviated day name uppercase */
 		.toCharSpecifier = "DY",
-			.createCustomExpr = MakeDayNameExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeDayNameExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* abbreviated day name */
 		.toCharSpecifier = "Dy",
-			.strftimeSpecifier = "%a",
-			.isCaseSensitive = true,
-			.isTextual = true
+		.strftimeSpecifier = "%a",
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* abbreviated day name lowercase */
 		.toCharSpecifier = "dy",
-			.createCustomExpr = MakeDayNameExpr,
-			.isCaseSensitive = true,
-			.isTextual = true
+		.createCustomExpr = MakeDayNameExpr,
+		.isCaseSensitive = true,
+		.isTextual = true
 	},
 	{
 		/* day of the year */
 		.toCharSpecifier = "DDD",
-			.strftimeSpecifier = "%-j",
-			.strftimeSpecifierPadded = "%j"
+		.strftimeSpecifier = "%-j",
+		.strftimeSpecifierPadded = "%j"
 	},
 	{
 		/* day of the year of ISO 8601 week aligned year */
@@ -493,50 +493,50 @@ static FormatSpecifierMapping SpecifierMappings[] =
 	{
 		/* day of the month */
 		.toCharSpecifier = "DD",
-			.strftimeSpecifier = "%-d",
-			.strftimeSpecifierPadded = "%d"
+		.strftimeSpecifier = "%-d",
+		.strftimeSpecifierPadded = "%d"
 	},
 	{
 		/* day of the week with Sunday = 1 */
 		.toCharSpecifier = "D",
-			.createCustomExpr = MakeDayOfWeekExpr,
+		.createCustomExpr = MakeDayOfWeekExpr,
 	},
 	{
 		/* day of the week with Monday = 1 */
 		.toCharSpecifier = "ID",
-			.strftimeSpecifier = "%u"
+		.strftimeSpecifier = "%u"
 	},
 	{
 		/* week of year starting on first day */
 		.toCharSpecifier = "WW",
-			.createCustomExpr = MakeWeekCountInYearExpr,
-			.padLength = -2,
-			.padString = "0"
+		.createCustomExpr = MakeWeekCountInYearExpr,
+		.padLength = -2,
+		.padString = "0"
 	},
 	{
 		/* week of month starting on first day */
 		.toCharSpecifier = "W",
-			.createCustomExpr = MakeWeekCountInMonthExpr
+		.createCustomExpr = MakeWeekCountInMonthExpr
 	},
 	{
 		/* week number ISO 8601 week aligned year */
 		.toCharSpecifier = "IW",
-			.strftimeSpecifierPadded = "%V",
-			.createCustomExpr = MakeIsoWeekNumberExpr,
-			.padLength = -2,
-			.padString = "0"
+		.strftimeSpecifierPadded = "%V",
+		.createCustomExpr = MakeIsoWeekNumberExpr,
+		.padLength = -2,
+		.padString = "0"
 	},
 	{
 		/* last digit of ISO 8601 week aligned year */
 		.toCharSpecifier = "I",
-			.createCustomExpr = MakeIYExpr
+		.createCustomExpr = MakeIYExpr
 	},
 	{
 		/* century */
 		.toCharSpecifier = "CC",
-			.createCustomExpr = MakeCenturyExpr,
-			.padLength = -2,
-			.padString = "0"
+		.createCustomExpr = MakeCenturyExpr,
+		.padLength = -2,
+		.padString = "0"
 	},
 	{
 		/* julian date */
@@ -546,7 +546,7 @@ static FormatSpecifierMapping SpecifierMappings[] =
 	{
 		/* quarter */
 		.toCharSpecifier = "Q",
-			.createCustomExpr = MakeQuarterExpr,
+		.createCustomExpr = MakeQuarterExpr,
 	},
 	{
 		/* month in uppercase roman numerals */
@@ -561,14 +561,14 @@ static FormatSpecifierMapping SpecifierMappings[] =
 	{
 		/* time zone hours */
 		.toCharSpecifier = "TZH",
-			.createCustomExpr = MakeTimeZoneHoursExpr,
-			.isTextual = true
+		.createCustomExpr = MakeTimeZoneHoursExpr,
+		.isTextual = true
 	},
 	{
 		/* time zone minutes */
 		.toCharSpecifier = "TZM",
-			.createCustomExpr = MakeTimeZoneMinutesExpr,
-			.isTextual = true
+		.createCustomExpr = MakeTimeZoneMinutesExpr,
+		.isTextual = true
 	},
 	{
 		/* uppercase time zone abbreviation */
@@ -583,8 +583,8 @@ static FormatSpecifierMapping SpecifierMappings[] =
 	{
 		/* timezone offset */
 		.toCharSpecifier = "OF",
-			.strftimeSpecifier = "%z",
-			.isTextual = true
+		.strftimeSpecifier = "%z",
+		.isTextual = true
 	},
 	{
 		/* fill mode, included for completeness, but handled separately */
@@ -593,22 +593,22 @@ static FormatSpecifierMapping SpecifierMappings[] =
 	{
 		/* fixed format mode, mainly for parsing */
 		.toCharSpecifier = "FX",
-			.ignore = true
+		.ignore = true
 	},
 	{
 		/* translation mode, mainly for parsing */
 		.toCharSpecifier = "TM",
-			.ignore = true
+		.ignore = true
 	},
 	{
 		/* spell mode (not implemented in postgres) */
 		.toCharSpecifier = "SP",
-			.ignore = true
+		.ignore = true
 	},
 	{
 		/* ensure % is escaped as %% */
 		.toCharSpecifier = "%",
-			.strftimeSpecifier = "%%"
+		.strftimeSpecifier = "%%"
 	},
 };
 

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -43,7 +43,7 @@ typedef struct DuckDBTypeMap
 	Oid			postgresTypeId;
 	Oid			postgresArrayTypeId;
 	const char *duckDBTypeAliases;
-}			DuckDBTypeMap;
+} DuckDBTypeMap;
 
 
 /* prototypes */
@@ -66,7 +66,7 @@ Oid			GetPGTypeForDuckDBTypeNameBuiltin(const char *name, int *typeMod, bool isA
  * canonical name or an alias. */
 
 static bool
-IsMatchingTypeNameOrAlias(const char *inputType, DuckDBTypeMap * typeMap)
+IsMatchingTypeNameOrAlias(const char *inputType, DuckDBTypeMap *typeMap)
 {
 	Assert(inputType != NULL && typeMap != NULL);
 

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -42,7 +42,7 @@
 
 static DuckDBTypeInfo ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 													 CopyDataFormat destinationFormat);
-static void AppendFieldIdValue(StringInfo map, Field * field, int fieldId);
+static void AppendFieldIdValue(StringInfo map, Field *field, int fieldId);
 static const char *ParquetVersionToString(ParquetVersion version);
 
 static DuckDBTypeInfo VARCHAR_TYPE =
@@ -66,7 +66,7 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 				 CopyDataFormat destinationFormat,
 				 CopyDataCompression destinationCompression,
 				 List *formatOptions,
-				 DataFileSchema * schema,
+				 DataFileSchema *schema,
 				 List *leafFields)
 {
 	StringInfoData command;
@@ -120,7 +120,7 @@ WriteQueryResultTo(char *query,
 				   CopyDataCompression destinationCompression,
 				   List *formatOptions,
 				   bool queryHasRowId,
-				   DataFileSchema * schema,
+				   DataFileSchema *schema,
 				   TupleDesc queryTupleDesc,
 				   List *leafFields,
 				   IcebergOutOfRangePolicy outOfRangePolicy,
@@ -492,7 +492,7 @@ TupleDescToColumnMapForWrite(TupleDesc tupleDesc, CopyDataFormat destinationForm
  * a field name to a field ID to a DuckDB map in string form.
  */
 void
-AppendFields(StringInfo map, DataFileSchema * schema)
+AppendFields(StringInfo map, DataFileSchema *schema)
 {
 	bool		addComma = false;
 
@@ -520,7 +520,7 @@ AppendFields(StringInfo map, DataFileSchema * schema)
  * https://duckdb.org/docs/sql/statements/copy
  */
 static void
-AppendFieldIdValue(StringInfo fieldIdsStr, Field * field, int fieldId)
+AppendFieldIdValue(StringInfo fieldIdsStr, Field *field, int fieldId)
 {
 #define CURRENT_FIELD_ID "__duckdb_field_id"
 

--- a/pg_lake_engine/src/utils/parallel_workers.c
+++ b/pg_lake_engine/src/utils/parallel_workers.c
@@ -39,7 +39,7 @@
 
 /* this should probably live in extension_base */
 
-static bool JobIsComplete(AttachedWorker * worker);
+static bool JobIsComplete(AttachedWorker *worker);
 
 /*
  * RunCommandsInParallel runs a list of commands in parallel, using at
@@ -187,7 +187,7 @@ RunCommandsInParallel(List *commands,
  * JobIsComplete() - check for completion
  */
 static bool
-JobIsComplete(AttachedWorker * worker)
+JobIsComplete(AttachedWorker *worker)
 {
 	bool		wait = false;
 

--- a/pg_lake_engine/src/utils/plan_cache.c
+++ b/pg_lake_engine/src/utils/plan_cache.c
@@ -60,7 +60,7 @@ typedef struct QueryPlanCacheEntry
 	SPIPlanPtr	plan;
 	uint32		planUseCount;
 	bool		isValid;
-}			QueryPlanCacheEntry;
+} QueryPlanCacheEntry;
 
 /* internal function declarations */
 static void InitializeQueryPlanCache(void);

--- a/pg_lake_engine/src/utils/s3_writer_utils.c
+++ b/pg_lake_engine/src/utils/s3_writer_utils.c
@@ -38,7 +38,7 @@ typedef struct ScheduledUpload
 {
 	char		remoteUrl[MAX_S3_PATH_LENGTH];
 	char		localFile[MAXPGPATH];
-}			ScheduledUpload;
+} ScheduledUpload;
 
 
 static char *CopyLocalFileToS3Command(char *localFileUri, char *s3Uri);

--- a/pg_lake_engine/src/utils/table_type.c
+++ b/pg_lake_engine/src/utils/table_type.c
@@ -32,7 +32,7 @@ typedef struct PgLakeTableTypeName
 {
 	char	   *name;
 	PgLakeTableType tableType;
-}			PgLakeTableTypeName;
+} PgLakeTableTypeName;
 
 static PgLakeTableTypeName PgLakeTableTypeNames[] =
 {

--- a/pg_lake_iceberg/include/pg_lake/http/http_client.h
+++ b/pg_lake_iceberg/include/pg_lake/http/http_client.h
@@ -31,7 +31,7 @@ typedef enum
 	HTTP_POST,
 	HTTP_PUT,
 	HTTP_DELETE
-}			HttpMethod;
+} HttpMethod;
 
 typedef struct
 {
@@ -41,7 +41,7 @@ typedef struct
 	char	   *headers;		/* raw response headers  */
 	size_t		headersLength;	/* length of response headers */
 	const char *errorMsg;		/* error message */
-}			HttpResult;
+} HttpResult;
 
 extern bool HttpClientTraceTraffic;
 

--- a/pg_lake_iceberg/include/pg_lake/iceberg/api/datafile.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/api/datafile.h
@@ -32,12 +32,12 @@
  *
  * The predicate function can be NULL, in which case all data files are included in the result.
  */
-typedef bool (*DataFilePredicateFn) (DataFile * dataFile);
+typedef bool (*DataFilePredicateFn) (DataFile *dataFile);
 
 /* read api */
-extern PGDLLEXPORT List *FetchDataFilesFromManifestEntry(IcebergManifestEntry * manifestEntry, DataFilePredicateFn dataFilePredicateFn);
-extern PGDLLEXPORT List *FetchDataFilesFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn);
-extern PGDLLEXPORT List *FetchDataFilePathsFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn);
-extern PGDLLEXPORT void FetchAllDataAndDeleteFilesFromCurrentSnapshot(IcebergTableMetadata * metadata, List **dataFiles, List **deleteFiles);
-extern PGDLLEXPORT void FetchAllDataAndDeleteFilePathsFromCurrentSnapshot(IcebergTableMetadata * metadata, List **dataFilePaths, List **deleteFilePaths);
-extern PGDLLEXPORT List *FetchDataFilesFromManifest(IcebergManifest * manifest, bool pathOnly, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn);
+extern PGDLLEXPORT List *FetchDataFilesFromManifestEntry(IcebergManifestEntry *manifestEntry, DataFilePredicateFn dataFilePredicateFn);
+extern PGDLLEXPORT List *FetchDataFilesFromSnapshot(IcebergSnapshot *snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn);
+extern PGDLLEXPORT List *FetchDataFilePathsFromSnapshot(IcebergSnapshot *snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn);
+extern PGDLLEXPORT void FetchAllDataAndDeleteFilesFromCurrentSnapshot(IcebergTableMetadata *metadata, List **dataFiles, List **deleteFiles);
+extern PGDLLEXPORT void FetchAllDataAndDeleteFilePathsFromCurrentSnapshot(IcebergTableMetadata *metadata, List **dataFilePaths, List **deleteFilePaths);
+extern PGDLLEXPORT List *FetchDataFilesFromManifest(IcebergManifest *manifest, bool pathOnly, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/api/manifest.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/api/manifest.h
@@ -31,22 +31,22 @@
  *
  * The predicate function can be NULL, in which case all manifests are included in the result.
  */
-typedef bool (*ManifestPredicateFn) (IcebergManifest * manifest);
+typedef bool (*ManifestPredicateFn) (IcebergManifest *manifest);
 
 /* predicates */
-extern PGDLLEXPORT bool IsManifestOfFileContentAdd(IcebergManifest * manifest);
-extern PGDLLEXPORT bool IsManifestOfFileContentDeletes(IcebergManifest * manifest);
+extern PGDLLEXPORT bool IsManifestOfFileContentAdd(IcebergManifest *manifest);
+extern PGDLLEXPORT bool IsManifestOfFileContentDeletes(IcebergManifest *manifest);
 
 /* read api */
-extern PGDLLEXPORT List *FetchManifestsFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manifestPredicateFn);
+extern PGDLLEXPORT List *FetchManifestsFromSnapshot(IcebergSnapshot *snapshot, ManifestPredicateFn manifestPredicateFn);
 
 /* write api */
 extern PGDLLEXPORT char *GenerateRemoteManifestPath(const char *location, const char *snapshotUUID, int manifestIndex, char *queryArguments);
 extern PGDLLEXPORT int64_t UploadIcebergManifestToURI(List *manifestEntries, char *manifestURI);
-extern PGDLLEXPORT IcebergManifest * CreateNewIcebergManifest(IcebergSnapshot * snapshot,
-															  int32_t partitionSpecId,
-															  List *allTransforms,
-															  int64 manifestFileSize,
-															  IcebergManifestContentType contentType,
-															  char *manifestPath,
-															  List *manifestEntries);
+extern PGDLLEXPORT IcebergManifest *CreateNewIcebergManifest(IcebergSnapshot *snapshot,
+															 int32_t partitionSpecId,
+															 List *allTransforms,
+															 int64 manifestFileSize,
+															 IcebergManifestContentType contentType,
+															 char *manifestPath,
+															 List *manifestEntries);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/api/manifest_entry.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/api/manifest_entry.h
@@ -31,23 +31,23 @@
  *
  * The predicate function can be NULL, in which case all manifest entries are included in the result.
  */
-typedef bool (*ManifestEntryPredicateFn) (IcebergManifestEntry * manifestEntry);
+typedef bool (*ManifestEntryPredicateFn) (IcebergManifestEntry *manifestEntry);
 
 /* predicates */
-extern PGDLLEXPORT bool IsManifestEntryStatusScannable(IcebergManifestEntry * manifestEntry);
+extern PGDLLEXPORT bool IsManifestEntryStatusScannable(IcebergManifestEntry *manifestEntry);
 
 /* read api */
-extern PGDLLEXPORT List *FetchManifestEntriesFromManifest(IcebergManifest * manifest, ManifestEntryPredicateFn manifestEntryPredicateFn);
+extern PGDLLEXPORT List *FetchManifestEntriesFromManifest(IcebergManifest *manifest, ManifestEntryPredicateFn manifestEntryPredicateFn);
 
 /* write api */
 extern PGDLLEXPORT void AppendNewManifestEntriesToSnapshot(const char *metadataLocation, bool mergeAddManifests,
-														   IcebergSnapshot * currentSnapshot, IcebergSnapshot * newSnapshot,
+														   IcebergSnapshot *currentSnapshot, IcebergSnapshot *newSnapshot,
 														   List *newDataManifestEntries, List *newPositionalDeleteManifestEntries,
 														   List *removedEntries, bool removeAllEntries);
 
 void		SetExistingStatusForOldSnapshotAddedEntries(List *manifestEntries, int64_t currentSnapshotId);
-void		UpdateManifestEntryStateToDeleted(IcebergManifest * manifest, IcebergManifestEntry * dataManifestEntry, int64_t snapshotId);
-List	   *FindAndAdjustDeletedManifestEntries(IcebergManifest * manifest, List *manifestEntryList,
+void		UpdateManifestEntryStateToDeleted(IcebergManifest *manifest, IcebergManifestEntry *dataManifestEntry, int64_t snapshotId);
+List	   *FindAndAdjustDeletedManifestEntries(IcebergManifest *manifest, List *manifestEntryList,
 												List *removeManifestEntryList, int64_t snapshotId,
 												bool allEntries);
 const char *IcebergAvroPhysicalTypeName(IcebergScalarAvroType type);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/api/partitioning.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/api/partitioning.h
@@ -36,7 +36,7 @@ typedef enum IcebergPartitionTransformType
 	PARTITION_TRANSFORM_BUCKET,
 	PARTITION_TRANSFORM_TRUNCATE,
 	PARTITION_TRANSFORM_VOID
-}			IcebergPartitionTransformType;
+} IcebergPartitionTransformType;
 
 typedef struct IcebergPartitionTransform
 {
@@ -70,4 +70,4 @@ typedef struct IcebergPartitionTransform
 
 	/* transform result's postgres type */
 	PGType		resultPgType;
-}			IcebergPartitionTransform;
+} IcebergPartitionTransform;

--- a/pg_lake_iceberg/include/pg_lake/iceberg/api/snapshot.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/api/snapshot.h
@@ -29,7 +29,7 @@
  *
  * The predicate function can be NULL, in which case all snapshots are included in the result.
  */
-typedef bool (*SnapshotPredicateFn) (IcebergTableMetadata * metadata, IcebergSnapshot * snapshot);
+typedef bool (*SnapshotPredicateFn) (IcebergTableMetadata *metadata, IcebergSnapshot *snapshot);
 
 /*
 * Represents IcebergSnapshot->summary->operation value.
@@ -41,17 +41,17 @@ typedef enum
 	SNAPSHOT_OPERATION_REPLACE,
 	SNAPSHOT_OPERATION_OVERWRITE,
 	SNAPSHOT_OPERATION_DELETE
-}			SnapshotOperation;
+} SnapshotOperation;
 
 
 /* predicates */
-extern PGDLLEXPORT bool IsCurrentSnapshot(IcebergTableMetadata * metadata, IcebergSnapshot * snapshot);
+extern PGDLLEXPORT bool IsCurrentSnapshot(IcebergTableMetadata *metadata, IcebergSnapshot *snapshot);
 
 /* read api */
-extern PGDLLEXPORT List *FetchSnapshotsFromTableMetadata(IcebergTableMetadata * metadata, SnapshotPredicateFn snapshotPredicateFn);
-extern PGDLLEXPORT IcebergSnapshot * GetCurrentSnapshot(IcebergTableMetadata * metadata, bool missingOk);
-extern PGDLLEXPORT IcebergSnapshot * GetIcebergSnapshotViaId(IcebergTableMetadata * metadata, uint64_t snapshotId);
+extern PGDLLEXPORT List *FetchSnapshotsFromTableMetadata(IcebergTableMetadata *metadata, SnapshotPredicateFn snapshotPredicateFn);
+extern PGDLLEXPORT IcebergSnapshot *GetCurrentSnapshot(IcebergTableMetadata *metadata, bool missingOk);
+extern PGDLLEXPORT IcebergSnapshot *GetIcebergSnapshotViaId(IcebergTableMetadata *metadata, uint64_t snapshotId);
 
 
 /* write api */
-extern PGDLLEXPORT IcebergSnapshot * CreateNewIcebergSnapshot(IcebergTableMetadata * metadata);
+extern PGDLLEXPORT IcebergSnapshot *CreateNewIcebergSnapshot(IcebergTableMetadata *metadata);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/api/table_metadata.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/api/table_metadata.h
@@ -28,17 +28,17 @@
 extern PGDLLEXPORT int IcebergMaxSnapshotAge;
 
 /* write api */
-extern PGDLLEXPORT IcebergTableMetadata * GenerateEmptyTableMetadata(char *location);
+extern PGDLLEXPORT IcebergTableMetadata *GenerateEmptyTableMetadata(char *location);
 extern PGDLLEXPORT char *GenerateInitialIcebergTableMetadataPath(Oid relationId);
-extern PGDLLEXPORT IcebergTableMetadata * GenerateInitialIcebergTableMetadata(Oid relationId);
+extern PGDLLEXPORT IcebergTableMetadata *GenerateInitialIcebergTableMetadata(Oid relationId);
 extern PGDLLEXPORT char *GenerateRemoteMetadataFilePath(int version, const char *location, char *queryArguments);
-extern PGDLLEXPORT void UploadTableMetadataToURI(IcebergTableMetadata * tableMetadata, char *metadataURI);
-extern PGDLLEXPORT void AdjustAndRetainMetadataLogs(IcebergTableMetadata * metadata, char *prevMetadataPath, size_t snapshotLogLength, int64_t prev_last_updated_ms);
-extern PGDLLEXPORT void UpdateLatestSnapshot(IcebergTableMetadata * tableMetadata, IcebergSnapshot * newSnapshot);
-extern PGDLLEXPORT List *RemoveOldSnapshotsFromMetadata(Oid relationId, IcebergTableMetadata * metadata, int maxSnapshotAgeInSecs, bool isVerbose);
-extern PGDLLEXPORT void GenerateSnapshotLogEntries(IcebergTableMetadata * metadata);
-extern PGDLLEXPORT int FindLargestPartitionFieldId(IcebergPartitionSpec * newSpec);
-extern PGDLLEXPORT void AppendCurrentPostgresSchema(Oid relationId, IcebergTableMetadata * metadata,
-													DataFileSchema * schema);
-extern PGDLLEXPORT void AppendPartitionSpec(IcebergTableMetadata * metadata, IcebergPartitionSpec * partitionSpec);
-extern PGDLLEXPORT List *GetAllIcebergPartitionSpecsFromTableMetadata(IcebergTableMetadata * metadata);
+extern PGDLLEXPORT void UploadTableMetadataToURI(IcebergTableMetadata *tableMetadata, char *metadataURI);
+extern PGDLLEXPORT void AdjustAndRetainMetadataLogs(IcebergTableMetadata *metadata, char *prevMetadataPath, size_t snapshotLogLength, int64_t prev_last_updated_ms);
+extern PGDLLEXPORT void UpdateLatestSnapshot(IcebergTableMetadata *tableMetadata, IcebergSnapshot *newSnapshot);
+extern PGDLLEXPORT List *RemoveOldSnapshotsFromMetadata(Oid relationId, IcebergTableMetadata *metadata, int maxSnapshotAgeInSecs, bool isVerbose);
+extern PGDLLEXPORT void GenerateSnapshotLogEntries(IcebergTableMetadata *metadata);
+extern PGDLLEXPORT int FindLargestPartitionFieldId(IcebergPartitionSpec *newSpec);
+extern PGDLLEXPORT void AppendCurrentPostgresSchema(Oid relationId, IcebergTableMetadata *metadata,
+													DataFileSchema *schema);
+extern PGDLLEXPORT void AppendPartitionSpec(IcebergTableMetadata *metadata, IcebergPartitionSpec *partitionSpec);
+extern PGDLLEXPORT List *GetAllIcebergPartitionSpecsFromTableMetadata(IcebergTableMetadata *metadata);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/api/table_schema.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/api/table_schema.h
@@ -23,13 +23,13 @@
 
 
 /* read api */
-extern PGDLLEXPORT IcebergTableSchema * GetIcebergTableSchemaByIdFromTableMetadata(IcebergTableMetadata * metadata, int schemaId);
-extern PGDLLEXPORT IcebergTableSchema * GetCurrentIcebergTableSchema(IcebergTableMetadata * metadata);
-extern PGDLLEXPORT List *GetLeafFieldsFromIcebergMetadata(IcebergTableMetadata * metadata);
-extern PGDLLEXPORT List *GetLeafFieldsForIcebergSchema(IcebergTableSchema * schema);
-extern PGDLLEXPORT DataFileSchemaField * GetDataFileSchemaFieldById(DataFileSchema * schema, int fieldId);
+extern PGDLLEXPORT IcebergTableSchema *GetIcebergTableSchemaByIdFromTableMetadata(IcebergTableMetadata *metadata, int schemaId);
+extern PGDLLEXPORT IcebergTableSchema *GetCurrentIcebergTableSchema(IcebergTableMetadata *metadata);
+extern PGDLLEXPORT List *GetLeafFieldsFromIcebergMetadata(IcebergTableMetadata *metadata);
+extern PGDLLEXPORT List *GetLeafFieldsForIcebergSchema(IcebergTableSchema *schema);
+extern PGDLLEXPORT DataFileSchemaField *GetDataFileSchemaFieldById(DataFileSchema *schema, int fieldId);
 
 /* write api */
-extern PGDLLEXPORT IcebergTableSchema * RebuildIcebergSchemaFromDataFileSchema(Oid foreignTableOid,
-																			   DataFileSchema * schema,
-																			   int *last_column_id);
+extern PGDLLEXPORT IcebergTableSchema *RebuildIcebergSchemaFromDataFileSchema(Oid foreignTableOid,
+																			  DataFileSchema *schema,
+																			  int *last_column_id);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/data_file_stats.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/data_file_stats.h
@@ -22,15 +22,15 @@
 #include "pg_lake/data_file/data_files.h"
 #include "pg_lake/iceberg/api.h"
 
-extern PGDLLEXPORT void SetIcebergDataFileStats(const DataFileStats * dataFileStats,
+extern PGDLLEXPORT void SetIcebergDataFileStats(const DataFileStats *dataFileStats,
 												int64_t *recordCount,
 												int64_t *fileSizeInBytes,
-												ColumnBound * *lowerBounds,
+												ColumnBound **lowerBounds,
 												size_t *nLowerBounds,
-												ColumnBound * *upperBounds,
+												ColumnBound **upperBounds,
 												size_t *nUpperBounds);
 extern PGDLLEXPORT unsigned char *IcebergSerializeColumnBoundText(char *columnBoundText,
-																  Field * field,
+																  Field *field,
 																  size_t *binaryLen);
-extern PGDLLEXPORT bool CanSerializeColumnBound(char *boundText, Field * field);
+extern PGDLLEXPORT bool CanSerializeColumnBound(char *boundText, Field *field);
 extern PGDLLEXPORT Datum ColumnBoundDatum(char *columnBoundText, PGType pgType);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
@@ -23,12 +23,12 @@
 #include "pg_lake/pgduck/type.h"
 #include "pg_lake/parquet/leaf_field.h"
 
-extern PGDLLEXPORT PGType IcebergFieldToPostgresType(Field * field);
-extern PGDLLEXPORT Field * PostgresTypeToIcebergField(PGType pgType,
-													  bool forAddColumn,
-													  int *subFieldIndex);
-extern PGDLLEXPORT void EnsureIcebergField(Field * field);
+extern PGDLLEXPORT PGType IcebergFieldToPostgresType(Field *field);
+extern PGDLLEXPORT Field *PostgresTypeToIcebergField(PGType pgType,
+													 bool forAddColumn,
+													 int *subFieldIndex);
+extern PGDLLEXPORT void EnsureIcebergField(Field *field);
 extern PGDLLEXPORT const char *IcebergTypeNameToDuckdbTypeName(const char *icebergTypeName);
-extern PGDLLEXPORT DataFileSchema * CreatePositionDeleteDataFileSchema(void);
+extern PGDLLEXPORT DataFileSchema *CreatePositionDeleteDataFileSchema(void);
 extern PGDLLEXPORT const char *GetIcebergJsonSerializedDefaultExpr(TupleDesc tupdesc, AttrNumber attnum,
-																   FieldStructElement * structElementField);
+																   FieldStructElement *structElementField);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_binary_serde.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_binary_serde.h
@@ -21,6 +21,6 @@
 
 #include "pg_lake/parquet/field.h"
 
-extern PGDLLEXPORT unsigned char *PGIcebergBinarySerializeBoundValue(Datum datum, Field * field, PGType pgType, size_t *binaryLen);
-extern PGDLLEXPORT unsigned char *PGIcebergBinarySerializePartitionFieldValue(Datum datum, Field * field, PGType pgType, size_t *binaryLen);
-extern PGDLLEXPORT Datum PGIcebergBinaryDeserialize(unsigned char *binaryVal, size_t binaryLen, Field * field, PGType pgType);
+extern PGDLLEXPORT unsigned char *PGIcebergBinarySerializeBoundValue(Datum datum, Field *field, PGType pgType, size_t *binaryLen);
+extern PGDLLEXPORT unsigned char *PGIcebergBinarySerializePartitionFieldValue(Datum datum, Field *field, PGType pgType, size_t *binaryLen);
+extern PGDLLEXPORT Datum PGIcebergBinaryDeserialize(unsigned char *binaryVal, size_t binaryLen, Field *field, PGType pgType);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_json_serde.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_type_json_serde.h
@@ -22,5 +22,5 @@
 #include "pg_lake/parquet/field.h"
 #include "pg_lake/pgduck/type.h"
 
-extern PGDLLEXPORT const char *PGIcebergJsonSerialize(Datum datum, Field * field, PGType pgType, bool *isNull);
-extern PGDLLEXPORT Datum PGIcebergJsonDeserialize(const char *jsonString, Field * field, PGType pgType, bool *isNull);
+extern PGDLLEXPORT const char *PGIcebergJsonSerialize(Datum datum, Field *field, PGType pgType, bool *isNull);
+extern PGDLLEXPORT Datum PGIcebergJsonDeserialize(const char *jsonString, Field *field, PGType pgType, bool *isNull);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/manifest_spec.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/manifest_spec.h
@@ -63,14 +63,14 @@ typedef struct ColumnStat
 {
 	int32_t		column_id;
 	int64_t		value;
-}			ColumnStat;
+} ColumnStat;
 
 typedef struct ColumnBound
 {
 	int32_t		column_id;
 	unsigned char *value;
 	size_t		value_length;
-}			ColumnBound;
+} ColumnBound;
 
 typedef struct FieldSummary
 {
@@ -82,7 +82,7 @@ typedef struct FieldSummary
 
 	unsigned char *upper_bound;
 	size_t		upper_bound_length;
-}			FieldSummary;
+} FieldSummary;
 
 /*
 * Important: Never change the order of the enum values.
@@ -115,7 +115,7 @@ typedef struct IcebergScalarAvroType
 	/* logical type: decimal */
 	int32_t		precision;
 	int32_t		scale;
-}			IcebergScalarAvroType;
+} IcebergScalarAvroType;
 
 typedef struct PartitionField
 {
@@ -124,13 +124,13 @@ typedef struct PartitionField
 	IcebergScalarAvroType value_type;
 	void	   *value;
 	size_t		value_length;
-}			PartitionField;
+} PartitionField;
 
 typedef struct Partition
 {
 	PartitionField *fields;
 	size_t		fields_length;
-}			Partition;
+} Partition;
 
 /*
  * IcebergManifest struct represents the Iceberg manifest file.
@@ -160,7 +160,7 @@ typedef struct IcebergManifest
 
 	char	   *key_metadata;
 	size_t		key_metadata_length;
-}			IcebergManifest;
+} IcebergManifest;
 
 /*
  * DataFile struct represents the data file in the Iceberg manifest.
@@ -210,7 +210,7 @@ typedef struct DataFile
 
 	bool		has_sort_order_id;
 	int32_t		sort_order_id;
-}			DataFile;
+} DataFile;
 
 /*
  * IcebergManifestEntry struct represents the Iceberg manifest entry.
@@ -230,7 +230,7 @@ typedef struct IcebergManifestEntry
 	int64_t		file_sequence_number;
 
 	DataFile	data_file;
-}			IcebergManifestEntry;
+} IcebergManifestEntry;
 
 extern List *ReadIcebergManifests(const char *manifestListPath);
 extern PGDLLEXPORT List *ReadManifestEntries(const char *manifestPath);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/metadata_spec.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/metadata_spec.h
@@ -45,7 +45,7 @@ typedef struct Property
 	size_t		key_length;
 	const char *value;
 	size_t		value_length;
-}			Property;
+} Property;
 
 
 /*
@@ -63,7 +63,7 @@ typedef struct IcebergTableSchema
 
 	int		   *identifier_field_ids;
 	size_t		identifier_field_ids_length;
-}			IcebergTableSchema;
+} IcebergTableSchema;
 
 
 /*
@@ -81,7 +81,7 @@ typedef struct IcebergPartitionSpecField
 	size_t		name_length;
 	const char *transform;
 	size_t		transform_length;
-}			IcebergPartitionSpecField;
+} IcebergPartitionSpecField;
 
 /*
 * Represents the partition specification of the Iceberg table.
@@ -91,7 +91,7 @@ typedef struct IcebergPartitionSpec
 	int32_t		spec_id;
 	IcebergPartitionSpecField *fields;
 	size_t		fields_length;
-}			IcebergPartitionSpec;
+} IcebergPartitionSpec;
 
 
 /*
@@ -109,7 +109,7 @@ typedef struct IcebergSnapshot
 	size_t		summary_length;
 	int32_t		schema_id;
 	bool		schema_id_set;
-}			IcebergSnapshot;
+} IcebergSnapshot;
 
 /*
 * Represents the log entry of the Iceberg snapshot.
@@ -118,7 +118,7 @@ typedef struct IcebergSnapshotLogEntry
 {
 	int64_t		timestamp_ms;
 	int64_t		snapshot_id;
-}			IcebergSnapshotLogEntry;
+} IcebergSnapshotLogEntry;
 
 /*
 * Represents the statistics of the Iceberg partition.
@@ -130,7 +130,7 @@ typedef struct IcebergPartitionStatistics
 	size_t		statistics_path_length;
 	int64_t		file_size_in_bytes;
 
-}			IcebergPartitionStatistics;
+} IcebergPartitionStatistics;
 
 /*
 * Represents the log entry of the Iceberg metadata.
@@ -140,7 +140,7 @@ typedef struct IcebergMetadataLogEntry
 	int64_t		timestamp_ms;
 	const char *metadata_file;
 	size_t		metadata_file_length;
-}			IcebergMetadataLogEntry;
+} IcebergMetadataLogEntry;
 
 /*
 * Represents the sort order field of the Iceberg table.
@@ -154,7 +154,7 @@ typedef struct IcebergSortOrderField
 	size_t		direction_length;
 	const char *null_order;
 	size_t		null_order_length;
-}			IcebergSortOrderField;
+} IcebergSortOrderField;
 
 /*
 * Represents the sort order of the Iceberg table.
@@ -164,14 +164,14 @@ typedef struct IcebergSortOrder
 	int32_t		order_id;
 	IcebergSortOrderField *fields;
 	size_t		fields_length;
-}			IcebergSortOrder;
+} IcebergSortOrder;
 
 typedef enum SnapshotReferenceType
 {
 	SNAPSHOT_REFERENCE_TYPE_TAG,
 	SNAPSHOT_REFERENCE_TYPE_BRANCH,
 	SNAPSHOT_REFERENCE_TYPE_INVALID
-}			SnapshotReferenceType;
+} SnapshotReferenceType;
 
 /*
 * Represents the reference of the Iceberg snapshot.
@@ -188,7 +188,7 @@ typedef struct SnapshotReference
 	int64_t		max_snapshot_age_ms;
 	bool		has_max_ref_age_ms;
 	int64_t		max_ref_age_ms;
-}			SnapshotReference;
+} SnapshotReference;
 
 /*
 * Represents the metadata of the blob-metadata field under
@@ -209,7 +209,7 @@ typedef struct BlobMetadata
 	Property   *properties;
 	size_t		properties_length;
 
-}			BlobMetadata;
+} BlobMetadata;
 
 /*
 * Represents the statistics of the Iceberg table.
@@ -229,7 +229,7 @@ typedef struct IcebergStatistics
 
 	BlobMetadata *blobs;
 	size_t		blobs_length;
-}			IcebergStatistics;
+} IcebergStatistics;
 
 
 /*
@@ -286,9 +286,9 @@ typedef struct IcebergTableMetadata
 
 	IcebergStatistics *statistics;
 	size_t		statistics_length;
-}			IcebergTableMetadata;
+} IcebergTableMetadata;
 
-extern PGDLLEXPORT IcebergTableMetadata * ReadIcebergTableMetadata(const char *tableMetadataPath);
-extern PGDLLEXPORT char *WriteIcebergTableMetadataToJson(IcebergTableMetadata * metadata);
-extern PGDLLEXPORT void AppendIcebergTableSchemaForRestCatalog(StringInfo command, IcebergTableSchema * schemas, size_t schemas_length);
-extern PGDLLEXPORT void AppendIcebergPartitionSpecFields(StringInfo command, IcebergPartitionSpecField * fields, size_t fields_length);
+extern PGDLLEXPORT IcebergTableMetadata *ReadIcebergTableMetadata(const char *tableMetadataPath);
+extern PGDLLEXPORT char *WriteIcebergTableMetadataToJson(IcebergTableMetadata *metadata);
+extern PGDLLEXPORT void AppendIcebergTableSchemaForRestCatalog(StringInfo command, IcebergTableSchema *schemas, size_t schemas_length);
+extern PGDLLEXPORT void AppendIcebergPartitionSpecFields(StringInfo command, IcebergPartitionSpecField *fields, size_t fields_length);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/operations/find_referenced_files.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/operations/find_referenced_files.h
@@ -21,8 +21,8 @@
 
 #include "pg_lake/iceberg/api/table_metadata.h"
 
-extern PGDLLEXPORT List *FindUnreferencedFilesForSnapshots(IcebergSnapshot * prevSnapshots, int prevSnapshotCount,
-														   IcebergSnapshot * currentSnapshots, int currentSnapshotCount);
+extern PGDLLEXPORT List *FindUnreferencedFilesForSnapshots(IcebergSnapshot *prevSnapshots, int prevSnapshotCount,
+														   IcebergSnapshot *currentSnapshots, int currentSnapshotCount);
 extern PGDLLEXPORT List *IcebergFindAllReferencedFiles(char *metadataPath);
 extern PGDLLEXPORT bool AppendFileToHash(const char *path, HTAB *referencedFilesHash);
 extern PGDLLEXPORT HTAB *CreateFilesHash(void);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/operations/manifest_merge.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/operations/manifest_merge.h
@@ -39,14 +39,14 @@ extern int	TargetManifestSizeKB;
 /* pg_lake_iceberg.manifest_min_count_to_merge */
 extern int	ManifestMinCountToMerge;
 
-extern PGDLLEXPORT List *MergeDataManifests(IcebergSnapshot * currentSnapshot,
+extern PGDLLEXPORT List *MergeDataManifests(IcebergSnapshot *currentSnapshot,
 											List *allTransforms,
 											List *dataManifests,
 											const char *metadataLocation,
 											const char *snapshotUUID,
 											bool isVerbose,
 											int *manifestIndex);
-extern PGDLLEXPORT bool RemoveDeletedManifestEntries(IcebergSnapshot * currentSnapshot,
+extern PGDLLEXPORT bool RemoveDeletedManifestEntries(IcebergSnapshot *currentSnapshot,
 													 List *allTransforms,
 													 List **manifests,
 													 IcebergManifestContentType contentType,

--- a/pg_lake_iceberg/include/pg_lake/iceberg/partitioning/partition.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/partitioning/partition.h
@@ -22,8 +22,8 @@
 #include "pg_lake/iceberg/manifest_spec.h"
 #include "pg_lake/iceberg/api/partitioning.h"
 
-extern PGDLLEXPORT Partition * CopyPartition(Partition * partition);
-extern PGDLLEXPORT void AppendPartitionField(Partition * partition, PartitionField * partitionField);
-extern PGDLLEXPORT uint64 ComputePartitionKey(const Partition * partition);
-extern PGDLLEXPORT uint64 ComputeSpecPartitionKey(int32_t partitionSpecId, const Partition * partition);
-extern PGDLLEXPORT IcebergPartitionTransform * FindPartitionTransformById(List *transforms, int32_t partitionFieldId, bool errorIfMissing);
+extern PGDLLEXPORT Partition *CopyPartition(Partition *partition);
+extern PGDLLEXPORT void AppendPartitionField(Partition *partition, PartitionField *partitionField);
+extern PGDLLEXPORT uint64 ComputePartitionKey(const Partition *partition);
+extern PGDLLEXPORT uint64 ComputeSpecPartitionKey(int32_t partitionSpecId, const Partition *partition);
+extern PGDLLEXPORT IcebergPartitionTransform *FindPartitionTransformById(List *transforms, int32_t partitionFieldId, bool errorIfMissing);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/partitioning/spec_generation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/partitioning/spec_generation.h
@@ -22,6 +22,6 @@
 
 #define DEFAULT_SPEC_ID 0
 
-extern PGDLLEXPORT IcebergPartitionSpec * BuildPartitionSpecFromPartitionTransforms(Oid relationId,
-																					List *CurrentPartitionTransformList,
-																					int largestSpecId);
+extern PGDLLEXPORT IcebergPartitionSpec *BuildPartitionSpecFromPartitionTransforms(Oid relationId,
+																				   List *CurrentPartitionTransformList,
+																				   int largestSpecId);

--- a/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
@@ -56,7 +56,7 @@ typedef enum RestCatalogOperationType
 	REST_CATALOG_REMOVE_SNAPSHOT = 5,
 	REST_CATALOG_DROP_TABLE = 6,
 	REST_CATALOG_SET_DEFAULT_PARTITION_ID = 7,
-}			RestCatalogOperationType;
+} RestCatalogOperationType;
 
 
 typedef struct RestCatalogRequest
@@ -71,7 +71,7 @@ typedef struct RestCatalogRequest
 	 * holds the full request body.
 	 */
 	char	   *body;
-}			RestCatalogRequest;
+} RestCatalogRequest;
 
 
 #define REST_CATALOG_AUTH_TOKEN_PATH "%s/api/catalog/v1/oauth/tokens"
@@ -79,7 +79,7 @@ typedef struct RestCatalogRequest
 
 extern PGDLLEXPORT void RegisterNamespaceToRestCatalog(const char *catalogName, const char *namespaceName);
 extern PGDLLEXPORT void StartStageRestCatalogIcebergTableCreate(Oid relationId);
-extern PGDLLEXPORT char *FinishStageRestCatalogIcebergTableCreateRestRequest(Oid relationId, DataFileSchema * dataFileSchema, List *partitionSpecs);
+extern PGDLLEXPORT char *FinishStageRestCatalogIcebergTableCreateRestRequest(Oid relationId, DataFileSchema *dataFileSchema, List *partitionSpecs);
 extern PGDLLEXPORT void ErrorIfRestNamespaceDoesNotExist(const char *catalogName, const char *namespaceName);
 extern PGDLLEXPORT char *GetRestCatalogName(Oid relationId);
 extern PGDLLEXPORT char *GetRestCatalogNamespace(Oid relationId);
@@ -92,9 +92,9 @@ extern PGDLLEXPORT void ReportHTTPError(HttpResult httpResult, int level);
 extern PGDLLEXPORT List *PostHeadersWithAuth(void);
 extern PGDLLEXPORT List *DeleteHeadersWithAuth(void);
 extern PGDLLEXPORT HttpResult SendRequestToRestCatalog(HttpMethod method, const char *url, const char *body, List *headers);
-extern PGDLLEXPORT RestCatalogRequest * GetAddSnapshotCatalogRequest(IcebergSnapshot * newSnapshot, Oid relationId);
-extern PGDLLEXPORT RestCatalogRequest * GetAddSchemaCatalogRequest(Oid relationId, DataFileSchema * dataFileSchema);
-extern PGDLLEXPORT RestCatalogRequest * GetSetCurrentSchemaCatalogRequest(Oid relationId, int32_t schemaId);
-extern PGDLLEXPORT RestCatalogRequest * GetAddPartitionCatalogRequest(Oid relationId, List *partitionSpec);
-extern PGDLLEXPORT RestCatalogRequest * GetSetPartitionDefaultIdCatalogRequest(Oid relationId, int specId);
-extern PGDLLEXPORT RestCatalogRequest * GetRemoveSnapshotCatalogRequest(List *removedSnapshotIds, Oid relationId);
+extern PGDLLEXPORT RestCatalogRequest *GetAddSnapshotCatalogRequest(IcebergSnapshot *newSnapshot, Oid relationId);
+extern PGDLLEXPORT RestCatalogRequest *GetAddSchemaCatalogRequest(Oid relationId, DataFileSchema *dataFileSchema);
+extern PGDLLEXPORT RestCatalogRequest *GetSetCurrentSchemaCatalogRequest(Oid relationId, int32_t schemaId);
+extern PGDLLEXPORT RestCatalogRequest *GetAddPartitionCatalogRequest(Oid relationId, List *partitionSpec);
+extern PGDLLEXPORT RestCatalogRequest *GetSetPartitionDefaultIdCatalogRequest(Oid relationId, int specId);
+extern PGDLLEXPORT RestCatalogRequest *GetRemoveSnapshotCatalogRequest(List *removedSnapshotIds, Oid relationId);

--- a/pg_lake_iceberg/src/http/http_client.c
+++ b/pg_lake_iceberg/src/http/http_client.c
@@ -57,7 +57,7 @@ static void CurlLogError(CURLcode curlCode, const char *error_buffer);
 static CURLcode CurlGloballyInitIfNotInitialized(void);
 static CURLcode CurlSetErrorBuffer(CURL *curl, char **errorBuffer);
 static CURLcode CurlSetOptions(CURL *curl, const char *url, HttpMethod method,
-							   const char *postData, HttpResult * httpResult);
+							   const char *postData, HttpResult *httpResult);
 static CURLcode CurlSetHeaders(CURL *curl, const List *headers, struct curl_slist **headerList);
 static void CurlGlobalCleanup(int code, Datum arg);
 static void CurlCleanup(CURL *curl, struct curl_slist *headerList);
@@ -133,7 +133,7 @@ CurlSetErrorBuffer(CURL *curl, char **errorBuffer)
  */
 static CURLcode
 CurlSetOptions(CURL *curl, const char *url, HttpMethod method,
-			   const char *postData, HttpResult * res)
+			   const char *postData, HttpResult *res)
 {
 	ereport(DEBUG4, (errmsg("setting libcurl options")));
 

--- a/pg_lake_iceberg/src/iceberg/api/datafile.c
+++ b/pg_lake_iceberg/src/iceberg/api/datafile.c
@@ -31,7 +31,7 @@
  * from given manifest entry.
  */
 List *
-FetchDataFilesFromManifestEntry(IcebergManifestEntry * manifestEntry, DataFilePredicateFn dataFilePredicateFn)
+FetchDataFilesFromManifestEntry(IcebergManifestEntry *manifestEntry, DataFilePredicateFn dataFilePredicateFn)
 {
 	if (manifestEntry == NULL)
 	{
@@ -55,7 +55,7 @@ FetchDataFilesFromManifestEntry(IcebergManifestEntry * manifestEntry, DataFilePr
  * from given snapshot.
  */
 List *
-FetchDataFilesFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn)
+FetchDataFilesFromSnapshot(IcebergSnapshot *snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn)
 {
 	List	   *manifests = FetchManifestsFromSnapshot(snapshot, manifestPredicateFn);
 
@@ -80,7 +80,7 @@ FetchDataFilesFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manif
  * from given snapshot.
  */
 List *
-FetchDataFilePathsFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn)
+FetchDataFilePathsFromSnapshot(IcebergSnapshot *snapshot, ManifestPredicateFn manifestPredicateFn, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn)
 {
 	List	   *manifests = FetchManifestsFromSnapshot(snapshot, manifestPredicateFn);
 
@@ -105,7 +105,7 @@ FetchDataFilePathsFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn m
  * from the current snapshot of given table metadata.
  */
 void
-FetchAllDataAndDeleteFilesFromCurrentSnapshot(IcebergTableMetadata * metadata, List **dataFiles, List **deleteFiles)
+FetchAllDataAndDeleteFilesFromCurrentSnapshot(IcebergTableMetadata *metadata, List **dataFiles, List **deleteFiles)
 {
 	if (metadata == NULL)
 	{
@@ -125,7 +125,7 @@ FetchAllDataAndDeleteFilesFromCurrentSnapshot(IcebergTableMetadata * metadata, L
  * file paths from the current snapshot of given table metadata.
  */
 void
-FetchAllDataAndDeleteFilePathsFromCurrentSnapshot(IcebergTableMetadata * metadata, List **dataFilePaths, List **deleteFilePaths)
+FetchAllDataAndDeleteFilePathsFromCurrentSnapshot(IcebergTableMetadata *metadata, List **dataFilePaths, List **deleteFilePaths)
 {
 	List	   *dataFiles = NIL;
 	List	   *deleteFiles = NIL;
@@ -156,7 +156,7 @@ FetchAllDataAndDeleteFilePathsFromCurrentSnapshot(IcebergTableMetadata * metadat
  * from given manifest.
  */
 List *
-FetchDataFilesFromManifest(IcebergManifest * manifest, bool pathOnly, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn)
+FetchDataFilesFromManifest(IcebergManifest *manifest, bool pathOnly, ManifestEntryPredicateFn manifestEntryPredicateFn, DataFilePredicateFn dataFilePredicateFn)
 {
 	if (manifest == NULL)
 	{

--- a/pg_lake_iceberg/src/iceberg/api/manifest.c
+++ b/pg_lake_iceberg/src/iceberg/api/manifest.c
@@ -33,10 +33,10 @@
 
 #include "utils/lsyscache.h"
 
-static void SetManifestFileAndRowCounts(IcebergManifest * manifest, List *manifestEntries);
-static void SetManifestPartitionSummary(IcebergManifest * manifest, List *manifestEntries, List *transforms);
-static FieldSummary * GetPartitionFieldSummaryFromDataFiles(List *dataFiles, int32_t partitionFieldIndex,
-															Field * resultField, PGType resultPgType);
+static void SetManifestFileAndRowCounts(IcebergManifest *manifest, List *manifestEntries);
+static void SetManifestPartitionSummary(IcebergManifest *manifest, List *manifestEntries, List *transforms);
+static FieldSummary *GetPartitionFieldSummaryFromDataFiles(List *dataFiles, int32_t partitionFieldIndex,
+														   Field *resultField, PGType resultPgType);
 
 
 /*
@@ -44,7 +44,7 @@ static FieldSummary * GetPartitionFieldSummaryFromDataFiles(List *dataFiles, int
  * ICEBERG_MANIFEST_FILE_CONTENT_DATA.
  */
 bool
-IsManifestOfFileContentAdd(IcebergManifest * manifest)
+IsManifestOfFileContentAdd(IcebergManifest *manifest)
 {
 	return manifest->content == ICEBERG_MANIFEST_FILE_CONTENT_DATA;
 }
@@ -54,7 +54,7 @@ IsManifestOfFileContentAdd(IcebergManifest * manifest)
  * ICEBERG_MANIFEST_FILE_CONTENT_DELETES.
  */
 bool
-IsManifestOfFileContentDeletes(IcebergManifest * manifest)
+IsManifestOfFileContentDeletes(IcebergManifest *manifest)
 {
 	return manifest->content == ICEBERG_MANIFEST_FILE_CONTENT_DELETES;
 }
@@ -64,7 +64,7 @@ IsManifestOfFileContentDeletes(IcebergManifest * manifest)
  * from given snapshot.
  */
 List *
-FetchManifestsFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manifestPredicateFn)
+FetchManifestsFromSnapshot(IcebergSnapshot *snapshot, ManifestPredicateFn manifestPredicateFn)
 {
 	if (snapshot == NULL)
 	{
@@ -134,7 +134,7 @@ GenerateRemoteManifestPath(const char *location, const char *snapshotUUID, int m
 * CreateNewIcebergManifest creates a new Iceberg manifest with the given parameters.
 */
 IcebergManifest *
-CreateNewIcebergManifest(IcebergSnapshot * snapshot,
+CreateNewIcebergManifest(IcebergSnapshot *snapshot,
 						 int32_t partitionSpecId,
 						 List *allTransforms,
 						 int64 manifestFileSize,
@@ -167,7 +167,7 @@ CreateNewIcebergManifest(IcebergSnapshot * snapshot,
  * files and rows in the manifest entry list and fills manifest's related fields.
  */
 static void
-SetManifestFileAndRowCounts(IcebergManifest * manifest, List *manifestEntries)
+SetManifestFileAndRowCounts(IcebergManifest *manifest, List *manifestEntries)
 {
 	ListCell   *manifestEntryCell = NULL;
 
@@ -204,7 +204,7 @@ SetManifestFileAndRowCounts(IcebergManifest * manifest, List *manifestEntries)
  * and max values for each partition field in all data files of the manifest.
  */
 static void
-SetManifestPartitionSummary(IcebergManifest * manifest, List *manifestEntries, List *transforms)
+SetManifestPartitionSummary(IcebergManifest *manifest, List *manifestEntries, List *transforms)
 {
 	List	   *dataFiles = NIL;
 
@@ -285,7 +285,7 @@ SetManifestPartitionSummary(IcebergManifest * manifest, List *manifestEntries, L
  */
 static FieldSummary *
 GetPartitionFieldSummaryFromDataFiles(List *dataFiles, int32_t partitionFieldIndex,
-									  Field * resultField, PGType resultPgType)
+									  Field *resultField, PGType resultPgType)
 {
 	FieldSummary *partitionSummary = palloc0(sizeof(FieldSummary));
 

--- a/pg_lake_iceberg/src/iceberg/api/manifest_entry.c
+++ b/pg_lake_iceberg/src/iceberg/api/manifest_entry.c
@@ -35,7 +35,7 @@
  * IsManifestEntryStatusScannable checks if the given manifest entry is scannable.
  */
 bool
-IsManifestEntryStatusScannable(IcebergManifestEntry * manifestEntry)
+IsManifestEntryStatusScannable(IcebergManifestEntry *manifestEntry)
 {
 	/*
 	 * Scans are planned by reading the manifest files for the current
@@ -50,7 +50,7 @@ IsManifestEntryStatusScannable(IcebergManifestEntry * manifestEntry)
  * from given manifest.
  */
 List *
-FetchManifestEntriesFromManifest(IcebergManifest * manifest, ManifestEntryPredicateFn manifestEntryPredicateFn)
+FetchManifestEntriesFromManifest(IcebergManifest *manifest, ManifestEntryPredicateFn manifestEntryPredicateFn)
 {
 	if (manifest == NULL)
 	{
@@ -84,7 +84,7 @@ FetchManifestEntriesFromManifest(IcebergManifest * manifest, ManifestEntryPredic
 * It also adjusts the row/file counts in the manifest.
 */
 void
-UpdateManifestEntryStateToDeleted(IcebergManifest * manifest, IcebergManifestEntry * dataManifestEntry, int64_t snapshotId)
+UpdateManifestEntryStateToDeleted(IcebergManifest *manifest, IcebergManifestEntry *dataManifestEntry, int64_t snapshotId)
 {
 	manifest->deleted_rows_count += dataManifestEntry->data_file.record_count;
 	manifest->deleted_files_count++;
@@ -134,7 +134,7 @@ SetExistingStatusForOldSnapshotAddedEntries(List *manifestEntries, int64_t curre
 * prepared to be created as a new manifest file with the deleted entries.
 */
 List *
-FindAndAdjustDeletedManifestEntries(IcebergManifest * manifest, List *manifestEntryList,
+FindAndAdjustDeletedManifestEntries(IcebergManifest *manifest, List *manifestEntryList,
 									List *removeManifestEntryList, int64_t snapshotId,
 									bool allEntries)
 {

--- a/pg_lake_iceberg/src/iceberg/api/snapshot.c
+++ b/pg_lake_iceberg/src/iceberg/api/snapshot.c
@@ -34,7 +34,7 @@ static int64_t GenerateIcebergSnapshotId(void);
  * IsCurrentSnapshot checks if the given snapshot is the current snapshot.
  */
 bool
-IsCurrentSnapshot(IcebergTableMetadata * metadata, IcebergSnapshot * snapshot)
+IsCurrentSnapshot(IcebergTableMetadata *metadata, IcebergSnapshot *snapshot)
 {
 	return snapshot->snapshot_id == metadata->current_snapshot_id;
 }
@@ -44,7 +44,7 @@ IsCurrentSnapshot(IcebergTableMetadata * metadata, IcebergSnapshot * snapshot)
  * from given table metadata.
  */
 List *
-FetchSnapshotsFromTableMetadata(IcebergTableMetadata * metadata, SnapshotPredicateFn snapshotPredicateFn)
+FetchSnapshotsFromTableMetadata(IcebergTableMetadata *metadata, SnapshotPredicateFn snapshotPredicateFn)
 {
 	if (metadata == NULL)
 	{
@@ -74,7 +74,7 @@ FetchSnapshotsFromTableMetadata(IcebergTableMetadata * metadata, SnapshotPredica
  * GetCurrentSnapshot gets the current snapshot from given table metadata.
  */
 IcebergSnapshot *
-GetCurrentSnapshot(IcebergTableMetadata * metadata, bool missingOk)
+GetCurrentSnapshot(IcebergTableMetadata *metadata, bool missingOk)
 {
 	if (metadata == NULL)
 	{
@@ -114,7 +114,7 @@ GetCurrentSnapshot(IcebergTableMetadata * metadata, bool missingOk)
 * an error is thrown.
 */
 IcebergSnapshot *
-GetIcebergSnapshotViaId(IcebergTableMetadata * metadata, uint64_t snapshotId)
+GetIcebergSnapshotViaId(IcebergTableMetadata *metadata, uint64_t snapshotId)
 {
 	int			snapshotIndex = 0;
 
@@ -139,7 +139,7 @@ GetIcebergSnapshotViaId(IcebergTableMetadata * metadata, uint64_t snapshotId)
  * CreateNewIcebergSnapshot creates a new snapshot for the given table metadata.
  */
 IcebergSnapshot *
-CreateNewIcebergSnapshot(IcebergTableMetadata * metadata)
+CreateNewIcebergSnapshot(IcebergTableMetadata *metadata)
 {
 	IcebergSnapshot *newSnapshot = palloc0(sizeof(IcebergSnapshot));
 

--- a/pg_lake_iceberg/src/iceberg/api/table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/api/table_metadata.c
@@ -68,16 +68,16 @@
 /* controlled via a GUC */
 int			IcebergMaxSnapshotAge = 0;	/* seconds */
 
-static void WriteMetadataJsonToTemporaryFile(IcebergTableMetadata * metadata, FILE *localFile);
-static void AddIcebergSnapshotToMetadata(IcebergTableMetadata * metadata, IcebergSnapshot * newSnapshot);
-static void DeleteUnreferencedFiles(Oid relationId, IcebergTableMetadata * metadata, IcebergSnapshot * expiredSnapshots,
-									int expiredSnapshotCount, IcebergSnapshot * nonExpiredSnapshots, int nonExpiredSnapshotCount);
-static void SetSnapshotReference(IcebergTableMetadata * metadata, uint64_t snapshotId);
-static void GroupExpiredSnapshots(IcebergTableMetadata * metadata, int maxSnapshotAgeInSecs,
-								  IcebergSnapshot * expiredSnapshots, int *expiredSnapshotCount,
-								  IcebergSnapshot * nonExpiredSnapshots, int *nonExpiredSnapshotCount);
-static bool SnapshotAgeExceeded(IcebergSnapshot * snapshot, int64_t currentTimeMs, int maxAgeInSecs);
-static int32_t MaxSchemaId(IcebergTableSchema * schemas, size_t schemasLength);
+static void WriteMetadataJsonToTemporaryFile(IcebergTableMetadata *metadata, FILE *localFile);
+static void AddIcebergSnapshotToMetadata(IcebergTableMetadata *metadata, IcebergSnapshot *newSnapshot);
+static void DeleteUnreferencedFiles(Oid relationId, IcebergTableMetadata *metadata, IcebergSnapshot *expiredSnapshots,
+									int expiredSnapshotCount, IcebergSnapshot *nonExpiredSnapshots, int nonExpiredSnapshotCount);
+static void SetSnapshotReference(IcebergTableMetadata *metadata, uint64_t snapshotId);
+static void GroupExpiredSnapshots(IcebergTableMetadata *metadata, int maxSnapshotAgeInSecs,
+								  IcebergSnapshot *expiredSnapshots, int *expiredSnapshotCount,
+								  IcebergSnapshot *nonExpiredSnapshots, int *nonExpiredSnapshotCount);
+static bool SnapshotAgeExceeded(IcebergSnapshot *snapshot, int64_t currentTimeMs, int maxAgeInSecs);
+static int32_t MaxSchemaId(IcebergTableSchema *schemas, size_t schemasLength);
 
 /*
 * GenerateEmptyTableMetadata generates an empty iceberg table metadata
@@ -132,7 +132,7 @@ GenerateEmptyTableMetadata(char *location)
 * snapshots in the metadata.
 */
 void
-GenerateSnapshotLogEntries(IcebergTableMetadata * metadata)
+GenerateSnapshotLogEntries(IcebergTableMetadata *metadata)
 {
 	int			snapshotLogLength = metadata->snapshots_length;
 
@@ -163,7 +163,7 @@ GenerateSnapshotLogEntries(IcebergTableMetadata * metadata)
 * override the existing snapshot reference.
 */
 static void
-SetSnapshotReference(IcebergTableMetadata * metadata, uint64_t snapshotId)
+SetSnapshotReference(IcebergTableMetadata *metadata, uint64_t snapshotId)
 {
 	if (metadata->refs == NULL)
 	{
@@ -186,7 +186,7 @@ SetSnapshotReference(IcebergTableMetadata * metadata, uint64_t snapshotId)
 * AddIcebergSnapshotToMetadata adds given snapshot in the metadata.
 */
 static void
-AddIcebergSnapshotToMetadata(IcebergTableMetadata * metadata, IcebergSnapshot * newSnapshot)
+AddIcebergSnapshotToMetadata(IcebergTableMetadata *metadata, IcebergSnapshot *newSnapshot)
 {
 	int			oldSize = metadata->snapshots_length;
 	int			newSize = oldSize + 1;
@@ -217,7 +217,7 @@ AddIcebergSnapshotToMetadata(IcebergTableMetadata * metadata, IcebergSnapshot * 
  * persisting the changes.
  */
 List *
-RemoveOldSnapshotsFromMetadata(Oid relationId, IcebergTableMetadata * metadata,
+RemoveOldSnapshotsFromMetadata(Oid relationId, IcebergTableMetadata *metadata,
 							   int maxSnapshotAgeInSecs, bool isVerbose)
 {
 	if (metadata->snapshots_length == 0)
@@ -298,8 +298,8 @@ RemoveOldSnapshotsFromMetadata(Oid relationId, IcebergTableMetadata * metadata,
 * and then deletes them from the remote storage.
 */
 static void
-DeleteUnreferencedFiles(Oid relationId, IcebergTableMetadata * metadata, IcebergSnapshot * expiredSnapshots, int expiredSnapshotCount,
-						IcebergSnapshot * nonExpiredSnapshots, int nonExpiredSnapshotCount)
+DeleteUnreferencedFiles(Oid relationId, IcebergTableMetadata *metadata, IcebergSnapshot *expiredSnapshots, int expiredSnapshotCount,
+						IcebergSnapshot *nonExpiredSnapshots, int nonExpiredSnapshotCount)
 {
 	TimestampTz orphanedAt = GetCurrentTransactionStartTimestamp();
 
@@ -322,7 +322,7 @@ DeleteUnreferencedFiles(Oid relationId, IcebergTableMetadata * metadata, Iceberg
 * new snapshot and also sets the last_updated_ms.
 */
 void
-UpdateLatestSnapshot(IcebergTableMetadata * tableMetadata, IcebergSnapshot * newSnapshot)
+UpdateLatestSnapshot(IcebergTableMetadata *tableMetadata, IcebergSnapshot *newSnapshot)
 {
 	/* add the new snapshot to the metadata */
 	AddIcebergSnapshotToMetadata(tableMetadata, newSnapshot);
@@ -383,7 +383,7 @@ GenerateRemoteMetadataFilePath(int version, const char *location, char *queryArg
 * iceberg table metadata to a temporary file.
 */
 static void
-WriteMetadataJsonToTemporaryFile(IcebergTableMetadata * metadata, FILE *file)
+WriteMetadataJsonToTemporaryFile(IcebergTableMetadata *metadata, FILE *file)
 {
 	char	   *metadataJson = WriteIcebergTableMetadataToJson(metadata);
 	int			contentLength = strlen(metadataJson);
@@ -403,7 +403,7 @@ WriteMetadataJsonToTemporaryFile(IcebergTableMetadata * metadata, FILE *file)
 * and uploads it to given uri.
 */
 void
-UploadTableMetadataToURI(IcebergTableMetadata * tableMetadata, char *metadataURI)
+UploadTableMetadataToURI(IcebergTableMetadata *tableMetadata, char *metadataURI)
 {
 	char	   *localFilePath = GenerateTempFileName(PG_LAKE_ICEBERG, true);
 
@@ -436,7 +436,7 @@ UploadTableMetadataToURI(IcebergTableMetadata * tableMetadata, char *metadataURI
 * removed if the new entry exceeds the limit.
 */
 void
-AdjustAndRetainMetadataLogs(IcebergTableMetadata * metadata, char *prevMetadataPath,
+AdjustAndRetainMetadataLogs(IcebergTableMetadata *metadata, char *prevMetadataPath,
 							size_t snapshotLogLength, int64_t prev_last_updated_ms)
 {
 	/* no snapshots, nothing to do */
@@ -489,9 +489,9 @@ AdjustAndRetainMetadataLogs(IcebergTableMetadata * metadata, char *prevMetadataP
 
 
 static void
-GroupExpiredSnapshots(IcebergTableMetadata * metadata, int maxSnapshotAgeInSecs,
-					  IcebergSnapshot * expiredSnapshots, int *expiredSnapshotCount,
-					  IcebergSnapshot * nonExpiredSnapshots, int *nonExpiredSnapshotCount)
+GroupExpiredSnapshots(IcebergTableMetadata *metadata, int maxSnapshotAgeInSecs,
+					  IcebergSnapshot *expiredSnapshots, int *expiredSnapshotCount,
+					  IcebergSnapshot *nonExpiredSnapshots, int *nonExpiredSnapshotCount)
 {
 	IcebergSnapshot *allSnapshots = metadata->snapshots;
 	int			allSnapshotCount = metadata->snapshots_length;
@@ -519,7 +519,7 @@ GroupExpiredSnapshots(IcebergTableMetadata * metadata, int maxSnapshotAgeInSecs,
 * current time and the maximum age.
 */
 static bool
-SnapshotAgeExceeded(IcebergSnapshot * snapshot, int64_t currentTimeMs, int maxAgeInSecs)
+SnapshotAgeExceeded(IcebergSnapshot *snapshot, int64_t currentTimeMs, int maxAgeInSecs)
 {
 	uint64_t	maxAgeMs = (uint64_t) maxAgeInSecs * 1000;
 
@@ -533,7 +533,7 @@ SnapshotAgeExceeded(IcebergSnapshot * snapshot, int64_t currentTimeMs, int maxAg
 * IcebergPartitionSpec, so we just need to find the largest one.
 */
 int
-FindLargestPartitionFieldId(IcebergPartitionSpec * newSpec)
+FindLargestPartitionFieldId(IcebergPartitionSpec *newSpec)
 {
 	int			largestFieldId = 0;
 
@@ -560,8 +560,8 @@ FindLargestPartitionFieldId(IcebergPartitionSpec * newSpec)
 * and appends it to the metadata.
 */
 void
-AppendCurrentPostgresSchema(Oid relationId, IcebergTableMetadata * metadata,
-							DataFileSchema * schema)
+AppendCurrentPostgresSchema(Oid relationId, IcebergTableMetadata *metadata,
+							DataFileSchema *schema)
 {
 	int			currentSchemaLength = metadata->schemas_length;
 
@@ -589,7 +589,7 @@ AppendCurrentPostgresSchema(Oid relationId, IcebergTableMetadata * metadata,
 * MaxSchemaId finds the maximum schema ID from the given schemas.
 */
 static int32_t
-MaxSchemaId(IcebergTableSchema * schemas, size_t schemasLength)
+MaxSchemaId(IcebergTableSchema *schemas, size_t schemasLength)
 {
 	int32_t		maxSchemaId = -1;
 
@@ -609,7 +609,7 @@ MaxSchemaId(IcebergTableSchema * schemas, size_t schemasLength)
 * AppendPartitionSpec appends given partition spec to the metadata.
 */
 void
-AppendPartitionSpec(IcebergTableMetadata * metadata, IcebergPartitionSpec * newSpec)
+AppendPartitionSpec(IcebergTableMetadata *metadata, IcebergPartitionSpec *newSpec)
 {
 	int			currentPartitionSpecLength = metadata->partition_specs_length;
 
@@ -638,7 +638,7 @@ AppendPartitionSpec(IcebergTableMetadata * metadata, IcebergPartitionSpec * newS
  * from the given metadata as a List.
  */
 List *
-GetAllIcebergPartitionSpecsFromTableMetadata(IcebergTableMetadata * metadata)
+GetAllIcebergPartitionSpecsFromTableMetadata(IcebergTableMetadata *metadata)
 {
 	List	   *partitionSpecs = NIL;
 

--- a/pg_lake_iceberg/src/iceberg/api/table_schema.c
+++ b/pg_lake_iceberg/src/iceberg/api/table_schema.c
@@ -31,14 +31,14 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 
-static IcebergTableSchema * GetIcebergTableSchemaById(IcebergTableMetadata * metadata, int schemaId);
-static List *GetLeafFieldsForField(Field * field, int fieldId, int *level);
+static IcebergTableSchema *GetIcebergTableSchemaById(IcebergTableMetadata *metadata, int schemaId);
+static List *GetLeafFieldsForField(Field *field, int fieldId, int *level);
 
 /*
  * GetIcebergTableSchemaByIdFromTableMetadata gets the schema by id from given table metadata.
  */
 IcebergTableSchema *
-GetIcebergTableSchemaByIdFromTableMetadata(IcebergTableMetadata * metadata, int schemaId)
+GetIcebergTableSchemaByIdFromTableMetadata(IcebergTableMetadata *metadata, int schemaId)
 {
 	if (metadata == NULL)
 	{
@@ -77,7 +77,7 @@ GetIcebergTableSchemaByIdFromTableMetadata(IcebergTableMetadata * metadata, int 
  * GetCurrentIcebergTableSchema gets the current Iceberg schema from the table metadata.
  */
 IcebergTableSchema *
-GetCurrentIcebergTableSchema(IcebergTableMetadata * metadata)
+GetCurrentIcebergTableSchema(IcebergTableMetadata *metadata)
 {
 	int32_t		schemaId = metadata->current_schema_id;
 
@@ -95,7 +95,7 @@ GetCurrentIcebergTableSchema(IcebergTableMetadata * metadata)
  * GetIcebergTableSchemaById gets the schema by id from given table metadata.
  */
 static IcebergTableSchema *
-GetIcebergTableSchemaById(IcebergTableMetadata * metadata, int schemaId)
+GetIcebergTableSchemaById(IcebergTableMetadata *metadata, int schemaId)
 {
 	if (metadata == NULL)
 	{
@@ -135,7 +135,7 @@ GetIcebergTableSchemaById(IcebergTableMetadata * metadata, int schemaId)
  * from the iceberg metadata.
  */
 List *
-GetLeafFieldsFromIcebergMetadata(IcebergTableMetadata * metadata)
+GetLeafFieldsFromIcebergMetadata(IcebergTableMetadata *metadata)
 {
 	IcebergTableSchema *schema = GetCurrentIcebergTableSchema(metadata);
 
@@ -147,7 +147,7 @@ GetLeafFieldsFromIcebergMetadata(IcebergTableMetadata * metadata)
  * GetLeafFieldsForIcebergSchema returns all leaf fields for the given iceberg schema.
  */
 List *
-GetLeafFieldsForIcebergSchema(IcebergTableSchema * schema)
+GetLeafFieldsForIcebergSchema(IcebergTableSchema *schema)
 {
 	List	   *leafFields = NIL;
 
@@ -174,7 +174,7 @@ GetLeafFieldsForIcebergSchema(IcebergTableSchema * schema)
  * iceberg field id.
  */
 DataFileSchemaField *
-GetDataFileSchemaFieldById(DataFileSchema * schema, int fieldId)
+GetDataFileSchemaFieldById(DataFileSchema *schema, int fieldId)
 {
 	DataFileSchemaField *schemaField = NULL;
 
@@ -208,7 +208,7 @@ GetDataFileSchemaFieldById(DataFileSchema * schema, int fieldId)
  * The level starts from 1 for the top-level field.
  */
 static List *
-GetLeafFieldsForField(Field * field, int fieldId, int *level)
+GetLeafFieldsForField(Field *field, int fieldId, int *level)
 {
 	List	   *leafFields = NIL;
 
@@ -292,7 +292,7 @@ GetLeafFieldsForField(Field * field, int fieldId, int *level)
 * given data file schema.
 */
 IcebergTableSchema *
-RebuildIcebergSchemaFromDataFileSchema(Oid foreignTableOid, DataFileSchema * schema,
+RebuildIcebergSchemaFromDataFileSchema(Oid foreignTableOid, DataFileSchema *schema,
 									   int *last_column_id)
 {
 	size_t		totalFields = schema->nfields;

--- a/pg_lake_iceberg/src/iceberg/data_file_stats.c
+++ b/pg_lake_iceberg/src/iceberg/data_file_stats.c
@@ -25,24 +25,24 @@
 
 #include "utils/lsyscache.h"
 
-static void SetColumnBoundsFromDataFileStats(const DataFileStats * dataFileStats,
-											 ColumnBound * *lowerBounds,
+static void SetColumnBoundsFromDataFileStats(const DataFileStats *dataFileStats,
+											 ColumnBound **lowerBounds,
 											 size_t *nLowerBounds,
-											 ColumnBound * *upperBounds,
+											 ColumnBound **upperBounds,
 											 size_t *nUpperBounds);
-static ColumnBound * CreateColumnBoundForLeafField(LeafField * leafField, char *columnBoundText);
+static ColumnBound *CreateColumnBoundForLeafField(LeafField *leafField, char *columnBoundText);
 
 /*
  * SetIcebergDataFileStats sets the record count, file size, lower and upper bounds
  * for the given data file stats.
  */
 void
-SetIcebergDataFileStats(const DataFileStats * dataFileStats,
+SetIcebergDataFileStats(const DataFileStats *dataFileStats,
 						int64_t *recordCount,
 						int64_t *fileSizeInBytes,
-						ColumnBound * *lowerBounds,
+						ColumnBound **lowerBounds,
 						size_t *nLowerBounds,
-						ColumnBound * *upperBounds,
+						ColumnBound **upperBounds,
 						size_t *nUpperBounds)
 {
 	*recordCount = dataFileStats->rowCount;
@@ -57,10 +57,10 @@ SetIcebergDataFileStats(const DataFileStats * dataFileStats,
  * in the given data file stats.
  */
 static void
-SetColumnBoundsFromDataFileStats(const DataFileStats * dataFileStats,
-								 ColumnBound * *lowerBounds,
+SetColumnBoundsFromDataFileStats(const DataFileStats *dataFileStats,
+								 ColumnBound **lowerBounds,
 								 size_t *nLowerBounds,
-								 ColumnBound * *upperBounds,
+								 ColumnBound **upperBounds,
 								 size_t *nUpperBounds)
 {
 	List	   *columnStats = dataFileStats->columnStats;
@@ -132,7 +132,7 @@ SetColumnBoundsFromDataFileStats(const DataFileStats * dataFileStats,
  * with Iceberg binary serialized value for the given leaf field.
  */
 static ColumnBound *
-CreateColumnBoundForLeafField(LeafField * leafField, char *columnBoundText)
+CreateColumnBoundForLeafField(LeafField *leafField, char *columnBoundText)
 {
 	size_t		valueLen = 0;
 	unsigned char *icebergSerializedValue = IcebergSerializeColumnBoundText(columnBoundText,
@@ -166,7 +166,7 @@ CreateColumnBoundForLeafField(LeafField * leafField, char *columnBoundText)
  * to Iceberg binary format.
  */
 unsigned char *
-IcebergSerializeColumnBoundText(char *columnBoundText, Field * field, size_t *binaryLen)
+IcebergSerializeColumnBoundText(char *columnBoundText, Field *field, size_t *binaryLen)
 {
 	PGType		pgType = IcebergFieldToPostgresType(field);
 
@@ -187,7 +187,7 @@ IcebergSerializeColumnBoundText(char *columnBoundText, Field * field, size_t *bi
  * representation (e.g. NaN/Inf floats).
  */
 bool
-CanSerializeColumnBound(char *boundText, Field * field)
+CanSerializeColumnBound(char *boundText, Field *field)
 {
 	if (boundText == NULL)
 		return false;

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -79,7 +79,7 @@ typedef enum IcebergType
 	ICEBERG_TYPE_LIST,
 	ICEBERG_TYPE_MAP,
 	ICEBERG_TYPE_STRUCT,
-}			IcebergType;
+} IcebergType;
 
 typedef struct IcebergTypeInfo
 {
@@ -88,14 +88,14 @@ typedef struct IcebergTypeInfo
 	/* additional context for decimal */
 	int			precision;
 	int			scale;
-}			IcebergTypeInfo;
+} IcebergTypeInfo;
 
 typedef struct IcebergToDuckDBType
 {
 	const char *icebergTypeName;
 	IcebergType icebergType;
 	DuckDBType	duckdbType;
-}			IcebergToDuckDBType;
+} IcebergToDuckDBType;
 
 
 static IcebergToDuckDBType IcebergToDuckDBTypes[] =
@@ -155,8 +155,8 @@ static IcebergToDuckDBType IcebergToDuckDBTypes[] =
 
 static DuckDBType GetDuckDBTypeFromIcebergType(IcebergType icebergType);
 static char *PostgresBaseTypeIdToIcebergTypeName(PGType pgType);
-static IcebergTypeInfo * GetIcebergTypeInfoFromTypeName(const char *typeName);
-static const char *GetIcebergJsonSerializedConstDefaultIfExists(const char *attrName, Field * field, Node *defaultExpr);
+static IcebergTypeInfo *GetIcebergTypeInfoFromTypeName(const char *typeName);
+static const char *GetIcebergJsonSerializedConstDefaultIfExists(const char *attrName, Field *field, Node *defaultExpr);
 
 
 /*
@@ -305,7 +305,7 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
  * 1. Get Postgres type from Field to serialize the Postgres type in duck format.
  */
 PGType
-IcebergFieldToPostgresType(Field * field)
+IcebergFieldToPostgresType(Field *field)
 {
 	EnsureIcebergField(field);
 
@@ -750,7 +750,7 @@ TupleDescGetDefault(TupleDesc tupdesc, AttrNumber attnum)
 */
 const char *
 GetIcebergJsonSerializedDefaultExpr(TupleDesc tupdesc, AttrNumber attnum,
-									FieldStructElement * structElementField)
+									FieldStructElement *structElementField)
 {
 	const char *attrName = structElementField->name;
 	Field	   *field = structElementField->type;
@@ -761,7 +761,7 @@ GetIcebergJsonSerializedDefaultExpr(TupleDesc tupdesc, AttrNumber attnum,
 
 
 static const char *
-GetIcebergJsonSerializedConstDefaultIfExists(const char *attrName, Field * field, Node *defaultExpr)
+GetIcebergJsonSerializedConstDefaultIfExists(const char *attrName, Field *field, Node *defaultExpr)
 {
 	EnsureIcebergField(field);
 
@@ -809,7 +809,7 @@ GetIcebergJsonSerializedConstDefaultIfExists(const char *attrName, Field * field
  * EnsureIcebergField ensures that the given field is valid Iceberg field.
  */
 void
-EnsureIcebergField(Field * field)
+EnsureIcebergField(Field *field)
 {
 #ifdef USE_ASSERT_CHECKING
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
@@ -52,7 +52,7 @@
 #endif
 
 
-static unsigned char *PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNullTerminator, size_t *binaryLen);
+static unsigned char *PGIcebergBinarySerialize(Datum datum, Field *field, PGType pgType, bool addNullTerminator, size_t *binaryLen);
 
 
 /*
@@ -62,7 +62,7 @@ static unsigned char *PGIcebergBinarySerialize(Datum datum, Field * field, PGTyp
  * They both are of avro "bytes" type. For those, addNullTerminator should be set to false.
  */
 unsigned char *
-PGIcebergBinarySerializeBoundValue(Datum datum, Field * field, PGType pgType, size_t *binaryLen)
+PGIcebergBinarySerializeBoundValue(Datum datum, Field *field, PGType pgType, size_t *binaryLen)
 {
 	bool		addNullTerminator = false;
 
@@ -77,7 +77,7 @@ PGIcebergBinarySerializeBoundValue(Datum datum, Field * field, PGType pgType, si
  * addNullTerminator should be set to true.
  */
 unsigned char *
-PGIcebergBinarySerializePartitionFieldValue(Datum datum, Field * field, PGType pgType, size_t *binaryLen)
+PGIcebergBinarySerializePartitionFieldValue(Datum datum, Field *field, PGType pgType, size_t *binaryLen)
 {
 	bool		addNullTerminator = true;
 
@@ -91,7 +91,7 @@ PGIcebergBinarySerializePartitionFieldValue(Datum datum, Field * field, PGType p
  * Only scalar types are supported for single value binary serde.
  */
 static unsigned char *
-PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNullTerminator, size_t *binaryLen)
+PGIcebergBinarySerialize(Datum datum, Field *field, PGType pgType, bool addNullTerminator, size_t *binaryLen)
 {
 	Assert(field->type == FIELD_TYPE_SCALAR);
 
@@ -353,7 +353,7 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
  * Only scalar types are supported for single value binary serde.
  */
 Datum
-PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field * field, PGType pgType)
+PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *field, PGType pgType)
 {
 	Assert(field && field->type == FIELD_TYPE_SCALAR);
 	Assert(binaryValue);

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
@@ -36,14 +36,14 @@
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
 
-static const char *PGScalarIcebergJsonSerialize(Datum scalarDatum, Field * field, PGType pgType);
-static const char *PGArrayIcebergJsonSerialize(Datum arrayDatum, Field * field, PGType pgType);
-static const char *PGStructIcebergJsonSerialize(Datum structDatum, Field * field, PGType pgType);
-static const char *PGMapIcebergJsonSerialize(Datum mapDatum, Field * field, PGType pgType);
-static Datum PGScalarIcebergJsonDeserialize(const char *scalarJson, Field * field, PGType pgType);
-static Datum PGArrayIcebergJsonDeserialize(const char *arrayJson, Field * field, PGType pgType);
-static Datum PGStructIcebergJsonDeserialize(const char *structJson, Field * field, PGType pgType);
-static Datum PGMapIcebergJsonDeserialize(const char *mapJson, Field * field, PGType pgType);
+static const char *PGScalarIcebergJsonSerialize(Datum scalarDatum, Field *field, PGType pgType);
+static const char *PGArrayIcebergJsonSerialize(Datum arrayDatum, Field *field, PGType pgType);
+static const char *PGStructIcebergJsonSerialize(Datum structDatum, Field *field, PGType pgType);
+static const char *PGMapIcebergJsonSerialize(Datum mapDatum, Field *field, PGType pgType);
+static Datum PGScalarIcebergJsonDeserialize(const char *scalarJson, Field *field, PGType pgType);
+static Datum PGArrayIcebergJsonDeserialize(const char *arrayJson, Field *field, PGType pgType);
+static Datum PGStructIcebergJsonDeserialize(const char *structJson, Field *field, PGType pgType);
+static Datum PGMapIcebergJsonDeserialize(const char *mapJson, Field *field, PGType pgType);
 
 /*
  * PGIcebergJsonSerialize converts PG datum to json serialized string according to
@@ -51,7 +51,7 @@ static Datum PGMapIcebergJsonDeserialize(const char *mapJson, Field * field, PGT
  * https://iceberg.apache.org/spec/#json-single-value-serialization
  */
 const char *
-PGIcebergJsonSerialize(Datum datum, Field * field, PGType pgType, bool *isNull)
+PGIcebergJsonSerialize(Datum datum, Field *field, PGType pgType, bool *isNull)
 {
 	if (*isNull)
 	{
@@ -98,7 +98,7 @@ PGIcebergJsonSerialize(Datum datum, Field * field, PGType pgType, bool *isNull)
  * serializes scalar values in the same way as Iceberg spec.
  */
 static const char *
-PGScalarIcebergJsonSerialize(Datum scalarDatum, Field * field, PGType pgType)
+PGScalarIcebergJsonSerialize(Datum scalarDatum, Field *field, PGType pgType)
 {
 	int16		typLen;
 	bool		typByVal;
@@ -179,7 +179,7 @@ PGScalarIcebergJsonSerialize(Datum scalarDatum, Field * field, PGType pgType)
  * Iceberg spec.
  */
 static const char *
-PGArrayIcebergJsonSerialize(Datum arrayDatum, Field * field, PGType pgType)
+PGArrayIcebergJsonSerialize(Datum arrayDatum, Field *field, PGType pgType)
 {
 	ArrayType  *array = DatumGetArrayTypeP(arrayDatum);
 
@@ -235,7 +235,7 @@ PGArrayIcebergJsonSerialize(Datum arrayDatum, Field * field, PGType pgType)
  * e.g. {"1": <val1>, "2": <val2>, ...}
  */
 static const char *
-PGStructIcebergJsonSerialize(Datum structDatum, Field * field, PGType pgType)
+PGStructIcebergJsonSerialize(Datum structDatum, Field *field, PGType pgType)
 {
 	TupleDesc	tupleDesc = lookup_rowtype_tupdesc(pgType.postgresTypeOid, pgType.postgresTypeMod);
 
@@ -282,7 +282,7 @@ PGStructIcebergJsonSerialize(Datum structDatum, Field * field, PGType pgType)
  * e.g. {"keys": [<key1>, <key2>, ...], "values": [<val1>, <val2>, ...]}
  */
 static const char *
-PGMapIcebergJsonSerialize(Datum mapDatum, Field * field, PGType pgType)
+PGMapIcebergJsonSerialize(Datum mapDatum, Field *field, PGType pgType)
 {
 	/* mapDatum is a domain over an array of a 2-col composite type */
 
@@ -402,7 +402,7 @@ PGMapIcebergJsonSerialize(Datum mapDatum, Field * field, PGType pgType)
  * PGIcebergJsonDeserialize converts json serialized Iceberg type to datum.
  */
 Datum
-PGIcebergJsonDeserialize(const char *jsonString, Field * field, PGType pgType, bool *isNull)
+PGIcebergJsonDeserialize(const char *jsonString, Field *field, PGType pgType, bool *isNull)
 {
 	if (strcasecmp(jsonString, "null") == 0)
 	{
@@ -442,7 +442,7 @@ PGIcebergJsonDeserialize(const char *jsonString, Field * field, PGType pgType, b
  * Input functions of scalar types are used to convert json string to scalar datum.
  */
 static Datum
-PGScalarIcebergJsonDeserialize(const char *scalarJson, Field * field, PGType pgType)
+PGScalarIcebergJsonDeserialize(const char *scalarJson, Field *field, PGType pgType)
 {
 	if (pgType.postgresTypeOid == BYTEAOID)
 	{
@@ -482,7 +482,7 @@ PGScalarIcebergJsonDeserialize(const char *scalarJson, Field * field, PGType pgT
  * PGArrayIcebergJsonDeserialize converts json serialized Iceberg array to datum.
  */
 static Datum
-PGArrayIcebergJsonDeserialize(const char *arrayJson, Field * field, PGType pgType)
+PGArrayIcebergJsonDeserialize(const char *arrayJson, Field *field, PGType pgType)
 {
 	MemoryContext callerContext = CurrentMemoryContext;
 
@@ -555,7 +555,7 @@ PGArrayIcebergJsonDeserialize(const char *arrayJson, Field * field, PGType pgTyp
  * e.g. {"1": <val1>, "2": <val2>, ...}
  */
 static Datum
-PGStructIcebergJsonDeserialize(const char *structJson, Field * field, PGType pgType)
+PGStructIcebergJsonDeserialize(const char *structJson, Field *field, PGType pgType)
 {
 	MemoryContext callerContext = CurrentMemoryContext;
 
@@ -624,7 +624,7 @@ PGStructIcebergJsonDeserialize(const char *structJson, Field * field, PGType pgT
  * e.g. {"keys": [<key1>, <key2>, ...], "values": [<val1>, <val2>, ...]}
  */
 static Datum
-PGMapIcebergJsonDeserialize(const char *mapJson, Field * field, PGType pgType)
+PGMapIcebergJsonDeserialize(const char *mapJson, Field *field, PGType pgType)
 {
 	MemoryContext callerContext = CurrentMemoryContext;
 

--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -103,7 +103,7 @@ typedef struct IcebergSnapshotBuilder
 
 	/* snapshot operation */
 	SnapshotOperation operation;
-}			IcebergSnapshotBuilder;
+} IcebergSnapshotBuilder;
 
 
 /*
@@ -114,32 +114,32 @@ typedef struct PartitionSpecManifestsEntries
 {
 	int32_t		partitionSpecId;
 	List	   *manifestEntries;
-}			PartitionSpecManifestsEntries;
+} PartitionSpecManifestsEntries;
 
-static IcebergSnapshotBuilder * CreateIcebergSnapshotBuilder(IcebergTableMetadata * metadata, List *metadataOperations);
-static void SetSnapshotOperation(IcebergSnapshot * snapshot, SnapshotOperation operation);
+static IcebergSnapshotBuilder *CreateIcebergSnapshotBuilder(IcebergTableMetadata *metadata, List *metadataOperations);
+static void SetSnapshotOperation(IcebergSnapshot *snapshot, SnapshotOperation operation);
 static SnapshotOperation SnapshotOperationSummary(List *metadataOperations);
 static void ProcessIcebergMetadataOperations(Oid relationId, List *metadataOperations,
-											 IcebergSnapshotBuilder * builder);
-static IcebergManifestEntry * CreateIcebergManifestEntryFromMetadataOperation(TableMetadataOperation * operation,
-																			  int64_t newSnapshotId,
-																			  int64_t sequenceNumber);
-static IcebergSnapshot * FinalizeNewSnapshot(IcebergSnapshotBuilder * builder,
-											 Oid relationId,
-											 const char *metadataLocation,
-											 int32_t currentSchemaId,
-											 List *allTransforms,
-											 bool isVerbose);
+											 IcebergSnapshotBuilder *builder);
+static IcebergManifestEntry *CreateIcebergManifestEntryFromMetadataOperation(TableMetadataOperation *operation,
+																			 int64_t newSnapshotId,
+																			 int64_t sequenceNumber);
+static IcebergSnapshot *FinalizeNewSnapshot(IcebergSnapshotBuilder *builder,
+											Oid relationId,
+											const char *metadataLocation,
+											int32_t currentSchemaId,
+											List *allTransforms,
+											bool isVerbose);
 static List *CreateNewManifestsForDeletedEntries(List *allManifestEntries, List *deletedManifestEntries,
-												 IcebergSnapshot * newSnapshot, const char *metadataLocation,
+												 IcebergSnapshot *newSnapshot, const char *metadataLocation,
 												 const char *snapshotUUID, int *manifestIndex,
 												 int partitionSpecId, List *partitionTransforms,
 												 IcebergManifestContentType contentType);
-static IcebergSnapshot * CopyIcebergSnapshot(IcebergSnapshot * src);
-static Property * CopyPropertiesArray(Property * src, int length);
+static IcebergSnapshot *CopyIcebergSnapshot(IcebergSnapshot *src);
+static Property *CopyPropertiesArray(Property *src, int length);
 static HTAB *MakePartitionManifestEntryHash(void);
 static void AddManifestEntryToHash(HTAB *hash, int32 partitionSpecId,
-								   IcebergManifestEntry * entry);
+								   IcebergManifestEntry *entry);
 static bool HasCreateTableOperation(List *metadataOperations);
 static void DeleteInProgressManifests(Oid relationId, List *manifests);
 
@@ -409,7 +409,7 @@ ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allT
  * of all the changes to the current snapshot.
  */
 static IcebergSnapshotBuilder *
-CreateIcebergSnapshotBuilder(IcebergTableMetadata * metadata, List *metadataOperations)
+CreateIcebergSnapshotBuilder(IcebergTableMetadata *metadata, List *metadataOperations)
 {
 	IcebergSnapshotBuilder *builder = palloc0(sizeof(IcebergSnapshotBuilder));
 
@@ -455,7 +455,7 @@ MakePartitionManifestEntryHash(void)
 * AddManifestEntryToHash adds a manifest entry to the hash table.
 */
 static void
-AddManifestEntryToHash(HTAB *hash, int32 partitionSpecId, IcebergManifestEntry * entry)
+AddManifestEntryToHash(HTAB *hash, int32 partitionSpecId, IcebergManifestEntry *entry)
 {
 	bool		found = false;
 	PartitionSpecManifestsEntries *manifestEntries = hash_search(hash, &partitionSpecId, HASH_ENTER, &found);
@@ -474,7 +474,7 @@ AddManifestEntryToHash(HTAB *hash, int32 partitionSpecId, IcebergManifestEntry *
 * SetSnapshotOperation sets the operation of the snapshot.
 */
 static void
-SetSnapshotOperation(IcebergSnapshot * snapshot, SnapshotOperation operation)
+SetSnapshotOperation(IcebergSnapshot *snapshot, SnapshotOperation operation)
 {
 	Property   *summary = palloc0(sizeof(Property));
 
@@ -622,7 +622,7 @@ SnapshotOperationSummary(List *metadataOperations)
 */
 static void
 ProcessIcebergMetadataOperations(Oid relationId, List *metadataOperations,
-								 IcebergSnapshotBuilder * builder)
+								 IcebergSnapshotBuilder *builder)
 {
 	ListCell   *operationCell = NULL;
 
@@ -831,7 +831,7 @@ ProcessIcebergMetadataOperations(Oid relationId, List *metadataOperations,
 * snapshot. If needed, we also apply manifest compaction.
 */
 static IcebergSnapshot *
-FinalizeNewSnapshot(IcebergSnapshotBuilder * builder, Oid relationId, const char *metadataLocation,
+FinalizeNewSnapshot(IcebergSnapshotBuilder *builder, Oid relationId, const char *metadataLocation,
 					int32_t currentSchemaId, List *allTransforms, bool isVerbose)
 {
 	IcebergSnapshot *currentSnapshot = builder->baseSnapshot;
@@ -1070,7 +1070,7 @@ FinalizeNewSnapshot(IcebergSnapshotBuilder * builder, Oid relationId, const char
 * final manifest list.
 */
 static List *
-CreateNewManifestsForDeletedEntries(List *allManifestEntries, List *deletedManifestEntries, IcebergSnapshot * newSnapshot,
+CreateNewManifestsForDeletedEntries(List *allManifestEntries, List *deletedManifestEntries, IcebergSnapshot *newSnapshot,
 									const char *metadataLocation, const char *snapshotUUID, int *manifestIndex,
 									int partitionSpecId, List *partitionTransforms, IcebergManifestContentType contentType)
 {
@@ -1118,7 +1118,7 @@ CreateNewManifestsForDeletedEntries(List *allManifestEntries, List *deletedManif
 * CreateIcebergManifestEntryFromMetadataOperation creates a new Iceberg manifest entry for the given metadata operation.
 */
 static IcebergManifestEntry *
-CreateIcebergManifestEntryFromMetadataOperation(TableMetadataOperation * operation, int64_t newSnapshotId, int64_t sequenceNumber)
+CreateIcebergManifestEntryFromMetadataOperation(TableMetadataOperation *operation, int64_t newSnapshotId, int64_t sequenceNumber)
 {
 	IcebergManifestEntry *manifestEntry = palloc0(sizeof(IcebergManifestEntry));
 
@@ -1220,7 +1220,7 @@ GetMetadataOperationTypes(List *metadataOperations)
 * CopyPropertiesArray creates a copy of the given Property array.
 */
 static Property *
-CopyPropertiesArray(Property * src, int length)
+CopyPropertiesArray(Property *src, int length)
 {
 	if (!src)
 		return NULL;
@@ -1242,7 +1242,7 @@ CopyPropertiesArray(Property * src, int length)
 * CopyIcebergSnapshot creates a copy of the given IcebergSnapshot.
 */
 static IcebergSnapshot *
-CopyIcebergSnapshot(IcebergSnapshot * src)
+CopyIcebergSnapshot(IcebergSnapshot *src)
 {
 	if (!src)
 		return NULL;

--- a/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
+++ b/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
@@ -42,7 +42,7 @@
 typedef struct FileHashEntry
 {
 	char		path[MAX_S3_PATH_LENGTH];
-}			FileHashEntry;
+} FileHashEntry;
 
 PG_FUNCTION_INFO_V1(find_all_referenced_files);
 PG_FUNCTION_INFO_V1(find_unreferenced_files);
@@ -52,9 +52,9 @@ PG_FUNCTION_INFO_V1(find_unreferenced_files_via_snapshot_ids);
 
 
 static void IcebergMetadataAddAllReferencedFiles(char *metadataPath, HTAB *fileHash);
-static void IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot * snapshot, HTAB *fileHash);
+static void IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot *snapshot, HTAB *fileHash);
 static List *FindUnreferencedFiles(List *prevMetadataList, char *currentMetadataPath);
-static IcebergSnapshot * GetIcebergSnapshotsViaSnapshotIdList(IcebergTableMetadata * metadata, List *snapshotIdList);
+static IcebergSnapshot *GetIcebergSnapshotsViaSnapshotIdList(IcebergTableMetadata *metadata, List *snapshotIdList);
 
 /*
 * find_all_referenced_files reads the metadata file and returns a list of
@@ -237,7 +237,7 @@ find_unreferenced_files_via_snapshot_ids(PG_FUNCTION_ARGS)
 }
 
 static IcebergSnapshot *
-GetIcebergSnapshotsViaSnapshotIdList(IcebergTableMetadata * metadata, List *snapshotIdList)
+GetIcebergSnapshotsViaSnapshotIdList(IcebergTableMetadata *metadata, List *snapshotIdList)
 {
 	int			snapshotCount = list_length(snapshotIdList);
 	IcebergSnapshot *snapshots = palloc0(sizeof(IcebergSnapshot) * snapshotCount);
@@ -299,8 +299,8 @@ FindUnreferencedFiles(List *prevMetadataList, char *currentMetadataPath)
 * snapshot ids instead of metadata paths.
 */
 List *
-FindUnreferencedFilesForSnapshots(IcebergSnapshot * prevSnapshots, int prevSnapshotCount,
-								  IcebergSnapshot * currentSnapshots, int currentSnapshotCount)
+FindUnreferencedFilesForSnapshots(IcebergSnapshot *prevSnapshots, int prevSnapshotCount,
+								  IcebergSnapshot *currentSnapshots, int currentSnapshotCount)
 {
 	HTAB	   *prevReferencedFileHash = CreateFilesHash();
 
@@ -419,7 +419,7 @@ IcebergMetadataAddAllReferencedFiles(char *metadataPath, HTAB *fileHash)
 * in the snapshot to the hash table.
 */
 static void
-IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot * snapshot, HTAB *fileHash)
+IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot *snapshot, HTAB *fileHash)
 {
 	bool		fileAlreadyExists = AppendFileToHash(snapshot->manifest_list, fileHash);
 

--- a/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
+++ b/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
@@ -46,7 +46,7 @@ typedef struct PartitionSpecManifestsEntry
 {
 	int32_t		partitionSpecId;
 	List	   *manifests;
-}			PartitionSpecManifestsEntry;
+} PartitionSpecManifestsEntry;
 
 
 /*
@@ -58,23 +58,23 @@ typedef struct ManifestGroup
 	List	   *manifests;
 	int32_t		partitionSpecId;
 	int64_t		totalSize;
-}			ManifestGroup;
+} ManifestGroup;
 
 
 static HTAB *GroupManifestsByPartitionSpecId(List *manifests);
-static ManifestGroup * FindBestFitManifestGroupForManifest(List *manifestGroups, IcebergManifest * manifest, int64_t targetSize);
+static ManifestGroup *FindBestFitManifestGroupForManifest(List *manifestGroups, IcebergManifest *manifest, int64_t targetSize);
 static List *CreateManifestGroupsWithTargetSize(List *manifests, int64_t targetSize);
-static bool RemoveDeletedManifestEntriesInternal(IcebergManifest * *manifest, IcebergSnapshot * currentSnapshot,
+static bool RemoveDeletedManifestEntriesInternal(IcebergManifest **manifest, IcebergSnapshot *currentSnapshot,
 												 List *allTransforms, IcebergManifestContentType contentType,
 												 const char *metadataLocation, const char *snapshotUUID, int *manifestIndex);
-static bool IsMergeableManifestGroup(ManifestGroup * manifestGroup, IcebergManifest * latestManifest);
-static IcebergManifest * MergeManifestGroup(ManifestGroup * mergeableManifestGroup, IcebergSnapshot * currentSnapshot,
-											List *allTransforms, int mergedManifestIndex, const char *metadataLocation,
-											const char *snapshotUUID);
+static bool IsMergeableManifestGroup(ManifestGroup *manifestGroup, IcebergManifest *latestManifest);
+static IcebergManifest *MergeManifestGroup(ManifestGroup *mergeableManifestGroup, IcebergSnapshot *currentSnapshot,
+										   List *allTransforms, int mergedManifestIndex, const char *metadataLocation,
+										   const char *snapshotUUID);
 
 #ifdef USE_ASSERT_CHECKING
 static int	IcebergManifestSequenceNumberComparator(const ListCell *manifestCell1, const ListCell *manifestCell2);
-static void EnsureLatestManifest(IcebergManifest * latestManifest, List *manifests);
+static void EnsureLatestManifest(IcebergManifest *latestManifest, List *manifests);
 #endif
 
 /* pg_lake_iceberg.enable_manifest_merge */
@@ -114,7 +114,7 @@ int			ManifestMinCountToMerge = DEFAULT_MANIFEST_MIN_COUNT_TO_MERGE;
  * 		  manifest files.
  */
 List *
-MergeDataManifests(IcebergSnapshot * currentSnapshot,
+MergeDataManifests(IcebergSnapshot *currentSnapshot,
 				   List *allTransforms,
 				   List *dataManifests,
 				   const char *metadataLocation,
@@ -198,7 +198,7 @@ MergeDataManifests(IcebergSnapshot * currentSnapshot,
  * true if any manifest is modified, false otherwise.
  */
 bool
-RemoveDeletedManifestEntries(IcebergSnapshot * currentSnapshot,
+RemoveDeletedManifestEntries(IcebergSnapshot *currentSnapshot,
 							 List *allTransforms,
 							 List **manifests,
 							 IcebergManifestContentType contentType,
@@ -376,7 +376,7 @@ CreateManifestGroupsWithTargetSize(List *manifests, int64_t targetSize)
  * Returns NULL if no best fit group is found.
  */
 static ManifestGroup *
-FindBestFitManifestGroupForManifest(List *manifestGroups, IcebergManifest * manifest, int64_t targetSize)
+FindBestFitManifestGroupForManifest(List *manifestGroups, IcebergManifest *manifest, int64_t targetSize)
 {
 	int			bestFitGroupIndex = -1;
 	int64_t		leastRemainingSize = INT64_MAX;
@@ -411,7 +411,7 @@ FindBestFitManifestGroupForManifest(List *manifestGroups, IcebergManifest * mani
  * IsMergeableManifestGroup checks if the manifest group can be merged.
  */
 static bool
-IsMergeableManifestGroup(ManifestGroup * manifestGroup, IcebergManifest * latestManifest)
+IsMergeableManifestGroup(ManifestGroup *manifestGroup, IcebergManifest *latestManifest)
 {
 	if (list_length(manifestGroup->manifests) == 1)
 	{
@@ -441,7 +441,7 @@ IsMergeableManifestGroup(ManifestGroup * manifestGroup, IcebergManifest * latest
  * the merged manifest to the remote location and returns it.
  */
 static IcebergManifest *
-MergeManifestGroup(ManifestGroup * mergeableManifestGroup, IcebergSnapshot * currentSnapshot,
+MergeManifestGroup(ManifestGroup *mergeableManifestGroup, IcebergSnapshot *currentSnapshot,
 				   List *allTransforms, int mergedManifestIndex, const char *metadataLocation,
 				   const char *snapshotUUID)
 {
@@ -491,7 +491,7 @@ MergeManifestGroup(ManifestGroup * mergeableManifestGroup, IcebergSnapshot * cur
  * true if the manifest was modified, false otherwise.
  */
 static bool
-RemoveDeletedManifestEntriesInternal(IcebergManifest * *manifest, IcebergSnapshot * currentSnapshot,
+RemoveDeletedManifestEntriesInternal(IcebergManifest **manifest, IcebergSnapshot *currentSnapshot,
 									 List *allTransforms, IcebergManifestContentType contentType,
 									 const char *metadataLocation, const char *snapshotUUID, int *manifestIndex)
 {
@@ -548,7 +548,7 @@ RemoveDeletedManifestEntriesInternal(IcebergManifest * *manifest, IcebergSnapsho
 
 #ifdef USE_ASSERT_CHECKING
 static void
-EnsureLatestManifest(IcebergManifest * latestManifest, List *manifests)
+EnsureLatestManifest(IcebergManifest *latestManifest, List *manifests)
 {
 	/* copy the list to not have flaky tests */
 	List	   *copyManifests = list_copy(manifests);

--- a/pg_lake_iceberg/src/iceberg/partitioning/partition.c
+++ b/pg_lake_iceberg/src/iceberg/partitioning/partition.c
@@ -33,7 +33,7 @@ static int	PartitionFieldCompare(const void *a, const void *b);
 * CopyPartition creates a copy of the given partition.
 */
 Partition *
-CopyPartition(Partition * partition)
+CopyPartition(Partition *partition)
 {
 	Partition  *copy = palloc0(sizeof(Partition));
 
@@ -69,7 +69,7 @@ CopyPartition(Partition * partition)
 * AppendPartitionField appends a partition field to the given partition.
 */
 void
-AppendPartitionField(Partition * partition, PartitionField * partitionField)
+AppendPartitionField(Partition *partition, PartitionField *partitionField)
 {
 	/*
 	 * if first element, do palloc, otherwise repalloc
@@ -123,8 +123,8 @@ AppendPartitionField(Partition * partition, PartitionField * partitionField)
 static int
 PartitionFieldCompare(const void *a, const void *b)
 {
-	const		PartitionField *fieldA = (const PartitionField *) a;
-	const		PartitionField *fieldB = (const PartitionField *) b;
+	const PartitionField *fieldA = (const PartitionField *) a;
+	const PartitionField *fieldB = (const PartitionField *) b;
 
 	if (fieldA->field_id < fieldB->field_id)
 		return -1;
@@ -142,14 +142,14 @@ PartitionFieldCompare(const void *a, const void *b)
  * due to 64 bits.
  */
 uint64
-ComputePartitionKey(const Partition * partition)
+ComputePartitionKey(const Partition *partition)
 {
 	/* seed – 0 is fine; we could pick any value */
 	uint64		hashValue = 0;
 
 	for (size_t partitionIndex = 0; partitionIndex < partition->fields_length; partitionIndex++)
 	{
-		const		PartitionField *partitionField = &partition->fields[partitionIndex];
+		const PartitionField *partitionField = &partition->fields[partitionIndex];
 
 		/*
 		 * 1. Mix in field_id Each partition can hold many fields.  Two
@@ -203,7 +203,7 @@ ComputePartitionKey(const Partition * partition)
  * due to 64 bits.
  */
 uint64
-ComputeSpecPartitionKey(int32_t partitionSpecId, const Partition * partition)
+ComputeSpecPartitionKey(int32_t partitionSpecId, const Partition *partition)
 {
 	uint64		specHash = hash_uint32((uint32) (partitionSpecId));
 

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -51,7 +51,7 @@ typedef struct PartitionFieldIdMapEntry
 	char		fieldName[PARTITION_FIELD_NAME_MAX_LENGTH];
 	int32_t		fieldId;
 	IcebergScalarAvroType fieldType;
-}			PartitionFieldIdMapEntry;
+} PartitionFieldIdMapEntry;
 
 
 /*
@@ -62,17 +62,17 @@ typedef struct ManifestReaderContext
 {
 	/* partition field name => field id mapping */
 	HTAB	   *partitionFieldMap;
-}			ManifestReaderContext;
+} ManifestReaderContext;
 
 
-static void ReadFieldSummaryFromAvro(avro_value_t * record, FieldSummary * summary, void *context);
-static void ReadColumnStatFromAvro(avro_value_t * record, ColumnStat * stat, void *context);
-static void ReadColumnBoundFromAvro(avro_value_t * record, ColumnBound * bound, void *context);
-static void ReadDataFileFromAvro(avro_value_t * record, DataFile * dataFile, ManifestReaderContext * context);
-static void ReadPartitionFromAvro(avro_value_t * record, Partition * partition, ManifestReaderContext * context);
-static void ReadIcebergManifestFromAvro(avro_value_t * record, IcebergManifest * manifest, void *context);
-static void ReadIcebergManifestEntryFromAvro(avro_value_t * record, IcebergManifestEntry * entry,
-											 ManifestReaderContext * context);
+static void ReadFieldSummaryFromAvro(avro_value_t * record, FieldSummary *summary, void *context);
+static void ReadColumnStatFromAvro(avro_value_t * record, ColumnStat *stat, void *context);
+static void ReadColumnBoundFromAvro(avro_value_t * record, ColumnBound *bound, void *context);
+static void ReadDataFileFromAvro(avro_value_t * record, DataFile *dataFile, ManifestReaderContext *context);
+static void ReadPartitionFromAvro(avro_value_t * record, Partition *partition, ManifestReaderContext *context);
+static void ReadIcebergManifestFromAvro(avro_value_t * record, IcebergManifest *manifest, void *context);
+static void ReadIcebergManifestEntryFromAvro(avro_value_t * record, IcebergManifestEntry *entry,
+											 ManifestReaderContext *context);
 static HTAB *CreateManifestPartitionFieldMap(AvroReader * manifestReader);
 static IcebergScalarAvroType IcebergAvroTypeFromString(const char *physicalTypeName, const char *logicalTypeName);
 
@@ -171,7 +171,7 @@ ReadManifestEntries(const char *manifestPath)
 }
 
 static void
-ReadIcebergManifestFromAvro(avro_value_t * record, IcebergManifest * manifest, void *context)
+ReadIcebergManifestFromAvro(avro_value_t * record, IcebergManifest *manifest, void *context)
 {
 	memset(manifest, '\0', sizeof(IcebergManifest));
 	AvroGetStringField(record, "manifest_path", AVRO_FIELD_REQUIRED, &manifest->manifest_path, &manifest->manifest_path_length);
@@ -227,7 +227,7 @@ ReadIcebergManifestFromAvro(avro_value_t * record, IcebergManifest * manifest, v
 
 
 static void
-ReadIcebergManifestEntryFromAvro(avro_value_t * record, IcebergManifestEntry * entry, ManifestReaderContext * context)
+ReadIcebergManifestEntryFromAvro(avro_value_t * record, IcebergManifestEntry *entry, ManifestReaderContext *context)
 {
 	memset(entry, '\0', sizeof(IcebergManifestEntry));
 	AvroGetInt32Field(record, "status", AVRO_FIELD_REQUIRED, (int32_t *) &entry->status);
@@ -239,7 +239,7 @@ ReadIcebergManifestEntryFromAvro(avro_value_t * record, IcebergManifestEntry * e
 
 
 static void
-ReadDataFileFromAvro(avro_value_t * record, DataFile * dataFile, ManifestReaderContext * context)
+ReadDataFileFromAvro(avro_value_t * record, DataFile *dataFile, ManifestReaderContext *context)
 {
 	memset(dataFile, '\0', sizeof(DataFile));
 	AvroGetInt32Field(record, "content", AVRO_FIELD_REQUIRED, (int32_t *) &dataFile->content);
@@ -293,7 +293,7 @@ ReadDataFileFromAvro(avro_value_t * record, DataFile * dataFile, ManifestReaderC
  * ReadPartitionFromAvro reads the partition from the avro record.
  */
 static void
-ReadPartitionFromAvro(avro_value_t * partitionRecord, Partition * partition, ManifestReaderContext * context)
+ReadPartitionFromAvro(avro_value_t * partitionRecord, Partition *partition, ManifestReaderContext *context)
 {
 	memset(partition, '\0', sizeof(Partition));
 
@@ -620,7 +620,7 @@ CreateManifestPartitionFieldMap(AvroReader * manifestReader)
 
 
 static void
-ReadFieldSummaryFromAvro(avro_value_t * record, FieldSummary * summary, void *context)
+ReadFieldSummaryFromAvro(avro_value_t * record, FieldSummary *summary, void *context)
 {
 	memset(summary, '\0', sizeof(FieldSummary));
 	AvroGetBoolField(record, "contains_null", AVRO_FIELD_REQUIRED, &summary->contains_null);
@@ -630,7 +630,7 @@ ReadFieldSummaryFromAvro(avro_value_t * record, FieldSummary * summary, void *co
 }
 
 static void
-ReadColumnStatFromAvro(avro_value_t * record, ColumnStat * stat, void *context)
+ReadColumnStatFromAvro(avro_value_t * record, ColumnStat *stat, void *context)
 {
 	memset(stat, '\0', sizeof(ColumnStat));
 	AvroGetInt32Field(record, "key", AVRO_FIELD_REQUIRED, &stat->column_id);
@@ -639,7 +639,7 @@ ReadColumnStatFromAvro(avro_value_t * record, ColumnStat * stat, void *context)
 
 
 static void
-ReadColumnBoundFromAvro(avro_value_t * record, ColumnBound * bound, void *context)
+ReadColumnBoundFromAvro(avro_value_t * record, ColumnBound *bound, void *context)
 {
 	memset(bound, '\0', sizeof(ColumnBound));
 	AvroGetInt32Field(record, "key", AVRO_FIELD_REQUIRED, &bound->column_id);

--- a/pg_lake_iceberg/src/iceberg/read_table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/read_table_metadata.c
@@ -35,26 +35,26 @@ static const char *SnapshotReferenceTypeName[] = {
 };
 
 
-static void ReadIcebergTableMetadataFromJson(JsonbContainer *json, IcebergTableMetadata * metadata);
-static void ReadIcebergTableSchema(JsonbContainer *json, IcebergTableSchema * schema);
-static void ReadIcebergTableSchemaField(JsonbContainer *json, DataFileSchemaField * field);
-static void ReadIcebergPartitionSpec(JsonbContainer *json, IcebergPartitionSpec * spec);
-static void ReadIcebergPartitionSpecField(JsonbContainer *json, IcebergPartitionSpecField * field);
-static void ReadIcebergSnapshot(JsonbContainer *json, IcebergSnapshot * snapshot);
-static void ReadIcebergSnapshotLogEntry(JsonbContainer *json, IcebergSnapshotLogEntry * entry);
-static void ReadIcebergPartitionStatistics(JsonbContainer *json, IcebergPartitionStatistics * entry);
-static void ReadIcebergMetadataLogEntry(JsonbContainer *json, IcebergMetadataLogEntry * entry);
-static void ReadIcebergSortOrder(JsonbContainer *json, IcebergSortOrder * order);
-static void ReadIcebergSortOrderField(JsonbContainer *json, IcebergSortOrderField * field);
-static void ReadSnapshotReference(const char *key, JsonbValue *jsonValue, SnapshotReference * ref);
-static void ReadSnapshotReferenceType(JsonbContainer *refJson, SnapshotReferenceType * type);
-static void ReadIcebergStatistics(JsonbContainer *json, IcebergStatistics * statistics);
-static void ReadBlobMetadata(JsonbContainer *json, BlobMetadata * metadata);
+static void ReadIcebergTableMetadataFromJson(JsonbContainer *json, IcebergTableMetadata *metadata);
+static void ReadIcebergTableSchema(JsonbContainer *json, IcebergTableSchema *schema);
+static void ReadIcebergTableSchemaField(JsonbContainer *json, DataFileSchemaField *field);
+static void ReadIcebergPartitionSpec(JsonbContainer *json, IcebergPartitionSpec *spec);
+static void ReadIcebergPartitionSpecField(JsonbContainer *json, IcebergPartitionSpecField *field);
+static void ReadIcebergSnapshot(JsonbContainer *json, IcebergSnapshot *snapshot);
+static void ReadIcebergSnapshotLogEntry(JsonbContainer *json, IcebergSnapshotLogEntry *entry);
+static void ReadIcebergPartitionStatistics(JsonbContainer *json, IcebergPartitionStatistics *entry);
+static void ReadIcebergMetadataLogEntry(JsonbContainer *json, IcebergMetadataLogEntry *entry);
+static void ReadIcebergSortOrder(JsonbContainer *json, IcebergSortOrder *order);
+static void ReadIcebergSortOrderField(JsonbContainer *json, IcebergSortOrderField *field);
+static void ReadSnapshotReference(const char *key, JsonbValue *jsonValue, SnapshotReference *ref);
+static void ReadSnapshotReferenceType(JsonbContainer *refJson, SnapshotReferenceType *type);
+static void ReadIcebergStatistics(JsonbContainer *json, IcebergStatistics *statistics);
+static void ReadBlobMetadata(JsonbContainer *json, BlobMetadata *metadata);
 static void ReadInt32(int input, int *value);
-static void ReadProperty(const char *key, JsonbValue *jsonValue, Property * property);
+static void ReadProperty(const char *key, JsonbValue *jsonValue, Property *property);
 static bool JsonExtractField(JsonbContainer *topLevelJsonContainer,
 							 char *fieldName, FieldRequired required,
-							 Field * *field);
+							 Field **field);
 
 
 /*
@@ -81,7 +81,7 @@ ReadIcebergTableMetadata(const char *tableMetadataPath)
 * table metadata.
 */
 static void
-ReadIcebergTableMetadataFromJson(JsonbContainer *json, IcebergTableMetadata * metadata)
+ReadIcebergTableMetadataFromJson(JsonbContainer *json, IcebergTableMetadata *metadata)
 {
 	memset(metadata, '\0', sizeof(IcebergTableMetadata));
 
@@ -161,7 +161,7 @@ ReadIcebergTableMetadataFromJson(JsonbContainer *json, IcebergTableMetadata * me
 
 
 static void
-ReadIcebergTableSchema(JsonbContainer *json, IcebergTableSchema * schema)
+ReadIcebergTableSchema(JsonbContainer *json, IcebergTableSchema *schema)
 {
 	memset(schema, '\0', sizeof(IcebergTableSchema));
 	JsonExtractInt32Field(json, "schema-id", FIELD_REQUIRED, &schema->schema_id);
@@ -180,7 +180,7 @@ ReadIcebergTableSchema(JsonbContainer *json, IcebergTableSchema * schema)
 
 
 static void
-ReadIcebergTableSchemaField(JsonbContainer *json, DataFileSchemaField * field)
+ReadIcebergTableSchemaField(JsonbContainer *json, DataFileSchemaField *field)
 {
 	memset(field, '\0', sizeof(DataFileSchemaField));
 
@@ -212,7 +212,7 @@ ReadIcebergTableSchemaField(JsonbContainer *json, DataFileSchemaField * field)
 
 
 static void
-ReadIcebergPartitionSpec(JsonbContainer *json, IcebergPartitionSpec * spec)
+ReadIcebergPartitionSpec(JsonbContainer *json, IcebergPartitionSpec *spec)
 {
 	memset(spec, '\0', sizeof(IcebergPartitionSpec));
 	JsonExtractInt32Field(json, "spec-id", FIELD_REQUIRED, &spec->spec_id);
@@ -224,7 +224,7 @@ ReadIcebergPartitionSpec(JsonbContainer *json, IcebergPartitionSpec * spec)
 
 
 static void
-ReadIcebergPartitionSpecField(JsonbContainer *json, IcebergPartitionSpecField * field)
+ReadIcebergPartitionSpecField(JsonbContainer *json, IcebergPartitionSpecField *field)
 {
 	memset(field, '\0', sizeof(IcebergPartitionSpecField));
 	JsonExtractInt32Field(json, "source-id", FIELD_REQUIRED, &field->source_id);
@@ -238,7 +238,7 @@ ReadIcebergPartitionSpecField(JsonbContainer *json, IcebergPartitionSpecField * 
 }
 
 static void
-ReadSnapshotReference(const char *key, JsonbValue *jsonValue, SnapshotReference * ref)
+ReadSnapshotReference(const char *key, JsonbValue *jsonValue, SnapshotReference *ref)
 {
 	memset(ref, '\0', sizeof(SnapshotReference));
 
@@ -269,7 +269,7 @@ ReadSnapshotReference(const char *key, JsonbValue *jsonValue, SnapshotReference 
 }
 
 static void
-ReadSnapshotReferenceType(JsonbContainer *refJson, SnapshotReferenceType * type)
+ReadSnapshotReferenceType(JsonbContainer *refJson, SnapshotReferenceType *type)
 {
 	const char *typeName = NULL;
 	size_t		typeNameLength = 0;
@@ -290,7 +290,7 @@ ReadSnapshotReferenceType(JsonbContainer *refJson, SnapshotReferenceType * type)
 }
 
 static void
-ReadProperty(const char *key, JsonbValue *jsonValue, Property * property)
+ReadProperty(const char *key, JsonbValue *jsonValue, Property *property)
 {
 	memset(property, '\0', sizeof(Property));
 
@@ -314,7 +314,7 @@ ReadInt32(int input, int *value)
 
 
 static void
-ReadIcebergSnapshot(JsonbContainer *json, IcebergSnapshot * snapshot)
+ReadIcebergSnapshot(JsonbContainer *json, IcebergSnapshot *snapshot)
 {
 	memset(snapshot, '\0', sizeof(IcebergSnapshot));
 	JsonExtractInt64Field(json, "snapshot-id", FIELD_REQUIRED, &snapshot->snapshot_id);
@@ -331,7 +331,7 @@ ReadIcebergSnapshot(JsonbContainer *json, IcebergSnapshot * snapshot)
 }
 
 static void
-ReadIcebergSnapshotLogEntry(JsonbContainer *json, IcebergSnapshotLogEntry * entry)
+ReadIcebergSnapshotLogEntry(JsonbContainer *json, IcebergSnapshotLogEntry *entry)
 {
 	memset(entry, '\0', sizeof(IcebergSnapshotLogEntry));
 	JsonExtractInt64Field(json, "timestamp-ms", FIELD_REQUIRED, &entry->timestamp_ms);
@@ -339,7 +339,7 @@ ReadIcebergSnapshotLogEntry(JsonbContainer *json, IcebergSnapshotLogEntry * entr
 }
 
 static void
-ReadIcebergPartitionStatistics(JsonbContainer *json, IcebergPartitionStatistics * entry)
+ReadIcebergPartitionStatistics(JsonbContainer *json, IcebergPartitionStatistics *entry)
 {
 	memset(entry, '\0', sizeof(IcebergPartitionStatistics));
 	JsonExtractInt64Field(json, "snapshot-id", FIELD_REQUIRED, &entry->snapshot_id);
@@ -348,7 +348,7 @@ ReadIcebergPartitionStatistics(JsonbContainer *json, IcebergPartitionStatistics 
 }
 
 static void
-ReadIcebergMetadataLogEntry(JsonbContainer *json, IcebergMetadataLogEntry * entry)
+ReadIcebergMetadataLogEntry(JsonbContainer *json, IcebergMetadataLogEntry *entry)
 {
 	memset(entry, '\0', sizeof(IcebergMetadataLogEntry));
 	JsonExtractInt64Field(json, "timestamp-ms", FIELD_REQUIRED, &entry->timestamp_ms);
@@ -357,7 +357,7 @@ ReadIcebergMetadataLogEntry(JsonbContainer *json, IcebergMetadataLogEntry * entr
 
 
 static void
-ReadIcebergSortOrder(JsonbContainer *json, IcebergSortOrder * order)
+ReadIcebergSortOrder(JsonbContainer *json, IcebergSortOrder *order)
 {
 	memset(order, '\0', sizeof(IcebergSortOrder));
 	JsonExtractInt32Field(json, "order-id", FIELD_REQUIRED, &order->order_id);
@@ -369,7 +369,7 @@ ReadIcebergSortOrder(JsonbContainer *json, IcebergSortOrder * order)
 
 
 static void
-ReadIcebergSortOrderField(JsonbContainer *json, IcebergSortOrderField * field)
+ReadIcebergSortOrderField(JsonbContainer *json, IcebergSortOrderField *field)
 {
 	memset(field, '\0', sizeof(IcebergSortOrderField));
 	JsonExtractStringField(json, "transform", FIELD_REQUIRED, &field->transform, &field->transform_length);
@@ -380,7 +380,7 @@ ReadIcebergSortOrderField(JsonbContainer *json, IcebergSortOrderField * field)
 
 
 static void
-ReadBlobMetadata(JsonbContainer *json, BlobMetadata * metadata)
+ReadBlobMetadata(JsonbContainer *json, BlobMetadata *metadata)
 {
 	memset(metadata, '\0', sizeof(BlobMetadata));
 	JsonExtractStringField(json, "type", FIELD_REQUIRED, &metadata->type, &metadata->type_length);
@@ -397,7 +397,7 @@ ReadBlobMetadata(JsonbContainer *json, BlobMetadata * metadata)
 }
 
 static void
-ReadIcebergStatistics(JsonbContainer *json, IcebergStatistics * statistics)
+ReadIcebergStatistics(JsonbContainer *json, IcebergStatistics *statistics)
 {
 	memset(statistics, '\0', sizeof(IcebergStatistics));
 	JsonExtractInt64Field(json, "snapshot-id", FIELD_REQUIRED, &statistics->snapshot_id);
@@ -413,7 +413,7 @@ ReadIcebergStatistics(JsonbContainer *json, IcebergStatistics * statistics)
 
 
 static void
-ReadIcebergTypeFieldElement(JsonbContainer *json, DataFileSchemaField * fieldElement)
+ReadIcebergTypeFieldElement(JsonbContainer *json, DataFileSchemaField *fieldElement)
 {
 	memset(fieldElement, '\0', sizeof(DataFileSchemaField));
 	JsonExtractInt32Field(json, "id", FIELD_REQUIRED, &fieldElement->id);
@@ -432,7 +432,7 @@ ReadIcebergTypeFieldElement(JsonbContainer *json, DataFileSchemaField * fieldEle
 
 
 static bool
-JsonExtractField(JsonbContainer *topLevelJsonContainer, char *fieldName, FieldRequired required, Field * *field)
+JsonExtractField(JsonbContainer *topLevelJsonContainer, char *fieldName, FieldRequired required, Field **field)
 {
 	JsonbValue *topLevelTypeFieldJson =
 		getKeyJsonValueFromContainer(topLevelJsonContainer, fieldName, strlen(fieldName), NULL);

--- a/pg_lake_iceberg/src/iceberg/write_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/write_manifest.c
@@ -28,15 +28,15 @@
 #include "pg_lake/iceberg/manifest_schema_v2.h"
 #include "pg_lake/util/string_utils.h"
 
-static void WriteColumnStatToAvro(ColumnStat * stat, avro_value_t * record);
-static void WriteColumnBoundToAvro(ColumnBound * bound, avro_value_t * record);
-static void WriteFieldSummaryToAvro(FieldSummary * summary, avro_value_t * record);
-static void WriteDataFileToAvro(DataFile * dataFile, avro_value_t * record);
-static void WritePartitionToAvro(Partition * partition, avro_value_t * record);
-static void WriteIcebergManifestToAvro(IcebergManifest * manifest, avro_value_t * record);
-static void WriteIcebergManifestEntryToAvro(IcebergManifestEntry * entry, avro_value_t * record);
+static void WriteColumnStatToAvro(ColumnStat *stat, avro_value_t * record);
+static void WriteColumnBoundToAvro(ColumnBound *bound, avro_value_t * record);
+static void WriteFieldSummaryToAvro(FieldSummary *summary, avro_value_t * record);
+static void WriteDataFileToAvro(DataFile *dataFile, avro_value_t * record);
+static void WritePartitionToAvro(Partition *partition, avro_value_t * record);
+static void WriteIcebergManifestToAvro(IcebergManifest *manifest, avro_value_t * record);
+static void WriteIcebergManifestEntryToAvro(IcebergManifestEntry *entry, avro_value_t * record);
 static const char *GetIcebergManifestJsonSchema(List *manifestEntries);
-static const char *AdjustPartitionsInManifestJsonSchema(char *manifestSchema, Partition * partition);
+static const char *AdjustPartitionsInManifestJsonSchema(char *manifestSchema, Partition *partition);
 
 
 /*
@@ -107,7 +107,7 @@ GetIcebergManifestJsonSchema(List *manifestEntries)
  * partition fields.
  */
 static const char *
-AdjustPartitionsInManifestJsonSchema(char *manifestSchema, Partition * partition)
+AdjustPartitionsInManifestJsonSchema(char *manifestSchema, Partition *partition)
 {
 	StringInfo	partitionFields = makeStringInfo();
 
@@ -184,7 +184,7 @@ WriteIcebergManifestList(const char *manifestListPath, List *manifests)
 }
 
 static void
-WriteIcebergManifestToAvro(IcebergManifest * manifest, avro_value_t * record)
+WriteIcebergManifestToAvro(IcebergManifest *manifest, avro_value_t * record)
 {
 	AvroSetStringField(record, "manifest_path", manifest->manifest_path);
 	AvroSetInt64Field(record, "manifest_length", manifest->manifest_length);
@@ -214,7 +214,7 @@ WriteIcebergManifestToAvro(IcebergManifest * manifest, avro_value_t * record)
 
 
 static void
-WriteIcebergManifestEntryToAvro(IcebergManifestEntry * entry, avro_value_t * record)
+WriteIcebergManifestEntryToAvro(IcebergManifestEntry *entry, avro_value_t * record)
 {
 	AvroSetInt32Field(record, "status", entry->status);
 	AvroSetNullableInt64Field(record, "snapshot_id", entry->snapshot_id, entry->has_snapshot_id);
@@ -225,7 +225,7 @@ WriteIcebergManifestEntryToAvro(IcebergManifestEntry * entry, avro_value_t * rec
 
 
 static void
-WriteDataFileToAvro(DataFile * dataFile, avro_value_t * record)
+WriteDataFileToAvro(DataFile *dataFile, avro_value_t * record)
 {
 	AvroSetInt32Field(record, "content", dataFile->content);
 	AvroSetStringField(record, "file_path", dataFile->file_path);
@@ -271,7 +271,7 @@ WriteDataFileToAvro(DataFile * dataFile, avro_value_t * record)
 }
 
 static void
-WritePartitionToAvro(Partition * partition, avro_value_t * record)
+WritePartitionToAvro(Partition *partition, avro_value_t * record)
 {
 	for (int i = 0; i < partition->fields_length; i++)
 	{
@@ -327,7 +327,7 @@ WritePartitionToAvro(Partition * partition, avro_value_t * record)
 }
 
 static void
-WriteColumnStatToAvro(ColumnStat * stat, avro_value_t * record)
+WriteColumnStatToAvro(ColumnStat *stat, avro_value_t * record)
 {
 	AvroSetInt32Field(record, "key", stat->column_id);
 	AvroSetInt64Field(record, "value", stat->value);
@@ -336,14 +336,14 @@ WriteColumnStatToAvro(ColumnStat * stat, avro_value_t * record)
 
 
 static void
-WriteColumnBoundToAvro(ColumnBound * bound, avro_value_t * record)
+WriteColumnBoundToAvro(ColumnBound *bound, avro_value_t * record)
 {
 	AvroSetInt32Field(record, "key", bound->column_id);
 	AvroSetBinaryField(record, "value", (void *) bound->value, bound->value_length);
 }
 
 static void
-WriteFieldSummaryToAvro(FieldSummary * summary, avro_value_t * record)
+WriteFieldSummaryToAvro(FieldSummary *summary, avro_value_t * record)
 {
 	/* fix: properly set summary->contains_null */
 	AvroSetBoolField(record, "contains_null", summary->contains_null);

--- a/pg_lake_iceberg/src/iceberg/write_table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/write_table_metadata.c
@@ -30,20 +30,20 @@
 #include "utils/jsonb.h"
 #include "utils/builtins.h"
 
-static void AppendProperties(StringInfo command, Property * properties, size_t properties_length);
-static void AppendField(StringInfo command, Field * field);
-static void AppendIcebergStructFields(StringInfo command, FieldStructElement * fields, size_t fields_length);
-static void AppendIcebergTableSchemas(StringInfo command, IcebergTableSchema * schemas, size_t schemas_length);
-static void AppendIcebergPartitionSpecs(StringInfo command, IcebergPartitionSpec * specs, size_t specs_length);
-static void AppendIcebergSnapshots(StringInfo command, IcebergSnapshot * snapshots, size_t snapshots_length);
-static void AppendIcebergSnapshotLogEntries(StringInfo command, IcebergSnapshotLogEntry * entries, size_t entries_length);
-static void AppendcebergPartitionStatistics(StringInfo command, IcebergPartitionStatistics * entries, size_t entries_length);
-static void AppendIcebergMetadataLogEntries(StringInfo command, IcebergMetadataLogEntry * entries, size_t entries_length);
-static void AppendIcebergSortOrderFields(StringInfo command, IcebergSortOrderField * fields, size_t fields_length);
-static void AppendIcebergSortOrders(StringInfo command, IcebergSortOrder * orders, size_t orders_length);
-static void AppendSnapshotReferences(StringInfo command, SnapshotReference * refs, size_t refs_length);
-static void AppendIcebergStatistics(StringInfo command, IcebergStatistics * statistics, size_t statistics_length);
-static void AppendBlobMetadata(StringInfo command, BlobMetadata * metadata, size_t metadata_length);
+static void AppendProperties(StringInfo command, Property *properties, size_t properties_length);
+static void AppendField(StringInfo command, Field *field);
+static void AppendIcebergStructFields(StringInfo command, FieldStructElement *fields, size_t fields_length);
+static void AppendIcebergTableSchemas(StringInfo command, IcebergTableSchema *schemas, size_t schemas_length);
+static void AppendIcebergPartitionSpecs(StringInfo command, IcebergPartitionSpec *specs, size_t specs_length);
+static void AppendIcebergSnapshots(StringInfo command, IcebergSnapshot *snapshots, size_t snapshots_length);
+static void AppendIcebergSnapshotLogEntries(StringInfo command, IcebergSnapshotLogEntry *entries, size_t entries_length);
+static void AppendcebergPartitionStatistics(StringInfo command, IcebergPartitionStatistics *entries, size_t entries_length);
+static void AppendIcebergMetadataLogEntries(StringInfo command, IcebergMetadataLogEntry *entries, size_t entries_length);
+static void AppendIcebergSortOrderFields(StringInfo command, IcebergSortOrderField *fields, size_t fields_length);
+static void AppendIcebergSortOrders(StringInfo command, IcebergSortOrder *orders, size_t orders_length);
+static void AppendSnapshotReferences(StringInfo command, SnapshotReference *refs, size_t refs_length);
+static void AppendIcebergStatistics(StringInfo command, IcebergStatistics *statistics, size_t statistics_length);
+static void AppendBlobMetadata(StringInfo command, BlobMetadata *metadata, size_t metadata_length);
 static void AppendIntArray(StringInfo command, int *array, size_t array_length);
 
 /*
@@ -52,7 +52,7 @@ static void AppendIntArray(StringInfo command, int *array, size_t array_length);
 * IcebergTableMetadata
 */
 char *
-WriteIcebergTableMetadataToJson(IcebergTableMetadata * metadata)
+WriteIcebergTableMetadataToJson(IcebergTableMetadata *metadata)
 {
 	StringInfo	command = makeStringInfo();
 
@@ -165,7 +165,7 @@ WriteIcebergTableMetadataToJson(IcebergTableMetadata * metadata)
 }
 
 static void
-AppendProperties(StringInfo command, Property * properties, size_t properties_length)
+AppendProperties(StringInfo command, Property *properties, size_t properties_length)
 {
 	appendStringInfoString(command, "{");
 
@@ -203,7 +203,7 @@ AppendIntArray(StringInfo command, int *array, size_t array_length)
 }
 
 static void
-AppendIcebergTableSchemas(StringInfo command, IcebergTableSchema * schemas, size_t schemas_length)
+AppendIcebergTableSchemas(StringInfo command, IcebergTableSchema *schemas, size_t schemas_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -249,7 +249,7 @@ AppendIcebergTableSchemas(StringInfo command, IcebergTableSchema * schemas, size
 * API calls.
 */
 void
-AppendIcebergTableSchemaForRestCatalog(StringInfo command, IcebergTableSchema * schemas, size_t schemas_length)
+AppendIcebergTableSchemaForRestCatalog(StringInfo command, IcebergTableSchema *schemas, size_t schemas_length)
 {
 	appendStringInfoString(command, "\"schema\":");
 
@@ -285,7 +285,7 @@ AppendIcebergTableSchemaForRestCatalog(StringInfo command, IcebergTableSchema * 
 
 
 static void
-AppendIcebergPartitionSpecs(StringInfo command, IcebergPartitionSpec * specs, size_t specs_length)
+AppendIcebergPartitionSpecs(StringInfo command, IcebergPartitionSpec *specs, size_t specs_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -313,7 +313,7 @@ AppendIcebergPartitionSpecs(StringInfo command, IcebergPartitionSpec * specs, si
 }
 
 static void
-AppendIcebergSnapshots(StringInfo command, IcebergSnapshot * snapshots, size_t snapshots_length)
+AppendIcebergSnapshots(StringInfo command, IcebergSnapshot *snapshots, size_t snapshots_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -364,7 +364,7 @@ AppendIcebergSnapshots(StringInfo command, IcebergSnapshot * snapshots, size_t s
 }
 
 static void
-AppendIcebergSnapshotLogEntries(StringInfo command, IcebergSnapshotLogEntry * entries, size_t entries_length)
+AppendIcebergSnapshotLogEntries(StringInfo command, IcebergSnapshotLogEntry *entries, size_t entries_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -392,7 +392,7 @@ AppendIcebergSnapshotLogEntries(StringInfo command, IcebergSnapshotLogEntry * en
 
 
 static void
-AppendcebergPartitionStatistics(StringInfo command, IcebergPartitionStatistics * entries, size_t entries_length)
+AppendcebergPartitionStatistics(StringInfo command, IcebergPartitionStatistics *entries, size_t entries_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -421,7 +421,7 @@ AppendcebergPartitionStatistics(StringInfo command, IcebergPartitionStatistics *
 }
 
 static void
-AppendIcebergMetadataLogEntries(StringInfo command, IcebergMetadataLogEntry * entries, size_t entries_length)
+AppendIcebergMetadataLogEntries(StringInfo command, IcebergMetadataLogEntry *entries, size_t entries_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -448,7 +448,7 @@ AppendIcebergMetadataLogEntries(StringInfo command, IcebergMetadataLogEntry * en
 }
 
 static void
-AppendIcebergSortOrders(StringInfo command, IcebergSortOrder * orders, size_t orders_length)
+AppendIcebergSortOrders(StringInfo command, IcebergSortOrder *orders, size_t orders_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -491,7 +491,7 @@ GetSnapshotReferenceType(SnapshotReferenceType type)
 }
 
 static void
-AppendSnapshotReferences(StringInfo command, SnapshotReference * refs, size_t refs_length)
+AppendSnapshotReferences(StringInfo command, SnapshotReference *refs, size_t refs_length)
 {
 	appendStringInfoString(command, "{");
 
@@ -544,7 +544,7 @@ AppendSnapshotReferences(StringInfo command, SnapshotReference * refs, size_t re
 }
 
 static void
-AppendIcebergStatistics(StringInfo command, IcebergStatistics * statistics, size_t statistics_length)
+AppendIcebergStatistics(StringInfo command, IcebergStatistics *statistics, size_t statistics_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -593,7 +593,7 @@ AppendIcebergStatistics(StringInfo command, IcebergStatistics * statistics, size
 
 
 static void
-AppendField(StringInfo command, Field * field)
+AppendField(StringInfo command, Field *field)
 {
 	switch (field->type)
 	{
@@ -644,7 +644,7 @@ AppendField(StringInfo command, Field * field)
 }
 
 static void
-AppendIcebergStructFields(StringInfo command, FieldStructElement * fields, size_t fields_length)
+AppendIcebergStructFields(StringInfo command, FieldStructElement *fields, size_t fields_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -722,7 +722,7 @@ AppendIcebergStructFields(StringInfo command, FieldStructElement * fields, size_
 
 
 void
-AppendIcebergPartitionSpecFields(StringInfo command, IcebergPartitionSpecField * fields, size_t fields_length)
+AppendIcebergPartitionSpecFields(StringInfo command, IcebergPartitionSpecField *fields, size_t fields_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -765,7 +765,7 @@ AppendIcebergPartitionSpecFields(StringInfo command, IcebergPartitionSpecField *
 }
 
 static void
-AppendIcebergSortOrderFields(StringInfo command, IcebergSortOrderField * fields, size_t fields_length)
+AppendIcebergSortOrderFields(StringInfo command, IcebergSortOrderField *fields, size_t fields_length)
 {
 	appendStringInfoString(command, "[");
 
@@ -800,7 +800,7 @@ AppendIcebergSortOrderFields(StringInfo command, IcebergSortOrderField * fields,
 }
 
 static void
-AppendBlobMetadata(StringInfo command, BlobMetadata * metadata, size_t metadata_length)
+AppendBlobMetadata(StringInfo command, BlobMetadata *metadata, size_t metadata_length)
 {
 	appendStringInfoString(command, "[");
 

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -77,7 +77,7 @@ typedef enum RestCatalogRequestRetryAction
 	REST_CATALOG_RETRY_BACKOFF_SHORT,	/* 429 Too Many Requests */
 	REST_CATALOG_RETRY_BACKOFF_LONG,	/* 503 Service Unavailable */
 	REST_CATALOG_RETRY_REFRESH_AUTH /* 419 Token Expired */
-}			RestCatalogRequestRetryAction;
+} RestCatalogRequestRetryAction;
 
 /*
 * StartStageRestCatalogIcebergTableCreate stages the creation of an iceberg table
@@ -147,7 +147,7 @@ StartStageRestCatalogIcebergTableCreate(Oid relationId)
 * catalog.
 */
 char *
-FinishStageRestCatalogIcebergTableCreateRestRequest(Oid relationId, DataFileSchema * dataFileSchema, List *partitionSpecs)
+FinishStageRestCatalogIcebergTableCreateRestRequest(Oid relationId, DataFileSchema *dataFileSchema, List *partitionSpecs)
 {
 	StringInfo	body = makeStringInfo();
 
@@ -904,7 +904,7 @@ AppendIcebergPartitionSpecForRestCatalog(List *partitionSpecs)
 * to the rest catalog for the given new snapshot.
 */
 RestCatalogRequest *
-GetAddSnapshotCatalogRequest(IcebergSnapshot * newSnapshot, Oid relationId)
+GetAddSnapshotCatalogRequest(IcebergSnapshot *newSnapshot, Oid relationId)
 {
 	StringInfo	body = makeStringInfo();
 
@@ -940,7 +940,7 @@ GetAddSnapshotCatalogRequest(IcebergSnapshot * newSnapshot, Oid relationId)
  * "the last added schema" per the REST spec).
  */
 RestCatalogRequest *
-GetAddSchemaCatalogRequest(Oid relationId, DataFileSchema * dataFileSchema)
+GetAddSchemaCatalogRequest(Oid relationId, DataFileSchema *dataFileSchema)
 {
 	StringInfo	body = makeStringInfo();
 

--- a/pg_lake_iceberg/src/test/test_http_client.c
+++ b/pg_lake_iceberg/src/test/test_http_client.c
@@ -32,7 +32,7 @@ PG_FUNCTION_INFO_V1(test_http_put);
 PG_FUNCTION_INFO_V1(test_http_with_retry);
 
 
-static Datum build_http_result(FunctionCallInfo fcinfo, const HttpResult * r);
+static Datum build_http_result(FunctionCallInfo fcinfo, const HttpResult *r);
 static List *extract_headers(FunctionCallInfo fcinfo, int argno);
 static bool TestShouldRetryRequestToRestCatalog(long status, int maxRetry, int retryNo);
 
@@ -155,7 +155,7 @@ extract_headers(FunctionCallInfo fcinfo, int argno)
 
 /* Helper: build (status, body, resp_headers) composite                    */
 static Datum
-build_http_result(FunctionCallInfo fcinfo, const HttpResult * r)
+build_http_result(FunctionCallInfo fcinfo, const HttpResult *r)
 {
 	TupleDesc	tupdesc;
 

--- a/pg_lake_iceberg/src/test/test_iceberg_binary_serde.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_binary_serde.c
@@ -30,12 +30,12 @@
 #include "utils/json.h"
 
 
-static ColumnBound * FindColumnBoundByColumnId(ColumnBound * bounds, int numBounds, int columnId);
-static LeafField * GetLeafFieldByColumnId(List *leafFields, int columnId);
-static List *DeserializeDataFileColumnBounds(List *leafFields, ColumnBound * columnBounds,
+static ColumnBound *FindColumnBoundByColumnId(ColumnBound *bounds, int numBounds, int columnId);
+static LeafField *GetLeafFieldByColumnId(List *leafFields, int columnId);
+static List *DeserializeDataFileColumnBounds(List *leafFields, ColumnBound *columnBounds,
 											 int boundsLength, List **columnTypes, List **columnIdDatums);
 static List *SerializeDataFileColumnBounds(List *leafFields, List *columnIdDatums, List *boundDatums, List **columnTypes);
-static Datum DeserializeColumnBound(ColumnBound * bound, LeafField * leafField);
+static Datum DeserializeColumnBound(ColumnBound *bound, LeafField *leafField);
 static Datum DataFileColumnBoundsToJsonDatum(List *boundDatums, List *columnIdDatums, List *columnTypes);
 
 PG_FUNCTION_INFO_V1(pg_lake_read_data_file_stats);
@@ -46,7 +46,7 @@ PG_FUNCTION_INFO_V1(pg_lake_serde_value);
  * FindColumnBoundByColumnId finds ColumnBound by column id.
  */
 static ColumnBound *
-FindColumnBoundByColumnId(ColumnBound * bounds, int numBounds, int columnId)
+FindColumnBoundByColumnId(ColumnBound *bounds, int numBounds, int columnId)
 {
 	for (int i = 0; i < numBounds; i++)
 	{
@@ -87,7 +87,7 @@ GetLeafFieldByColumnId(List *leafFields, int columnId)
  * DeserializeColumnBound converts ColumnBound to datum.
  */
 static Datum
-DeserializeColumnBound(ColumnBound * bound, LeafField * leafField)
+DeserializeColumnBound(ColumnBound *bound, LeafField *leafField)
 {
 	Field	   *field = leafField->field;
 
@@ -101,7 +101,7 @@ DeserializeColumnBound(ColumnBound * bound, LeafField * leafField)
  * DeserializeDataFileColumnBounds deserializes ColumnBounds to datums.
  */
 static List *
-DeserializeDataFileColumnBounds(List *leafFields, ColumnBound * columnBounds,
+DeserializeDataFileColumnBounds(List *leafFields, ColumnBound *columnBounds,
 								int boundsLength, List **columnTypes, List **columnIdDatums)
 {
 	List	   *boundDatums = NIL;

--- a/pg_lake_iceberg/src/test/test_iceberg_manifest.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_manifest.c
@@ -32,7 +32,7 @@
 static const char *FetchCurrentSnapshotManifestListPathFromTableMetadataUri(const char *tableMetadataPath);
 static List *FetchDataFilePathsFromTableMetadataUri(const char *tableMetadataPath, bool isDelete);
 static List *FetchManifestPathsFromManifestListUri(const char *manifestListPath);
-static const char *ExternalPartitionValueToString(PartitionField * field);
+static const char *ExternalPartitionValueToString(PartitionField *field);
 
 PG_FUNCTION_INFO_V1(reserialize_iceberg_manifest_list);
 PG_FUNCTION_INFO_V1(reserialize_iceberg_manifest);
@@ -346,7 +346,7 @@ current_partition_fields(PG_FUNCTION_ARGS)
  * should be used for internal partitioning.
  */
 static const char *
-ExternalPartitionValueToString(PartitionField * field)
+ExternalPartitionValueToString(PartitionField *field)
 {
 	if (field->value == NULL)
 	{

--- a/pg_lake_table/include/pg_lake/ddl/alter_table.h
+++ b/pg_lake_table/include/pg_lake/ddl/alter_table.h
@@ -19,12 +19,12 @@
 
 #include "pg_lake/ddl/utility_hook.h"
 
-bool		ProcessAlterTable(ProcessUtilityParams * params, void *arg);
-bool		ProcessAlterType(ProcessUtilityParams * params, void *arg);
-bool		ProcessEnumStatement(ProcessUtilityParams * params, void *arg);
-bool		ProcessAlterTypeAttributeRename(ProcessUtilityParams * processUtilityParams, void *arg);
-void		PostProcessRenameWritablePgLakeTable(ProcessUtilityParams * params, void *arg);
-void		PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams * params, void *arg);
+bool		ProcessAlterTable(ProcessUtilityParams *params, void *arg);
+bool		ProcessAlterType(ProcessUtilityParams *params, void *arg);
+bool		ProcessEnumStatement(ProcessUtilityParams *params, void *arg);
+bool		ProcessAlterTypeAttributeRename(ProcessUtilityParams *processUtilityParams, void *arg);
+void		PostProcessRenameWritablePgLakeTable(ProcessUtilityParams *params, void *arg);
+void		PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams *params, void *arg);
 
 /* allow other hooks */
 typedef void (*PgLakeAlterTableHookType) (Oid relationOid, AlterTableStmt *stmt);

--- a/pg_lake_table/include/pg_lake/ddl/create_table.h
+++ b/pg_lake_table/include/pg_lake/ddl/create_table.h
@@ -19,10 +19,10 @@
 
 #include "pg_lake/ddl/utility_hook.h"
 
-bool		ProcessCreatePgLakeTable(ProcessUtilityParams * params, void *arg);
-bool		ProcessCreateAsSelectPgLakeTable(ProcessUtilityParams * params, void *arg);
-bool		ErrorUnsupportedCreatePgLakeTableHandler(ProcessUtilityParams * params, void *arg);
-void		CreatePgLakeTableCheckUnsupportedFeaturesPostProcess(ProcessUtilityParams * params, void *arg);
+bool		ProcessCreatePgLakeTable(ProcessUtilityParams *params, void *arg);
+bool		ProcessCreateAsSelectPgLakeTable(ProcessUtilityParams *params, void *arg);
+bool		ErrorUnsupportedCreatePgLakeTableHandler(ProcessUtilityParams *params, void *arg);
+void		CreatePgLakeTableCheckUnsupportedFeaturesPostProcess(ProcessUtilityParams *params, void *arg);
 bool		ColumnDefIsPseudoSerial(ColumnDef *column);
 List	   *GetRestrictedColumnDefList(List *columnDefList);
 

--- a/pg_lake_table/include/pg_lake/ddl/ddl_changes.h
+++ b/pg_lake_table/include/pg_lake/ddl/ddl_changes.h
@@ -37,7 +37,7 @@ typedef enum DDLOperationType
 	DDL_COLUMN_DROP_NOT_NULL = 8,
 	DDL_TABLE_SET_PARTITION_BY = 9,
 	DDL_TABLE_DROP_PARTITION_BY = 10,
-}			DDLOperationType;
+} DDLOperationType;
 
 /*
  * IcebergDDLOperation represents a ddl operation on table metadata.
@@ -60,6 +60,6 @@ typedef struct IcebergDDLOperation
 
 	/* applicable for changing partition_by */
 	List	   *parsedTransforms;
-}			IcebergDDLOperation;
+} IcebergDDLOperation;
 
 extern void ApplyDDLChanges(Oid relationId, List *ddlOperations);

--- a/pg_lake_table/include/pg_lake/ddl/drop_table.h
+++ b/pg_lake_table/include/pg_lake/ddl/drop_table.h
@@ -23,5 +23,5 @@ extern bool SkipDropAccessHook;
 
 extern void InitializeDropTableHandler(void);
 extern bool CheckIfTypeIsUsedInIcebergTable(Oid typeId);
-extern bool ProcessDropPgLakeTable(ProcessUtilityParams * params, void *arg);
+extern bool ProcessDropPgLakeTable(ProcessUtilityParams *params, void *arg);
 extern void TryMarkAllReferencedFilesForDeletion(Oid relationId);

--- a/pg_lake_table/include/pg_lake/ddl/vacuum.h
+++ b/pg_lake_table/include/pg_lake/ddl/vacuum.h
@@ -21,4 +21,4 @@
 extern int	MaxFileRemovalsPerVacuum;
 extern int	MaxCompactionsPerVacuum;
 
-bool		ProcessVacuumPgLakeTable(ProcessUtilityParams * params, void *arg);
+bool		ProcessVacuumPgLakeTable(ProcessUtilityParams *params, void *arg);

--- a/pg_lake_table/include/pg_lake/duckdb/transform_query_to_duckdb.h
+++ b/pg_lake_table/include/pg_lake/duckdb/transform_query_to_duckdb.h
@@ -30,5 +30,5 @@
 #define SKIP_FULL_MATCH_FILES (1 << 1)
 
 extern char *ReplaceReadTableFunctionCalls(char *query,
-										   PgLakeScanSnapshot * snapshot,
+										   PgLakeScanSnapshot *snapshot,
 										   int scanFlags);

--- a/pg_lake_table/include/pg_lake/fdw/data_file_pruning.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_file_pruning.h
@@ -31,7 +31,7 @@ typedef enum PruneType
 {
 	PARTIAL_MATCH,
 	FULL_MATCH
-}			PruneType;
+} PruneType;
 
 extern bool EnableDataFilePruning;
 extern bool EnablePartitionPruning;

--- a/pg_lake_table/include/pg_lake/fdw/data_file_stats_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_file_stats_catalog.h
@@ -28,5 +28,5 @@
 
 extern void AddDataFileColumnStatsToCatalog(Oid relationId, const char *path, List *columnStatsList);
 extern void AddDataFilePartitionValueToCatalog(Oid relationId, int32 partitionSpecId, int64 fileId,
-											   Partition * partition);
+											   Partition *partition);
 extern bool DataFileColumnStatsCatalogExists(void);

--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -31,7 +31,7 @@ typedef struct TableDataFileHashEntry
 {
 	char		filePath[MAX_S3_PATH_LENGTH];
 	TableDataFile dataFile;
-}			TableDataFileHashEntry;
+} TableDataFileHashEntry;
 
 
 /* external control of whether to add to in-transaction temp table */

--- a/pg_lake_table/include/pg_lake/fdw/partition_transform.h
+++ b/pg_lake_table/include/pg_lake/fdw/partition_transform.h
@@ -23,18 +23,18 @@
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/api/partitioning.h"
 
-extern Partition * ComputePartitionTupleForTuple(List *transforms, TupleTableSlot *slot);
-extern void *ApplyBucketTransformToColumn(IcebergPartitionTransform * transform,
+extern Partition *ComputePartitionTupleForTuple(List *transforms, TupleTableSlot *slot);
+extern void *ApplyBucketTransformToColumn(IcebergPartitionTransform *transform,
 										  Datum columnValue, bool isNull,
 										  size_t *bucketSize);
 extern List *CurrentPartitionTransformList(Oid relationId);
-extern IcebergPartitionSpec * GetPartitionSpecIfAlreadyExist(Oid relationId, List *partitionTransforms);
+extern IcebergPartitionSpec *GetPartitionSpecIfAlreadyExist(Oid relationId, List *partitionTransforms);
 extern List *AllPartitionTransformList(Oid relationId);
 extern List *GetPartitionTransformsFromSpecFields(Oid relationId, List *specFields);
-extern void *DeserializePartitionValueFromPGText(IcebergPartitionTransform * transform,
+extern void *DeserializePartitionValueFromPGText(IcebergPartitionTransform *transform,
 												 const char *valueText, size_t *valueLength);
-extern const char *SerializePartitionValueToPGText(void *value, size_t valueLength, IcebergPartitionTransform * transform);
+extern const char *SerializePartitionValueToPGText(void *value, size_t valueLength, IcebergPartitionTransform *transform);
 extern Datum PartitionValueToDatum(IcebergPartitionTransformType transformType, void *value, size_t valueLength,
 								   PGType pgType, bool *isNull);
 extern void ErrorIfColumnEverUsedInIcebergPartitionSpec(Oid relationId, AttrNumber attrNumber, char *operation);
-extern IcebergScalarAvroType GetTransformResultAvroType(IcebergPartitionTransform * transform);
+extern IcebergScalarAvroType GetTransformResultAvroType(IcebergPartitionTransform *transform);

--- a/pg_lake_table/include/pg_lake/fdw/pg_lake_table.h
+++ b/pg_lake_table/include/pg_lake/fdw/pg_lake_table.h
@@ -148,7 +148,7 @@ typedef struct PgLakeRelationInfo
 	 * representing the relation.
 	 */
 	int			relation_index;
-}			PgLakeRelationInfo;
+} PgLakeRelationInfo;
 
 /*
  * Method used by ANALYZE to sample remote rows.
@@ -160,7 +160,7 @@ typedef enum PgLakeSamplingMethod
 	ANALYZE_SAMPLE_RANDOM,		/* remote random() */
 	ANALYZE_SAMPLE_SYSTEM,		/* TABLESAMPLE system */
 	ANALYZE_SAMPLE_BERNOULLI	/* TABLESAMPLE bernoulli */
-}			PgLakeSamplingMethod;
+} PgLakeSamplingMethod;
 
 
 /* hook */

--- a/pg_lake_table/include/pg_lake/fdw/schema_operations/field_id_mapping_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/schema_operations/field_id_mapping_catalog.h
@@ -27,13 +27,13 @@
 
 #define INVALID_FIELD_ID 0
 
-extern PGDLLEXPORT DataFileSchema * GetDataFileSchemaForInternalIcebergTable(Oid relationId);
+extern PGDLLEXPORT DataFileSchema *GetDataFileSchemaForInternalIcebergTable(Oid relationId);
 extern PGDLLEXPORT List *GetLeafFieldsForInternalIcebergTable(Oid relationId);
 extern PGDLLEXPORT List *GetRegisteredFieldForAttributes(Oid relationId, List *attrNos);
-extern PGDLLEXPORT DataFileSchemaField * GetRegisteredFieldForAttribute(Oid relationId, AttrNumber attrNo);
+extern PGDLLEXPORT DataFileSchemaField *GetRegisteredFieldForAttribute(Oid relationId, AttrNumber attrNo);
 extern PGDLLEXPORT AttrNumber GetAttributeForFieldId(Oid relationId, int fieldId);
 extern PGDLLEXPORT void UpdateRegisteredFieldWriteDefaultForAttribute(Oid relationId, AttrNumber attNum, const char *writeDefault);
 extern PGDLLEXPORT int GetLargestRegisteredFieldId(Oid relationId);
-extern PGDLLEXPORT void RegisterIcebergColumnMapping(Oid relationId, Field * field,
+extern PGDLLEXPORT void RegisterIcebergColumnMapping(Oid relationId, Field *field,
 													 AttrNumber attNo, int parentFieldId, PGType pgType,
 													 int fieldId, const char *writeDefault, const char *initialDefault);

--- a/pg_lake_table/include/pg_lake/fdw/schema_operations/register_field_ids.h
+++ b/pg_lake_table/include/pg_lake/fdw/schema_operations/register_field_ids.h
@@ -38,15 +38,15 @@ typedef struct PostgresColumnMapping
 
 	/* field that is mapped to postgres column */
 	DataFileSchemaField *field;
-}			PostgresColumnMapping;
+} PostgresColumnMapping;
 
 extern PGDLLEXPORT void RegisterPostgresColumnMappings(List *pgColumnMappingList);
 extern PGDLLEXPORT List *CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, bool forAddColumn);
 extern PGDLLEXPORT List *CreatePostgresColumnMappingsForIcebergTableFromExternalMetadata(Oid relationId);
-extern PGDLLEXPORT DataFileSchema * GetDataFileSchemaForTable(Oid relationId);
-extern PGDLLEXPORT DataFileSchema * GetDataFileSchemaForTableWithExclusion(Oid relationId, List *excludedColumns);
-extern PGDLLEXPORT DataFileSchema * GetDataFileSchemaForExternalIcebergTable(char *metadataPath);
+extern PGDLLEXPORT DataFileSchema *GetDataFileSchemaForTable(Oid relationId);
+extern PGDLLEXPORT DataFileSchema *GetDataFileSchemaForTableWithExclusion(Oid relationId, List *excludedColumns);
+extern PGDLLEXPORT DataFileSchema *GetDataFileSchemaForExternalIcebergTable(char *metadataPath);
 extern PGDLLEXPORT List *GetLeafFieldsForExternalIcebergTable(char *metadataPath);
 extern PGDLLEXPORT List *GetLeafFieldsForTable(Oid relationId);
 extern PGDLLEXPORT const char *GetDuckSerializedIcebergFieldInitialDefault(const char *initialDefault,
-																		   Field * field);
+																		   Field *field);

--- a/pg_lake_table/include/pg_lake/fdw/shippable.h
+++ b/pg_lake_table/include/pg_lake/fdw/shippable.h
@@ -42,7 +42,7 @@ typedef enum NotShippableReason
 	NOT_SHIPPABLE_SQL_JOIN_MERGED_COLUMNS_ALIAS,
 	NOT_SHIPPABLE_SQL_UNNEST_GROUP_BY_OR_WINDOW,
 	NOT_SHIPPABLE_INFINITE_CONST_VALUE
-}			NotShippableReason;
+} NotShippableReason;
 
 
 typedef struct NotShippableObject
@@ -50,7 +50,7 @@ typedef struct NotShippableObject
 	Oid			classId;		/* Class OID identifying the type of object */
 	Oid			objectId;		/* Specific object OID (if applicable) */
 	NotShippableReason reason;	/* Categorizes why the object isn't shippable */
-}			NotShippableObject;
+} NotShippableObject;
 
 extern bool is_builtin(Oid objectId);
 extern bool is_shippable(Oid objectId, Oid classId, Node *expr);

--- a/pg_lake_table/include/pg_lake/fdw/snapshot.h
+++ b/pg_lake_table/include/pg_lake/fdw/snapshot.h
@@ -39,7 +39,7 @@ typedef struct PgLakeFileScan
 
 	/* true if we already determined that all rows match our filters */
 	bool		allRowsMatch;
-}			PgLakeFileScan;
+} PgLakeFileScan;
 
 /*
  * PgLakeTableScan represents a single table to scan.
@@ -59,7 +59,7 @@ typedef struct PgLakeTableScan
 	List	   *childScans;
 
 	bool		isUpdateDelete;
-}			PgLakeTableScan;
+} PgLakeTableScan;
 
 /*
  * PgLakeScanSnapshot represents the snapshot of all the tables
@@ -68,7 +68,7 @@ typedef struct PgLakeTableScan
 typedef struct PgLakeScanSnapshot
 {
 	List	   *tableScans;
-}			PgLakeScanSnapshot;
+} PgLakeScanSnapshot;
 
 
 PgLakeScanSnapshot *CreatePgLakeScanSnapshot(List *rteList,
@@ -76,11 +76,11 @@ PgLakeScanSnapshot *CreatePgLakeScanSnapshot(List *rteList,
 											 ParamListInfo externalParams,
 											 bool includeChildren,
 											 Oid resultRelationId);
-PgLakeTableScan *GetTableScanByRelationId(PgLakeScanSnapshot * snapshot, Oid relationId);
+PgLakeTableScan *GetTableScanByRelationId(PgLakeScanSnapshot *snapshot, Oid relationId);
 extern PGDLLEXPORT List *GetFileScanPathList(List *fileScans, uint64 *rowCount, bool skipFullScans);
-void		SnapshotFilesScanned(PgLakeScanSnapshot * scanSnapshot, int *dataFileScans, int *deleteFileScans);
+void		SnapshotFilesScanned(PgLakeScanSnapshot *scanSnapshot, int *dataFileScans, int *deleteFileScans);
 extern PGDLLEXPORT void CreateTableScanForIcebergMetadata(Oid relationId,
-														  IcebergTableMetadata * metadata,
+														  IcebergTableMetadata *metadata,
 														  List *baseRestrictInfoList,
 														  List **fileScans,
 														  List **positionDeleteScans);

--- a/pg_lake_table/include/pg_lake/fdw/update_tracking.h
+++ b/pg_lake_table/include/pg_lake/fdw/update_tracking.h
@@ -41,8 +41,8 @@ typedef struct RelationUpdateTrackingState
 
 	/* the slot for inserting row IDs */
 	TupleTableSlot *rowLocationSlot;
-}			RelationUpdateTrackingState;
+} RelationUpdateTrackingState;
 
-bool		BeginRelationUpdateTracking(RelationUpdateTrackingState * state, Oid relationId);
-bool		IsFirstUpdateOfTuple(RelationUpdateTrackingState * state, ItemPointer rowLocation);
-void		FinishRelationUpdateTracking(RelationUpdateTrackingState * state);
+bool		BeginRelationUpdateTracking(RelationUpdateTrackingState *state, Oid relationId);
+bool		IsFirstUpdateOfTuple(RelationUpdateTrackingState *state, ItemPointer rowLocation);
+void		FinishRelationUpdateTracking(RelationUpdateTrackingState *state);

--- a/pg_lake_table/include/pg_lake/fdw/writable_table.h
+++ b/pg_lake_table/include/pg_lake/fdw/writable_table.h
@@ -48,7 +48,7 @@ typedef enum DataFileModificationType
 
 	/* new data file (Parquet) */
 	ADD_DATA_FILE,
-}			DataFileModificationType;
+} DataFileModificationType;
 
 /*
  * DataFileModification represents a batch of modifications to a source file.
@@ -80,7 +80,7 @@ typedef struct DataFileModification
 	/* if the caller already reserved a row ID range, where does it start? */
 	int64		reservedRowIdStart;
 	DataFileStats *fileStats;
-}			DataFileModification;
+} DataFileModification;
 
 
 /* pg_lake_table.copy_on_write_threshold */
@@ -119,7 +119,7 @@ extern PGDLLEXPORT bool TryLockTableForUpdate(Oid relationId);
 
 extern PGDLLEXPORT List *PrepareCSVInsertion(Oid relationId, char *insertCSV, int64 rowCount,
 											 int64 reservedRowIdStart, int maximumLineSize,
-											 DataFileSchema * schema);
+											 DataFileSchema *schema);
 
 extern PGDLLEXPORT int64 AddQueryResultToTable(Oid relationId, char *readQuery,
 											   TupleDesc queryTupleDesc,

--- a/pg_lake_table/include/pg_lake/partitioning/partition_by_parser.h
+++ b/pg_lake_table/include/pg_lake/partitioning/partition_by_parser.h
@@ -25,5 +25,5 @@ extern PGDLLEXPORT const char *GetIcebergTablePartitionByOption(Oid relationId);
 extern List *ParseIcebergTablePartitionBy(Oid relationId);
 extern bool IsIcebergTableWithDefaultPartitionSpec(Oid relationId);
 extern List *AnalyzeIcebergTablePartitionBy(Oid relationId, List *parsedTransforms);
-extern PGType GetTransformResultPGType(IcebergPartitionTransform * transform);
+extern PGType GetTransformResultPGType(IcebergPartitionTransform *transform);
 extern PGDLLEXPORT const char *GetIcebergTablePartitionByOption(Oid relationId);

--- a/pg_lake_table/include/pg_lake/partitioning/partition_spec_catalog.h
+++ b/pg_lake_table/include/pg_lake/partitioning/partition_spec_catalog.h
@@ -37,19 +37,19 @@ typedef struct IcebergPartitionSpecHashEntry
 {
 	int32		specId;			/* hash key: spec id */
 	IcebergPartitionSpec *spec; /* the partition spec */
-}			IcebergPartitionSpecHashEntry;
+} IcebergPartitionSpecHashEntry;
 
 
 extern void UpdateDefaultPartitionSpecId(Oid relationId, int specId);
-extern void InsertPartitionSpecAndPartitionFields(Oid relationId, IcebergPartitionSpec * spec);
+extern void InsertPartitionSpecAndPartitionFields(Oid relationId, IcebergPartitionSpec *spec);
 extern int	GetLargestSpecId(Oid relationId);
 extern List *GetAllIcebergPartitionSpecIds(Oid relationId);
 extern PGDLLEXPORT int GetCurrentSpecId(Oid relationId);
 extern int	GetLargestPartitionFieldId(Oid relationId);
-extern IcebergPartitionSpecField * GetIcebergPartitionFieldFromCatalog(Oid relationId, int fieldId);
+extern IcebergPartitionSpecField *GetIcebergPartitionFieldFromCatalog(Oid relationId, int fieldId);
 extern List *GetIcebergSpecPartitionFieldsFromCatalog(Oid relationId, int specId);
 extern List *GetAllPartitionSpecFields(Oid relationId);
-extern Partition * GetDataFilePartition(Oid relationId, List *partitionTransforms,
-										const char *path, int32 *partitionSpecId);
+extern Partition *GetDataFilePartition(Oid relationId, List *partitionTransforms,
+									   const char *path, int32 *partitionSpecId);
 extern HTAB *GetAllPartitionSpecsFromCatalog(Oid relationId);
 extern HTAB *CreatePartitionSpecHash(void);

--- a/pg_lake_table/include/pg_lake/planner/dbt.h
+++ b/pg_lake_table/include/pg_lake/planner/dbt.h
@@ -29,7 +29,7 @@ typedef struct DbtApplicationQueryContext
 {
 	/* tables that are in the FROM clause of the query */
 	List	   *rtable;
-}			DbtApplicationQueryContext;
+} DbtApplicationQueryContext;
 
 
 extern bool AddForeignTablesToRelkindInArrayFilter(Node *node, void *context);

--- a/pg_lake_table/include/pg_lake/planner/extensible_nodes.h
+++ b/pg_lake_table/include/pg_lake/planner/extensible_nodes.h
@@ -33,14 +33,14 @@
 typedef enum PgLakeNodeTag
 {
 	T_PlannerRelationRestriction = PGL_NODE_TAG_START,
-}			PgLakeNodeTag;
+} PgLakeNodeTag;
 
 
 typedef struct PgLakeNode
 {
 	ExtensibleNode extensible;
 	PgLakeNodeTag pgl_tag;
-}			PgLakeNode;
+} PgLakeNode;
 
 
 /* filled in extensible_nodes.c */

--- a/pg_lake_table/include/pg_lake/planner/restriction_collector.h
+++ b/pg_lake_table/include/pg_lake/planner/restriction_collector.h
@@ -33,7 +33,7 @@ typedef struct PlannerRelationRestriction
 
 	RangeTblEntry *rte;
 	List	   *baseRestrictionList;
-}			PlannerRelationRestriction;
+} PlannerRelationRestriction;
 
 /*
 * Map entry for the restriction map.
@@ -43,7 +43,7 @@ typedef struct RestrictionMapEntry
 	int			uniqueRelationIdentifier;
 
 	PlannerRelationRestriction *relationRestriction;
-}			RestrictionMapEntry;
+} RestrictionMapEntry;
 
 /*
 * Map of PlannerRelationRestrictions.
@@ -52,7 +52,7 @@ typedef struct PlannerRelationRestrictionContext
 {
 	/* mapping uniqueRelationIdentifier to PlannerRelationRestriction */
 	HTAB	   *relationRestrictionMap;
-}			PlannerRelationRestrictionContext;
+} PlannerRelationRestrictionContext;
 
 extern set_rel_pathlist_hook_type PrevRelPathlistHook;
 

--- a/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
+++ b/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
@@ -31,7 +31,7 @@ typedef struct TableMetadataOperationTracker
 	bool		relationDataFileChanged;
 	bool		relationManifestMergeRequested;
 	bool		relationSnapshotExpirationRequested;
-}			TableMetadataOperationTracker;
+} TableMetadataOperationTracker;
 
 
 extern PGDLLEXPORT void ConsumeTrackedIcebergMetadataChanges(bool isVerbose);

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -66,7 +66,7 @@ typedef enum PgLakeDDLType
 	PG_LAKE_DDL_ALTER_TABLE,
 	PG_LAKE_DDL_RENAME_TABLE,
 	PG_LAKE_DDL_SET_SCHEMA,
-}			PgLakeDDLType;
+} PgLakeDDLType;
 
 typedef struct PgLakeDDLTypeInfo
 {
@@ -82,14 +82,14 @@ typedef struct PgLakeDDLTypeInfo
 		ObjectType	renameObjectType;
 		ObjectType	alterSchemaObjectType;
 	}			ddlInfo;
-}			PgLakeDDLTypeInfo;
+} PgLakeDDLTypeInfo;
 
 typedef struct PgLakeDDL
 {
 	PgLakeDDLTypeInfo ddlTypeInfo;
 	bool		(*allowedForIceberg) (Node *, Oid relationId);
 	bool		(*allowedForWritableLake) (Node *, Oid relationId);
-}			PgLakeDDL;
+} PgLakeDDL;
 
 #define ALTER_TABLE_DDL(cmdType, icebergFunc, writableLakeFunc) \
 	{ \
@@ -223,7 +223,7 @@ static void MaybeConvertUnsupportedNumericColumnsToDoubleInAlterStmt(AlterTableS
  * message thrown by regular ProcessUtility.
  */
 bool
-ProcessAlterTable(ProcessUtilityParams * processUtilityParams, void *arg)
+ProcessAlterTable(ProcessUtilityParams *processUtilityParams, void *arg)
 {
 	PlannedStmt *plannedStmt = processUtilityParams->plannedStmt;
 
@@ -476,7 +476,7 @@ ErrorIfUnsupportedTypeAddedForIcebergTables(AlterTableStmt *alterStmt)
 
 
 bool
-ProcessAlterType(ProcessUtilityParams * processUtilityParams, void *arg)
+ProcessAlterType(ProcessUtilityParams *processUtilityParams, void *arg)
 {
 	PlannedStmt *plannedStmt = processUtilityParams->plannedStmt;
 
@@ -523,7 +523,7 @@ ProcessAlterType(ProcessUtilityParams * processUtilityParams, void *arg)
 * in an iceberg table.
 */
 bool
-ProcessEnumStatement(ProcessUtilityParams * processUtilityParams, void *arg)
+ProcessEnumStatement(ProcessUtilityParams *processUtilityParams, void *arg)
 {
 	PlannedStmt *plannedStmt = processUtilityParams->plannedStmt;
 
@@ -551,7 +551,7 @@ ProcessEnumStatement(ProcessUtilityParams * processUtilityParams, void *arg)
 * that is used in an iceberg table.
 */
 bool
-ProcessAlterTypeAttributeRename(ProcessUtilityParams * processUtilityParams, void *arg)
+ProcessAlterTypeAttributeRename(ProcessUtilityParams *processUtilityParams, void *arg)
 {
 	PlannedStmt *plannedStmt = processUtilityParams->plannedStmt;
 
@@ -624,7 +624,7 @@ RequiresNewIcebergSchema(AlterTableStmt *alterStmt)
  * throws an error if it is not.
  */
 void
-PostProcessRenameWritablePgLakeTable(ProcessUtilityParams * params, void *arg)
+PostProcessRenameWritablePgLakeTable(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -709,7 +709,7 @@ PostProcessRenameWritablePgLakeTable(ProcessUtilityParams * params, void *arg)
  * tables and throws an error if it is not.
  */
 void
-PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams * params, void *arg)
+PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -760,13 +760,13 @@ PostProcessAlterWritablePgLakeTableSchema(ProcessUtilityParams * params, void *a
 static const PgLakeDDL *
 FindPgLakeDDL(PgLakeDDLTypeInfo ddlTypeInfo)
 {
-	const		PgLakeDDL *pgLakeDDL = NULL;
+	const PgLakeDDL *pgLakeDDL = NULL;
 
 	int			pgLakeDDLIndex = 0;
 
 	for (pgLakeDDLIndex = 0; pgLakeDDLIndex < N_PG_LAKE_DDLS; pgLakeDDLIndex++)
 	{
-		const		PgLakeDDL *currentPgLakeDDL = &PgLakeDDLs[pgLakeDDLIndex];
+		const PgLakeDDL *currentPgLakeDDL = &PgLakeDDLs[pgLakeDDLIndex];
 
 		if (ddlTypeInfo.ddlType != currentPgLakeDDL->ddlTypeInfo.ddlType)
 		{
@@ -806,7 +806,7 @@ ShouldPgLakeThrowErrorForDDL(PgLakeTableType tableType,
 							 PgLakeDDLTypeInfo ddlTypeInfo,
 							 Node *arg)
 {
-	const		PgLakeDDL *pgLakeDDL = FindPgLakeDDL(ddlTypeInfo);
+	const PgLakeDDL *pgLakeDDL = FindPgLakeDDL(ddlTypeInfo);
 
 	if (pgLakeDDL == NULL)
 	{

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -99,9 +99,9 @@ static void EnsureCreateIcebergTableSupported(CreateStmt *createStmt);
 static List *ExpandTableElements(List *tableElements);
 static List *ExpandTableLikeClause(TableLikeClause *table_like_clause);
 
-static bool ProcessCreateLakeTable(ProcessUtilityParams * params);
-static bool ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params);
-static bool ProcessCreateIcebergTableFromCreateStmt(ProcessUtilityParams * params);
+static bool ProcessCreateLakeTable(ProcessUtilityParams *params);
+static bool ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams *params);
+static bool ProcessCreateIcebergTableFromCreateStmt(ProcessUtilityParams *params);
 static void ErrorIfNotInManagedStorageRegion(char *location);
 static void ErrorIfTypeUnsupportedForIcebergTablesInternal(Oid typeOid, int32 typmod, int level, char *columnName);
 static void ErrorIfLocationIsNotEmpty(const char *location);
@@ -126,7 +126,7 @@ static char *SetIcebergTableLocationOptionFromDefaultPrefix(Oid relationId,
 * converted to int8, etc.)
 */
 void
-CreatePgLakeTableCheckUnsupportedFeaturesPostProcess(ProcessUtilityParams * params, void *arg)
+CreatePgLakeTableCheckUnsupportedFeaturesPostProcess(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -326,7 +326,7 @@ ErrorIfUsingGeometryWithoutSpatialAnalytics(List *columnDefList)
 * combinations such as writable tables without column definitions.
 */
 bool
-ErrorUnsupportedCreatePgLakeTableHandler(ProcessUtilityParams * params, void *arg)
+ErrorUnsupportedCreatePgLakeTableHandler(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -523,7 +523,7 @@ IsConflictingColumnNameForReadParquet(const char *columnName)
  *   - CREATE TABLE name (<col_defs>) USING pg_lake_iceberg WITH (location = <>)
  */
 bool
-ProcessCreatePgLakeTable(ProcessUtilityParams * params, void *arg)
+ProcessCreatePgLakeTable(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -555,7 +555,7 @@ ProcessCreatePgLakeTable(ProcessUtilityParams * params, void *arg)
  * that creates pg_lake tables.
  */
 static bool
-ProcessCreateLakeTable(ProcessUtilityParams * params)
+ProcessCreateLakeTable(ProcessUtilityParams *params)
 {
 	Assert(IsA(params->plannedStmt->utilityStmt, CreateForeignTableStmt));
 
@@ -634,7 +634,7 @@ ProcessCreateLakeTable(ProcessUtilityParams * params)
  * statements that are pg_lake_iceberg tables.
  */
 static bool
-ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
+ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams *params)
 {
 	Assert(IsA(params->plannedStmt->utilityStmt, CreateForeignTableStmt));
 
@@ -1069,7 +1069,7 @@ ErrorIfLocationIsNotEmpty(const char *location)
  * to foreign tables.
  */
 static bool
-ProcessCreateIcebergTableFromCreateStmt(ProcessUtilityParams * params)
+ProcessCreateIcebergTableFromCreateStmt(ProcessUtilityParams *params)
 {
 	Assert(IsA(params->plannedStmt->utilityStmt, CreateStmt));
 

--- a/pg_lake_table/src/ddl/create_table_as_select.c
+++ b/pg_lake_table/src/ddl/create_table_as_select.c
@@ -69,7 +69,7 @@ static uint64 InsertIntoIcebergTable(Query *selectQuery, char *qualifiedTableNam
  * - CREATE TABLE name USING pg_lake_iceberg WITH (location = <>) AS VALUES ( ... )
  */
 bool
-ProcessCreateAsSelectPgLakeTable(ProcessUtilityParams * params, void *arg)
+ProcessCreateAsSelectPgLakeTable(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 

--- a/pg_lake_table/src/ddl/ddl_changes.c
+++ b/pg_lake_table/src/ddl/ddl_changes.c
@@ -42,7 +42,7 @@
 
 static void ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 								   List **droppedColumns, char **metadataLocation,
-								   IcebergPartitionSpec * *partitionSpec,
+								   IcebergPartitionSpec **partitionSpec,
 								   bool *isIcebergTableCreated);
 static bool DDLsRequireIcebergSchemaChange(List *ddlOperations);
 
@@ -90,7 +90,7 @@ ApplyDDLChanges(Oid relationId, List *ddlOperations)
 static void
 ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 					   List **droppedColumns, char **metadataLocation,
-					   IcebergPartitionSpec * *partitionSpec,
+					   IcebergPartitionSpec **partitionSpec,
 					   bool *isIcebergTableCreated)
 {
 	*isIcebergTableCreated = false;

--- a/pg_lake_table/src/ddl/drop_table.c
+++ b/pg_lake_table/src/ddl/drop_table.c
@@ -91,7 +91,7 @@ InitializeDropTableHandler(void)
  * drop pg_lake tables.
  */
 bool
-ProcessDropPgLakeTable(ProcessUtilityParams * params, void *arg)
+ProcessDropPgLakeTable(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -86,7 +86,7 @@ static void PgLakeIcebergVacuumForTables(MemoryContext outOfTransactionMemoryCon
 static bool IsVacuumLakeTable(VacuumStmt *vacuumStmt);
 static List *GetAutoVacuumEnabledTables(List *relationIdList);
 static bool IsAutoVacuumEnabled(Oid relationId);
-static void VacuumLakeTables(ProcessUtilityParams * utilityParams);
+static void VacuumLakeTables(ProcessUtilityParams *utilityParams);
 static List *GetPgLakePartitionIds(Oid relationId);
 static bool ProcessVacuumPgLakeIcebergFlag(VacuumStmt *vacuumStmt);
 static void VacuumCompactDataFiles(Oid relationId, bool isFull, bool isVerbose);
@@ -349,7 +349,7 @@ IsAutoVacuumEnabled(Oid relationId)
  * VACUUM statements on pg_lake tables
  */
 bool
-ProcessVacuumPgLakeTable(ProcessUtilityParams * params, void *arg)
+ProcessVacuumPgLakeTable(ProcessUtilityParams *params, void *arg)
 {
 	PlannedStmt *plannedStmt = params->plannedStmt;
 
@@ -465,7 +465,7 @@ IsVacuumLakeTable(VacuumStmt *vacuumStmt)
  * tables and then proceeds with regular VACUUM for the remaining tables.
  */
 static void
-VacuumLakeTables(ProcessUtilityParams * utilityParams)
+VacuumLakeTables(ProcessUtilityParams *utilityParams)
 {
 	Assert(IsA(utilityParams->plannedStmt->utilityStmt, VacuumStmt));
 	VacuumStmt *vacuumStmt = (VacuumStmt *) utilityParams->plannedStmt->utilityStmt;

--- a/pg_lake_table/src/duckdb/transform_query_to_duckdb.c
+++ b/pg_lake_table/src/duckdb/transform_query_to_duckdb.c
@@ -58,7 +58,7 @@
 #include "pg_lake/util/rel_utils.h"
 #include "pg_lake/util/string_utils.h"
 
-static char *BuildReadDataSourceQueryForTableScan(PgLakeTableScan * tableScan,
+static char *BuildReadDataSourceQueryForTableScan(PgLakeTableScan *tableScan,
 												  bool skipFullMatchFiles,
 												  TupleDesc projection);
 static void EnsureServerType(Oid relationId);
@@ -75,7 +75,7 @@ static void EnsureServerType(Oid relationId);
  */
 char *
 ReplaceReadTableFunctionCalls(char *query,
-							  PgLakeScanSnapshot * snapshot,
+							  PgLakeScanSnapshot *snapshot,
 							  int scanFlags)
 {
 	bool		explainRequested = (scanFlags & EXPLAIN_REQUESTED) != 0;
@@ -155,7 +155,7 @@ ReplaceReadTableFunctionCalls(char *query,
  * If parentDesc is specified, use it
  */
 static char *
-BuildReadDataSourceQueryForTableScan(PgLakeTableScan * tableScan, bool skipFullMatchFiles, TupleDesc projection)
+BuildReadDataSourceQueryForTableScan(PgLakeTableScan *tableScan, bool skipFullMatchFiles, TupleDesc projection)
 {
 	Oid			relationId = tableScan->relationId;
 	ForeignTable *foreignTable = GetForeignTable(relationId);

--- a/pg_lake_table/src/fdw/data_file_pruning.c
+++ b/pg_lake_table/src/fdw/data_file_pruning.c
@@ -101,7 +101,7 @@ typedef struct ColumnToFieldIdMapping
 
 	bool		constByVal;
 	int16		typLen;
-}			ColumnToFieldIdMapping;
+} ColumnToFieldIdMapping;
 
 static HTAB *CreateFieldIdMappingHash(void);
 static void AddFieldIdsUsedInQuery(HTAB *fieldIdsToUseInBounds, Oid relationId,
@@ -110,11 +110,11 @@ static void AddFieldIdsUsedInQuery(HTAB *fieldIdsToUseInBounds, Oid relationId,
 static List *GetPartitionSpecFieldsUsedInQuery(Oid relationId, HTAB *fieldIdsToUseInBounds);
 static List *GetExternalIcebergFieldsForAttributes(Oid relationId, List *attrNos);
 static List *GetColumnBoundConstraints(Oid relationId, HTAB *fieldIdCache, List *columnStats,
-									   List *partitionTransformsUsedInQuery, Partition * partition);
+									   List *partitionTransformsUsedInQuery, Partition *partition);
 static List *GetColumnBoundConstraintsFromColumnStats(Oid relationId, List *columnStats,
-													  ColumnToFieldIdMapping * entry);
-static List *GetColumnBoundConstraintsFromPartition(Oid relationId, ColumnToFieldIdMapping * entry,
-													List *partitionTransformsUsedInQuery, Partition * partition);
+													  ColumnToFieldIdMapping *entry);
+static List *GetColumnBoundConstraintsFromPartition(Oid relationId, ColumnToFieldIdMapping *entry,
+													List *partitionTransformsUsedInQuery, Partition *partition);
 static void StripAllImplicitCoercionsInList(List *baseRestrictInfoList);
 static Node *StripAllImplicitCoercions(Node *expr);
 static Node *StripAllImplicitCoercionsMutator(Node *node, void *context);
@@ -129,44 +129,44 @@ static Oid	GetOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumbe
 static HTAB *TryCreateBatchFilterHash(List *baseRestrictInfoList, Var *filenameCol);
 
 /* partition pruning functions */
-static Expr *PartitionFieldBoundConstraint(PartitionField * partitionField,
-										   IcebergPartitionTransform * partitionTransform,
-										   ColumnToFieldIdMapping * entry);
-static BoolExpr *TruncatePartitionFieldBoundConstraint(PartitionField * partitionField,
-													   IcebergPartitionTransform * partitionTransform,
-													   ColumnToFieldIdMapping * entry);
+static Expr *PartitionFieldBoundConstraint(PartitionField *partitionField,
+										   IcebergPartitionTransform *partitionTransform,
+										   ColumnToFieldIdMapping *entry);
+static BoolExpr *TruncatePartitionFieldBoundConstraint(PartitionField *partitionField,
+													   IcebergPartitionTransform *partitionTransform,
+													   ColumnToFieldIdMapping *entry);
 
-static Expr *IdentityPartitionFieldBoundConstraint(PartitionField * partitionField,
-												   IcebergPartitionTransform * partitionTransform,
-												   ColumnToFieldIdMapping * entry);
-static BoolExpr *YearPartitionFieldBoundConstraint(PartitionField * partitionField,
-												   IcebergPartitionTransform * partitionTransform,
-												   ColumnToFieldIdMapping * entry);
-static BoolExpr *MonthPartitionFieldBoundConstraint(PartitionField * partitionField,
-													IcebergPartitionTransform * partitionTransform,
-													ColumnToFieldIdMapping * entry);
-static BoolExpr *DayPartitionFieldBoundConstraint(PartitionField * partitionField,
-												  IcebergPartitionTransform * partitionTransform,
-												  ColumnToFieldIdMapping * entry);
-static BoolExpr *HourPartitionFieldBoundConstraint(PartitionField * partitionField,
-												   IcebergPartitionTransform * partitionTransform,
-												   ColumnToFieldIdMapping * entry);
-static OpExpr *BucketPartitionFieldBoundConstraint(PartitionField * partitionField,
-												   IcebergPartitionTransform * partitionTransform,
-												   ColumnToFieldIdMapping * entry);
+static Expr *IdentityPartitionFieldBoundConstraint(PartitionField *partitionField,
+												   IcebergPartitionTransform *partitionTransform,
+												   ColumnToFieldIdMapping *entry);
+static BoolExpr *YearPartitionFieldBoundConstraint(PartitionField *partitionField,
+												   IcebergPartitionTransform *partitionTransform,
+												   ColumnToFieldIdMapping *entry);
+static BoolExpr *MonthPartitionFieldBoundConstraint(PartitionField *partitionField,
+													IcebergPartitionTransform *partitionTransform,
+													ColumnToFieldIdMapping *entry);
+static BoolExpr *DayPartitionFieldBoundConstraint(PartitionField *partitionField,
+												  IcebergPartitionTransform *partitionTransform,
+												  ColumnToFieldIdMapping *entry);
+static BoolExpr *HourPartitionFieldBoundConstraint(PartitionField *partitionField,
+												   IcebergPartitionTransform *partitionTransform,
+												   ColumnToFieldIdMapping *entry);
+static OpExpr *BucketPartitionFieldBoundConstraint(PartitionField *partitionField,
+												   IcebergPartitionTransform *partitionTransform,
+												   ColumnToFieldIdMapping *entry);
 
 static OpExpr *CreateConstraintWithEquality(OpExpr *eqOp, bool constByVal, int16 typLen,
 											Datum equalityDatum);
 static char *TruncateUpperBoundForText(char *upperBound, size_t truncateLen);
 static bytea *TruncateUpperBoundForBytea(bytea *data, int truncateLen);
-static List *ExtendClausesForBucketPartitioning(Partition * partition,
+static List *ExtendClausesForBucketPartitioning(Partition *partition,
 												List *partitionTransformsUsedInQuery,
 												HTAB *fieldIdMapping,
 												List *baseRestrictInfoList);
 static List *ExtendBaseRestrictInfoForBucketPartition(List *baseRestrictInfoList,
-													  IcebergPartitionTransform * partitionTransform,
+													  IcebergPartitionTransform *partitionTransform,
 													  OpExpr *syntheticColEqualityOperator);
-static OpExpr *GetSyntheticBucketForPartitionField(PartitionField * partitionField,
+static OpExpr *GetSyntheticBucketForPartitionField(PartitionField *partitionField,
 												   OpExpr *syntheticColEqualityOperator);
 static Const *ConstantEqualityOperatorExpressionOnColumn(Expr *clause, AttrNumber attrNo);
 static bool EqualityOperator(Oid opno);
@@ -516,7 +516,7 @@ AddFieldIdsUsedInQuery(HTAB *fieldIdsUsedInQuery, Oid relationId, PgLakeTablePro
 */
 static List *
 GetColumnBoundConstraints(Oid relationId, HTAB *fieldIdMapping, List *columnStats,
-						  List *partitionTransformsUsedInQuery, Partition * partition)
+						  List *partitionTransformsUsedInQuery, Partition *partition)
 {
 	List	   *constraintList = NIL;
 
@@ -568,7 +568,7 @@ GetColumnBoundConstraints(Oid relationId, HTAB *fieldIdMapping, List *columnStat
 */
 static List *
 GetColumnBoundConstraintsFromColumnStats(Oid relationId, List *columnStats,
-										 ColumnToFieldIdMapping * entry)
+										 ColumnToFieldIdMapping *entry)
 {
 	List	   *constraintList = NIL;
 	ListCell   *columnStatCell = NULL;
@@ -674,8 +674,8 @@ GetColumnBoundConstraintsFromColumnStats(Oid relationId, List *columnStats,
 * statistics stored in iceberg metadata.
 */
 static List *
-GetColumnBoundConstraintsFromPartition(Oid relationId, ColumnToFieldIdMapping * entry,
-									   List *partitionTransformsUsedInQuery, Partition * partition)
+GetColumnBoundConstraintsFromPartition(Oid relationId, ColumnToFieldIdMapping *entry,
+									   List *partitionTransformsUsedInQuery, Partition *partition)
 {
 	List	   *constraintList = NIL;
 	int			partitionFieldCount = partition ? partition->fields_length : 0;
@@ -714,8 +714,8 @@ GetColumnBoundConstraintsFromPartition(Oid relationId, ColumnToFieldIdMapping * 
 * partition transform.
 */
 static Expr *
-PartitionFieldBoundConstraint(PartitionField * partitionField, IcebergPartitionTransform * partitionTransform,
-							  ColumnToFieldIdMapping * entry)
+PartitionFieldBoundConstraint(PartitionField *partitionField, IcebergPartitionTransform *partitionTransform,
+							  ColumnToFieldIdMapping *entry)
 {
 	IcebergPartitionTransformType type = partitionTransform->type;
 
@@ -760,9 +760,9 @@ PartitionFieldBoundConstraint(PartitionField * partitionField, IcebergPartitionT
 *   column = partitionField->value
 */
 static Expr *
-IdentityPartitionFieldBoundConstraint(PartitionField * partitionField,
-									  IcebergPartitionTransform * partitionTransform,
-									  ColumnToFieldIdMapping * entry)
+IdentityPartitionFieldBoundConstraint(PartitionField *partitionField,
+									  IcebergPartitionTransform *partitionTransform,
+									  ColumnToFieldIdMapping *entry)
 {
 	/* non-null values */
 	if (partitionField->value != NULL)
@@ -788,9 +788,9 @@ IdentityPartitionFieldBoundConstraint(PartitionField * partitionField,
 * TruncatePartitionFieldBoundConstraint
 */
 static BoolExpr *
-TruncatePartitionFieldBoundConstraint(PartitionField * partitionField,
-									  IcebergPartitionTransform * partitionTransform,
-									  ColumnToFieldIdMapping * entry)
+TruncatePartitionFieldBoundConstraint(PartitionField *partitionField,
+									  IcebergPartitionTransform *partitionTransform,
+									  ColumnToFieldIdMapping *entry)
 {
 	BoolExpr   *columnBoundExclusiveUpper = copyObject(entry->columnBoundExclusiveUpper);
 	PGType		pgType = partitionTransform->pgType;
@@ -896,9 +896,9 @@ TruncatePartitionFieldBoundConstraint(PartitionField * partitionField,
 * YearPartitionFieldBoundConstraint
 */
 static BoolExpr *
-YearPartitionFieldBoundConstraint(PartitionField * partitionField,
-								  IcebergPartitionTransform * partitionTransform,
-								  ColumnToFieldIdMapping * entry)
+YearPartitionFieldBoundConstraint(PartitionField *partitionField,
+								  IcebergPartitionTransform *partitionTransform,
+								  ColumnToFieldIdMapping *entry)
 {
 	BoolExpr   *columnBoundExclusiveUpper = copyObject(entry->columnBoundExclusiveUpper);
 	PGType		pgType = partitionTransform->pgType;
@@ -955,9 +955,9 @@ YearPartitionFieldBoundConstraint(PartitionField * partitionField,
 * MonthPartitionFieldBoundConstraint
 */
 static BoolExpr *
-MonthPartitionFieldBoundConstraint(PartitionField * partitionField,
-								   IcebergPartitionTransform * partitionTransform,
-								   ColumnToFieldIdMapping * entry)
+MonthPartitionFieldBoundConstraint(PartitionField *partitionField,
+								   IcebergPartitionTransform *partitionTransform,
+								   ColumnToFieldIdMapping *entry)
 {
 	BoolExpr   *columnBoundExclusiveUpper = copyObject(entry->columnBoundExclusiveUpper);
 	PGType		pgType = partitionTransform->pgType;
@@ -1013,9 +1013,9 @@ MonthPartitionFieldBoundConstraint(PartitionField * partitionField,
 * DayPartitionFieldBoundConstraint
 */
 static BoolExpr *
-DayPartitionFieldBoundConstraint(PartitionField * partitionField,
-								 IcebergPartitionTransform * partitionTransform,
-								 ColumnToFieldIdMapping * entry)
+DayPartitionFieldBoundConstraint(PartitionField *partitionField,
+								 IcebergPartitionTransform *partitionTransform,
+								 ColumnToFieldIdMapping *entry)
 {
 	BoolExpr   *columnBoundExclusiveUpper = copyObject(entry->columnBoundExclusiveUpper);
 	PGType		pgType = partitionTransform->pgType;
@@ -1070,9 +1070,9 @@ DayPartitionFieldBoundConstraint(PartitionField * partitionField,
 * HourPartitionFieldBoundConstraint
 */
 static BoolExpr *
-HourPartitionFieldBoundConstraint(PartitionField * partitionField,
-								  IcebergPartitionTransform * partitionTransform,
-								  ColumnToFieldIdMapping * entry)
+HourPartitionFieldBoundConstraint(PartitionField *partitionField,
+								  IcebergPartitionTransform *partitionTransform,
+								  ColumnToFieldIdMapping *entry)
 {
 	BoolExpr   *columnBoundExclusiveUpper = copyObject(entry->columnBoundExclusiveUpper);
 	PGType		pgType = partitionTransform->pgType;
@@ -1153,9 +1153,9 @@ HourPartitionFieldBoundConstraint(PartitionField * partitionField,
 * BucketPartitionFieldBoundConstraint
 */
 static OpExpr *
-BucketPartitionFieldBoundConstraint(PartitionField * partitionField,
-									IcebergPartitionTransform * partitionTransform,
-									ColumnToFieldIdMapping * entry)
+BucketPartitionFieldBoundConstraint(PartitionField *partitionField,
+									IcebergPartitionTransform *partitionTransform,
+									ColumnToFieldIdMapping *entry)
 {
 	if (entry->syntheticColEqualityOperator == NULL)
 	{
@@ -1808,7 +1808,7 @@ GetExternalIcebergFieldsForAttributes(Oid relationId, List *columnsUsedInFilters
 * bucket partition transform always returns int32.
 */
 static OpExpr *
-GetSyntheticBucketForPartitionField(PartitionField * partitionField,
+GetSyntheticBucketForPartitionField(PartitionField *partitionField,
 									OpExpr *syntheticColEqualityOperator)
 {
 	/*
@@ -1836,7 +1836,7 @@ GetSyntheticBucketForPartitionField(PartitionField * partitionField,
 * where partition_col is the column that is used for bucket partition transforms.
 */
 static List *
-ExtendClausesForBucketPartitioning(Partition * partition, List *partitionTransformsUsedInQuery,
+ExtendClausesForBucketPartitioning(Partition *partition, List *partitionTransformsUsedInQuery,
 								   HTAB *fieldIdMapping, List *clauses)
 {
 	List	   *syntheticClauseList = NIL;
@@ -1889,7 +1889,7 @@ ExtendClausesForBucketPartitioning(Partition * partition, List *partitionTransfo
 */
 static List *
 ExtendBaseRestrictInfoForBucketPartition(List *clauses,
-										 IcebergPartitionTransform * partitionTransform,
+										 IcebergPartitionTransform *partitionTransform,
 										 OpExpr *syntheticColEqualityOperator)
 {
 	AttrNumber	columnAttrNo = partitionTransform->attnum;

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -75,8 +75,8 @@
 PgLakeAddDataFileHookType PgLakeAddDataFileHook = NULL;
 
 
-static void FillDataFileColumnStats(TableDataFile * dataFile, int64 fieldId, int rowIndex);
-static void FillPartitionFieldFromCatalog(TableDataFile * dataFile, List *partitionTransforms,
+static void FillDataFileColumnStats(TableDataFile *dataFile, int64 fieldId, int rowIndex);
+static void FillPartitionFieldFromCatalog(TableDataFile *dataFile, List *partitionTransforms,
 										  int64 partitionFieldId, int rowIndex);
 static int64 AddDataFileToTable(Oid relationId, const char *path, int64 rowCount,
 								int64 fileSize, DataFileContent content, int64 rowIdStart);
@@ -91,12 +91,12 @@ static HTAB *CreateDataFilesHash(void);
 static HTAB *CreateDataFilesByPathHash(void);
 static List *TableDataFileHashToList(HTAB *dataFiles);
 static bool ColumnStatAlreadyAdded(List *columnStats, int64 fieldId);
-static bool PartitionFieldAlreadyAdded(Partition * partition, int64 fieldId);
+static bool PartitionFieldAlreadyAdded(Partition *partition, int64 fieldId);
 static void CreateTxDataFileIdsTempTableIfNotExists(void);
 static void InsertDataFileIdIntoTransactionTable(int64 fileId);
-static DataFileColumnStats * CreateDataFileColumnStats(int fieldId, PGType pgType,
-													   char *lowerBoundText,
-													   char *upperBoundText);
+static DataFileColumnStats *CreateDataFileColumnStats(int fieldId, PGType pgType,
+													  char *lowerBoundText,
+													  char *upperBoundText);
 
 /*
  * GetTableDataFilesFromCatalog returns a list of TableDataFile for each data and deletion file
@@ -392,7 +392,7 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 * from the catalog. It is a helper function for GetTableDataFilesFromCatalog.
 */
 static void
-FillDataFileColumnStats(TableDataFile * dataFile, int64 fieldId, int rowIndex)
+FillDataFileColumnStats(TableDataFile *dataFile, int64 fieldId, int rowIndex)
 {
 	bool		isPgTypeNull = false;
 	bool		isPgTypeModNull = false;
@@ -433,7 +433,7 @@ FillDataFileColumnStats(TableDataFile * dataFile, int64 fieldId, int rowIndex)
 * the catalog. It is a helper function for GetTableDataFilesFromCatalog.
 */
 static void
-FillPartitionFieldFromCatalog(TableDataFile * dataFile, List *partitionTransforms, int64 partitionFieldId,
+FillPartitionFieldFromCatalog(TableDataFile *dataFile, List *partitionTransforms, int64 partitionFieldId,
 							  int rowIndex)
 {
 	/* not null enforced by the catalog */
@@ -482,7 +482,7 @@ FillPartitionFieldFromCatalog(TableDataFile * dataFile, List *partitionTransform
 * present in the partition.
 */
 static bool
-PartitionFieldAlreadyAdded(Partition * partition, int64 fieldId)
+PartitionFieldAlreadyAdded(Partition *partition, int64 fieldId)
 {
 	for (int i = 0; i < partition->fields_length; i++)
 	{
@@ -1360,7 +1360,7 @@ ApplyDataFileCatalogChanges(Oid relationId, List *metadataOperations)
  */
 void
 AddDataFilePartitionValueToCatalog(Oid relationId, int32 partitionSpecId, int64 fileId,
-								   Partition * partition)
+								   Partition *partition)
 {
 	Assert(partition != NULL);
 	Assert(partition->fields_length > 0);

--- a/pg_lake_table/src/fdw/deparse_ruleutils.c
+++ b/pg_lake_table/src/fdw/deparse_ruleutils.c
@@ -59,7 +59,7 @@ typedef struct ReplacePgLakeTableContext
 
 	/* whether a ctid Var is present */
 	bool		hasCtidVar;
-}			ReplacePgLakeTableContext;
+} ReplacePgLakeTableContext;
 
 typedef struct FixCtidVarContext
 {
@@ -68,13 +68,13 @@ typedef struct FixCtidVarContext
 
 	/* range table of the current query */
 	List	   *rtable;
-}			FixCtidVarContext;
+} FixCtidVarContext;
 
 static char *DeparseQualifiedQuery(Query *query);
 static bool ReplacePgLakeTableWalker(Node *node,
-									 ReplacePgLakeTableContext * context);
+									 ReplacePgLakeTableContext *context);
 static bool FixCtidVarWalker(Node *node,
-							 FixCtidVarContext * context);
+							 FixCtidVarContext *context);
 
 /*
  * ReplacePgLakeTableWithReadTableFunc replaces all occurrences of
@@ -139,7 +139,7 @@ RteListToOidList(List *rteList)
 * the context.
 */
 static bool
-ReplacePgLakeTableWalker(Node *node, ReplacePgLakeTableContext * context)
+ReplacePgLakeTableWalker(Node *node, ReplacePgLakeTableContext *context)
 {
 	if (node == NULL)
 	{
@@ -239,7 +239,7 @@ ReplacePgLakeTableWalker(Node *node, ReplacePgLakeTableContext * context)
 * since they cannot have attribute number -1.
 */
 static bool
-FixCtidVarWalker(Node *node, FixCtidVarContext * context)
+FixCtidVarWalker(Node *node, FixCtidVarContext *context)
 {
 	if (node == NULL)
 	{

--- a/pg_lake_table/src/fdw/multi_data_file_dest.c
+++ b/pg_lake_table/src/fdw/multi_data_file_dest.c
@@ -102,11 +102,11 @@ typedef struct MultiDataFileUploadDestReceiver
 	 * dest receiver).
 	 */
 	int			maxWriteTempFileSizeMB;
-}			MultiDataFileUploadDestReceiver;
+} MultiDataFileUploadDestReceiver;
 
 
-static void CreateChildDestReceiver(MultiDataFileUploadDestReceiver * self);
-static void FlushChildDestReceiver(MultiDataFileUploadDestReceiver * self);
+static void CreateChildDestReceiver(MultiDataFileUploadDestReceiver *self);
+static void FlushChildDestReceiver(MultiDataFileUploadDestReceiver *self);
 static void StartDestReceiver(DestReceiver *self, int operation, TupleDesc typeinfo);
 static bool ReceiveSlot(TupleTableSlot *slot, DestReceiver *self);
 static void ShutdownDestReceiver(DestReceiver *self);
@@ -179,7 +179,7 @@ CreateMultiDataFileDestReceiver(Oid relationId,
  * CreateChildDestReceiver creates the DestReceiver for the current file.
  */
 static void
-CreateChildDestReceiver(MultiDataFileUploadDestReceiver * self)
+CreateChildDestReceiver(MultiDataFileUploadDestReceiver *self)
 {
 	/* use the same memory context that was used to create the DestReceiver */
 	MemoryContext oldContext = MemoryContextSwitchTo(self->childContext);
@@ -205,7 +205,7 @@ CreateChildDestReceiver(MultiDataFileUploadDestReceiver * self)
  * one or more data files.
  */
 static void
-FlushChildDestReceiver(MultiDataFileUploadDestReceiver * self)
+FlushChildDestReceiver(MultiDataFileUploadDestReceiver *self)
 {
 	self->currentDest->rShutdown(self->currentDest);
 

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -54,15 +54,15 @@ typedef struct PgLakeOption
 {
 	const char *keyword;
 	Oid			optcontext;		/* OID of catalog in which option may appear */
-}			PgLakeOption;
+} PgLakeOption;
 
 
 /*
  * Valid options for lake_table.
  * Allocated and filled in InitPgLakeOptions.
  */
-static PgLakeOption * pg_lake_options;
-static PgLakeOption * pg_lake_iceberg_options;
+static PgLakeOption *pg_lake_options;
+static PgLakeOption *pg_lake_iceberg_options;
 
 /*
  * Helper functions

--- a/pg_lake_table/src/fdw/partition_transform.c
+++ b/pg_lake_table/src/fdw/partition_transform.c
@@ -40,34 +40,34 @@
 #include "pg_lake/util/rel_utils.h"
 #include "pg_lake/util/timetz.h"
 
-static PartitionField * ApplyPartitionTransformToTuple(IcebergPartitionTransform * transform,
-													   TupleTableSlot *slot);
-static void *ApplyIdentityTransformToColumn(IcebergPartitionTransform * transform,
+static PartitionField *ApplyPartitionTransformToTuple(IcebergPartitionTransform *transform,
+													  TupleTableSlot *slot);
+static void *ApplyIdentityTransformToColumn(IcebergPartitionTransform *transform,
 											Datum columnValue, bool isNull,
 											size_t *valueSize);
-static void *ApplyTruncateTransformToColumn(IcebergPartitionTransform * transform,
+static void *ApplyTruncateTransformToColumn(IcebergPartitionTransform *transform,
 											Datum columnValue, bool isNull,
 											size_t *valueSize);
-static void *ApplyYearTransformToColumn(IcebergPartitionTransform * transform,
+static void *ApplyYearTransformToColumn(IcebergPartitionTransform *transform,
 										Datum columnValue, bool isNull,
 										size_t *valueSize);
-static void *ApplyMonthTransformToColumn(IcebergPartitionTransform * transform,
+static void *ApplyMonthTransformToColumn(IcebergPartitionTransform *transform,
 										 Datum columnValue, bool isNull,
 										 size_t *valueSize);
-static void *ApplyDayTransformToColumn(IcebergPartitionTransform * transform,
+static void *ApplyDayTransformToColumn(IcebergPartitionTransform *transform,
 									   Datum columnValue, bool isNull,
 									   size_t *valueSize);
-static void *ApplyHourTransformToColumn(IcebergPartitionTransform * transform,
+static void *ApplyHourTransformToColumn(IcebergPartitionTransform *transform,
 										Datum columnValue, bool isNull,
 										size_t *valueSize);
-static IcebergPartitionTransform * GetPartitionTransformFromSpecField(Oid relationId,
-																	  IcebergPartitionSpecField * specField);
-static void ParseTransformName(const char *name, IcebergPartitionTransformType * type,
+static IcebergPartitionTransform *GetPartitionTransformFromSpecField(Oid relationId,
+																	 IcebergPartitionSpecField *specField);
+static void ParseTransformName(const char *name, IcebergPartitionTransformType *type,
 							   size_t *bucketCount, size_t *truncateLen);
 static bool ParseBracketUintSize(const char *name, const char *prefix, size_t *outVal);
-static void *DatumToPartitionValue(IcebergPartitionTransform * transform, Datum columnValue, bool isNull,
+static void *DatumToPartitionValue(IcebergPartitionTransform *transform, Datum columnValue, bool isNull,
 								   size_t *valuelength);
-static bool PartitionTransformsEqual(IcebergPartitionSpec * spec, List *partitionTransforms);
+static bool PartitionTransformsEqual(IcebergPartitionSpec *spec, List *partitionTransforms);
 
 /*
  * ComputePartitionTupleForTuple applies relative partition transforms
@@ -137,7 +137,7 @@ GetPartitionSpecIfAlreadyExist(Oid relationId, List *partitionTransforms)
 * if they are equal, false otherwise.
 */
 static bool
-PartitionTransformsEqual(IcebergPartitionSpec * spec, List *partitionTransforms)
+PartitionTransformsEqual(IcebergPartitionSpec *spec, List *partitionTransforms)
 {
 	if (spec->fields_length != list_length(partitionTransforms))
 		return false;
@@ -248,7 +248,7 @@ GetPartitionTransformsFromSpecFields(Oid relationId, List *specFields)
 * bucket count, and truncate length for ease of use.
 */
 static IcebergPartitionTransform *
-GetPartitionTransformFromSpecField(Oid relationId, IcebergPartitionSpecField * specField)
+GetPartitionTransformFromSpecField(Oid relationId, IcebergPartitionSpecField *specField)
 {
 	IcebergPartitionTransform *transform = palloc0(sizeof(IcebergPartitionTransform));
 
@@ -298,7 +298,7 @@ GetPartitionTransformFromSpecField(Oid relationId, IcebergPartitionSpecField * s
  */
 static void
 ParseTransformName(const char *name,
-				   IcebergPartitionTransformType * type,
+				   IcebergPartitionTransformType *type,
 				   size_t *bucketCount,
 				   size_t *truncateLen)
 {
@@ -410,7 +410,7 @@ ParseBracketUintSize(const char *name, const char *prefix, size_t *outVal)
  * and returns the partition field.
  */
 static PartitionField *
-ApplyPartitionTransformToTuple(IcebergPartitionTransform * transform, TupleTableSlot *slot)
+ApplyPartitionTransformToTuple(IcebergPartitionTransform *transform, TupleTableSlot *slot)
 {
 	PartitionField *field = palloc0(sizeof(PartitionField));
 
@@ -469,7 +469,7 @@ ApplyPartitionTransformToTuple(IcebergPartitionTransform * transform, TupleTable
  * and returns the computed partition value.
  */
 static void *
-ApplyIdentityTransformToColumn(IcebergPartitionTransform * transform, Datum columnValue,
+ApplyIdentityTransformToColumn(IcebergPartitionTransform *transform, Datum columnValue,
 							   bool isNull, size_t *valueSize)
 {
 	if (isNull)
@@ -488,7 +488,7 @@ ApplyIdentityTransformToColumn(IcebergPartitionTransform * transform, Datum colu
  * and returns the computed partition value.
  */
 static void *
-ApplyTruncateTransformToColumn(IcebergPartitionTransform * transform, Datum columnValue,
+ApplyTruncateTransformToColumn(IcebergPartitionTransform *transform, Datum columnValue,
 							   bool isNull, size_t *valueSize)
 {
 	if (isNull)
@@ -549,7 +549,7 @@ ApplyTruncateTransformToColumn(IcebergPartitionTransform * transform, Datum colu
  * and returns the computed partition value.
  */
 static void *
-ApplyYearTransformToColumn(IcebergPartitionTransform * transform, Datum columnValue, bool isNull,
+ApplyYearTransformToColumn(IcebergPartitionTransform *transform, Datum columnValue, bool isNull,
 						   size_t *valueSize)
 {
 	if (isNull)
@@ -599,7 +599,7 @@ ApplyYearTransformToColumn(IcebergPartitionTransform * transform, Datum columnVa
  * and returns the computed partition value.
  */
 static void *
-ApplyMonthTransformToColumn(IcebergPartitionTransform * transform, Datum columnValue, bool isNull,
+ApplyMonthTransformToColumn(IcebergPartitionTransform *transform, Datum columnValue, bool isNull,
 							size_t *valueSize)
 {
 	if (isNull)
@@ -649,7 +649,7 @@ ApplyMonthTransformToColumn(IcebergPartitionTransform * transform, Datum columnV
  * and returns the computed partition value.
  */
 static void *
-ApplyDayTransformToColumn(IcebergPartitionTransform * transform, Datum columnValue, bool isNull,
+ApplyDayTransformToColumn(IcebergPartitionTransform *transform, Datum columnValue, bool isNull,
 						  size_t *valueSize)
 {
 	if (isNull)
@@ -699,7 +699,7 @@ ApplyDayTransformToColumn(IcebergPartitionTransform * transform, Datum columnVal
  * and returns the computed partition value.
  */
 static void *
-ApplyHourTransformToColumn(IcebergPartitionTransform * transform, Datum columnValue, bool isNull,
+ApplyHourTransformToColumn(IcebergPartitionTransform *transform, Datum columnValue, bool isNull,
 						   size_t *valueSize)
 {
 	if (isNull)
@@ -756,7 +756,7 @@ ApplyHourTransformToColumn(IcebergPartitionTransform * transform, Datum columnVa
  * and returns the computed partition value.
  */
 void *
-ApplyBucketTransformToColumn(IcebergPartitionTransform * transform, Datum columnValue, bool isNull,
+ApplyBucketTransformToColumn(IcebergPartitionTransform *transform, Datum columnValue, bool isNull,
 							 size_t *bucketSize)
 {
 	if (isNull)
@@ -883,7 +883,7 @@ ApplyBucketTransformToColumn(IcebergPartitionTransform * transform, Datum column
  * GetTransformResultAvroType returns the result type of the transform.
  */
 IcebergScalarAvroType
-GetTransformResultAvroType(IcebergPartitionTransform * transform)
+GetTransformResultAvroType(IcebergPartitionTransform *transform)
 {
 	IcebergScalarAvroType type = {0};
 
@@ -985,7 +985,7 @@ GetTransformResultAvroType(IcebergPartitionTransform * transform)
  * SerializePartitionValueToPGText returns Postgres text representation of the partition field value.
  */
 const char *
-SerializePartitionValueToPGText(void *value, size_t valueLength, IcebergPartitionTransform * transform)
+SerializePartitionValueToPGText(void *value, size_t valueLength, IcebergPartitionTransform *transform)
 {
 	if (value == NULL)
 	{
@@ -1016,7 +1016,7 @@ SerializePartitionValueToPGText(void *value, size_t valueLength, IcebergPartitio
  * from the given Postgres text representation.
  */
 void *
-DeserializePartitionValueFromPGText(IcebergPartitionTransform * transform,
+DeserializePartitionValueFromPGText(IcebergPartitionTransform *transform,
 									const char *valueText, size_t *valueLength)
 {
 	if (valueText == NULL)
@@ -1102,7 +1102,7 @@ PartitionValueToDatum(IcebergPartitionTransformType transformType, void *value, 
  * DatumToPartitionValue converts the column value to a partition value.
  */
 static void *
-DatumToPartitionValue(IcebergPartitionTransform * transform, Datum columnValue, bool isNull,
+DatumToPartitionValue(IcebergPartitionTransform *transform, Datum columnValue, bool isNull,
 					  size_t *valueLength)
 {
 	if (isNull)

--- a/pg_lake_table/src/fdw/partitioning/partition_by_parser.c
+++ b/pg_lake_table/src/fdw/partitioning/partition_by_parser.c
@@ -43,12 +43,12 @@ static void SkipWhitespace(const char **ptr);
 static int	ParseInteger(const char **ptr);
 static char *ParseIdentifier(const char **ptr);
 static IcebergPartitionTransformType LookupTransformType(const char *str);
-static IcebergPartitionTransform * ParseOneTransform(const char **ptr);
+static IcebergPartitionTransform *ParseOneTransform(const char **ptr);
 static const char *NormalizeTransformColumnName(const char *colName);
 
 /* analyzer helpers */
-static void EnsureTransformSourceColumnExists(IcebergPartitionTransform * transform, Oid relationId);
-static void EnsureTransformSourceColumnScalar(IcebergPartitionTransform * transform, DataFileSchemaField * sourceField);
+static void EnsureTransformSourceColumnExists(IcebergPartitionTransform *transform, Oid relationId);
+static void EnsureTransformSourceColumnScalar(IcebergPartitionTransform *transform, DataFileSchemaField *sourceField);
 static void EnsureNoDuplicateTransforms(List *transforms);
 static void EnsureValidTypeForTransform(IcebergPartitionTransformType transformType, Oid typeOid);
 static void EnsureValidTypeForIdentityTransform(Oid typeOid);
@@ -60,9 +60,9 @@ static void EnsureValidTypeForTruncateTransform(Oid typeOid);
 static void EnsureValidTypeForBucketTransform(Oid typeOid);
 static bool IsDateOrTimestampType(Oid typeOid);
 static bool IsTimeOrTimestampType(Oid typeOid);
-static const char *GenerateTransformName(IcebergPartitionTransform * transform);
-static const char *GeneratePartitionFieldName(IcebergPartitionTransform * transform, Oid relationId);
-static int32_t AdjustTypmodForTruncateTransformIfNeeded(IcebergPartitionTransform * transform);
+static const char *GenerateTransformName(IcebergPartitionTransform *transform);
+static const char *GeneratePartitionFieldName(IcebergPartitionTransform *transform, Oid relationId);
+static int32_t AdjustTypmodForTruncateTransformIfNeeded(IcebergPartitionTransform *transform);
 
 
 /*
@@ -588,7 +588,7 @@ GetIcebergTablePartitionByOption(Oid relationId)
  * GenerateTransformName generates the transform name for the given transform.
  */
 static const char *
-GenerateTransformName(IcebergPartitionTransform * transform)
+GenerateTransformName(IcebergPartitionTransform *transform)
 {
 	switch (transform->type)
 	{
@@ -620,7 +620,7 @@ GenerateTransformName(IcebergPartitionTransform * transform)
  * GeneratePartitionFieldName generates the partition field name for given transform.
  */
 static const char *
-GeneratePartitionFieldName(IcebergPartitionTransform * transform, Oid relationId)
+GeneratePartitionFieldName(IcebergPartitionTransform *transform, Oid relationId)
 {
 	switch (transform->type)
 	{
@@ -653,7 +653,7 @@ GeneratePartitionFieldName(IcebergPartitionTransform * transform, Oid relationId
  * given transform exists in the relation. If it doesn't, it raises an error.
  */
 static void
-EnsureTransformSourceColumnExists(IcebergPartitionTransform * transform, Oid relationId)
+EnsureTransformSourceColumnExists(IcebergPartitionTransform *transform, Oid relationId)
 {
 	Relation	rel;
 	TupleDesc	desc;
@@ -700,7 +700,7 @@ EnsureTransformSourceColumnExists(IcebergPartitionTransform * transform, Oid rel
   * GetTransformResultPGType returns the result type of the transform.
   */
 PGType
-GetTransformResultPGType(IcebergPartitionTransform * transform)
+GetTransformResultPGType(IcebergPartitionTransform *transform)
 {
 	Oid			resultType = InvalidOid;
 	int32_t		resultTypMod = -1;
@@ -758,7 +758,7 @@ GetTransformResultPGType(IcebergPartitionTransform * transform)
  * It currently only applies to VARCHAR(n) and BPCHAR(n) types.
  */
 static int32_t
-AdjustTypmodForTruncateTransformIfNeeded(IcebergPartitionTransform * transform)
+AdjustTypmodForTruncateTransformIfNeeded(IcebergPartitionTransform *transform)
 {
 	PGType		pgType = transform->pgType;
 
@@ -793,7 +793,7 @@ AdjustTypmodForTruncateTransformIfNeeded(IcebergPartitionTransform * transform)
  * given transform is a scalar type. If it isn't, it raises an error.
  */
 static void
-EnsureTransformSourceColumnScalar(IcebergPartitionTransform * transform, DataFileSchemaField * sourceField)
+EnsureTransformSourceColumnScalar(IcebergPartitionTransform *transform, DataFileSchemaField *sourceField)
 {
 	if (sourceField->type->type != FIELD_TYPE_SCALAR)
 		ereport(ERROR,

--- a/pg_lake_table/src/fdw/partitioning/partition_spec_catalog.c
+++ b/pg_lake_table/src/fdw/partitioning/partition_spec_catalog.c
@@ -29,10 +29,10 @@
 #include "pg_extension_base/spi_helpers.h"
 
 static void InsertIcebergPartitionSpec(Oid relationId,
-									   IcebergPartitionSpec * spec);
+									   IcebergPartitionSpec *spec);
 static void InsertIcebergPartitionField(Oid relationId,
 										int specId,
-										IcebergPartitionSpecField * field);
+										IcebergPartitionSpecField *field);
 static List *GetAllPartitionSpecFieldsForExternalIcebergTable(char *metadataPath);
 static List *GetAllPartitionSpecFieldsForInternalIcebergTable(Oid relationId);
 
@@ -372,7 +372,7 @@ UpdateDefaultPartitionSpecId(Oid relationId, int specId)
 * lake_table.partition_fields tables.
 */
 void
-InsertPartitionSpecAndPartitionFields(Oid relationId, IcebergPartitionSpec * spec)
+InsertPartitionSpecAndPartitionFields(Oid relationId, IcebergPartitionSpec *spec)
 {
 	/* insert the partition spec */
 	InsertIcebergPartitionSpec(relationId, spec);
@@ -391,7 +391,7 @@ InsertPartitionSpecAndPartitionFields(Oid relationId, IcebergPartitionSpec * spe
 * lake_table.partition_specs table.
 */
 static void
-InsertIcebergPartitionSpec(Oid relationId, IcebergPartitionSpec * spec)
+InsertIcebergPartitionSpec(Oid relationId, IcebergPartitionSpec *spec)
 {
 	DECLARE_SPI_ARGS(2);
 
@@ -415,7 +415,7 @@ InsertIcebergPartitionSpec(Oid relationId, IcebergPartitionSpec * spec)
 * lake_table.partition_fields table.
 */
 static void
-InsertIcebergPartitionField(Oid relationId, int specId, IcebergPartitionSpecField * field)
+InsertIcebergPartitionField(Oid relationId, int specId, IcebergPartitionSpecField *field)
 {
 	DECLARE_SPI_ARGS(6);
 

--- a/pg_lake_table/src/fdw/partitioning/partitioned_dest_receiver.c
+++ b/pg_lake_table/src/fdw/partitioning/partitioned_dest_receiver.c
@@ -55,7 +55,7 @@ typedef struct PartitionPartitionDestReceiverHashEntry
 	DestReceiver *multiDataFileDestReceiver;
 	int			rowCount;
 	Partition  *partition;
-}			PartitionPartitionDestReceiverHashEntry;
+} PartitionPartitionDestReceiverHashEntry;
 
 /*
  * Our custom PartitioningDestReceiver structure.
@@ -92,7 +92,7 @@ typedef struct PartitioningDestReceiverData
 
 	/* operation of the DestReceiver */
 	int			operation;
-}			PartitioningDestReceiverData;
+} PartitioningDestReceiverData;
 
 
 static void StartPartitionedDestReceiver(DestReceiver *self, int operation, TupleDesc typeinfo);
@@ -101,8 +101,8 @@ static void ShutdownPartitionedDestReceiver(DestReceiver *self);
 static void DestroyPartitionedDestReceiver(DestReceiver *self);
 
 static HTAB *InitializePartitionsHash(MemoryContext parentContext);
-static void AssignPartitionForModificationList(List *modifications, int32 partitionSpecId, Partition * partition);
-static List *FlushLargestPartitionedDestReceiver(PartitioningDestReceiverData * myState);
+static void AssignPartitionForModificationList(List *modifications, int32 partitionSpecId, Partition *partition);
+static List *FlushLargestPartitionedDestReceiver(PartitioningDestReceiverData *myState);
 
 /* controlled by a GUC */
 int			MaxOpenFilesForPartitionedWrite = 5000;
@@ -180,7 +180,7 @@ GetPartitionedDestReceiverModifications(DestReceiver *dest)
 
 
 static void
-AssignPartitionForModificationList(List *modifications, int32 partitionSpecId, Partition * partition)
+AssignPartitionForModificationList(List *modifications, int32 partitionSpecId, Partition *partition)
 {
 	ListCell   *cell;
 
@@ -298,7 +298,7 @@ PartitionedDestReceiveSlot(TupleTableSlot *slot, DestReceiver *self)
 * to MaxOpenFilesForPartitionedWrite.
 */
 static List *
-FlushLargestPartitionedDestReceiver(PartitioningDestReceiverData * myState)
+FlushLargestPartitionedDestReceiver(PartitioningDestReceiverData *myState)
 {
 	HTAB	   *partitionsHash = myState->partitionsHash;
 	HASH_SEQ_STATUS seqStatus;

--- a/pg_lake_table/src/fdw/pg_lake_table.c
+++ b/pg_lake_table/src/fdw/pg_lake_table.c
@@ -197,7 +197,7 @@ typedef struct PgLakeScanState
 	uint64		skippableRows;
 	uint64		skippableDataFiles;
 
-}			PgLakeScanState;
+} PgLakeScanState;
 
 /*
  * PgLakeFileModifyState holds the state for modifications to an existing
@@ -221,7 +221,7 @@ typedef struct PgLakeFileModifyState
 	/* number of rows modified by UPDATE/DELETE */
 	int64		modifiedRowCount;
 
-}			PgLakeFileModifyState;
+} PgLakeFileModifyState;
 
 /*
  * Execution state of a foreign insert/update/delete operation.
@@ -265,7 +265,7 @@ typedef struct PgLakeModifyState
 	/* for update row movement if subplan result rel */
 	struct PgLakeModifyState *aux_fmstate;	/* foreign-insert state, if
 											 * created */
-}			PgLakeModifyState;
+} PgLakeModifyState;
 
 /*
  * This enum describes what's kept in the fdw_private list for a ForeignPath.
@@ -291,7 +291,7 @@ typedef struct
 	double		limit_tuples;
 	int64		count_est;
 	int64		offset_est;
-}			PgLakePathExtraData;
+} PgLakePathExtraData;
 
 /*
  * Identify the attribute where data conversion fails.
@@ -317,7 +317,7 @@ typedef struct ResultFileIndex
 {
 	char		path[MAXPGPATH];
 	int			index;
-}			ResultFileIndex;
+} ResultFileIndex;
 
 /*
  * FindResultRelationScanStateContext is passed down via plan_tree_walker
@@ -330,7 +330,7 @@ typedef struct FindResultRelationScanStateContext
 
 	/* the lake scan we found */
 	PgLakeScanState *lakeScan;
-}			FindResultRelationScanStateContext;
+} FindResultRelationScanStateContext;
 
 
 PgLakeModifyValidityCheckHookType PgLakeModifyValidityCheckHook = NULL;
@@ -402,7 +402,7 @@ static TupleTableSlot *postgresExecForeignDelete(EState *estate,
 												 ResultRelInfo *resultRelInfo,
 												 TupleTableSlot *slot,
 												 TupleTableSlot *planSlot);
-static void DeleteSingleRow(PgLakeModifyState * fmstate,
+static void DeleteSingleRow(PgLakeModifyState *fmstate,
 							ItemPointer ctid);
 static void StoreDeleteReturningSlot(TupleTableSlot *planSlot,
 									 TupleTableSlot *returningSlot,
@@ -440,7 +440,7 @@ static void estimate_path_cost_size(PlannerInfo *root,
 									RelOptInfo *foreignrel,
 									List *param_join_conds,
 									List *pathkeys,
-									PgLakePathExtraData * fpextra,
+									PgLakePathExtraData *fpextra,
 									double *p_rows, int *p_width,
 									int *p_disabled_nodes,
 									Cost *p_startup_cost, Cost *p_total_cost);
@@ -449,13 +449,13 @@ static bool ec_member_matches_foreign(PlannerInfo *root, RelOptInfo *rel,
 									  void *arg);
 static void send_prepared_statement(ForeignScanState *node);
 static void fetch_more_data(ForeignScanState *node);
-static PgLakeModifyState * create_foreign_modify(Relation rel,
-												 Index resultRangeTableIndex,
-												 ModifyTableState *mtstate);
-static PgLakeScanState * FindResultRelationScanState(PlanState *planState,
-													 Oid relationId);
+static PgLakeModifyState *create_foreign_modify(Relation rel,
+												Index resultRangeTableIndex,
+												ModifyTableState *mtstate);
+static PgLakeScanState *FindResultRelationScanState(PlanState *planState,
+													Oid relationId);
 static bool FindResultRelationScanStateWalker(PlanState *planState,
-											  FindResultRelationScanStateContext * context);
+											  FindResultRelationScanStateContext *context);
 static void prepare_query_params(PlanState *node,
 								 List *fdw_exprs,
 								 int numParams,
@@ -496,31 +496,31 @@ static void add_foreign_final_paths(PlannerInfo *root,
 									RelOptInfo *input_rel,
 									RelOptInfo *final_rel,
 									FinalPathExtraData *extra);
-static void apply_server_options(PgLakeRelationInfo * fpinfo);
-static void apply_table_options(PgLakeRelationInfo * fpinfo);
-static void merge_fdw_options(PgLakeRelationInfo * fpinfo,
-							  const PgLakeRelationInfo * fpinfo_o,
-							  const PgLakeRelationInfo * fpinfo_i);
+static void apply_server_options(PgLakeRelationInfo *fpinfo);
+static void apply_table_options(PgLakeRelationInfo *fpinfo);
+static void merge_fdw_options(PgLakeRelationInfo *fpinfo,
+							  const PgLakeRelationInfo *fpinfo_o,
+							  const PgLakeRelationInfo *fpinfo_i);
 
 static void IcebergErrorOrClampSlotInPlace(TupleTableSlot *slot, TupleDesc tupleDesc,
 										   IcebergOutOfRangePolicy policy);
-static void ClampAndCheckConstraints(PgLakeModifyState * fmstate,
+static void ClampAndCheckConstraints(PgLakeModifyState *fmstate,
 									 ResultRelInfo *resultRelInfo,
 									 TupleTableSlot *slot, EState *estate);
-static void WriteInsertRecord(PgLakeModifyState * modifyState, TupleTableSlot *slot);
-static void PrepareDeletionSlot(PgLakeFileModifyState * fileModifyState,
+static void WriteInsertRecord(PgLakeModifyState *modifyState, TupleTableSlot *slot);
+static void PrepareDeletionSlot(PgLakeFileModifyState *fileModifyState,
 								uint64 fileRowNumber,
 								TupleTableSlot *deleteSlot);
-static void WriteDeleteRecord(PgLakeFileModifyState * fileModifyState,
+static void WriteDeleteRecord(PgLakeFileModifyState *fileModifyState,
 							  TupleTableSlot *deleteSlot);
 static TupleDesc CreateRowIdTupleDesc(void);
 static ItemPointer RowIdRecordStringToItemPointer(char *recordString,
-												  PgLakeScanState * scanState);
+												  PgLakeScanState *scanState);
 static uint64 ExtractFileIndexFromItemPointer(ItemPointer ctid,
 											  int fileRowNumberBits);
 static uint64 ExtractFileRowNumberFromItemPointer(ItemPointer ctid,
 												  int fileRowNumberBits);
-static void FinishForeignModify(PgLakeModifyState * modifyState);
+static void FinishForeignModify(PgLakeModifyState *modifyState);
 
 static void ErrorIfSystemColumnUsed(Oid relationId, AttrNumber attnum);
 static bool AdjustUniqueRelationIdentifiersViaAlias(Node *node, void *context);
@@ -2333,7 +2333,7 @@ postgresExecForeignDelete(EState *estate,
  * DeleteSingleRow deletes a single row specified by the ctid column in planSlot.
  */
 static void
-DeleteSingleRow(PgLakeModifyState * fmstate, ItemPointer ctid)
+DeleteSingleRow(PgLakeModifyState *fmstate, ItemPointer ctid)
 {
 	/* deleteSlot can be NULL for WHERE false, but we should not get here */
 	Assert(fmstate->deleteSlot != NULL);
@@ -2646,7 +2646,7 @@ IcebergErrorOrClampSlotInPlace(TupleTableSlot *slot, TupleDesc tupleDesc,
  * ourselves.
  */
 static void
-ClampAndCheckConstraints(PgLakeModifyState * fmstate,
+ClampAndCheckConstraints(PgLakeModifyState *fmstate,
 						 ResultRelInfo *resultRelInfo,
 						 TupleTableSlot *slot, EState *estate)
 {
@@ -2666,7 +2666,7 @@ ClampAndCheckConstraints(PgLakeModifyState * fmstate,
  * WriteInsertRecord forwards the tuple to the insert destination.
  */
 static void
-WriteInsertRecord(PgLakeModifyState * modifyState, TupleTableSlot *slot)
+WriteInsertRecord(PgLakeModifyState *modifyState, TupleTableSlot *slot)
 {
 	DestReceiver *insertDest = modifyState->insertDest;
 
@@ -2688,7 +2688,7 @@ WriteInsertRecord(PgLakeModifyState * modifyState, TupleTableSlot *slot)
  * deleteSlot.
  */
 static void
-PrepareDeletionSlot(PgLakeFileModifyState * fileModifyState,
+PrepareDeletionSlot(PgLakeFileModifyState *fileModifyState,
 					uint64 fileRowNumber,
 					TupleTableSlot *deleteSlot)
 {
@@ -2723,7 +2723,7 @@ PrepareDeletionSlot(PgLakeFileModifyState * fileModifyState,
  * modified.
  */
 static void
-WriteDeleteRecord(PgLakeFileModifyState * fileModifyState,
+WriteDeleteRecord(PgLakeFileModifyState *fileModifyState,
 				  TupleTableSlot *deleteSlot)
 {
 	DestReceiver *deleteDest = fileModifyState->deleteDest;
@@ -2778,7 +2778,7 @@ CreateRowIdTupleDesc(void)
  */
 static ItemPointer
 RowIdRecordStringToItemPointer(char *recordString,
-							   PgLakeScanState * scanState)
+							   PgLakeScanState *scanState)
 {
 	int			recordTypeMod = scanState->rowLocationTypeMod;
 	HTAB	   *resultFileIndexes = scanState->resultFileIndexes;
@@ -2853,7 +2853,7 @@ ExtractFileRowNumberFromItemPointer(ItemPointer ctid, int fileRowNumberBits)
  * FinishForeignModify finalizes a write to pg_lake table.
  */
 static void
-FinishForeignModify(PgLakeModifyState * fmstate)
+FinishForeignModify(PgLakeModifyState *fmstate)
 {
 	ListCell   *fileModifyCell = NULL;
 	List	   *modifications = NIL;
@@ -3107,7 +3107,7 @@ estimate_path_cost_size(PlannerInfo *root,
 						RelOptInfo *foreignrel,
 						List *param_join_conds,
 						List *pathkeys,
-						PgLakePathExtraData * fpextra,
+						PgLakePathExtraData *fpextra,
 						double *p_rows, int *p_width,
 						int *p_disabled_nodes,
 						Cost *p_startup_cost, Cost *p_total_cost)
@@ -3718,7 +3718,7 @@ FindResultRelationScanState(PlanState *planState, Oid resultRelationId)
  */
 static bool
 FindResultRelationScanStateWalker(PlanState *planState,
-								  FindResultRelationScanStateContext * context)
+								  FindResultRelationScanStateContext *context)
 {
 	if (planState == NULL)
 		return false;
@@ -4414,7 +4414,7 @@ add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel,
  * New options might also require tweaking merge_fdw_options().
  */
 static void
-apply_server_options(PgLakeRelationInfo * fpinfo)
+apply_server_options(PgLakeRelationInfo *fpinfo)
 {
 	/* we always assume the estimates are fetched from remote server */
 	fpinfo->use_remote_estimate = true;
@@ -4440,7 +4440,7 @@ apply_server_options(PgLakeRelationInfo * fpinfo)
  * New options might also require tweaking merge_fdw_options().
  */
 static void
-apply_table_options(PgLakeRelationInfo * fpinfo)
+apply_table_options(PgLakeRelationInfo *fpinfo)
 {
 	/* we always assume the estimates are fetched from remote server */
 	fpinfo->use_remote_estimate = true;
@@ -4456,9 +4456,9 @@ apply_table_options(PgLakeRelationInfo * fpinfo)
  * expected to NULL.
  */
 static void
-merge_fdw_options(PgLakeRelationInfo * fpinfo,
-				  const PgLakeRelationInfo * fpinfo_o,
-				  const PgLakeRelationInfo * fpinfo_i)
+merge_fdw_options(PgLakeRelationInfo *fpinfo,
+				  const PgLakeRelationInfo *fpinfo_o,
+				  const PgLakeRelationInfo *fpinfo_i)
 {
 	/* We must always have fpinfo_o. */
 	Assert(fpinfo_o);

--- a/pg_lake_table/src/fdw/position_delete_dest.c
+++ b/pg_lake_table/src/fdw/position_delete_dest.c
@@ -60,7 +60,7 @@ typedef struct PositionDeleteFileDest
 
 	/* number of deleted rows */
 	int64		deletedRowCount;
-}			PositionDeleteFileDest;
+} PositionDeleteFileDest;
 
 /*
  * PositionDeleteDestReceiver is a DestReceiver that writes position delete tuples
@@ -88,12 +88,12 @@ typedef struct PositionDeleteDestReceiver
 	/* operation of the DestReceiver */
 	int			operation;
 
-}			PositionDeleteDestReceiver;
+} PositionDeleteDestReceiver;
 
 
 static HTAB *CreateFileDestsHash(void);
-static PositionDeleteFileDest * GetPositionDeleteFileDest(PositionDeleteDestReceiver * self,
-														  int64 fileId);
+static PositionDeleteFileDest *GetPositionDeleteFileDest(PositionDeleteDestReceiver *self,
+														 int64 fileId);
 static void StartDestReceiver(DestReceiver *self, int operation, TupleDesc typeinfo);
 static bool ReceiveSlot(TupleTableSlot *slot, DestReceiver *self);
 static void PrepareDeletionSlot(Datum pathDatum, Datum rowNumberDatum,
@@ -165,7 +165,7 @@ CreateFileDestsHash(void)
  * to build the position delete file for a given data file ID.
  */
 static PositionDeleteFileDest *
-GetPositionDeleteFileDest(PositionDeleteDestReceiver * self, int64 fileId)
+GetPositionDeleteFileDest(PositionDeleteDestReceiver *self, int64 fileId)
 {
 	bool		fileDestFound = false;
 	PositionDeleteFileDest *fileDest =

--- a/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
+++ b/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
@@ -51,7 +51,7 @@
 #include "pg_lake/util/rel_utils.h"
 #include "pg_extension_base/spi_helpers.h"
 
-static DataFileSchemaField * CreateRegisteredFieldForAttribute(Oid relationId, int spiIndex);
+static DataFileSchemaField *CreateRegisteredFieldForAttribute(Oid relationId, int spiIndex);
 static void InsertFieldMapping(Oid relationId, int attrIcebergFieldId,
 							   AttrNumber pg_attnum, PGType pgType,
 							   const char *writeDefault, const char *initialDefault,
@@ -670,7 +670,7 @@ GetLargestRegisteredFieldId(Oid relationId)
 * RegisterIcebergColumnMapping inserts field mapping for a relation column.
 */
 void
-RegisterIcebergColumnMapping(Oid relationId, Field * field,
+RegisterIcebergColumnMapping(Oid relationId, Field *field,
 							 AttrNumber attNo, int parentFieldId, PGType pgType,
 							 int fieldId, const char *writeDefault, const char *initialDefault)
 {

--- a/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
+++ b/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
@@ -51,7 +51,7 @@
 #include "pg_lake/pgduck/serialize.h"
 
 
-static DataFileSchema * GetDataFileSchemaForTableInternal(Oid relationId);
+static DataFileSchema *GetDataFileSchemaForTableInternal(Oid relationId);
 
 /*
 * RegisterPostgresColumnMappings adds entries to the
@@ -390,7 +390,7 @@ GetLeafFieldsForTable(Oid relationId)
  */
 const char *
 GetDuckSerializedIcebergFieldInitialDefault(const char *initialDefault,
-											Field * field)
+											Field *field)
 {
 	EnsureIcebergField(field);
 

--- a/pg_lake_table/src/fdw/shippable.c
+++ b/pg_lake_table/src/fdw/shippable.c
@@ -105,10 +105,10 @@ static Oid *ParameterOidArray(char **parameterTypes, int parameterCount);
 static ShippableCacheEntry *EnterShippableCacheEntry(Oid objectId, Oid classId, bool shippable);
 static void LoadShippableBuiltinFunctions(void);
 static void LoadShippableSpatialFunctions(void);
-static void LoadShippablePgduckFunctions(const PGDuckShippableFunction * functions, int functionCount);
+static void LoadShippablePgduckFunctions(const PGDuckShippableFunction *functions, int functionCount);
 static void LoadShippableBuiltinOperators(void);
 static void LoadShippableSpatialOperators(void);
-static void LoadShippablePgduckOperators(const PGDuckShippableOperator * operators, int operatorCount);
+static void LoadShippablePgduckOperators(const PGDuckShippableOperator *operators, int operatorCount);
 static bool IsShippableStructType(Oid objectId);
 static char *GetObjectDescription(Oid classId, Oid objectId);
 
@@ -328,12 +328,12 @@ static void
 LoadShippableBuiltinOperators(void)
 {
 	int			numTypes = 0;
-	const		PGDuckShippableOperatorsByType *operatorTypes =
+	const PGDuckShippableOperatorsByType *operatorTypes =
 		GetPGDuckShippableOperatorsByType(&numTypes);
 
 	for (int typeIndex = 0; typeIndex < numTypes; typeIndex++)
 	{
-		const		PGDuckShippableOperatorsByType shippableOperatorsByType =
+		const PGDuckShippableOperatorsByType shippableOperatorsByType =
 			operatorTypes[typeIndex];
 
 		LoadShippablePgduckOperators(shippableOperatorsByType.oprs,
@@ -349,7 +349,7 @@ static void
 LoadShippableSpatialOperators(void)
 {
 	int			operatorCount = 0;
-	const		PGDuckShippableOperator *operators = GetShippableSpatialOperators(&operatorCount);
+	const PGDuckShippableOperator *operators = GetShippableSpatialOperators(&operatorCount);
 
 	LoadShippablePgduckOperators(operators, operatorCount);
 }
@@ -360,7 +360,7 @@ LoadShippableSpatialOperators(void)
  * array into the shippable cache.
  */
 static void
-LoadShippablePgduckOperators(const PGDuckShippableOperator * operators, int operatorCount)
+LoadShippablePgduckOperators(const PGDuckShippableOperator *operators, int operatorCount)
 {
 	for (int oprIndex = 0; oprIndex < operatorCount; oprIndex++)
 	{
@@ -410,7 +410,7 @@ static void
 LoadShippableBuiltinFunctions(void)
 {
 	int			functionCount = 0;
-	const		PGDuckShippableFunction *functions = GetShippableBuiltinFunctions(&functionCount);
+	const PGDuckShippableFunction *functions = GetShippableBuiltinFunctions(&functionCount);
 
 	LoadShippablePgduckFunctions(functions, functionCount);
 }
@@ -423,7 +423,7 @@ static void
 LoadShippableSpatialFunctions(void)
 {
 	int			functionCount = 0;
-	const		PGDuckShippableFunction *functions = GetShippableSpatialFunctions(&functionCount);
+	const PGDuckShippableFunction *functions = GetShippableSpatialFunctions(&functionCount);
 
 	LoadShippablePgduckFunctions(functions, functionCount);
 }
@@ -434,7 +434,7 @@ LoadShippableSpatialFunctions(void)
  * shippable cache.
  */
 static void
-LoadShippablePgduckFunctions(const PGDuckShippableFunction * functions, int functionCount)
+LoadShippablePgduckFunctions(const PGDuckShippableFunction *functions, int functionCount)
 {
 	for (size_t procIndex = 0; procIndex < functionCount; procIndex++)
 	{

--- a/pg_lake_table/src/fdw/snapshot.c
+++ b/pg_lake_table/src/fdw/snapshot.c
@@ -52,12 +52,12 @@
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
 
-static PgLakeTableScan * CreateTableScanForRelation(Oid relationId,
-													Snapshot snapshot,
-													int uniqueRelationIdentifier,
-													List *baseRestrictInfoList,
-													bool includeChildren,
-													bool isResultRelation);
+static PgLakeTableScan *CreateTableScanForRelation(Oid relationId,
+												   Snapshot snapshot,
+												   int uniqueRelationIdentifier,
+												   List *baseRestrictInfoList,
+												   bool includeChildren,
+												   bool isResultRelation);
 static List *GetPositionDeleteTableDataFileForDataFiles(Oid relationId, List *dataFileList,
 														Snapshot snapshot);
 static List *GetBaseRestrictInfoForRelation(List *relationRestrictionsList,
@@ -65,7 +65,7 @@ static List *GetBaseRestrictInfoForRelation(List *relationRestrictionsList,
 static void ConvertIcebergDataFilesToFileScan(List *dataFiles, List *deleteFiles,
 											  List **fileScans,
 											  List **positionDeleteFileScans);
-static void ErrorIfSchemasDoNotMatch(Oid relationId, IcebergTableMetadata * metadata);
+static void ErrorIfSchemasDoNotMatch(Oid relationId, IcebergTableMetadata *metadata);
 static int	NullSafeStrcmp(const char *a, const char *b);
 static bool TypesAreCompatible(PGType pgType, PGType icebergType);
 
@@ -371,7 +371,7 @@ NullSafeStrcmp(const char *a, const char *b)
 * table schema matches the Postgres table schema.
 */
 static void
-ErrorIfSchemasDoNotMatch(Oid relationId, IcebergTableMetadata * metadata)
+ErrorIfSchemasDoNotMatch(Oid relationId, IcebergTableMetadata *metadata)
 {
 	IcebergTableSchema *icebergTableSchema = GetCurrentIcebergTableSchema(metadata);
 	List	   *postgresColumnMappings =
@@ -547,7 +547,7 @@ GetPositionDeleteTableDataFileForDataFiles(Oid relationId, List *dataFileList,
 * Iceberg table metadata with the currentSnapshot.
 */
 void
-CreateTableScanForIcebergMetadata(Oid relationId, IcebergTableMetadata * metadata, List *baseRestrictInfoList,
+CreateTableScanForIcebergMetadata(Oid relationId, IcebergTableMetadata *metadata, List *baseRestrictInfoList,
 								  List **fileScans, List **positionDeleteScans)
 {
 	List	   *dataFiles = NIL;
@@ -605,7 +605,7 @@ ConvertIcebergDataFilesToFileScan(List *dataFiles, List *deleteFiles,
  * GetTableScanByRelationId returns the table scan for a given relation ID.
  */
 PgLakeTableScan *
-GetTableScanByRelationId(PgLakeScanSnapshot * snapshot, Oid relationId)
+GetTableScanByRelationId(PgLakeScanSnapshot *snapshot, Oid relationId)
 {
 	ListCell   *tableCell = NULL;
 
@@ -657,7 +657,7 @@ GetFileScanPathList(List *fileScans, uint64 *rowCount, bool skipFullScans)
 * and delete file scans in the snapshot.
 */
 void
-SnapshotFilesScanned(PgLakeScanSnapshot * scanSnapshot, int *dataFileScans,
+SnapshotFilesScanned(PgLakeScanSnapshot *scanSnapshot, int *dataFileScans,
 					 int *deleteFileScans)
 {
 	*dataFileScans = 0;

--- a/pg_lake_table/src/fdw/update_tracking.c
+++ b/pg_lake_table/src/fdw/update_tracking.c
@@ -78,7 +78,7 @@ static Oid	CreateUpdateTrackingTable(RangeVar *updateTableName);
  * is active and we return false.
  */
 bool
-BeginRelationUpdateTracking(RelationUpdateTrackingState * state, Oid relationId)
+BeginRelationUpdateTracking(RelationUpdateTrackingState *state, Oid relationId)
 {
 	RangeVar   *updateTableName = GetUpdateTableRangeVar(relationId);
 
@@ -225,7 +225,7 @@ CreateUpdateTrackingTable(RangeVar *updateTableName)
  * spills to disk.
  */
 bool
-IsFirstUpdateOfTuple(RelationUpdateTrackingState * state, ItemPointer rowLocation)
+IsFirstUpdateOfTuple(RelationUpdateTrackingState *state, ItemPointer rowLocation)
 {
 	MemoryContext oldContext = MemoryContextSwitchTo(state->perTupleContext);
 
@@ -275,7 +275,7 @@ IsFirstUpdateOfTuple(RelationUpdateTrackingState * state, ItemPointer rowLocatio
  * to track which rows have been updated by the current command.
  */
 void
-FinishRelationUpdateTracking(RelationUpdateTrackingState * state)
+FinishRelationUpdateTracking(RelationUpdateTrackingState *state)
 {
 	char	   *tableName = get_rel_name(RelationGetRelid(state->updateRel));
 

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -92,22 +92,22 @@ typedef struct CompactionDataFileHashEntry
 	uint64		partitionHash;	/* combined hash of partition spec + partition
 								 * tuple */
 	List	   *dataFiles;
-}			CompactionDataFileHashEntry;
+} CompactionDataFileHashEntry;
 
 
 static List *ApplyInsertFile(Relation rel, char *insertFile, int64 rowCount,
 							 int64 reservedRowIdStart, int32 partitionSpecId,
-							 Partition * partition, DataFileStats * fileStats);
+							 Partition *partition, DataFileStats *fileStats);
 static List *ApplyDeleteFile(Relation rel, char *sourcePath, int64 sourceRowCount,
 							 int64 liveRowCount, char *deleteFile, int64 deletedRowCount,
 							 int64 *totalPositionDeletedRows);
 static List *GetDataFilePathsFromStatsList(List *dataFileStats);
 static List *GetNewFileOpsFromFileStats(Oid relationId, List *dataFileStats,
-										int32 partitionSpecId, Partition * partition, int64 rowCount,
+										int32 partitionSpecId, Partition *partition, int64 rowCount,
 										bool isVerbose, List **newFiles);
 static bool ShouldRewriteAfterDeletions(int64 sourceRowCount, uint64 totalDeletedRowCount);
-static CompactionDataFileHashEntry * GetPartitionWithMostEligibleFiles(Oid relationId, TimestampTz compactionStartTime,
-																	   bool forceMerge, bool forceCompactDeletions);
+static CompactionDataFileHashEntry *GetPartitionWithMostEligibleFiles(Oid relationId, TimestampTz compactionStartTime,
+																	  bool forceMerge, bool forceCompactDeletions);
 static HTAB *CreateCompactionDataFileHash(void);
 static HTAB *GroupDataFilesByPartition(List *dataFiles, TimestampTz compactionStartTime, bool forceMerge);
 static List *FilterCompactionCandidates(List *dataFiles, TimestampTz compactionStartTime, bool forceMerge,
@@ -121,7 +121,7 @@ static List *PrepareToAddQueryResultToTable(Oid relationId,
 											char *readQuery,
 											TupleDesc queryTupleDesc,
 											int32 partitionSpecId,
-											Partition * partition,
+											Partition *partition,
 											bool queryHasRowId,
 											bool allowSplit,
 											bool isVerbose,
@@ -170,7 +170,7 @@ List	   *DeferredModifications = NIL;
 static List *
 ApplyInsertFile(Relation rel, char *insertFile, int64 rowCount,
 				int64 reservedRowIdStart, int32 partitionSpecId,
-				Partition * partition, DataFileStats * dataFileStats)
+				Partition *partition, DataFileStats *dataFileStats)
 {
 	ereport(WriteLogLevel, (errmsg("adding %s with " INT64_FORMAT " rows ",
 								   insertFile, rowCount)));
@@ -218,7 +218,7 @@ ApplyInsertFile(Relation rel, char *insertFile, int64 rowCount,
 List *
 PrepareCSVInsertion(Oid relationId, char *insertCSV, int64 rowCount,
 					int64 reservedRowIdStart, int maximumLineSize,
-					DataFileSchema * schema)
+					DataFileSchema *schema)
 {
 	Relation	relation = table_open(relationId, RowExclusiveLock);
 	ForeignTable *foreignTable = GetForeignTable(relationId);
@@ -351,7 +351,7 @@ GetDataFilePathsFromStatsList(List *dataFileStats)
  * and adds them to the metadata operations list to be returned.
  */
 static List *
-GetNewFileOpsFromFileStats(Oid relationId, List *dataFileStats, int32 partitionSpecId, Partition * partition,
+GetNewFileOpsFromFileStats(Oid relationId, List *dataFileStats, int32 partitionSpecId, Partition *partition,
 						   int64 rowCount, bool isVerbose, List **newFiles)
 {
 	*newFiles = NIL;
@@ -990,7 +990,7 @@ TryCompactDataFiles(Oid relationId, TupleDesc tupleDescriptor, List *candidates,
  */
 static List *
 PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryTupleDesc,
-							   int32 partitionSpecId, Partition * partition,
+							   int32 partitionSpecId, Partition *partition,
 							   bool queryHasRowId, bool allowSplit, bool isVerbose,
 							   IcebergOutOfRangePolicy outOfRangePolicy,
 							   bool wrapNativeIntervals)

--- a/pg_lake_table/src/planner/explain.c
+++ b/pg_lake_table/src/planner/explain.c
@@ -29,7 +29,7 @@
 
 
 static void ExplainNotShippableObjects(HTAB *notShippableObjects, ExplainState *es);
-static const char *NotShippableObjectToString(const NotShippableObject * notShippableObject);
+static const char *NotShippableObjectToString(const NotShippableObject *notShippableObject);
 
 ExplainOneQuery_hook_type PrevExplainOneQueryHook = NULL;
 
@@ -127,7 +127,7 @@ ExplainNotShippableObjects(HTAB *notShippableObjects, ExplainState *es)
  * NotShippableObjectToString returns a string of why a particular object was deemed not shippable.
  */
 static const char *
-NotShippableObjectToString(const NotShippableObject * notShippableObject)
+NotShippableObjectToString(const NotShippableObject *notShippableObject)
 {
 	StringInfo	message = makeStringInfo();
 

--- a/pg_lake_table/src/planner/query_pushdown.c
+++ b/pg_lake_table/src/planner/query_pushdown.c
@@ -91,19 +91,19 @@ typedef struct IsShippableContext
 
 	/* map of not shippable objects */
 	HTAB	   *notShippableObjects;
-}			IsShippableContext;
+} IsShippableContext;
 
 
 static PlannedStmt *LakeTablePlanner(Query *parse, const char *queryString,
 									 int cursorOptions, ParamListInfo boundParams);
 static bool AdjustParseTreeForPgLake(Node *node, void *context);
-static bool ProcessNotShippableExpressionWalker(Node *node, IsShippableContext * context);
+static bool ProcessNotShippableExpressionWalker(Node *node, IsShippableContext *context);
 static bool AddMissingRTEAliasaes(Node *node, void *context);
 static bool TargetListHasOnlyResjunk(List *targetList);
 static bool AllInheritorsAreLakeTable(Oid relationId);
-static bool ExpressionHasCollation(Node *node, IsShippableContext * context);
-static bool ExpressionHasNonShippableObject(Node *node, bool srfAllowed, IsShippableContext * context);
-static bool ExpressionReturnsNonShippableType(Node *node, IsShippableContext * context);
+static bool ExpressionHasCollation(Node *node, IsShippableContext *context);
+static bool ExpressionHasNonShippableObject(Node *node, bool srfAllowed, IsShippableContext *context);
+static bool ExpressionReturnsNonShippableType(Node *node, IsShippableContext *context);
 static PlannedStmt *GenerateInsertSelectPushdownPlan(PlannedStmt *localPlan,
 													 Query *query);
 static PlannedStmt *GeneratePushdownPlan(PlannedStmt *localPlan, Query *originalQuery);
@@ -123,9 +123,9 @@ static void RemoveUnusedParametersFromList(Query *query, ParamListInfo paramList
 static bool FindAllParams(Node *node, List **allParams);
 static List *CreateInternalCustomScanTargetList(List *existingTargetlist);
 static List *CreateCustomScanOutputTargetList(List *customScanTargetList);
-static void TryRecordNotShippableObject(IsShippableContext * context, Oid objectId,
+static void TryRecordNotShippableObject(IsShippableContext *context, Oid objectId,
 										Oid classId, NotShippableReason reason);
-static void RecordNotShippableObject(IsShippableContext * context, Oid objectId,
+static void RecordNotShippableObject(IsShippableContext *context, Oid objectId,
 									 Oid classId, NotShippableReason reason);
 static HTAB *CreateNotShippableObjectsHash(void);
 
@@ -179,7 +179,7 @@ typedef struct QueryPushdownScanState
 	ParamListInfo paramListInfo;
 	int			numParams;
 	const char **parameterValues;
-}			QueryPushdownScanState;
+} QueryPushdownScanState;
 
 
 /*
@@ -549,7 +549,7 @@ CollectNotShippableObjects(Node *node)
  * given context if the context is configured to record such objects.
  */
 static void
-TryRecordNotShippableObject(IsShippableContext * context, Oid objectId,
+TryRecordNotShippableObject(IsShippableContext *context, Oid objectId,
 							Oid classId, NotShippableReason reason)
 {
 	if (context->stopAtFirstNotShippable)
@@ -564,7 +564,7 @@ TryRecordNotShippableObject(IsShippableContext * context, Oid objectId,
  * given context.
  */
 static void
-RecordNotShippableObject(IsShippableContext * context, Oid objectId,
+RecordNotShippableObject(IsShippableContext *context, Oid objectId,
 						 Oid classId, NotShippableReason reason)
 {
 	Assert(context->notShippableObjects != NULL);
@@ -608,7 +608,7 @@ CreateNotShippableObjectsHash(void)
  * Otherwise, it stops at the first not shippable object and returns true.
  */
 static bool
-ProcessNotShippableExpressionWalker(Node *node, IsShippableContext * context)
+ProcessNotShippableExpressionWalker(Node *node, IsShippableContext *context)
 {
 	if (node == NULL)
 	{
@@ -826,7 +826,7 @@ ProcessNotShippableExpressionWalker(Node *node, IsShippableContext * context)
 * Note that this function does not recurse into sub-expressions.
 */
 static bool
-ExpressionHasNonShippableObject(Node *node, bool srfAllowed, IsShippableContext * context)
+ExpressionHasNonShippableObject(Node *node, bool srfAllowed, IsShippableContext *context)
 {
 	if (IsA(node, FuncExpr))
 	{
@@ -1047,7 +1047,7 @@ AllInheritorsAreLakeTable(Oid relationId)
 * has a collation. This check is inline with the foreign_expr_walker().
 */
 static bool
-ExpressionHasCollation(Node *node, IsShippableContext * context)
+ExpressionHasCollation(Node *node, IsShippableContext *context)
 {
 	switch (nodeTag(node))
 	{
@@ -1121,7 +1121,7 @@ ExpressionHasCollation(Node *node, IsShippableContext * context)
  * returns a shippable type, or false if the node is not an expression.
  */
 static bool
-ExpressionReturnsNonShippableType(Node *node, IsShippableContext * context)
+ExpressionReturnsNonShippableType(Node *node, IsShippableContext *context)
 {
 	switch (nodeTag(node))
 	{

--- a/pg_lake_table/src/planner/restriction_collector.c
+++ b/pg_lake_table/src/planner/restriction_collector.c
@@ -58,15 +58,15 @@ typedef struct ReplaceExternalParamsContext
 	bool		withPgDuckConsts;
 	ParamListInfo boundParams;
 
-}			ReplaceExternalParamsContext;
+} ReplaceExternalParamsContext;
 
 set_rel_pathlist_hook_type PrevRelPathlistHook = NULL;
 
-static PlannerRelationRestrictionContext * CurrentRestrictionContext(void);
+static PlannerRelationRestrictionContext *CurrentRestrictionContext(void);
 static int	GenerateNewUniqueRelationIdentifier(void);
 static bool RestrictionExists(List *baseRestrictionList, RestrictInfo *restrictInfo);
 static Node *ReplaceExternalParamsWithPgConsts(Node *inputNode, ParamListInfo boundParams);
-static Node *ReplaceExternalParamsWithConsts(Node *inputNode, ReplaceExternalParamsContext * context);
+static Node *ReplaceExternalParamsWithConsts(Node *inputNode, ReplaceExternalParamsContext *context);
 
 
 /*
@@ -398,7 +398,7 @@ ReplaceExternalParamsWithPgConsts(Node *inputNode, ParamListInfo boundParams)
  * optimizer/optimizer.c.
  */
 static Node *
-ReplaceExternalParamsWithConsts(Node *inputNode, ReplaceExternalParamsContext * context)
+ReplaceExternalParamsWithConsts(Node *inputNode, ReplaceExternalParamsContext *context)
 {
 	if (inputNode == NULL)
 	{

--- a/pg_lake_table/src/test/hide_lake_objects.c
+++ b/pg_lake_table/src/test/hide_lake_objects.c
@@ -90,7 +90,7 @@ static List *GetObjectCreatedByLakeFuncArgs(Oid catalogTableId, int catalogTable
 typedef struct ReferencedObject
 {
 	ObjectAddress referenced;
-}			ReferencedObject;
+} ReferencedObject;
 
 /*
  * GUC hides any objects, which is created by pg_lake_table extension, from catalog queries,

--- a/pg_lake_table/src/transaction/external_heavy_asserts.c
+++ b/pg_lake_table/src/transaction/external_heavy_asserts.c
@@ -43,12 +43,12 @@ static void AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relati
 static void AssertInternalAndExternalIcebergDataFileColumnStatsMatch(List *internalColumnStatsList,
 																	 List *externalLowerBounds,
 																	 List *externalUpperBounds);
-static List *RemoveDroppedFieldBounds(const List *existingLeafFields, ColumnBound * bounds, size_t boundsLen);
+static List *RemoveDroppedFieldBounds(const List *existingLeafFields, ColumnBound *bounds, size_t boundsLen);
 static int	TableDataFileCompare(const ListCell *a, const ListCell *b);
 static int	DataFileCompare(const ListCell *a, const ListCell *b);
 static int	DataFileColumnStatsCompare(const ListCell *a, const ListCell *b);
 static int	PartitionFieldCompare(const ListCell *a, const ListCell *b);
-static List *PartitionArrayToList(PartitionField * fields, size_t fieldsLength);
+static List *PartitionArrayToList(PartitionField *fields, size_t fieldsLength);
 static int	ColumnBoundCompare(const ListCell *a, const ListCell *b);
 static void DataFileToTableScanList(List *dataFileList, List **fileScans,
 									List **positionDeletes);
@@ -56,7 +56,7 @@ static void ErrorIfIcebergMetadataIsOutOfSync(Oid relationId, List *fileScans,
 											  List *positionDeleteScans);
 static int	ComparePgLakeFileScan(const ListCell *p1, const ListCell *p2);
 static void ErrorIfScanListsAreNotEqual(List *scanList1, List *scanList2, const char *scanType);
-static void AssertInternalAndExternalTableSchemaMatch(Oid relationId, DataFileSchema * internalSchema);
+static void AssertInternalAndExternalTableSchemaMatch(Oid relationId, DataFileSchema *internalSchema);
 static int	FieldCompare(const ListCell *a, const ListCell *b);
 static void AssertInternalAndExternalLeafFieldsMatch(Oid relationId, List *internalLeafFields);
 
@@ -589,7 +589,7 @@ AssertInternalAndExternalIcebergDataFileColumnStatsMatch(List *internalColumnSta
  * RemoveDroppedFieldBounds removes the bounds of dropped fields.
  */
 static List *
-RemoveDroppedFieldBounds(const List *existingLeafFields, ColumnBound * bounds, size_t boundsLen)
+RemoveDroppedFieldBounds(const List *existingLeafFields, ColumnBound *bounds, size_t boundsLen)
 {
 	List	   *nonDroppedBounds = NIL;
 
@@ -662,7 +662,7 @@ PartitionFieldCompare(const ListCell *a, const ListCell *b)
 }
 
 static List *
-PartitionArrayToList(PartitionField * fields, size_t fieldsLength)
+PartitionArrayToList(PartitionField *fields, size_t fieldsLength)
 {
 	List	   *partitionFields = NIL;
 
@@ -827,7 +827,7 @@ ErrorIfScanListsAreNotEqual(List *scanList1, List *scanList2, const char *scanTy
 * iceberg metadata.
 */
 static void
-AssertInternalAndExternalTableSchemaMatch(Oid relationId, DataFileSchema * internalSchema)
+AssertInternalAndExternalTableSchemaMatch(Oid relationId, DataFileSchema *internalSchema)
 {
 
 	char	   *metadataPath = GetIcebergMetadataLocation(relationId, false);

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -78,24 +78,24 @@ typedef struct RestCatalogRequestPerTable
 
 
 	List	   *tableModifyRequests;
-}			RestCatalogRequestPerTable;
+} RestCatalogRequestPerTable;
 
 static void ApplyTrackedIcebergMetadataChanges(bool isVerbose);
 static void RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operationType);
 static void InitTableMetadataTrackerHashIfNeeded(void);
 static void InitRestCatalogRequestsHashIfNeeded(void);
-static HTAB *CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata);
-static void FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
+static HTAB *CreateDataFilesHashForMetadata(IcebergTableMetadata *metadata);
+static void FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata *metadata,
 										  List **addedFiles, List **removedFilePaths);
-static HTAB *CreatePartitionSpecsHashForMetadata(IcebergTableMetadata * metadata);
-static List *FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTableMetadata * metadata);
-static IcebergTableMetadata * GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker);
-static List *GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
+static HTAB *CreatePartitionSpecsHashForMetadata(IcebergTableMetadata *metadata);
+static List *FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTableMetadata *metadata);
+static IcebergTableMetadata *GetLastPushedIcebergMetadata(const TableMetadataOperationTracker *opTracker);
+static List *GetDataFileMetadataOperations(const TableMetadataOperationTracker *opTracker,
 										   List *allTransforms);
-static List *GetDDLMetadataOperations(const TableMetadataOperationTracker * opTracker);
+static List *GetDDLMetadataOperations(const TableMetadataOperationTracker *opTracker);
 static void DeleteInProgressAddedFiles(Oid relationId, List *addedFiles);
-static bool AreSchemasEqual(IcebergTableSchema * existingSchema, DataFileSchema * newSchema);
-static int32_t GetSchemaIdForIcebergTableIfExists(const TableMetadataOperationTracker * opTracker, DataFileSchema * schema);
+static bool AreSchemasEqual(IcebergTableSchema *existingSchema, DataFileSchema *newSchema);
+static int32_t GetSchemaIdForIcebergTableIfExists(const TableMetadataOperationTracker *opTracker, DataFileSchema *schema);
 static int	ComparePartitionSpecsById(const ListCell *a, const ListCell *b);
 
 static char *IdentifierJson(const char *namespaceFlat, const char *tableName);
@@ -823,7 +823,7 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
  * from the given Iceberg table metadata.
  */
 static HTAB *
-CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
+CreateDataFilesHashForMetadata(IcebergTableMetadata *metadata)
 {
 	HTAB	   *dataFilesMap = CreateFilesHash();
 
@@ -855,7 +855,7 @@ CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
  * removedFilePaths: file paths, which are added before the current tx, that are removed since the metadata
  */
 static void
-FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
+FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata *metadata,
 							  List **addedFiles, List **removedFilePaths)
 {
 	/* create metadata's data files */
@@ -912,7 +912,7 @@ DeleteInProgressAddedFiles(Oid relationId, List *addedFiles)
  * from the given Iceberg table metadata.
  */
 static HTAB *
-CreatePartitionSpecsHashForMetadata(IcebergTableMetadata * metadata)
+CreatePartitionSpecsHashForMetadata(IcebergTableMetadata *metadata)
 {
 	HTAB	   *partitionSpecsMap = CreatePartitionSpecHash();
 
@@ -950,7 +950,7 @@ CreatePartitionSpecsHashForMetadata(IcebergTableMetadata * metadata)
  * with those in the metadata and returns a list of new partition specs.
  */
 static List *
-FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTableMetadata * metadata)
+FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTableMetadata *metadata)
 {
 	HTAB	   *metadataSpecs = CreatePartitionSpecsHashForMetadata(metadata);
 
@@ -979,7 +979,7 @@ FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTableMetadata * me
  * for the specified relation. It returns NULL if no metadata is found.
  */
 static IcebergTableMetadata *
-GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker)
+GetLastPushedIcebergMetadata(const TableMetadataOperationTracker *opTracker)
 {
 	/* table is just created, no metadata is pushed yet */
 	if (opTracker->relationCreated)
@@ -997,7 +997,7 @@ GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker)
  * in the specified relation.
  */
 static List *
-GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
+GetDataFileMetadataOperations(const TableMetadataOperationTracker *opTracker,
 							  List *allTransforms)
 {
 	/*
@@ -1069,7 +1069,7 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
  * the given relation.
  */
 static List *
-GetDDLMetadataOperations(const TableMetadataOperationTracker * opTracker)
+GetDDLMetadataOperations(const TableMetadataOperationTracker *opTracker)
 {
 	Assert(opTracker->relationCreated || opTracker->relationAltered || opTracker->relationPartitionByChanged);
 
@@ -1171,7 +1171,7 @@ ComparePartitionSpecsById(const ListCell *a, const ListCell *b)
  * in the iceberg table metadata. If it exists, it returns the schema ID, otherwise -1.
 */
 static int32_t
-GetSchemaIdForIcebergTableIfExists(const TableMetadataOperationTracker * opTracker, DataFileSchema * schema)
+GetSchemaIdForIcebergTableIfExists(const TableMetadataOperationTracker *opTracker, DataFileSchema *schema)
 {
 	IcebergTableMetadata *metadata = GetLastPushedIcebergMetadata(opTracker);
 
@@ -1197,7 +1197,7 @@ GetSchemaIdForIcebergTableIfExists(const TableMetadataOperationTracker * opTrack
 * AreSchemasEqual compares two schemas for equality.
 */
 static bool
-AreSchemasEqual(IcebergTableSchema * existingSchema, DataFileSchema * newSchema)
+AreSchemasEqual(IcebergTableSchema *existingSchema, DataFileSchema *newSchema)
 {
 	if (existingSchema->fields_length != newSchema->nfields)
 		return false;

--- a/pgduck_server/include/command_line/command_line.h
+++ b/pgduck_server/include/command_line/command_line.h
@@ -46,7 +46,7 @@ typedef struct
 	bool		debug;
 	char	   *init_file_path;
 	char	   *pidfile_path;
-}			CommandLineOptions;
+} CommandLineOptions;
 
 CommandLineOptions parse_arguments(int argc, char *argv[]);
 

--- a/pgduck_server/include/duckdb/type_conversion.h
+++ b/pgduck_server/include/duckdb/type_conversion.h
@@ -55,8 +55,8 @@ typedef struct DuckDBTypeInfo
 	 * for DuckDB types.
 	 */
 				DuckDBStatus(*to_text) (duckdb_vector vector, duckdb_logical_type logicalType, int row, TextOutputBuffer * buffer);
-}			DuckDBTypeInfo;
+} DuckDBTypeInfo;
 
-extern DuckDBTypeInfo * find_duck_type_info(duckdb_type duckType);
+extern DuckDBTypeInfo *find_duck_type_info(duckdb_type duckType);
 
 #endif

--- a/pgduck_server/include/pgserver/client_threadpool.h
+++ b/pgduck_server/include/pgserver/client_threadpool.h
@@ -32,7 +32,7 @@ extern int	MaxThreads;
 extern int	MaxAllowedClients;
 
 extern void pgclient_threadpool_init(int maxAllowedClients);
-extern int	pgclient_threadpool_reserve_slot(PGClient * client);
+extern int	pgclient_threadpool_reserve_slot(PGClient *client);
 extern void pgclient_threadpool_free_slot(int threadIndex);
 #if PG_VERSION_NUM >= 180000
 extern int	pgclient_threadpool_cancel_thread(int cancellationProcId, uint8 *cancellationToken,

--- a/pgduck_server/include/pgserver/pgserver.h
+++ b/pgduck_server/include/pgserver/pgserver.h
@@ -42,15 +42,15 @@ typedef struct PGServer
 	 * simple protocol and extended protocol etc.
 	 */
 	void	   *(*startFunction) (void *);
-}			PGServer;
+} PGServer;
 
-extern int	pgserver_init(PGServer * pgServer,
+extern int	pgserver_init(PGServer *pgServer,
 						  char *unixSocketPath,
 						  char *unixSocketOwningGroup,
 						  int unixSocketPermissions,
 						  int port);
-extern int	pgserver_run(PGServer * pgServer);
-extern void pgserver_destroy(PGServer * pgServer);
+extern int	pgserver_run(PGServer *pgServer);
+extern void pgserver_destroy(PGServer *pgServer);
 
 
 #endif							/* PGDUCK_PG_SERVER_H */

--- a/pgduck_server/include/pgsession/pgsession.h
+++ b/pgduck_server/include/pgsession/pgsession.h
@@ -74,7 +74,7 @@ typedef struct PGClient
 	int32		cancellationToken;
 #endif
 	int			threadIndex;
-}			PGClient;
+} PGClient;
 
 typedef uint32 ProtocolVersion;
 
@@ -94,7 +94,7 @@ typedef enum PreparedStatementState
 
 	/* prepared statement successfully bound */
 	PREPARED_STATEMENT_BOUND
-}			PreparedStatementState;
+} PreparedStatementState;
 
 /*
  * ResponseFormat describes the expected format of the response.
@@ -109,7 +109,7 @@ typedef struct ResponseFormat
 	 * data to clients.
 	 */
 	bool		isTransmit;
-}			ResponseFormat;
+} ResponseFormat;
 
 
 /*
@@ -133,7 +133,7 @@ typedef struct PgSessionPreparedStatement
 	/* current state of the prepared statement */
 	PreparedStatementState state;
 
-}			PgSessionPreparedStatement;
+} PgSessionPreparedStatement;
 
 
 
@@ -175,7 +175,7 @@ typedef struct PGSession
 
 	int			lastReportedSendErrno;	/* needed to make pgsession_flush
 										 * thread-safe */
-}			PGSession;
+} PGSession;
 
 /* per-client entrance point for the pgsession logic */
 extern void *pgsession_handle_connection(void *input);

--- a/pgduck_server/include/pgsession/pgsession_io.h
+++ b/pgduck_server/include/pgsession/pgsession_io.h
@@ -25,18 +25,18 @@
 
 #include "include/pgsession/pgsession.h"
 
-extern int	pgsession_put_message(PGSession * session, char messageType, char *buf, size_t bufferLength);
-extern int	pgsession_putemptymessage(PGSession * session, char msgtype);
-extern int	pgsession_get_message(PGSession * session, StringInfo message, int maxLength);
-extern int	pgsession_read_startup_packet(PGSession * session);
-extern int	pgsession_read_command(PGSession * session, StringInfo inputMessage);
-extern int	pgsession_get_bytes(PGSession * session, char *buf, size_t len);
-extern int	pgsession_get_byte(PGSession * session);
-extern int	pgsession_receive(PGSession * session);
-extern int	pgsession_put_bytes(PGSession * session, char *buf, size_t bufferLength);
-extern int	pgsession_flush(PGSession * session);
+extern int	pgsession_put_message(PGSession *session, char messageType, char *buf, size_t bufferLength);
+extern int	pgsession_putemptymessage(PGSession *session, char msgtype);
+extern int	pgsession_get_message(PGSession *session, StringInfo message, int maxLength);
+extern int	pgsession_read_startup_packet(PGSession *session);
+extern int	pgsession_read_command(PGSession *session, StringInfo inputMessage);
+extern int	pgsession_get_bytes(PGSession *session, char *buf, size_t len);
+extern int	pgsession_get_byte(PGSession *session);
+extern int	pgsession_receive(PGSession *session);
+extern int	pgsession_put_bytes(PGSession *session, char *buf, size_t bufferLength);
+extern int	pgsession_flush(PGSession *session);
 extern char *pgduck_client_to_server(const char *s, int len);
 extern void pq_sendstring(StringInfo buf, const char *str);
-extern int	pgsession_send_postgres_error(PGSession * pgSession, int errSev, char *errorMessage);
+extern int	pgsession_send_postgres_error(PGSession *pgSession, int errSev, char *errorMessage);
 
 #endif							/* // PGDUCK_PG_SESSION_IO_H */

--- a/pgduck_server/include/pgsession/pqformat.h
+++ b/pgduck_server/include/pgsession/pqformat.h
@@ -187,8 +187,8 @@ pq_writestring(StringInfoData *pg_restrict buf, const char *pg_restrict str)
 
 extern void pq_beginmessage(StringInfo buf, char msgtype);
 extern void pq_beginmessage_reuse(StringInfo buf, char msgtype);
-extern int	pq_endmessage(PGSession * session, StringInfo buf);
-extern int	pq_endmessage_reuse(PGSession * session, StringInfo buf);
+extern int	pq_endmessage(PGSession *session, StringInfo buf);
+extern int	pq_endmessage_reuse(PGSession *session, StringInfo buf);
 extern const char *pq_getmsgstring(StringInfo msg);
 extern unsigned int pq_getmsgint(StringInfo msg, int b, bool *readFailed);
 extern void pq_copymsgbytes(StringInfo msg, char *buf, int datalen, bool *readFailed);

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -108,7 +108,7 @@ static duckdb_state run_command_on_duckdb_with_callback(const char *command,
 														void *callbackArg);
 static DuckDBStatus return_query_result_to_pgsession(DuckDBSession * duckSession,
 													 duckdb_result duckResult,
-													 ResponseFormat * responseFormat,
+													 ResponseFormat *responseFormat,
 													 char **errorMessage);
 static duckdb_state process_single_result_as_text(duckdb_result * result,
 												  void *callbackArg);
@@ -117,18 +117,18 @@ static DuckDBStatus return_command_completion_pgsession(DuckDBSession * duckSess
 static void duckdb_query_result_init(DuckDBQueryResult * duckdb_query_result,
 									 duckdb_result * duckResult);
 static DuckDBStatus duckdb_query_result_send_column_metadata(DuckDBQueryResult * duckdb_query_result,
-															 PGSession * clientSession,
-															 ResponseFormat * responseFormat);
+															 PGSession *clientSession,
+															 ResponseFormat *responseFormat);
 static DuckDBStatus process_and_send_data_chunks(DuckDBQueryResult * duckdb_query_result,
-												 PGSession * clientSession,
-												 ResponseFormat * responseFormat,
+												 PGSession *clientSession,
+												 ResponseFormat *responseFormat,
 												 idx_t * rowsReturned,
 												 char **errorMessage);
 static DuckDBStatus process_data_chunk(duckdb_data_chunk chunk, StringInfoData *buf,
-									   PGSession * clientSession,
+									   PGSession *clientSession,
 									   DuckDBResultColumn * resultColumns,
 									   idx_t columnCount,
-									   ResponseFormat * responseFormat);
+									   ResponseFormat *responseFormat);
 static void create_result_column_state(DuckDBResultColumn * resultColumn,
 									   duckdb_data_chunk chunk,
 									   idx_t columnCount);
@@ -137,7 +137,7 @@ static void duckdb_query_result_destroy(DuckDBQueryResult * duckdb_query_result)
 static DuckDBStatus duckdb_vector_to_pg_wire(duckdb_vector vector, duckdb_type duckType,
 											 duckdb_logical_type logicalType,
 											 int row,
-											 ResponseFormat * responseFormat,
+											 ResponseFormat *responseFormat,
 											 StringInfo output);
 static bool is_set_command(const char *command);
 static void append_escaped_csv(StringInfo buffer, char *value);
@@ -627,7 +627,7 @@ process_single_result_as_text(duckdb_result * duckResult, void *callbackArg)
  * PostgreSQL client session.
  */
 DuckDBStatus
-duckdb_session_init(DuckDBSession * duckSession, PGSession * clientSession)
+duckdb_session_init(DuckDBSession * duckSession, PGSession *clientSession)
 {
 	if (!IsDuckDBInitialized)
 	{
@@ -672,7 +672,7 @@ static DuckDBStatus
 duckdb_vector_to_pg_wire(duckdb_vector vector, duckdb_type duckType,
 						 duckdb_logical_type logicalType,
 						 int row,
-						 ResponseFormat * responseFormat,
+						 ResponseFormat *responseFormat,
 						 StringInfo output)
 {
 	DuckDBTypeInfo *typeMap = find_duck_type_info(duckType);
@@ -719,7 +719,7 @@ duckdb_vector_to_pg_wire(duckdb_vector vector, duckdb_type duckType,
  */
 DuckDBStatus
 duckdb_session_run_command(DuckDBSession * duckSession, const char *queryString,
-						   ResponseFormat * responseFormat, char **errorMessage)
+						   ResponseFormat *responseFormat, char **errorMessage)
 {
 	duckdb_result duckResult;
 	duckdb_state duckState = duckdb_query(duckSession->connection, queryString, &duckResult);
@@ -904,7 +904,7 @@ duckdb_session_bind_varchar(DuckDBSession * duckSession,
 */
 DuckDBStatus
 duckdb_session_execute_prepared(DuckDBSession * duckSession,
-								ResponseFormat * responseFormat,
+								ResponseFormat *responseFormat,
 								char **errorMessage)
 {
 	duckdb_result duckResult;
@@ -958,7 +958,7 @@ duckdb_session_execute_prepared(DuckDBSession * duckSession,
  */
 static DuckDBStatus
 return_query_result_to_pgsession(DuckDBSession * duckSession, duckdb_result duckResult,
-								 ResponseFormat * responseFormat, char **errorMessage)
+								 ResponseFormat *responseFormat, char **errorMessage)
 {
 	DuckDBQueryResult duckdb_query_result;
 
@@ -1103,8 +1103,8 @@ duckdb_query_result_init(DuckDBQueryResult * duckdb_query_result, duckdb_result 
  */
 static DuckDBStatus
 duckdb_query_result_send_column_metadata(DuckDBQueryResult * duckdb_query_result,
-										 PGSession * clientSession,
-										 ResponseFormat * responseFormat)
+										 PGSession *clientSession,
+										 ResponseFormat *responseFormat)
 {
 	StringInfoData *buf = &duckdb_query_result->buf;
 	duckdb_result *duckResult = duckdb_query_result->duckResult;
@@ -1178,8 +1178,8 @@ duckdb_query_result_send_column_metadata(DuckDBQueryResult * duckdb_query_result
  */
 static DuckDBStatus
 process_and_send_data_chunks(DuckDBQueryResult * duckdb_query_result,
-							 PGSession * clientSession,
-							 ResponseFormat * responseFormat,
+							 PGSession *clientSession,
+							 ResponseFormat *responseFormat,
 							 idx_t * rowsReturned,
 							 char **errorMessage)
 {
@@ -1256,9 +1256,9 @@ process_and_send_data_chunks(DuckDBQueryResult * duckdb_query_result,
  * of query results in CSV format through CopyData messages.
  */
 static DuckDBStatus
-process_data_chunk(duckdb_data_chunk chunk, StringInfoData *buf, PGSession * clientSession,
+process_data_chunk(duckdb_data_chunk chunk, StringInfoData *buf, PGSession *clientSession,
 				   DuckDBResultColumn * resultColumns, idx_t columnCount,
-				   ResponseFormat * responseFormat)
+				   ResponseFormat *responseFormat)
 {
 	idx_t		chunkSize = duckdb_data_chunk_get_size(chunk);
 	bool		isTransmit = responseFormat->isTransmit;

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -58,13 +58,13 @@ typedef struct PgClientThreadState
 	/* DuckDB connection to interrupt */
 	duckdb_connection duckdbConnection;
 
-}			PgClientThreadState;
+} PgClientThreadState;
 
 int			MaxAllowedClients;
 int			MaxThreads;
 
 /* all accesses to ClientThreadPool should happen while holding a lock */
-static PgClientThreadState * ClientThreadPool;
+static PgClientThreadState *ClientThreadPool;
 static int	ActiveClientThreadCount = 0;
 
 
@@ -127,7 +127,7 @@ pgclient_threadpool_init(int maxAllowedClients)
  * if no slot was available.
  */
 int
-pgclient_threadpool_reserve_slot(PGClient * client)
+pgclient_threadpool_reserve_slot(PGClient *client)
 {
 	int			usedThreadIndex = InvalidThreadIndex;
 	int			cancellationProcId = 0;

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -56,7 +56,7 @@ typedef struct PgClientThreadInitState
 	void	   *(*startFunction) (void *);
 	PGClient   *pgClient;
 
-}			PgClientThreadInitState;
+} PgClientThreadInitState;
 
 
 /* copied from UNIXSOCK_PATH from PG source */
@@ -64,24 +64,24 @@ typedef struct PgClientThreadInitState
 		snprintf(path, sizeof(path), "%s/.s.PGSQL.%d", \
 				 (sockdir), (port))
 
-static int	create_and_bind_unix_socket(PGServer * server, char *unixSocketPath,
+static int	create_and_bind_unix_socket(PGServer *server, char *unixSocketPath,
 										char *unixSocketOwningGroup,
 										int unixSocketPermissions,
 										int port);
-static int	acquire_domain_socket_lock_file(PGServer * server, int port);
+static int	acquire_domain_socket_lock_file(PGServer *server, int port);
 static int	set_unix_socket_permissions(char *unixSocketPath, char *groupName,
 										int permissionsMask);
-static int	pgserver_create_client_thread(const PgClientThreadInitState * initState);
+static int	pgserver_create_client_thread(const PgClientThreadInitState *initState);
 static void *pgclient_thread_main(void *arg);
 static void pgclient_thread_cleanup(void *arg);
-static void touch_internal_files(PGServer * pgServer, time_t now);
+static void touch_internal_files(PGServer *pgServer, time_t now);
 
 /*
  * pgserver_create initializes a PostgreSQL wire compatible server
  * and starts listening on the given port.
  */
 int
-pgserver_init(PGServer * pgServer,
+pgserver_init(PGServer *pgServer,
 			  char *unixSocketPath,
 			  char *unixSocketOwningGroup,
 			  int unixSocketPermissions,
@@ -113,7 +113,7 @@ pgserver_init(PGServer * pgServer,
  * requirements as Postgres has. Hence, our code is simpler than Postgres'.
  */
 static int
-create_and_bind_unix_socket(PGServer * server,
+create_and_bind_unix_socket(PGServer *server,
 							char *unixSocketPath,
 							char *unixSocketOwningGroup,
 							int unixSocketPermissions,
@@ -235,7 +235,7 @@ create_and_bind_unix_socket(PGServer * server,
  * Acquire a lockfile for the specified Unix socket file.
  */
 static int
-acquire_domain_socket_lock_file(PGServer * server, int port)
+acquire_domain_socket_lock_file(PGServer *server, int port)
 {
 	/* no lock file for abstract sockets */
 	if (server->unixSocketPath[0] == '@')
@@ -413,7 +413,7 @@ enable_shutdown_signals(void)
  * pgserver_run is the main loop for the PostgreSQL wire compatible server.
  */
 int
-pgserver_run(PGServer * pgServer)
+pgserver_run(PGServer *pgServer)
 {
 	if (install_shutdown_signal_handlers() != STATUS_OK)
 		return STATUS_ERROR;
@@ -524,7 +524,7 @@ pgserver_run(PGServer * pgServer)
  * any remaining threads.
  */
 void
-pgserver_destroy(PGServer * pgServer)
+pgserver_destroy(PGServer *pgServer)
 {
 	PGDUCK_SERVER_LOG("Shutting down: closing listening socket");
 	closesocket(pgServer->listeningSocket);
@@ -557,7 +557,7 @@ pgserver_destroy(PGServer * pgServer)
  * SIGINT/SIGTERM.
  */
 static int
-pgserver_create_client_thread(const PgClientThreadInitState * initState)
+pgserver_create_client_thread(const PgClientThreadInitState *initState)
 {
 	pthread_t	threadId;
 	pthread_attr_t threadAttr;
@@ -655,7 +655,7 @@ pgclient_thread_cleanup(void *arg)
  * never have put the socket file in /tmp...)
  */
 static void
-touch_internal_files(PGServer * pgServer, time_t now)
+touch_internal_files(PGServer *pgServer, time_t now)
 {
 	/* no files for abstract sockets */
 	if (pgServer->unixSocketPath[0] != '@')

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -93,28 +93,28 @@
 	 (oom_is_fatal && (status) == DUCKDB_OUT_OF_MEMORY_ERROR))
 
 /* The main functions that implement PG protocol */
-static int	pgsession_send_auth_ok(PGSession * pgSession);
+static int	pgsession_send_auth_ok(PGSession *pgSession);
 #if PG_VERSION_NUM >= 180000
-static int	pgsession_send_cancellation_key(PGSession * pgSession, int cancellationProcId, uint8 *cancellationToken,
+static int	pgsession_send_cancellation_key(PGSession *pgSession, int cancellationProcId, uint8 *cancellationToken,
 											size_t cancellationTokenSize);
 #else
-static int	pgsession_send_cancellation_key(PGSession * pgSession, int cancellationProcId, int32 cancellationToken);
+static int	pgsession_send_cancellation_key(PGSession *pgSession, int cancellationProcId, int32 cancellationToken);
 #endif
-static int	pgsession_send_server_version(PGSession * pgSession, const char *serverVersion);
-static int	pgsession_send_client_encoding(PGSession * pgSession, const char *clientEncoding);
-static int	pgsession_send_extra_float_digits(PGSession * pgSession, const char *extra_float_digits);
-static int	pgsession_send_ready_for_query(PGSession * pgSession);
-static int	pgsession_init(PGSession * pgSession, PGClient * pgClient);
-static int	pgsession_destroy(PGSession * pgSession);
-static void pgsession_prepared_statement_deallocate(PGSession * pgSession);
-static void pgsession_log_client_info(PGClient * pgClient);
-static int	handle_pgsession_error_message(DuckDBStatus status, PGSession * pgSession,
+static int	pgsession_send_server_version(PGSession *pgSession, const char *serverVersion);
+static int	pgsession_send_client_encoding(PGSession *pgSession, const char *clientEncoding);
+static int	pgsession_send_extra_float_digits(PGSession *pgSession, const char *extra_float_digits);
+static int	pgsession_send_ready_for_query(PGSession *pgSession);
+static int	pgsession_init(PGSession *pgSession, PGClient *pgClient);
+static int	pgsession_destroy(PGSession *pgSession);
+static void pgsession_prepared_statement_deallocate(PGSession *pgSession);
+static void pgsession_log_client_info(PGClient *pgClient);
+static int	handle_pgsession_error_message(DuckDBStatus status, PGSession *pgSession,
 										   char *errorMessage);
 
-static int	process_query_message(PGSession * pgSession, StringInfo inputMessage);
-static int	process_parse_message(PGSession * pgSession, StringInfo inputMessage);
-static int	process_bind_message(PGSession * pgSession, StringInfo inputMessage);
-static int	process_execute_message(PGSession * pgSession, StringInfo inputMessage);
+static int	process_query_message(PGSession *pgSession, StringInfo inputMessage);
+static int	process_parse_message(PGSession *pgSession, StringInfo inputMessage);
+static int	process_bind_message(PGSession *pgSession, StringInfo inputMessage);
+static int	process_execute_message(PGSession *pgSession, StringInfo inputMessage);
 
 static bool is_transmit_query(const char *queryString);
 
@@ -367,7 +367,7 @@ finally:
  * Otherwise, it returns OK.
  */
 static int
-process_query_message(PGSession * pgSession, StringInfo inputMessage)
+process_query_message(PGSession *pgSession, StringInfo inputMessage)
 {
 	const char *queryString = pq_getmsgstring(inputMessage);
 
@@ -444,7 +444,7 @@ process_query_message(PGSession * pgSession, StringInfo inputMessage)
  * Otherwise, it returns OK.
 */
 static int
-process_parse_message(PGSession * pgSession, StringInfo inputMessage)
+process_parse_message(PGSession *pgSession, StringInfo inputMessage)
 {
 	/*
 	 * A single session only supports a single unnamed prepared statement. We
@@ -600,7 +600,7 @@ process_parse_message(PGSession * pgSession, StringInfo inputMessage)
  * Otherwise, it returns OK.
 */
 static int
-process_bind_message(PGSession * pgSession, StringInfo inputMessage)
+process_bind_message(PGSession *pgSession, StringInfo inputMessage)
 {
 	if (pgSession->pgSessionPreparedStmt.state != PREPARED_STATEMENT_PARSED &&
 		pgSession->pgSessionPreparedStmt.state != PREPARED_STATEMENT_BOUND)
@@ -771,7 +771,7 @@ process_bind_message(PGSession * pgSession, StringInfo inputMessage)
  * Otherwise, it returns OK.
  */
 static int
-process_execute_message(PGSession * pgSession, StringInfo inputMessage)
+process_execute_message(PGSession *pgSession, StringInfo inputMessage)
 {
 	if (pgSession->pgSessionPreparedStmt.state != PREPARED_STATEMENT_BOUND)
 	{
@@ -849,7 +849,7 @@ process_execute_message(PGSession * pgSession, StringInfo inputMessage)
  * Helper function to handle different DuckDB statuses.
  */
 static int
-handle_pgsession_error_message(DuckDBStatus status, PGSession * pgSession, char *errorMessage)
+handle_pgsession_error_message(DuckDBStatus status, PGSession *pgSession, char *errorMessage)
 {
 	int			errorRes;
 
@@ -884,7 +884,7 @@ handle_pgsession_error_message(DuckDBStatus status, PGSession * pgSession, char 
  * the server is ready for a query.
  */
 static int
-pgsession_send_ready_for_query(PGSession * pgSession)
+pgsession_send_ready_for_query(PGSession *pgSession)
 {
 	StringInfoData buf;
 
@@ -906,7 +906,7 @@ pgsession_send_ready_for_query(PGSession * pgSession)
  * authentication is done.
  */
 static int
-pgsession_send_auth_ok(PGSession * pgSession)
+pgsession_send_auth_ok(PGSession *pgSession)
 {
 	StringInfoData buf;
 
@@ -926,7 +926,7 @@ pgsession_send_auth_ok(PGSession * pgSession)
  */
 #if PG_VERSION_NUM >= 180000
 static int
-pgsession_send_cancellation_key(PGSession * pgSession, int cancellationProcId, uint8 *cancelKey, size_t cancelKeyLength)
+pgsession_send_cancellation_key(PGSession *pgSession, int cancellationProcId, uint8 *cancelKey, size_t cancelKeyLength)
 {
 	StringInfoData buf;
 
@@ -943,7 +943,7 @@ pgsession_send_cancellation_key(PGSession * pgSession, int cancellationProcId, u
 }
 #else
 static int
-pgsession_send_cancellation_key(PGSession * pgSession, int cancellationProcId, int32 cancellationToken)
+pgsession_send_cancellation_key(PGSession *pgSession, int cancellationProcId, int32 cancellationToken)
 {
 	StringInfoData buf;
 
@@ -965,7 +965,7 @@ pgsession_send_cancellation_key(PGSession * pgSession, int cancellationProcId, i
  * SendServerVersion sends the server version to the client
  */
 static int
-pgsession_send_server_version(PGSession * pgSession, const char *serverVersion)
+pgsession_send_server_version(PGSession *pgSession, const char *serverVersion)
 {
 	StringInfoData buf;
 
@@ -985,7 +985,7 @@ pgsession_send_server_version(PGSession * pgSession, const char *serverVersion)
  * SendServerVersion sends the server version to the client
  */
 static int
-pgsession_send_client_encoding(PGSession * pgSession, const char *clientEncoding)
+pgsession_send_client_encoding(PGSession *pgSession, const char *clientEncoding)
 {
 	StringInfoData buf;
 
@@ -1006,7 +1006,7 @@ pgsession_send_client_encoding(PGSession * pgSession, const char *clientEncoding
  * pgsession_send_extra_float_digits sends the extra_float_digits to the client
  */
 static int
-pgsession_send_extra_float_digits(PGSession * pgSession, const char *extra_float_digits)
+pgsession_send_extra_float_digits(PGSession *pgSession, const char *extra_float_digits)
 {
 	StringInfoData buf;
 
@@ -1029,7 +1029,7 @@ pgsession_send_extra_float_digits(PGSession * pgSession, const char *extra_float
  * Extracted from BackendInitialize() from postmaster.c
  */
 static void
-pgsession_log_client_info(PGClient * pgClient)
+pgsession_log_client_info(PGClient *pgClient)
 {
 	int			retVal = 0;
 	char		clientHost[NI_MAXHOST];
@@ -1068,7 +1068,7 @@ pgsession_log_client_info(PGClient * pgClient)
  * pgsession_init initializes the pgSession state.
  */
 static int
-pgsession_init(PGSession * pgSession, PGClient * pgClient)
+pgsession_init(PGSession *pgSession, PGClient *pgClient)
 {
 	memset(pgSession, '\0', sizeof(PGSession));
 	pgSession->pgClient = pgClient;
@@ -1094,7 +1094,7 @@ pgsession_init(PGSession * pgSession, PGClient * pgClient)
  * pgsession_destroy frees any memory associated with the pgSession.
  */
 static int
-pgsession_destroy(PGSession * pgSession)
+pgsession_destroy(PGSession *pgSession)
 {
 	pg_free(pgSession->pqSendBuffer);
 	duckdb_session_destroy(&pgSession->duckSession);
@@ -1108,7 +1108,7 @@ pgsession_destroy(PGSession * pgSession)
 * deallocating the previous prepared statement, if any.
 */
 static void
-pgsession_prepared_statement_deallocate(PGSession * pgSession)
+pgsession_prepared_statement_deallocate(PGSession *pgSession)
 {
 	if (pgSession->pgSessionPreparedStmt.state != PREPARED_STATEMENT_INVALID)
 	{

--- a/pgduck_server/src/pgsession/pgsession_io.c
+++ b/pgduck_server/src/pgsession/pgsession_io.c
@@ -55,7 +55,7 @@ static int	process_cancel_request(char *startupPacketBuf, int startupPacketLen);
  * Derived from SocketBackend() at postgres.c
  */
 int
-pgsession_read_command(PGSession * pgSession, StringInfo inputMessage)
+pgsession_read_command(PGSession *pgSession, StringInfo inputMessage)
 {
 	int			maxMessageLength;
 
@@ -144,7 +144,7 @@ pgsession_read_command(PGSession * pgSession, StringInfo inputMessage)
  *		returns 0 if OK, EOF if trouble
  */
 int
-pgsession_get_message(PGSession * pgSession, StringInfo message, int maxLength)
+pgsession_get_message(PGSession *pgSession, StringInfo message, int maxLength)
 {
 	int32		messageLength;
 
@@ -196,7 +196,7 @@ pgsession_get_message(PGSession * pgSession, StringInfo message, int maxLength)
  * The logic is extracted from ProcessStartupPacket() in postgres.
  */
 int
-pgsession_read_startup_packet(PGSession * pgSession)
+pgsession_read_startup_packet(PGSession *pgSession)
 {
 	int			startupPacketLen = 0;
 	char	   *startupPacketBuf = NULL;
@@ -393,7 +393,7 @@ pq_sendstring(StringInfo buf, const char *str)
  * Derived from pq_getbytes in postgres
  */
 int
-pgsession_get_bytes(PGSession * pgSession, char *buf, size_t len)
+pgsession_get_bytes(PGSession *pgSession, char *buf, size_t len)
 {
 	size_t		amount;
 
@@ -427,7 +427,7 @@ pgsession_get_bytes(PGSession * pgSession, char *buf, size_t len)
  * Derived from pq_recvbuf in postgres.
  */
 int
-pgsession_receive(PGSession * pgSession)
+pgsession_receive(PGSession *pgSession)
 {
 	if (pgSession->pqRecvPointer > 0)
 	{
@@ -497,7 +497,7 @@ pgsession_receive(PGSession * pgSession)
  *      returns 0 if OK, EOF if trouble
  */
 int
-pgsession_put_message(PGSession * pgSession, char messageType, char *buf, size_t bufferLength)
+pgsession_put_message(PGSession *pgSession, char messageType, char *buf, size_t bufferLength)
 {
 	uint32		n32;
 
@@ -526,7 +526,7 @@ pgsession_put_message(PGSession * pgSession, char messageType, char *buf, size_t
 * buffer of the pgSession.
 */
 int
-pgsession_putemptymessage(PGSession * pgSession, char msgtype)
+pgsession_putemptymessage(PGSession *pgSession, char msgtype)
 {
 	return pgsession_put_message(pgSession, msgtype, NULL, 0);
 }
@@ -536,7 +536,7 @@ pgsession_putemptymessage(PGSession * pgSession, char msgtype)
  * and flushes the buffer if it is full.
  */
 int
-pgsession_put_bytes(PGSession * pgSession, char *buf, size_t bufferLength)
+pgsession_put_bytes(PGSession *pgSession, char *buf, size_t bufferLength)
 {
 	size_t		amount;
 
@@ -574,7 +574,7 @@ pgsession_put_bytes(PGSession * pgSession, char *buf, size_t bufferLength)
  * and the socket is in non-blocking mode), or EOF if trouble.
  */
 int
-pgsession_flush(PGSession * pgSession)
+pgsession_flush(PGSession *pgSession)
 {
 	char	   *bufPtr = pgSession->pqSendBuffer + pgSession->pqSendStart;
 	char	   *bufEnd = pgSession->pqSendBuffer + pgSession->pqSendPointer;
@@ -643,7 +643,7 @@ pgsession_flush(PGSession * pgSession)
  *		pq_getbyte	- get a single byte from connection, or return EOF
  */
 int
-pgsession_get_byte(PGSession * pgSession)
+pgsession_get_byte(PGSession *pgSession)
 {
 	while (pgSession->pqRecvPointer >= pgSession->pqRecvLength)
 	{
@@ -664,7 +664,7 @@ pgsession_get_byte(PGSession * pgSession)
  * Derived from send_message_to_frontend
  */
 int
-pgsession_send_postgres_error(PGSession * pgSession, int errSev, char *errorMessage)
+pgsession_send_postgres_error(PGSession *pgSession, int errSev, char *errorMessage)
 {
 	StringInfoData msgBuffer;
 

--- a/pgduck_server/src/pgsession/pqformat.c
+++ b/pgduck_server/src/pgsession/pqformat.c
@@ -144,7 +144,7 @@ pq_beginmessage_reuse(StringInfo buf, char msgtype)
  * --------------------------------
  */
 int
-pq_endmessage(PGSession * session, StringInfo buf)
+pq_endmessage(PGSession *session, StringInfo buf)
 {
 	/* msgtype was saved in cursor field */
 	int			ret = pgsession_put_message(session, buf->cursor, buf->data, buf->len);
@@ -165,7 +165,7 @@ pq_endmessage(PGSession * session, StringInfo buf)
  */
 
 int
-pq_endmessage_reuse(PGSession * session, StringInfo buf)
+pq_endmessage_reuse(PGSession *session, StringInfo buf)
 {
 	/* msgtype was saved in cursor field */
 	return pgsession_put_message(session, buf->cursor, buf->data, buf->len);

--- a/pgduck_server/src/utils/pgduck_log_utils.c
+++ b/pgduck_server/src/utils/pgduck_log_utils.c
@@ -32,7 +32,7 @@ typedef struct ErrorCode
 {
 	int			code;
 	const char *description;
-}			ErrorCode;
+} ErrorCode;
 
 
 /* Define the lookup table for error codes, derived from elog.h */

--- a/tools/extract_typedefs.sh
+++ b/tools/extract_typedefs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Extracts typedef names from C source files in the given directories.
+# Handles named structs/enums/unions, anonymous structs/enums/unions,
+# function pointers, and simple type aliases.
+#
+# Usage: tools/extract_typedefs.sh dir1 dir2 ...
+# Output: sorted unique type names, one per line (pgindent typedefs format)
+
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 dir1 [dir2 ...]" >&2
+	exit 1
+fi
+
+FILES=$(find "$@" \( -name '*.c' -o -name '*.h' \) \
+	-not -path '*/duckdb/*' \
+	-not -path '*/avro/*')
+
+{
+	# Named structs/enums/unions: typedef struct FooBar
+	echo "$FILES" | xargs grep -h '^typedef' | \
+		sed -En 's/^typedef[[:space:]]+(struct|enum|union)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*/\2/p'
+
+	# Anonymous structs/enums/unions: } FooBar;
+	echo "$FILES" | xargs grep -h '^}' | \
+		sed -En 's/^\}[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;.*/\1/p'
+
+	# Function pointers: typedef ... (*FuncName)(...)
+	echo "$FILES" | xargs grep -h '^typedef' | \
+		sed -En 's/^typedef[[:space:]].*\(\*[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\).*/\1/p'
+
+	# Simple type aliases: typedef ExistingType NewName;
+	# Excludes struct/enum/union and function pointers already handled above
+	echo "$FILES" | xargs grep -h '^typedef' | \
+		grep -v 'struct\|enum\|union' | grep -v '(\*' | \
+		sed -En 's/^typedef[[:space:]]+.+[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;.*/\1/p'
+} | sort -u

--- a/tools/extract_typedefs.sh
+++ b/tools/extract_typedefs.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 #
 # Extracts typedef names from C source files in the given directories.
-# Handles named structs/enums/unions, anonymous structs/enums/unions,
-# function pointers, and simple type aliases.
+# Output: sorted unique type names, one per line (pgindent typedefs format)
 #
 # Usage: tools/extract_typedefs.sh dir1 dir2 ...
-# Output: sorted unique type names, one per line (pgindent typedefs format)
 
 set -euo pipefail
 
@@ -14,26 +12,23 @@ if [ $# -eq 0 ]; then
 	exit 1
 fi
 
-FILES=$(find "$@" \( -name '*.c' -o -name '*.h' \) \
+# Single grep pass: collect all typedef and closing-brace lines
+LINES=$(find "$@" \( -name '*.c' -o -name '*.h' \) \
 	-not -path '*/duckdb/*' \
-	-not -path '*/avro/*')
+	-not -path '*/avro/*' \
+	-print0 | \
+	xargs -0 grep -hE '^(typedef|})')
 
 {
-	# Named structs/enums/unions: typedef struct FooBar
-	echo "$FILES" | xargs grep -h '^typedef' | \
-		sed -En 's/^typedef[[:space:]]+(struct|enum|union)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*/\2/p'
+	# typedef struct/enum/union Name ...
+	echo "$LINES" | sed -En 's/^typedef[[:space:]]+(struct|enum|union)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*/\2/p'
 
-	# Anonymous structs/enums/unions: } FooBar;
-	echo "$FILES" | xargs grep -h '^}' | \
-		sed -En 's/^\}[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;.*/\1/p'
+	# } Name; (anonymous struct/enum/union)
+	echo "$LINES" | sed -En 's/^\}[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;.*/\1/p'
 
-	# Function pointers: typedef ... (*FuncName)(...)
-	echo "$FILES" | xargs grep -h '^typedef' | \
-		sed -En 's/^typedef[[:space:]].*\(\*[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\).*/\1/p'
+	# typedef ... (*Name)(...) (function pointers)
+	echo "$LINES" | sed -En 's/^typedef.*\(\*[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\).*/\1/p'
 
-	# Simple type aliases: typedef ExistingType NewName;
-	# Excludes struct/enum/union and function pointers already handled above
-	echo "$FILES" | xargs grep -h '^typedef' | \
-		grep -v 'struct\|enum\|union' | grep -v '(\*' | \
-		sed -En 's/^typedef[[:space:]]+.+[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;.*/\1/p'
+	# typedef ... Name; (simple aliases, also catches typedef struct X Y;)
+	echo "$LINES" | sed -En 's/^typedef.*[[:space:]]([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*;[[:space:]]*$/\1/p'
 } | sort -u


### PR DESCRIPTION
### Description

Register pg_lake's custom types in the typedefs list, and combine with the Postgres typedefs for pg_indent. Idea from @sfc-gh-dachristensen https://github.com/Snowflake-Labs/pg_lake/pull/317#discussion_r3096531004

This PR also fixes our current formatting issues.

---

### Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**