### PR TITLE
iceberg: preserve required as NOT NULL when auto-detecting columns

### DIFF
--- a/pg_lake_table/src/describe/describe.c
+++ b/pg_lake_table/src/describe/describe.c
@@ -197,6 +197,18 @@ DescribeColumnsFromIcebergMetadataURI(char *uri, bool emitFilename)
 
 		ColumnDef  *column = makeColumnDef(columnName, typeOid, typemod, collationId);
 
+		/*
+		 * Propagate the iceberg "required" flag to postgres NOT NULL so the
+		 * empty-column-list auto-detect form
+		 *   CREATE TABLE foo () USING iceberg WITH (catalog='rest', read_only=true, ...)
+		 * doesn't trip ErrorIfSchemasDoNotMatch's
+		 *   columnMapping->attNotNull != icebergField->required
+		 * check at projection time. Without this, every auto-detected column
+		 * is nullable while the iceberg schema may have required fields,
+		 * forcing users to enumerate columns explicitly with NOT NULL.
+		 */
+		column->is_not_null = field->required;
+
 		columns = lappend(columns, column);
 	}
 


### PR DESCRIPTION
## Summary

When you create a read-only foreign table against an iceberg REST catalog with an empty column list:

```sql
CREATE TABLE foo ()
USING iceberg
WITH (catalog='rest', read_only=true, catalog_namespace='ns', catalog_table_name='t');
```

`DescribeColumnsFromIcebergMetadataURI` derives the postgres columns from the iceberg schema but always leaves `ColumnDef.is_not_null = false`. Iceberg fields with `required: true` end up as nullable in postgres. Then on the first projection, [`ErrorIfSchemasDoNotMatch` in `snapshot.c:413`](https://github.com/Snowflake-Labs/pg_lake/blob/main/pg_lake_table/src/fdw/snapshot.c#L413) trips its strict-equality check:

```c
columnMapping->attNotNull != icebergField->required
```

and you get:

```
ERROR: Schema mismatch between Iceberg and Postgres for field ids 1 vs 1
HINT: Please drop and recreate the table "..."
```

The current workaround is to enumerate every column by hand with explicit `NOT NULL` matching iceberg's `required` flags, which defeats the point of the empty-column form. This affects any external table whose iceberg schema has any `required: true` field, e.g. a typical CDC feed where the timestamp + action columns are required.

This patch sets `column->is_not_null = field->required` at column construction time, so the auto-detect path matches what `ErrorIfSchemasDoNotMatch` later compares against.

## Test plan

- [x] Manually verified against a CDC events table whose iceberg schema has `required: true` on `created` and `action`. Before: empty `()` form errors with "Schema mismatch ... field ids 1 vs 1". After (with this patch): empty `()` form returns rows with non-null required columns and matches the explicit-NOT-NULL form behavior.
- [ ] CI / existing pytests in `pg_lake_table/tests/pytests/` (no test changes in this PR; happy to add one if maintainers prefer).

## Notes

- `DescribeColumnsFromIcebergMetadataURI` is also called from raw-parquet describes (`describe.c:75`). For raw parquet, `field->required` reflects whatever the parquet thrift says — which is usually `false` for spec-compliant iceberg parquet and arbitrary for legacy. The behavior change there is "we now respect what the parquet says about required", which seems strictly more correct than dropping the bit, but happy to gate this to the iceberg path if maintainers want.
- Related discussion: #83.