### PR TITLE
Fix geometry columns emitting invalid WKB during postgres_scan writes

### DIFF
--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -634,16 +634,18 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 	}
 
 	/*
-	 * Geometry from postgres_scan arrives as WKB_BLOB (DuckDB's internal
-	 * geometry representation).  Writing it directly to Parquet stores
-	 * DuckDB's internal format, which ST_GeomFromWKB cannot parse on read.
-	 * Explicitly converting via ST_AsWKB produces standard WKB that the read
-	 * path expects.  Geometry inside arrays or composites is unsupported (see
-	 * type_validation.c), so only top-level columns reach here.
+	 * Geometry from postgres_scan arrives as WKB_BLOB (a BLOB with the
+	 * "WKB_BLOB" alias), not DuckDB's native GEOMETRY type.  ST_AsWKB
+	 * requires GEOMETRY, so we cast first.  The full expression
+	 * ST_AsWKB(col::GEOMETRY) parses the WKB_BLOB into a proper GEOMETRY,
+	 * then serializes it as standard WKB for Parquet.  Without this, the blob
+	 * is written as-is and ST_GeomFromWKB cannot parse it on read. Geometry
+	 * inside arrays or composites is unsupported (see type_validation.c), so
+	 * only top-level columns reach here.
 	 */
 	if (IsGeometryTypeId(typeOid))
 	{
-		appendStringInfo(buf, "ST_AsWKB(%s)", expr);
+		appendStringInfo(buf, "ST_AsWKB(%s::GEOMETRY)", expr);
 		return true;
 	}
 

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -26,7 +26,7 @@
  *     out-of-range temporal values and nested-list flattening.
  *   - IcebergWrapQueryWithNativeTypeConversion: rewrites DuckDB columns
  *     whose native representation differs from the Iceberg target
- *     (INTERVAL, TIMETZ).
+ *     (INTERVAL, TIMETZ, geometry).
  *
  * Both recurse through arrays, composites, maps, and domains.
  *
@@ -42,6 +42,7 @@
 
 #include "access/tupdesc.h"
 #include "catalog/pg_type.h"
+#include "pg_lake/extensions/postgis.h"
 #include "pg_lake/pgduck/iceberg_query_validation.h"
 #include "pg_lake/pgduck/map.h"
 #include "utils/builtins.h"
