### PR TITLE
Pin PGINDENT_PG_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,11 @@ UNAME_S := $(shell uname -s)
 
 # List of targets for indent checks
 INDENT_TARGETS = pgduck_server $(EXTENSION_TARGETS)
-TYPEDEFS = /tmp/typedefs-$(PG_MAJOR_VERSION).list
+
+# Pinned PG version for formatting (pgindent/typedefs). Must match CI
+# (lint-check-18 in pytest_all.yml).
+PGINDENT_PG_VERSION := 18
+TYPEDEFS = /tmp/typedefs-$(PGINDENT_PG_VERSION).list
 
 CMAKE_AVRO_ARGS = -DCMAKE_INSTALL_PREFIX=avrolib -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
@@ -71,7 +75,7 @@ endif
 typedefs: $(TYPEDEFS)
 
 $(TYPEDEFS):
-	curl -o $(TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PG_MAJOR_VERSION)_STABLE
+	curl -o $(TYPEDEFS) https://buildfarm.postgresql.org/cgi-bin/typedefs.pl?branch=REL_$(PGINDENT_PG_VERSION)_STABLE
 
 check-indent: typedefs
 	pgindent --typedefs=$(TYPEDEFS) --check --diff $(INDENT_TARGETS)


### PR DESCRIPTION
### Description
`make reindent` downloaded typedefs based on whatever PG the developer had installed locally, which could differ from CI (pinned to PG18) and cause spurious lint failures. By introducing `PGINDENT_PG_VERSION := 18`, all developers download the same PG18 typedefs regardless of their local PG installation, matching CI behavior.

---

### Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**