### PR TITLE
Upload postgres log artifacts to CI

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -137,6 +137,7 @@ runs:
 
     - name: Upload postgres test logs
       uses: actions/upload-artifact@v4
+      if: success() || failure()
       with:
         name: postgres-logs-${{ inputs.pg_version }}-${{ inputs.test_make_target }}
         path: |

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -134,3 +134,14 @@ runs:
         else
           make ${{ inputs.test_make_target }}
         fi
+
+    - name: Upload postgres test logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: postgres-logs-${{ inputs.from_pg_version }}-${{ inputs.test_make_target }}
+        path: |
+          /tmp/pg_lake_tests/logfile
+          /tmp/pg_installcheck_tests/logfile
+          /tmp/pytest-of-*/**/postgres*.log
+        retention-days: 3
+

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -137,7 +137,7 @@ runs:
 
     - name: Upload postgres test logs
       uses: actions/upload-artifact@v4
-      if: success() || failure()
+      if: always()
       with:
         name: postgres-logs-${{ inputs.pg_version }}-${{ inputs.test_make_target }}
         path: |

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -138,7 +138,7 @@ runs:
     - name: Upload postgres test logs
       uses: actions/upload-artifact@v4
       with:
-        name: postgres-logs-${{ inputs.from_pg_version }}-${{ inputs.test_make_target }}
+        name: postgres-logs-${{ inputs.pg_version }}-${{ inputs.test_make_target }}
         path: |
           /tmp/pg_lake_tests/logfile
           /tmp/pg_installcheck_tests/logfile


### PR DESCRIPTION
Assist in debugging by uploading postgres-related logs as a github artifact.

We may also want to bump the default `log_level` to include at least `debug1`, but something is better than nothing at this point.
