### PR TITLE
Bump max_replication_slots in CI

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -106,6 +106,7 @@ runs:
           
           echo "listen_addresses = 'localhost'" >> /tmp/pg_installcheck_tests/postgresql.conf
           echo "max_worker_processes = 100" >> /tmp/pg_installcheck_tests/postgresql.conf
+          echo "max_replication_slots = 100" >> /tmp/pg_installcheck_tests/postgresql.conf
           echo "pg_lake_engine.orphaned_file_retention_period=0" >> /tmp/pg_installcheck_tests/postgresql.conf
           echo "pg_lake_iceberg.autovacuum_naptime=5" >> /tmp/pg_installcheck_tests/postgresql.conf
           echo "unix_socket_directories = '/tmp/pg_installcheck_tests'" >> /tmp/pg_installcheck_tests/postgresql.conf

--- a/test_common/helpers/server.py
+++ b/test_common/helpers/server.py
@@ -578,6 +578,8 @@ def initdb(initdb_bindir, db_path, db_user):
             "max_prepared_transactions=100",
             "--set",
             "max_worker_processes=100",
+            "--set",
+            "max_replication_slots=100",
             # get rid of unused files, as well as stress test file removal
             "--set",
             "pg_lake_engine.orphaned_file_retention_period=0",


### PR DESCRIPTION
Some tests that rely on this codebase generate a lot of replication slots; let's just go ahead and set to a value that we are likely to never need to exceed.
