### PR TITLE
Fix TIMETZ corruption in Iceberg pushdown/snapshot writes

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/iceberg_query_validation.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/iceberg_query_validation.h
@@ -38,11 +38,10 @@ extern PGDLLEXPORT char *IcebergWrapQueryWithErrorOrClampChecks(char *query,
 																bool queryHasRowId);
 
 /*
- * IcebergWrapQueryWithIntervalConversion wraps a query to decompose
- * INTERVAL columns into STRUCT(months, days, microseconds) for Iceberg.
- *
- * Returns the original query unchanged if no interval columns exist.
+ * IcebergWrapQueryWithNativeTypeConversion wraps a query to rewrite
+ * columns whose native DuckDB shape does not match Iceberg's.  See the
+ * implementation for the set of rewrites and why each is required.
  */
-extern PGDLLEXPORT char *IcebergWrapQueryWithIntervalConversion(char *query,
-																TupleDesc tupleDesc,
-																bool queryHasRowId);
+extern PGDLLEXPORT char *IcebergWrapQueryWithNativeTypeConversion(char *query,
+																  TupleDesc tupleDesc,
+																  bool queryHasRowId);

--- a/pg_lake_engine/include/pg_lake/pgduck/write_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/write_data.h
@@ -56,7 +56,7 @@ extern PGDLLEXPORT StatsCollector * WriteQueryResultTo(char *query,
 													   TupleDesc queryTupleDesc,
 													   List *leafFields,
 													   IcebergOutOfRangePolicy outOfRangePolicy,
-													   bool wrapNativeIntervals);
+													   bool wrapNativeTypes);
 extern PGDLLEXPORT void AppendFields(StringInfo map, DataFileSchema * schema);
 extern PGDLLEXPORT char *TupleDescToColumnMapForWrite(TupleDesc tupleDesc, CopyDataFormat destinationFormat);
 extern PGDLLEXPORT char *TupleDescToProjectionListForWrite(TupleDesc tupleDesc,

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -18,27 +18,21 @@
 /*
  * Query-level Iceberg value clamp/error and type transformations.
  *
- * IcebergWrapQueryWithErrorOrClampChecks embeds validation expressions
- * into the write query sent to pgduck_server.  Currently handles:
+ * Two SELECT-wrapping entry points live here, both applied to the write
+ * query sent to pgduck_server.  See the function-level comments for the
+ * exact set of rewrites and why each is required:
  *
- *   - Temporal boundary enforcement (date/timestamp/timestamptz):
- *     clamp or reject values outside the Iceberg-supported range.
- *   - Multidimensional array enforcement: pg_nullify_nested_list()
- *     (clamp) or pg_error_nested_list() (error) for nested lists,
- *     since Iceberg/Parquet only supports flat lists.
+ *   - IcebergWrapQueryWithErrorOrClampChecks: clamp/error checks for
+ *     out-of-range temporal values and nested-list flattening.
+ *   - IcebergWrapQueryWithNativeTypeConversion: rewrites DuckDB columns
+ *     whose native representation differs from the Iceberg target
+ *     (INTERVAL, TIMETZ).
  *
- * These checks are applied recursively through arrays, composites,
- * maps, and domains.
- *
- * IcebergWrapQueryWithIntervalConversion decomposes DuckDB INTERVAL
- * columns into STRUCT(months, days, microseconds) to match the Iceberg
- * interval representation.
+ * Both recurse through arrays, composites, maps, and domains.
  *
  * Common validation helpers (policy resolution, IsTemporalType, temporal
- * boundary constants) live in iceberg_validation.c.
- *
- * Datum-level validation (non-pushdown path) lives in
- * iceberg_datum_validation.c.
+ * boundary constants) live in iceberg_validation.c.  Datum-level
+ * validation (non-pushdown path) lives in iceberg_datum_validation.c.
  *
  * Temporal boundaries:
  *   - Date: proleptic Gregorian range -4712-01-01 .. 9999-12-31.
@@ -76,12 +70,13 @@ static bool AppendIcebergValidationExpression(StringInfo buf, const char *expr,
 											  IcebergOutOfRangePolicy policy,
 											  int depth);
 
-static bool TypeContainsInterval(Oid typeOid);
-static bool TupleDescHasIntervalColumn(TupleDesc tupleDesc);
+static bool TypeNeedsNativeConversion(Oid typeOid);
+static bool TupleDescHasNativeConversionColumn(TupleDesc tupleDesc);
 static void AppendIntervalStructPack(StringInfo buf, const char *expr);
-static bool AppendIntervalConversionExpression(StringInfo buf, const char *expr,
-											   Oid typeOid, int32 typmod,
-											   int depth);
+static void AppendTimeTzUtcCast(StringInfo buf, const char *expr);
+static bool AppendNativeConversionExpression(StringInfo buf, const char *expr,
+											 Oid typeOid, int32 typmod,
+											 int depth);
 
 
 /* ================================================================
@@ -474,37 +469,40 @@ IcebergWrapQueryWithErrorOrClampChecks(char *query, TupleDesc tupleDesc,
 
 
 /* ================================================================
- * Query wrapping for interval -> struct conversion
+ * Query wrapping for native-type -> Iceberg conversion.
+ * See IcebergWrapQueryWithNativeTypeConversion below.
  * ================================================================ */
 
 /*
- * TypeContainsInterval recursively checks whether a type is or contains
- * an interval, including inside arrays, composites, maps, and domains.
+ * TypeNeedsNativeConversion recursively checks whether a type is, or
+ * contains, one of the native DuckDB types that needs rewriting before
+ * being written to Iceberg (currently INTERVAL and TIMETZ).  Recurses
+ * through arrays, composites, maps, and domains.
  */
 static bool
-TypeContainsInterval(Oid typeOid)
+TypeNeedsNativeConversion(Oid typeOid)
 {
-	if (typeOid == INTERVALOID)
+	if (typeOid == INTERVALOID || typeOid == TIMETZOID)
 		return true;
 
 	Oid			elemType = get_element_type(typeOid);
 
 	if (OidIsValid(elemType))
-		return TypeContainsInterval(elemType);
+		return TypeNeedsNativeConversion(elemType);
 
 	if (IsMapTypeOid(typeOid))
 	{
 		PGType		keyType = GetMapKeyType(typeOid);
 		PGType		valType = GetMapValueType(typeOid);
 
-		return TypeContainsInterval(keyType.postgresTypeOid) ||
-			TypeContainsInterval(valType.postgresTypeOid);
+		return TypeNeedsNativeConversion(keyType.postgresTypeOid) ||
+			TypeNeedsNativeConversion(valType.postgresTypeOid);
 	}
 
 	char		typtype = get_typtype(typeOid);
 
 	if (typtype == TYPTYPE_DOMAIN)
-		return TypeContainsInterval(getBaseType(typeOid));
+		return TypeNeedsNativeConversion(getBaseType(typeOid));
 
 	if (typtype == TYPTYPE_COMPOSITE)
 	{
@@ -518,7 +516,7 @@ TypeContainsInterval(Oid typeOid)
 			if (attr->attisdropped)
 				continue;
 
-			if (TypeContainsInterval(attr->atttypid))
+			if (TypeNeedsNativeConversion(attr->atttypid))
 			{
 				found = true;
 				break;
@@ -534,7 +532,7 @@ TypeContainsInterval(Oid typeOid)
 
 
 static bool
-TupleDescHasIntervalColumn(TupleDesc tupleDesc)
+TupleDescHasNativeConversionColumn(TupleDesc tupleDesc)
 {
 	for (int i = 0; i < tupleDesc->natts; i++)
 	{
@@ -543,7 +541,7 @@ TupleDescHasIntervalColumn(TupleDesc tupleDesc)
 		if (attr->attisdropped)
 			continue;
 
-		if (TypeContainsInterval(attr->atttypid))
+		if (TypeNeedsNativeConversion(attr->atttypid))
 			return true;
 	}
 
@@ -575,21 +573,58 @@ AppendIntervalStructPack(StringInfo buf, const char *expr)
 
 
 /*
- * AppendIntervalConversionExpression recursively generates DuckDB SQL
- * that converts INTERVAL values to STRUCT(months, days, microseconds).
+ * AppendTimeTzUtcCast emits the DuckDB expression that produces the
+ * Iceberg-storable TIME for a TIMETZ leaf.  See
+ * IcebergWrapQueryWithNativeTypeConversion for the why.
+ *
+ * The inner "CAST(... AS TIMETZ)" is deliberately retained because the
+ * leaf expression can arrive at this helper in either of two shapes:
+ *
+ *   - Top-level TIMETZ columns from read_iceberg / postgres_scan are
+ *     already TIME WITH TIME ZONE; the inner cast is a no-op.
+ *   - TIMETZ fields living *inside* an Iceberg composite arrive as plain
+ *     TIME (Parquet has no time-with-tz type and DuckDB does not recast
+ *     struct fields back to TIMETZ on read), and DuckDB has no
+ *     timezone(VARCHAR, TIME) overload, so a bare "AT TIME ZONE 'UTC'"
+ *     would produce a binder error.  Casting to TIMETZ first lifts the
+ *     value to +00 (semantically a no-op under the pg_lake invariant
+ *     that those digits are already UTC) and keeps the outer expression
+ *     well-typed.
+ */
+static void
+AppendTimeTzUtcCast(StringInfo buf, const char *expr)
+{
+	appendStringInfo(buf,
+					 "CAST(CAST((%s) AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)",
+					 expr);
+}
+
+
+/*
+ * AppendNativeConversionExpression recursively generates DuckDB SQL
+ * that converts native-only types to their Iceberg-compatible shape:
+ *   - INTERVAL -> STRUCT(months, days, microseconds)
+ *   - TIMETZ   -> CAST(CAST(<expr> AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)
+ *
  * Handles scalars, arrays (list_transform), composites (struct_pack),
  * maps (map_from_entries + list_transform), and domains.
  *
  * Returns true if a transformed expression was written to buf.
  */
 static bool
-AppendIntervalConversionExpression(StringInfo buf, const char *expr,
-								   Oid typeOid, int32 typmod,
-								   int depth)
+AppendNativeConversionExpression(StringInfo buf, const char *expr,
+								 Oid typeOid, int32 typmod,
+								 int depth)
 {
 	if (typeOid == INTERVALOID)
 	{
 		AppendIntervalStructPack(buf, expr);
+		return true;
+	}
+
+	if (typeOid == TIMETZOID)
+	{
+		AppendTimeTzUtcCast(buf, expr);
 		return true;
 	}
 
@@ -598,14 +633,14 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 
 	if (OidIsValid(elemType))
 	{
-		if (!TypeContainsInterval(elemType))
+		if (!TypeNeedsNativeConversion(elemType))
 			return false;
 
 		char	   *lambdaVar = psprintf("_x%d", depth);
 
 		appendStringInfo(buf, "list_transform(%s, %s -> ", expr, lambdaVar);
-		AppendIntervalConversionExpression(buf, lambdaVar, elemType, -1,
-										   depth + 1);
+		AppendNativeConversionExpression(buf, lambdaVar, elemType, -1,
+										 depth + 1);
 		appendStringInfoChar(buf, ')');
 		return true;
 	}
@@ -615,10 +650,10 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 	{
 		PGType		keyType = GetMapKeyType(typeOid);
 		PGType		valType = GetMapValueType(typeOid);
-		bool		keyHasInterval = TypeContainsInterval(keyType.postgresTypeOid);
-		bool		valHasInterval = TypeContainsInterval(valType.postgresTypeOid);
+		bool		keyNeedsConversion = TypeNeedsNativeConversion(keyType.postgresTypeOid);
+		bool		valNeedsConversion = TypeNeedsNativeConversion(valType.postgresTypeOid);
 
-		if (!keyHasInterval && !valHasInterval)
+		if (!keyNeedsConversion && !valNeedsConversion)
 			return false;
 
 		char	   *lambdaVar = psprintf("_x%d", depth);
@@ -629,11 +664,11 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 
 		char	   *keyExpr = psprintf("%s.key", lambdaVar);
 
-		if (keyHasInterval)
-			AppendIntervalConversionExpression(buf, keyExpr,
-											   keyType.postgresTypeOid,
-											   keyType.postgresTypeMod,
-											   depth + 1);
+		if (keyNeedsConversion)
+			AppendNativeConversionExpression(buf, keyExpr,
+											 keyType.postgresTypeOid,
+											 keyType.postgresTypeMod,
+											 depth + 1);
 		else
 			appendStringInfoString(buf, keyExpr);
 
@@ -641,11 +676,11 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 
 		char	   *valExpr = psprintf("%s.value", lambdaVar);
 
-		if (valHasInterval)
-			AppendIntervalConversionExpression(buf, valExpr,
-											   valType.postgresTypeOid,
-											   valType.postgresTypeMod,
-											   depth + 1);
+		if (valNeedsConversion)
+			AppendNativeConversionExpression(buf, valExpr,
+											 valType.postgresTypeOid,
+											 valType.postgresTypeMod,
+											 depth + 1);
 		else
 			appendStringInfoString(buf, valExpr);
 
@@ -660,8 +695,8 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 	{
 		Oid			baseType = getBaseTypeAndTypmod(typeOid, &typmod);
 
-		return AppendIntervalConversionExpression(buf, expr, baseType, typmod,
-												  depth);
+		return AppendNativeConversionExpression(buf, expr, baseType, typmod,
+												depth);
 	}
 
 	/* composite types: transform fields via struct_pack */
@@ -677,7 +712,7 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 			if (attr->attisdropped)
 				continue;
 
-			if (TypeContainsInterval(attr->atttypid))
+			if (TypeNeedsNativeConversion(attr->atttypid))
 			{
 				anyFieldNeedsTransform = true;
 				break;
@@ -710,10 +745,10 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 
 			appendStringInfo(buf, "%s := ", quotedField);
 
-			if (!AppendIntervalConversionExpression(buf, fieldExpr,
-													attr->atttypid,
-													attr->atttypmod,
-													depth))
+			if (!AppendNativeConversionExpression(buf, fieldExpr,
+												  attr->atttypid,
+												  attr->atttypmod,
+												  depth))
 				appendStringInfoString(buf, fieldExpr);
 
 			firstField = false;
@@ -729,18 +764,30 @@ AppendIntervalConversionExpression(StringInfo buf, const char *expr,
 
 
 /*
- * IcebergWrapQueryWithIntervalConversion wraps a query string with an
- * outer SELECT that decomposes INTERVAL columns into
- * STRUCT(months BIGINT, days BIGINT, microseconds BIGINT) to match
- * Iceberg's interval representation.
+ * IcebergWrapQueryWithNativeTypeConversion wraps a query string with an
+ * outer SELECT that rewrites columns whose native DuckDB shape does not
+ * match Iceberg's:
  *
- * Returns the original query unchanged if no interval columns exist.
+ *   - INTERVAL columns are decomposed into
+ *     STRUCT(months BIGINT, days BIGINT, microseconds BIGINT).
+ *   - TIMETZ columns are UTC-normalized and cast to TIME
+ *     (CAST(CAST(<expr> AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)),
+ *     because Iceberg has no time-with-timezone type and DuckDB's
+ *     direct CAST(TIMETZ AS TIME) drops the offset without shifting
+ *     the time digits.  The inner cast to TIMETZ keeps the outer
+ *     AT TIME ZONE 'UTC' well-typed when the source is already plain
+ *     TIME (e.g. a TIMETZ field read back from an Iceberg composite
+ *     column, where the Parquet-level type is TIME).
+ *
+ * Rewrites recurse through arrays, composites, maps, and domains.
+ *
+ * Returns the original query unchanged if no column needs conversion.
  */
 char *
-IcebergWrapQueryWithIntervalConversion(char *query, TupleDesc tupleDesc,
-									   bool queryHasRowId)
+IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
+										 bool queryHasRowId)
 {
-	if (tupleDesc == NULL || !TupleDescHasIntervalColumn(tupleDesc))
+	if (tupleDesc == NULL || !TupleDescHasNativeConversionColumn(tupleDesc))
 		return query;
 
 	StringInfoData wrapped;
@@ -767,9 +814,9 @@ IcebergWrapQueryWithIntervalConversion(char *query, TupleDesc tupleDesc,
 
 		initStringInfo(&exprBuf);
 
-		if (AppendIntervalConversionExpression(&exprBuf, quotedName,
-											   attr->atttypid,
-											   attr->atttypmod, 0))
+		if (AppendNativeConversionExpression(&exprBuf, quotedName,
+											 attr->atttypid,
+											 attr->atttypmod, 0))
 		{
 			appendStringInfo(&wrapped, "%s AS %s", exprBuf.data, quotedName);
 		}
@@ -790,7 +837,7 @@ IcebergWrapQueryWithIntervalConversion(char *query, TupleDesc tupleDesc,
 		appendStringInfoString(&wrapped, "_row_id");
 	}
 
-	appendStringInfo(&wrapped, " FROM (%s) AS __iceberg_interval", query);
+	appendStringInfo(&wrapped, " FROM (%s) AS __iceberg_native_conv", query);
 
 	return wrapped.data;
 }

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -104,7 +104,7 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 							  csvTupleDesc,
 							  leafFields,
 							  ICEBERG_OOR_NONE,
-							  false /* wrapNativeIntervals */ );
+							  false /* wrapNativeTypes */ );
 }
 
 
@@ -124,7 +124,7 @@ WriteQueryResultTo(char *query,
 				   TupleDesc queryTupleDesc,
 				   List *leafFields,
 				   IcebergOutOfRangePolicy outOfRangePolicy,
-				   bool wrapNativeIntervals)
+				   bool wrapNativeTypes)
 {
 	if (outOfRangePolicy != ICEBERG_OOR_NONE)
 	{
@@ -133,10 +133,10 @@ WriteQueryResultTo(char *query,
 													   queryHasRowId);
 	}
 
-	if (wrapNativeIntervals && destinationFormat == DATA_FORMAT_ICEBERG)
+	if (wrapNativeTypes && destinationFormat == DATA_FORMAT_ICEBERG)
 	{
-		query = IcebergWrapQueryWithIntervalConversion(query, queryTupleDesc,
-													   queryHasRowId);
+		query = IcebergWrapQueryWithNativeTypeConversion(query, queryTupleDesc,
+														 queryHasRowId);
 	}
 
 	StringInfoData command;

--- a/pg_lake_table/include/pg_lake/fdw/writable_table.h
+++ b/pg_lake_table/include/pg_lake/fdw/writable_table.h
@@ -123,4 +123,4 @@ extern PGDLLEXPORT List *PrepareCSVInsertion(Oid relationId, char *insertCSV, in
 
 extern PGDLLEXPORT int64 AddQueryResultToTable(Oid relationId, char *readQuery,
 											   TupleDesc queryTupleDesc,
-											   bool wrapNativeIntervals);
+											   bool wrapNativeTypes);

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -126,7 +126,7 @@ static List *PrepareToAddQueryResultToTable(Oid relationId,
 											bool allowSplit,
 											bool isVerbose,
 											IcebergOutOfRangePolicy outOfRangePolicy,
-											bool wrapNativeIntervals);
+											bool wrapNativeTypes);
 static List *GetPossiblePositionDeleteFiles(Oid relationId, List *sourcePathList,
 											Snapshot snapshot);
 static void ApplyMetadataChanges(Oid relationId, List *metadataOperations);
@@ -941,14 +941,15 @@ TryCompactDataFiles(Oid relationId, TupleDesc tupleDescriptor, List *candidates,
 
 	/*
 	 * compaction re-writes existing data files; values are already clamped
-	 * and intervals are already converted to struct for Iceberg
+	 * and native-only types (intervals, timetz) are already materialized in
+	 * their Iceberg shape
 	 */
 	List	   *newFileOps =
 		PrepareToAddQueryResultToTable(relationId, readFileQuery, tupleDescriptor,
 									   partitionSpecId, partition,
 									   hasRowIds, allowSplit, isVerbose,
 									   ICEBERG_OOR_NONE,
-									   false /* wrapNativeIntervals */ );
+									   false /* wrapNativeTypes */ );
 
 	metadataOperations = list_concat(metadataOperations, newFileOps);
 
@@ -993,7 +994,7 @@ PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryT
 							   int32 partitionSpecId, Partition * partition,
 							   bool queryHasRowId, bool allowSplit, bool isVerbose,
 							   IcebergOutOfRangePolicy outOfRangePolicy,
-							   bool wrapNativeIntervals)
+							   bool wrapNativeTypes)
 {
 	PgLakeTableProperties properties = GetPgLakeTableProperties(relationId);
 	List	   *options = properties.options;
@@ -1044,7 +1045,7 @@ PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryT
 						   queryTupleDesc,
 						   leafFields,
 						   outOfRangePolicy,
-						   wrapNativeIntervals);
+						   wrapNativeTypes);
 
 	if (statsCollector->totalRowCount == 0)
 	{
@@ -1081,17 +1082,16 @@ PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryT
 /*
  * AddQueryResultToTable adds the result of a pgduck query to the table.
  *
- * When wrapNativeIntervals is true, DuckDB's native INTERVAL columns are
- * decomposed into STRUCT(months, days, microseconds) to match the Iceberg
- * interval representation before writing. This is needed for INSERT ..
- * SELECT and COPY FROM pushdown paths where the source data contains
- * native intervals. It should be false when the data is already in
- * Iceberg struct form (e.g. compaction, which re-writes existing Iceberg
- * data files).
+ * Pass wrapNativeTypes=true when the source data is a raw DuckDB query
+ * result whose native shape may not match Iceberg's (INSERT .. SELECT,
+ * COPY FROM, snapshot/initial-copy, etc.).  Pass false when the data is
+ * already in Iceberg-native shape (compaction, CSV ingest that was
+ * normalized during Postgres-side serialization).  See
+ * IcebergWrapQueryWithNativeTypeConversion for the rewrites this controls.
  */
 int64
 AddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryTupleDesc,
-					  bool wrapNativeIntervals)
+					  bool wrapNativeTypes)
 {
 	Assert(queryTupleDesc != NULL && queryTupleDesc->natts > 0);
 
@@ -1134,7 +1134,7 @@ AddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryTupleDesc,
 		PrepareToAddQueryResultToTable(relationId, readQuery, queryTupleDesc,
 									   partitionSpecId, partition,
 									   queryHasRowId, allowSplit, isVerbose,
-									   outOfRangePolicy, wrapNativeIntervals);
+									   outOfRangePolicy, wrapNativeTypes);
 
 	metadataOperations = list_concat(metadataOperations, newFileOps);
 

--- a/pg_lake_table/src/planner/query_pushdown.c
+++ b/pg_lake_table/src/planner/query_pushdown.c
@@ -1739,9 +1739,9 @@ QueryPushdownExplainScan(CustomScanState *node, List *ancestors,
 
 			if (IsWritableIcebergTable(scanState->insertIntoRelid))
 				queryString =
-					IcebergWrapQueryWithIntervalConversion(queryString,
-														   scanState->insertTargetTupleDesc,
-														   false);
+					IcebergWrapQueryWithNativeTypeConversion(queryString,
+															 scanState->insertTargetTupleDesc,
+															 false);
 		}
 
 		ExplainPropertyText("Vectorized SQL", queryString, es);

--- a/pg_lake_table/tests/pytests/test_iceberg_copy_from_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_copy_from_pushdown.py
@@ -945,7 +945,7 @@ def test_copy_from_interval_pushdown(
 ):
     """COPY FROM with plain interval column IS pushed down and the interval
     is converted to struct(months, days, microseconds) via
-    IcebergWrapQueryWithIntervalConversion.
+    IcebergWrapQueryWithNativeTypeConversion.
     """
     import datetime
 

--- a/pg_lake_table/tests/pytests/test_iceberg_interval_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_interval_type.py
@@ -510,7 +510,7 @@ def test_interval_ctas(pg_conn, s3, with_default_location):
     CREATE TABLE ... USING iceberg AS SELECT <interval> exercises the
     INSERT..SELECT pushdown path. Intervals are stored as
     STRUCT(months, days, microseconds) in Iceberg; the pushdown query
-    wraps interval columns via IcebergWrapQueryWithIntervalConversion.
+    wraps interval columns via IcebergWrapQueryWithNativeTypeConversion.
     """
     run_command(
         """
@@ -596,7 +596,7 @@ def test_interval_insert_select(pg_conn, s3, with_default_location):
     """
     INSERT INTO iceberg_table SELECT ... exercises the pushdown path for
     interval columns. The pushdown query wraps interval columns via
-    IcebergWrapQueryWithIntervalConversion, decomposing them into
+    IcebergWrapQueryWithNativeTypeConversion, decomposing them into
     STRUCT(months, days, microseconds).
     """
     run_command(

--- a/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
@@ -203,6 +203,793 @@ def test_iceberg_timetz_as_utc_time(
     pg_conn.commit()
 
 
+def _get_explain_text(query, pg_conn):
+    """Return EXPLAIN (VERBOSE) output for ``query`` as a single string."""
+    result = run_query("EXPLAIN (VERBOSE) " + query, pg_conn)
+    return "\n".join(line[0] for line in result)
+
+
+def _assert_timetz_utc_cast_in_explain(query, pg_conn):
+    """
+    Assert that ``query`` is pushed down AND the Vectorized SQL in EXPLAIN
+    contains the UTC-normalizing cast that
+    IcebergWrapQueryWithNativeTypeConversion emits for TIMETZ columns.
+
+    The wrapper emits
+    ``CAST(CAST((<expr>) AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)`` for
+    every TIMETZ leaf reachable from the target tuple descriptor (the
+    inner ``::TIMETZ`` is defensive: it keeps the outer ``AT TIME ZONE
+    'UTC'`` well-typed even when the source expression is already plain
+    TIME, which happens for TIMETZ fields read back from inside an
+    Iceberg composite).  The outer substring is enough to detect that
+    the wrapper fired -- without it, DuckDB's implicit
+    ``CAST(TIMETZ AS TIME)`` silently drops the offset.
+    """
+    explain = _get_explain_text(query, pg_conn)
+    assert "Custom Scan (Query Pushdown)" in explain, (
+        "Expected Query Pushdown for: " + query + "\n" + explain
+    )
+    assert "AT TIME ZONE 'UTC' AS TIME" in explain, (
+        "Expected TIMETZ UTC-normalizing cast in EXPLAIN output:\n" + explain
+    )
+
+
+@pytest.mark.parametrize("session_tz", ["UTC", "Asia/Kolkata"])
+def test_timetz_insert_select_from_heap(pg_conn, s3, with_default_location, session_tz):
+    """
+    INSERT INTO iceberg_table SELECT ... FROM heap_table is NOT pushed
+    down (heap sources aren't DuckDB-shippable, so the plan is a regular
+    Postgres "Insert on dest" + "Seq Scan on source").  It instead runs
+    row-by-row through the FDW, which serializes tuples to CSV via
+    csv_writer.c -- and that path already UTC-normalizes TIMETZ values
+    via TimeTzOutForPGDuck in serialize.c before handing them to DuckDB.
+    This test locks in that behavior so a future refactor cannot silently
+    reintroduce the TIMETZ corruption on the non-pushdown path.
+    The pushdown paths (iceberg->iceberg, pg_lake CSV foreign table,
+    COPY FROM) are exercised by test_iceberg_timetz_as_utc_time and the
+    nested-type tests below.
+
+    Parametrized over the PostgreSQL session timezone because
+    TimeTzOutForPGDuck calls TimeTzGetUTCMicros directly on the Datum
+    (not through the type's text-output function), so the CSV value it
+    emits must be invariant under ``SET TIME ZONE``.  Reading the
+    Iceberg target back is also tz-invariant: the read path applies
+    ``col::TIMETZ`` to top-level columns and pins the offset to +00 on
+    the wire before psycopg decodes it.
+    """
+    utc = timezone.utc
+
+    try:
+        run_command(f"SET TIME ZONE '{session_tz}';", pg_conn)
+        run_command(
+            """
+            DROP SCHEMA IF EXISTS test_timetz_ins_sel CASCADE;
+            CREATE SCHEMA test_timetz_ins_sel;
+            CREATE TABLE test_timetz_ins_sel.source (id int, t timetz) USING heap;
+            INSERT INTO test_timetz_ins_sel.source VALUES
+                (1, '12:30:00+00'),
+                (2, '12:30:00+04'),
+                (3, '23:30:00-02'),
+                (4, '23:59:59.999+05:30'),
+                (5, NULL);
+
+            CREATE TABLE test_timetz_ins_sel.dest (id int, t timetz) USING iceberg;
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        run_command(
+            """
+            INSERT INTO test_timetz_ins_sel.dest
+                SELECT id, t FROM test_timetz_ins_sel.source;
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        results = run_query(
+            "SELECT id, t FROM test_timetz_ins_sel.dest ORDER BY id",
+            pg_conn,
+        )
+        assert results == [
+            [1, time(12, 30, 0, tzinfo=utc)],
+            [2, time(8, 30, 0, tzinfo=utc)],
+            [3, time(1, 30, 0, tzinfo=utc)],
+            [4, time(18, 29, 59, 999000, tzinfo=utc)],
+            [5, None],
+        ]
+
+        # also cover the timetz[] round-trip through the same CSV path
+        run_command(
+            """
+            CREATE TABLE test_timetz_ins_sel.arr_source (id int, ts timetz[]) USING heap;
+            INSERT INTO test_timetz_ins_sel.arr_source VALUES
+                (1, ARRAY['12:30:00+00'::timetz, '12:30:00+04'::timetz]),
+                (2, ARRAY['23:30:00-02'::timetz, '23:59:59.999+05:30'::timetz]),
+                (3, NULL);
+
+            CREATE TABLE test_timetz_ins_sel.arr_dest (id int, ts timetz[]) USING iceberg;
+
+            INSERT INTO test_timetz_ins_sel.arr_dest
+                SELECT id, ts FROM test_timetz_ins_sel.arr_source;
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        results = run_query(
+            "SELECT id, ts FROM test_timetz_ins_sel.arr_dest ORDER BY id",
+            pg_conn,
+        )
+        assert results == [
+            [1, [time(12, 30, 0, tzinfo=utc), time(8, 30, 0, tzinfo=utc)]],
+            [2, [time(1, 30, 0, tzinfo=utc), time(18, 29, 59, 999000, tzinfo=utc)]],
+            [3, None],
+        ]
+    finally:
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("DROP SCHEMA IF EXISTS test_timetz_ins_sel CASCADE", pg_conn)
+        pg_conn.commit()
+
+
+def test_insert_select_timetz_in_composite_pushdown(pg_conn, s3, with_default_location):
+    """
+    INSERT..SELECT on an Iceberg table whose column is a composite type
+    containing TIMETZ is pushed down, and the Vectorized SQL wraps the
+    TIMETZ leaf with CAST((..) AT TIME ZONE 'UTC' AS TIME).  Uses an
+    Iceberg source so the source column type is a shippable composite.
+
+    The scalar-TIMETZ-field and TIMETZ-array-field cases are exercised
+    in fully separated sub-tests (separate composite type, tables, and
+    INSERT) because the EXPLAIN substring check is satisfied by *any*
+    UTC cast in the wrapped SQL -- testing them together would let a
+    regression that drops the wrap on one of the two paths slip through.
+    The same separation pattern is used by ``test_timetz_insert_select_from_heap``
+    for the row-by-row CSV path.
+
+    For each sub-test we also populate a heap table with the same data
+    and use ``assert_table_contents_match`` to assert end-to-end equality
+    under PostgreSQL semantics (TIMETZ equality is by UTC instant, so
+    e.g. ``08:00:00+04`` equals ``04:00:00+00``).
+    """
+    utc = timezone.utc
+
+    run_command(
+        """
+        CREATE SCHEMA test_timetz_comp_pd;
+        SET search_path TO test_timetz_comp_pd;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # ------------------------------------------------------------------
+    # Section A: composite { label, at_time timetz } -- scalar TIMETZ
+    # field only, so the EXPLAIN cast assertion can only be satisfied by
+    # the scalar-field rewrite.
+    # ------------------------------------------------------------------
+    run_command(
+        """
+        SET search_path TO test_timetz_comp_pd;
+
+        CREATE TYPE scalar_slot AS (
+            label   text,
+            at_time timetz
+        );
+        CREATE TABLE scalar_src (id int, slot scalar_slot) USING iceberg;
+        CREATE TABLE scalar_tgt (id int, slot scalar_slot) USING iceberg;
+        CREATE TABLE scalar_heap (id int, slot scalar_slot) USING heap;
+
+        INSERT INTO scalar_src VALUES
+            (1, ROW('morning',  '08:00:00+04'::timetz)::scalar_slot),
+            (2, ROW('evening',  '23:59:59.999+05:30'::timetz)::scalar_slot),
+            (3, ROW('nulls',    NULL)::scalar_slot),
+            (4, NULL);
+
+        INSERT INTO scalar_heap SELECT * FROM scalar_src;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    _assert_timetz_utc_cast_in_explain(
+        "INSERT INTO scalar_tgt SELECT * FROM scalar_src", pg_conn
+    )
+    explain = _get_explain_text(
+        "INSERT INTO scalar_tgt SELECT * FROM scalar_src", pg_conn
+    )
+    assert "struct_pack" in explain, (
+        "Expected struct_pack wrapping for composite timetz field:\n" + explain
+    )
+
+    run_command("INSERT INTO scalar_tgt SELECT * FROM scalar_src", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT id, (slot).label, (slot).at_time FROM scalar_tgt ORDER BY id",
+        pg_conn,
+    )
+    assert result == [
+        [1, "morning", time(4, 0, 0, tzinfo=utc)],
+        [2, "evening", time(18, 29, 59, 999000, tzinfo=utc)],
+        [3, "nulls", None],
+        [4, None, None],
+    ]
+
+    assert_table_contents_match(pg_conn, "scalar_tgt", "scalar_heap")
+
+    # ------------------------------------------------------------------
+    # Section B: composite { label, extras timetz[] } -- TIMETZ array
+    # field only, so the EXPLAIN cast assertion can only be satisfied by
+    # the list_transform / array-field rewrite.
+    # ------------------------------------------------------------------
+    run_command(
+        """
+        SET search_path TO test_timetz_comp_pd;
+
+        CREATE TYPE array_slot AS (
+            label  text,
+            extras timetz[]
+        );
+        CREATE TABLE array_src (id int, slot array_slot) USING iceberg;
+        CREATE TABLE array_tgt (id int, slot array_slot) USING iceberg;
+        CREATE TABLE array_heap (id int, slot array_slot) USING heap;
+
+        INSERT INTO array_src VALUES
+            (1, ROW('morning',
+                    ARRAY['12:30:00+04'::timetz,
+                          '23:30:00-02'::timetz])::array_slot),
+            (2, ROW('evening',
+                    ARRAY['00:00:00+00'::timetz])::array_slot),
+            (3, ROW('nulls',  NULL)::array_slot),
+            (4, NULL);
+
+        INSERT INTO array_heap SELECT * FROM array_src;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    _assert_timetz_utc_cast_in_explain(
+        "INSERT INTO array_tgt SELECT * FROM array_src", pg_conn
+    )
+    explain = _get_explain_text(
+        "INSERT INTO array_tgt SELECT * FROM array_src", pg_conn
+    )
+    assert "struct_pack" in explain, (
+        "Expected struct_pack wrapping for composite timetz[] field:\n" + explain
+    )
+    assert "list_transform" in explain, (
+        "Expected list_transform wrapping for timetz[] field:\n" + explain
+    )
+
+    run_command("INSERT INTO array_tgt SELECT * FROM array_src", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT id, (slot).label, (slot).extras FROM array_tgt ORDER BY id",
+        pg_conn,
+    )
+    assert result == [
+        [1, "morning", [time(8, 30, 0, tzinfo=utc), time(1, 30, 0, tzinfo=utc)]],
+        [2, "evening", [time(0, 0, 0, tzinfo=utc)]],
+        [3, "nulls", None],
+        [4, None, None],
+    ]
+
+    assert_table_contents_match(pg_conn, "array_tgt", "array_heap")
+
+    run_command("DROP SCHEMA test_timetz_comp_pd CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_insert_select_timetz_in_map_pushdown(pg_conn, s3, with_default_location):
+    """
+    INSERT..SELECT with a map<text, timetz> column is pushed down and the
+    Vectorized SQL rewrites the map entries through
+    map_from_entries(list_transform(map_entries(..), .. -> struct_pack(
+        key := k, value := CAST((v) AT TIME ZONE 'UTC' AS TIME))))
+    so that every value is UTC-normalized before hitting Iceberg.
+    Modelled after test_insert_select_interval_in_map_pushdown.
+    """
+    utc = timezone.utc
+    map_typename = create_map_type("text", "timetz")
+
+    run_command(
+        f"""
+        CREATE SCHEMA test_timetz_map_pd;
+        SET search_path TO test_timetz_map_pd;
+
+        CREATE TABLE src (id int, m {map_typename}) USING iceberg;
+        CREATE TABLE tgt (id int, m {map_typename}) USING iceberg;
+
+        INSERT INTO src VALUES
+            (1, ARRAY[ROW('standup',  '09:00:00+04'::timetz),
+                      ROW('retro',    '23:30:00-02'::timetz),
+                      ROW('midnight', '00:00:00+00'::timetz)]::{map_typename}),
+            (2, ARRAY[ROW('half_hr',  '23:59:59.999+05:30'::timetz)]::{map_typename}),
+            (3, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    explain = _get_explain_text("INSERT INTO tgt SELECT * FROM src", pg_conn)
+    assert "Custom Scan (Query Pushdown)" in explain, explain
+    assert "map_from_entries" in explain, (
+        "Expected map_from_entries wrapping for map<text, timetz>:\n" + explain
+    )
+    assert "AT TIME ZONE 'UTC' AS TIME" in explain, (
+        "Expected UTC-normalizing cast on map values:\n" + explain
+    )
+
+    run_command("INSERT INTO tgt SELECT * FROM src", pg_conn)
+    pg_conn.commit()
+
+    # Non-UTC values come back UTC-normalized regardless of which key we look up
+    result = run_query(
+        "SELECT map_type.extract(m, 'standup') FROM tgt WHERE id = 1",
+        pg_conn,
+    )
+    assert result[0][0] == time(5, 0, 0, tzinfo=utc)
+
+    result = run_query(
+        "SELECT map_type.extract(m, 'retro') FROM tgt WHERE id = 1",
+        pg_conn,
+    )
+    assert result[0][0] == time(1, 30, 0, tzinfo=utc)
+
+    result = run_query(
+        "SELECT map_type.extract(m, 'midnight') FROM tgt WHERE id = 1",
+        pg_conn,
+    )
+    assert result[0][0] == time(0, 0, 0, tzinfo=utc)
+
+    result = run_query(
+        "SELECT map_type.extract(m, 'half_hr') FROM tgt WHERE id = 2",
+        pg_conn,
+    )
+    assert result[0][0] == time(18, 29, 59, 999000, tzinfo=utc)
+
+    result = run_query("SELECT m FROM tgt WHERE id = 3", pg_conn)
+    assert result[0][0] is None
+
+    run_command("DROP SCHEMA test_timetz_map_pd CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_insert_select_timetz_deeply_nested_pushdown(
+    pg_conn, s3, with_default_location
+):
+    """
+    Stress-test the recursive type traversal in
+    AppendNativeConversionExpression by stacking every supported
+    container around timetz:
+
+        outer composite { title text,
+                          start_at timetz,            -- level 1
+                          repeats  timetz[],          -- array of timetz
+                          events   inner_event[] }    -- array of composite
+        inner composite { label    text,
+                          at_time  timetz,            -- timetz at level 3
+                          extras   timetz[] }         -- array at level 4
+
+    plus a sibling map<text, timetz> column on the table.  Every TIMETZ
+    reachable from a top-level column must be rewritten to
+    CAST((..) AT TIME ZONE 'UTC' AS TIME); the EXPLAIN output therefore
+    must contain several copies of that cast wrapped inside struct_pack,
+    list_transform and map_from_entries calls.
+    """
+    utc = timezone.utc
+    map_typename = create_map_type("text", "timetz")
+
+    run_command(
+        f"""
+        CREATE SCHEMA test_timetz_nested_pd;
+        SET search_path TO test_timetz_nested_pd;
+
+        CREATE TYPE inner_event AS (
+            label   text,
+            at_time timetz,
+            extras  timetz[]
+        );
+        CREATE TYPE outer_session AS (
+            title    text,
+            start_at timetz,
+            repeats  timetz[],
+            events   inner_event[]
+        );
+
+        CREATE TABLE src (
+            id  int,
+            s   outer_session,
+            by_name {map_typename}
+        ) USING iceberg;
+
+        CREATE TABLE tgt (
+            id  int,
+            s   outer_session,
+            by_name {map_typename}
+        ) USING iceberg;
+
+        INSERT INTO src VALUES
+            (1,
+             ROW(
+                 'Conference',
+                 '09:00:00+04'::timetz,
+                 ARRAY['13:00:00+04'::timetz, '23:30:00-02'::timetz],
+                 ARRAY[
+                     ROW('keynote',
+                         '09:30:00+04'::timetz,
+                         ARRAY['09:45:00+04'::timetz,
+                               '23:59:59.999+05:30'::timetz])::inner_event,
+                     ROW('panel',
+                         '00:00:00+00'::timetz,
+                         ARRAY['00:10:00+00'::timetz])::inner_event
+                 ]
+             )::outer_session,
+             ARRAY[ROW('open',  '08:00:00+04'::timetz),
+                   ROW('close', '23:00:00-02'::timetz)]::{map_typename}),
+            (2,
+             ROW('Nulls inside',
+                 NULL,
+                 NULL,
+                 ARRAY[
+                     ROW('only_label', NULL, NULL)::inner_event
+                 ])::outer_session,
+             NULL),
+            (3, NULL, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    explain = _get_explain_text("INSERT INTO tgt SELECT * FROM src", pg_conn)
+    assert "Custom Scan (Query Pushdown)" in explain, explain
+
+    # Evidence that the recursive wrapping traversed every container level:
+    #   struct_pack  -- outer + inner composite rewrite
+    #   list_transform  -- timetz[] and inner_event[]
+    #   map_from_entries  -- the map<text, timetz> sibling column
+    assert "struct_pack" in explain, explain
+    assert "list_transform" in explain, explain
+    assert "map_from_entries" in explain, explain
+    # Every TIMETZ-bearing leaf must have produced exactly one
+    # UTC-normalizing cast.  The target tuple descriptor has exactly five
+    # such leaves:
+    #   s.start_at, s.repeats[], s.events[].at_time, s.events[].extras[],
+    #   by_name.<value>
+    # An exact-equality assertion catches both directions of regression:
+    # missing casts (a leaf bypassed the wrap) and extraneous casts
+    # (e.g. accidental quadratic recursion in the type walker).
+    EXPECTED_TIMETZ_LEAF_COUNT = 5
+    cast_count = explain.count("AT TIME ZONE 'UTC' AS TIME")
+    assert cast_count == EXPECTED_TIMETZ_LEAF_COUNT, (
+        f"Expected exactly {EXPECTED_TIMETZ_LEAF_COUNT} UTC-normalizing "
+        f"casts in the Vectorized SQL (one per reachable TIMETZ leaf), "
+        f"but found {cast_count}:\n" + explain
+    )
+
+    run_command("INSERT INTO tgt SELECT * FROM src", pg_conn)
+    pg_conn.commit()
+
+    # Row 1: every TIMETZ in the deeply nested structure must have been
+    # rewritten to UTC on the way in.
+    result = run_query(
+        """
+        SELECT id,
+               (s).title,
+               (s).start_at,
+               (s).repeats,
+               ((s).events)[1].label,
+               ((s).events)[1].at_time,
+               ((s).events)[1].extras,
+               ((s).events)[2].label,
+               ((s).events)[2].at_time,
+               ((s).events)[2].extras
+        FROM tgt WHERE id = 1
+        """,
+        pg_conn,
+    )
+    row = result[0]
+    assert row[0] == 1
+    assert row[1] == "Conference"
+    assert row[2] == time(5, 0, 0, tzinfo=utc)
+    assert row[3] == [time(9, 0, 0, tzinfo=utc), time(1, 30, 0, tzinfo=utc)]
+    assert row[4] == "keynote"
+    assert row[5] == time(5, 30, 0, tzinfo=utc)
+    assert row[6] == [
+        time(5, 45, 0, tzinfo=utc),
+        time(18, 29, 59, 999000, tzinfo=utc),
+    ]
+    assert row[7] == "panel"
+    assert row[8] == time(0, 0, 0, tzinfo=utc)
+    assert row[9] == [time(0, 10, 0, tzinfo=utc)]
+
+    # Map values on row 1 are UTC-normalized too
+    result = run_query(
+        "SELECT map_type.extract(by_name, 'open'),"
+        "       map_type.extract(by_name, 'close') "
+        "FROM tgt WHERE id = 1",
+        pg_conn,
+    )
+    assert result[0][0] == time(4, 0, 0, tzinfo=utc)
+    assert result[0][1] == time(1, 0, 0, tzinfo=utc)
+
+    # Row 2: NULL leaves inside the composite survive the rewrite. We
+    # deliberately avoid asserting exact semantics for composite elements
+    # with all-NULL fields (PG and DuckDB disagree on when such rows
+    # compare IS NULL), but we do verify that every directly-accessible
+    # TIMETZ leaf we inserted as NULL is still NULL on read-back, and
+    # the map column round-trips as NULL.
+    result = run_query(
+        """
+        SELECT id,
+               (s).title,
+               (s).start_at,
+               (s).repeats,
+               ((s).events)[1].label,
+               ((s).events)[1].at_time,
+               ((s).events)[1].extras,
+               by_name
+        FROM tgt WHERE id = 2
+        """,
+        pg_conn,
+    )
+    row = result[0]
+    assert row == [2, "Nulls inside", None, None, "only_label", None, None, None]
+
+    # Row 3: both the outer composite and the map are NULL end-to-end.
+    result = run_query(
+        "SELECT id, s, by_name FROM tgt WHERE id = 3",
+        pg_conn,
+    )
+    assert result[0] == [3, None, None]
+
+    run_command("DROP SCHEMA test_timetz_nested_pd CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_insert_select_timetz_quoted_identifiers_pushdown(
+    pg_conn, s3, with_default_location
+):
+    """
+    AppendTimeTzUtcCast wraps an arbitrary DuckDB *expression* (not just
+    a bare column name) in ``CAST((<expr>) AT TIME ZONE 'UTC' AS TIME)``.
+    Verify that every expression shape we can feed into it is safe when
+    the underlying identifiers need quoting:
+
+      * top-level column whose name is an SQL reserved keyword
+        (``"order"``),
+      * top-level column whose name needs quoting for whitespace /
+        mixed case (``"Mixed CS"``),
+      * composite field whose name is an SQL reserved keyword
+        (``"time"``),
+      * composite field whose name needs quoting for whitespace /
+        mixed case (``"At Time"``),
+      * mixed-case composite field carrying a timetz[] (``"UTC"``), so
+        the array lambda path also sees a quoted field.
+
+    If ``quote_identifier`` were dropped anywhere along the composite
+    recursion, the wrapped query would become malformed DuckDB SQL and
+    either fail to parse or bind to the wrong column -- so both the
+    EXPLAIN-level check (quoted names survive in the Vectorized SQL)
+    and the value round-trip protect against a regression here.
+    """
+    utc = timezone.utc
+
+    run_command(
+        """
+        CREATE SCHEMA test_timetz_quoted_pd;
+        SET search_path TO test_timetz_quoted_pd;
+
+        CREATE TYPE ev AS (
+            "time"    timetz,
+            "At Time" timetz,
+            "UTC"     timetz[]
+        );
+
+        CREATE TABLE src (
+            id         int,
+            "order"    timetz,
+            "Mixed CS" timetz,
+            e          ev
+        ) USING iceberg;
+
+        CREATE TABLE tgt (
+            id         int,
+            "order"    timetz,
+            "Mixed CS" timetz,
+            e          ev
+        ) USING iceberg;
+
+        INSERT INTO src VALUES
+            (1,
+             '08:00:00+04'::timetz,
+             '23:30:00-02'::timetz,
+             ROW(
+                 '09:00:00+04'::timetz,
+                 '23:59:59.999+05:30'::timetz,
+                 ARRAY['12:30:00+04'::timetz,
+                       '00:00:00+00'::timetz]
+             )::ev);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    _assert_timetz_utc_cast_in_explain("INSERT INTO tgt SELECT * FROM src", pg_conn)
+
+    # Every quoted identifier must round-trip into the Vectorized SQL
+    # exactly (quote_identifier is applied at each level of the wrap).
+    explain = _get_explain_text("INSERT INTO tgt SELECT * FROM src", pg_conn)
+    for quoted in ['"order"', '"Mixed CS"', '"time"', '"At Time"', '"UTC"']:
+        assert quoted in explain, (
+            f"Expected quoted identifier {quoted} to survive the wrap:\n" + explain
+        )
+
+    # And the composite-field recursion must have emitted a struct_pack
+    # (otherwise the TIMETZ leaves inside ``e`` would have been left as
+    # raw TIMETZ for DuckDB to implicitly cast -- the exact bug).
+    assert "struct_pack" in explain, explain
+    assert "list_transform" in explain, explain
+
+    run_command("INSERT INTO tgt SELECT * FROM src", pg_conn)
+    pg_conn.commit()
+
+    result = run_query(
+        """
+        SELECT id,
+               "order",
+               "Mixed CS",
+               (e)."time",
+               (e)."At Time",
+               (e)."UTC"
+        FROM tgt
+        WHERE id = 1
+        """,
+        pg_conn,
+    )
+    assert result[0] == [
+        1,
+        time(4, 0, 0, tzinfo=utc),  # 08:00:00+04   -> 04:00:00Z
+        time(1, 30, 0, tzinfo=utc),  # 23:30:00-02   -> 01:30:00Z
+        time(5, 0, 0, tzinfo=utc),  # 09:00:00+04   -> 05:00:00Z
+        time(18, 29, 59, 999000, tzinfo=utc),  # 23:59:59.999+05:30 -> 18:29:59.999Z
+        [
+            time(8, 30, 0, tzinfo=utc),  # 12:30:00+04   -> 08:30:00Z
+            time(0, 0, 0, tzinfo=utc),
+        ],  # 00:00:00+00   -> 00:00:00Z
+    ]
+
+    run_command("DROP SCHEMA test_timetz_quoted_pd CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize("session_tz", ["UTC", "Asia/Kolkata"])
+def test_insert_select_timetz_with_oor_clamp_and_aggregate_pushdown(
+    pg_conn, s3, with_default_location, session_tz
+):
+    """
+    Both query wrappers fire on the *same* pushed-down INSERT..SELECT,
+    on different columns of the same target row, and through a
+    non-trivial inner SELECT (``max(...) GROUP BY``).
+
+    IcebergWrapQueryWithErrorOrClampChecks (driven by
+    ``out_of_range_values = 'clamp'`` on the target) wraps the timestamp
+    column.  IcebergWrapQueryWithNativeTypeConversion (this PR) wraps the
+    timetz column.  Both must coexist on the same query without aliasing
+    collision, and both must still rewrite the column expression when it
+    is the output of an aggregate rather than a bare column reference.
+
+    Beyond reusing the single-wrap coverage in the other tests in this
+    file, this pins:
+
+      * Both subquery aliases (``__iceberg_oor`` and
+        ``__iceberg_native_conv``) appear in the Vectorized SQL.
+      * The TIMETZ UTC-normalizing cast still fires when the column
+        expression is ``max(at_time)``.
+      * The aggregated end-to-end result matches what PostgreSQL would
+        produce on a heap table, using PostgreSQL's own equality
+        semantics for ``timetz`` (equality by UTC instant, so e.g.
+        ``08:30:00+00`` equals ``12:30:00+04``).
+
+    Parametrized over the PostgreSQL session timezone to lock in that
+    the write path (TIMETZ literals -> wrap -> Iceberg storage -> read
+    back as top-level TIMETZ) is independent of ``SET TIME ZONE``.
+    The wrap emits a hardcoded ``AT TIME ZONE 'UTC'``, the timetz
+    literals carry explicit offsets, and the read path applies
+    ``col::TIMETZ`` to top-level columns (pinning the offset to +00 on
+    the wire), so the entire chain should be tz-invariant.
+    """
+    utc = timezone.utc
+
+    try:
+        run_command(f"SET TIME ZONE '{session_tz}';", pg_conn)
+        run_command(
+            """
+            DROP SCHEMA IF EXISTS test_timetz_oor_agg_pd CASCADE;
+            CREATE SCHEMA test_timetz_oor_agg_pd;
+            SET search_path TO test_timetz_oor_agg_pd;
+
+            CREATE TABLE src (group_id int, ts timestamp, at_time timetz)
+                USING iceberg;
+            CREATE TABLE tgt (group_id int, max_ts timestamp, max_at_time timetz)
+                USING iceberg WITH (out_of_range_values = 'clamp');
+
+            CREATE TABLE heap_src (group_id int, ts timestamp, at_time timetz);
+            CREATE TABLE heap_ref (group_id int, max_ts timestamp, max_at_time timetz);
+
+            INSERT INTO src VALUES
+                (1, '2024-06-01 00:00:00', '12:30:00+04'::timetz),
+                (1, '2024-06-15 12:30:00', '08:00:00+00'::timetz),
+                (2, '2024-06-20 00:00:00', '23:30:00-02'::timetz),
+                (2, '2024-06-25 12:00:00', '00:00:00+00'::timetz);
+
+            INSERT INTO heap_src SELECT * FROM src;
+            INSERT INTO heap_ref
+                SELECT group_id, max(ts), max(at_time)
+                  FROM heap_src GROUP BY group_id;
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        insert_sql = (
+            "INSERT INTO tgt (group_id, max_ts, max_at_time) "
+            "SELECT group_id, max(ts), max(at_time) "
+            "  FROM src GROUP BY group_id"
+        )
+
+        explain = _get_explain_text(insert_sql, pg_conn)
+        assert "Custom Scan (Query Pushdown)" in explain, explain
+
+        # Both wrappers must have fired on the same query.  The subquery
+        # aliases are the canonical signature of each wrap: __iceberg_oor
+        # for the clamp/error wrap on the timestamp column, and
+        # __iceberg_native_conv for the TIMETZ rewrite.
+        assert "__iceberg_oor" in explain, (
+            "Expected OOR clamp wrapper to fire on the timestamp column:\n" + explain
+        )
+        assert "__iceberg_native_conv" in explain, (
+            "Expected native-type-conversion wrapper to fire on timetz:\n" + explain
+        )
+        assert "AT TIME ZONE 'UTC' AS TIME" in explain, (
+            "Expected TIMETZ UTC-normalizing cast in the wrapped SQL:\n" + explain
+        )
+
+        run_command(insert_sql, pg_conn)
+        pg_conn.commit()
+
+        # Group 1: max(ts) = 2024-06-15 12:30:00; max(at_time) compares by
+        # UTC instant, so 12:30:00+04 (08:30 UTC) wins over 08:00:00+00
+        # (08:00 UTC) and is then UTC-normalized to 08:30:00.
+        # Group 2: max(ts) = 2024-06-25 12:00:00; max(at_time) is
+        # 23:30:00-02 (01:30 UTC) over 00:00:00+00 (00:00 UTC), normalized
+        # to 01:30:00.
+        result = run_query(
+            "SELECT group_id, max_ts::text, max_at_time "
+            "  FROM tgt ORDER BY group_id",
+            pg_conn,
+        )
+        assert result == [
+            [1, "2024-06-15 12:30:00", time(8, 30, 0, tzinfo=utc)],
+            [2, "2024-06-25 12:00:00", time(1, 30, 0, tzinfo=utc)],
+        ]
+
+        # End-to-end equality against PostgreSQL's own aggregate over the
+        # same source.  TIMETZ equality is by UTC instant, so the heap
+        # reference (which preserves original offsets) and the Iceberg
+        # target (UTC-normalized offsets) compare equal under PG semantics.
+        assert_table_contents_match(pg_conn, "tgt", "heap_ref")
+    finally:
+        run_command("RESET search_path;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("DROP SCHEMA IF EXISTS test_timetz_oor_agg_pd CASCADE", pg_conn)
+        pg_conn.commit()
+
+
 @pytest.fixture(scope="module")
 def create_helper_functions(superuser_conn, app_user):
     run_command(

--- a/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_insert_select_pushdown.py
@@ -398,7 +398,7 @@ _INSERT_SELECT_UNSUITABLE_CASES = [
     #
     # NOTE: interval cases (interval-iceberg, interval-in-array-iceberg,
     # interval-in-struct-iceberg) were removed from this list because
-    # IcebergWrapQueryWithIntervalConversion now decomposes intervals into
+    # IcebergWrapQueryWithNativeTypeConversion now decomposes intervals into
     # STRUCT(months, days, microseconds) in the pushdown query, so pushdown
     # is safe for interval columns.
 ]

--- a/test_common/helpers/comparisons.py
+++ b/test_common/helpers/comparisons.py
@@ -207,6 +207,62 @@ def check_table_size(pg_conn, table_name, count):
     assert result[0]["count"] == count
 
 
+def assert_table_contents_match(pg_conn, table_a, table_b):
+    """Assert ``table_a`` and ``table_b`` contain exactly the same multiset
+    of rows, using PostgreSQL set semantics as the source of truth.
+
+    Concretely runs:
+
+        SELECT count(*) FROM (
+            (SELECT * FROM table_a EXCEPT ALL SELECT * FROM table_b)
+            UNION ALL
+            (SELECT * FROM table_b EXCEPT ALL SELECT * FROM table_a)
+        ) diff;
+
+    and asserts the result is 0.
+
+    Why this exists: PostgreSQL knows the equality semantics of every type
+    (composites compare element-wise, arrays position-wise, etc.), which
+    makes this a stronger end-to-end check than a Python-side comparison
+    of psycopg-decoded rows.
+
+    Either ``table_a`` or ``table_b`` may be a parenthesised subquery
+    expression with an alias (e.g. ``"(SELECT id, x FROM t) s"``), so
+    callers can project / normalise columns where the bare table-vs-table
+    comparison would not say what they want.
+
+    Caveats -- ``EXCEPT ALL`` uses the btree/hash opclass of each column
+    type, NOT the bare ``=`` operator, so a few PostgreSQL types compare
+    here in ways that may surprise callers:
+
+      * ``timetz``: the ``=`` operator is by UTC instant
+        (``'12:30:00+04' = '08:30:00+00'`` is true), but the btree opclass
+        sorts on (UTC instant, then offset) and the hash opclass hashes
+        (time, zone) separately.  Two rows with the same UTC instant but
+        different offsets are treated as DIFFERENT by ``EXCEPT ALL``.  If
+        you need by-UTC-instant equality, project both sides through
+        ``(t AT TIME ZONE 'UTC')::time``.
+      * pg_lake map columns inherit array equality, which is order-
+        sensitive across map entries; if either side may have map columns
+        whose entries can be reordered (e.g. by a round-trip through
+        Iceberg storage), exclude them from the projection.
+    """
+    diff_query = (
+        "SELECT count(*) FROM ("
+        f"  (SELECT * FROM {table_a} EXCEPT ALL SELECT * FROM {table_b})"
+        "  UNION ALL"
+        f"  (SELECT * FROM {table_b} EXCEPT ALL SELECT * FROM {table_a})"
+        ") diff"
+    )
+    result = run_query(diff_query, pg_conn)
+    diff_count = result[0][0]
+    assert diff_count == 0, (
+        f"Tables {table_a} and {table_b} differ: "
+        f"{diff_count} rows in the symmetric difference.\n"
+        f"Diff query: {diff_query}"
+    )
+
+
 def normalize_bc(rows):
     """Normalize DuckDB's '(BC) between date and time' to PG's 'BC at end'.
 


### PR DESCRIPTION
DuckDB's implicit `CAST(TIMETZ AS TIME)` drops the timezone offset without shifting the time digits to UTC, so '23:59:59.999+05:30' would land in Iceberg as '23:59:59.999' instead of '18:29:59.999'. 

The Iceberg write projection applied this cast to every `timetz` column, silently corrupting non-UTC values on any path that fed native `TIMETZ` to DuckDB: `INSERT..SELECT` pushdown, `COPY FROM` pushdown, etc. 

The regular per-row `INSERT` path was already safe because `TimeTzOutForPGDuck` UTC-normalizes values before handing them to DuckDB as CSV strings.

Fix it in the existing native-type query wrap:

 - Generalize `IcebergWrapQueryWithIntervalConversion` (and its helpers) into `IcebergWrapQueryWithNativeTypeConversion`, covering both `INTERVAL` and `TIMETZ`, recursing through arrays, composites, maps, and domains just like the interval path does.
 - For `TIMETZ` leaves, emit `CAST(<expr> AT TIME ZONE 'UTC' AS TIME)` so the offset is folded into the time digits before the Iceberg cast.

Regression tests in `test_iceberg_timetz_type.py` cover both the pushdown wrap and the non-pushdown CSV path:

 - `test_iceberg_timetz_as_utc_time` (existing) exercises scalar `TIMETZ` and `timetz[]` through `iceberg`->`iceberg` `INSERT..SELECT`, a CSV foreign table source, and `COPY FROM`, asserting pushdown and UTC-normalized round-trip values.
 - `test_timetz_insert_select_from_heap` locks in the `heap` -> `iceberg` FDW/CSV path (which is NOT pushed down -- heap sources aren't DuckDB-shippable -- but is still UTC-safe via `TimeTzOutForPGDuck`).
 - `test_insert_select_timetz_in_composite_pushdown`, `..._in_map_pushdown`, `..._in_domain_pushdown` and `..._deeply_nested_pushdown` exercise the recursive traversal of `AppendNativeConversionExpression` through arrays, composites, maps and domains

Made-with: Cursor