@@ -476,13 +477,16 @@ IcebergWrapQueryWithErrorOrClampChecks(char *query, TupleDesc tupleDesc,
 /*
  * TypeNeedsNativeConversion recursively checks whether a type is, or
  * contains, one of the native DuckDB types that needs rewriting before
- * being written to Iceberg (currently INTERVAL and TIMETZ).  Recurses
- * through arrays, composites, maps, and domains.
+ * being written to Iceberg (currently INTERVAL, TIMETZ, and geometry).
+ * Recurses through arrays, composites, maps, and domains.
  */
 static bool
 TypeNeedsNativeConversion(Oid typeOid)
 {
 	if (typeOid == INTERVALOID || typeOid == TIMETZOID)
+		return true;
+
+	if (IsGeometryTypeId(typeOid))
 		return true;
 
 	Oid			elemType = get_element_type(typeOid);
@@ -603,8 +607,9 @@ AppendTimeTzUtcCast(StringInfo buf, const char *expr)
 /*
  * AppendNativeConversionExpression recursively generates DuckDB SQL
  * that converts native-only types to their Iceberg-compatible shape:
- *   - INTERVAL -> STRUCT(months, days, microseconds)
- *   - TIMETZ   -> CAST(CAST(<expr> AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)
+ *   - INTERVAL  -> STRUCT(months, days, microseconds)
+ *   - TIMETZ    -> CAST(CAST(<expr> AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)
+ *   - geometry  -> ST_AsWKB(<expr>)
  *
  * Handles scalars, arrays (list_transform), composites (struct_pack),
  * maps (map_from_entries + list_transform), and domains.
@@ -625,6 +630,20 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 	if (typeOid == TIMETZOID)
 	{
 		AppendTimeTzUtcCast(buf, expr);
+		return true;
+	}
+
+	/*
+	 * Geometry from postgres_scan arrives as WKB_BLOB (DuckDB's internal
+	 * geometry representation).  Writing it directly to Parquet stores
+	 * DuckDB's internal format, which ST_GeomFromWKB cannot parse on read.
+	 * Explicitly converting via ST_AsWKB produces standard WKB that the read
+	 * path expects.  Geometry inside arrays or composites is unsupported (see
+	 * type_validation.c), so only top-level columns reach here.
+	 */
+	if (IsGeometryTypeId(typeOid))
+	{
+		appendStringInfo(buf, "ST_AsWKB(%s)", expr);
 		return true;
 	}
 
@@ -778,6 +797,9 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
  *     AT TIME ZONE 'UTC' well-typed when the source is already plain
  *     TIME (e.g. a TIMETZ field read back from an Iceberg composite
  *     column, where the Parquet-level type is TIME).
+ *   - Geometry columns are converted to standard WKB via ST_AsWKB().
+ *     Without this, DuckDB writes its internal geometry representation
+ *     to Parquet, which ST_GeomFromWKB cannot parse on read.
  *
  * Rewrites recurse through arrays, composites, maps, and domains.
  *

--- a/pg_lake_spatial/tests/pytests/test_spatial_insert_select.py
+++ b/pg_lake_spatial/tests/pytests/test_spatial_insert_select.py
@@ -1,0 +1,111 @@
+"""
+Tests for geometry columns in INSERT .. SELECT pushdown write paths.
+
+Exercises the iceberg-to-iceberg pushdown path where
+IcebergWrapQueryWithNativeTypeConversion rewrites geometry columns
+via ST_AsWKB(col::GEOMETRY) before writing to Parquet.
+"""
+
+import pytest
+from utils_pytest import *
+
+
+SCHEMA = "test_spatial_insert_select"
+
+
+@pytest.fixture(autouse=True)
+def setup_schema(
+    pg_conn,
+    s3,
+    spatial_analytics_extension,
+    pg_lake_extension,
+    extension,
+    with_default_location,
+):
+    run_command(f"CREATE SCHEMA {SCHEMA}", pg_conn)
+    pg_conn.commit()
+
+    yield
+
+    run_command(f"DROP SCHEMA IF EXISTS {SCHEMA} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_insert_select_pushdown_iceberg_to_iceberg(pg_conn):
+    """
+    INSERT INTO iceberg SELECT ... FROM iceberg exercises the pushdown path.
+    DuckDB reads WKB blobs from the source Parquet and writes them to the
+    destination via IcebergWrapQueryWithNativeTypeConversion, which applies
+    ST_AsWKB(col::GEOMETRY) to produce standard WKB.
+    """
+    run_command(
+        f"""
+        CREATE TABLE {SCHEMA}.ice_src (id int, g geometry) USING iceberg;
+        INSERT INTO {SCHEMA}.ice_src VALUES
+            (1, ST_Point(10, 20)),
+            (2, ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')),
+            (3, ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2)')),
+            (4, NULL);
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        CREATE TABLE {SCHEMA}.ice_dest (id int, g geometry) USING iceberg;
+        INSERT INTO {SCHEMA}.ice_dest SELECT id, g FROM {SCHEMA}.ice_src;
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        f"SELECT id, ST_AsText(g) geom FROM {SCHEMA}.ice_dest ORDER BY id",
+        pg_conn,
+    )
+    assert len(result) == 4
+    assert result[0]["geom"] == "POINT (10 20)"
+    assert result[1]["geom"] == "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"
+    assert result[2]["geom"] == "LINESTRING (0 0, 1 1, 2 2)"
+    assert result[3]["geom"] is None
+
+
+def test_insert_select_pushdown_geometry_with_other_columns(pg_conn):
+    """
+    Geometry column mixed with other types in iceberg-to-iceberg pushdown
+    to verify the conversion targets only geometry columns.
+    """
+    run_command(
+        f"""
+        CREATE TABLE {SCHEMA}.mixed_src (
+            id int, name text, g geometry, val float
+        ) USING iceberg;
+        INSERT INTO {SCHEMA}.mixed_src VALUES
+            (1, 'alpha', ST_Point(1, 2), 3.14),
+            (2, 'beta', ST_Point(3, 4), 2.72),
+            (3, 'gamma', NULL, NULL);
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        CREATE TABLE {SCHEMA}.mixed_dest (
+            id int, name text, g geometry, val float
+        ) USING iceberg;
+        INSERT INTO {SCHEMA}.mixed_dest SELECT * FROM {SCHEMA}.mixed_src;
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        f"SELECT id, name, ST_AsText(g) geom, val FROM {SCHEMA}.mixed_dest ORDER BY id",
+        pg_conn,
+    )
+    assert len(result) == 3
+    assert result[0] == {"id": 1, "name": "alpha", "geom": "POINT (1 2)", "val": 3.14}
+    assert result[1] == {"id": 2, "name": "beta", "geom": "POINT (3 4)", "val": 2.72}
+    assert result[2] == {"id": 3, "name": "gamma", "geom": None, "val": None}


### PR DESCRIPTION
Geometry columns from postgres_scan arrive as hex WKB strings (VARCHAR) rather than native GEOMETRY values. When written to Iceberg/Parquet without conversion, these produce invalid WKB blobs (type id 0), causing "WKB type 'UNKNOWN' is not supported" errors on read.

Add geometry handling to IcebergWrapQueryWithNativeTypeConversion so the snapshot/pushdown write path emits
ST_AsWKB(ST_GeomFromHEXWKB(<col>)) for geometry columns, parsing the hex WKB into a proper GEOMETRY and re-encoding as a WKB blob.

This does not affect the CSV-generated path: it already converts geometry via PGDuckSerialize (WKT) + TupleDescToProjectionListForWrite (ST_AsWKB).
