### PR TITLE
Bound iceberg manifest-rewrite memory under high-churn workloads

### DIFF
--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -135,6 +135,13 @@ static List *CreateNewManifestsForDeletedEntries(List *allManifestEntries, List 
 												 const char *snapshotUUID, int *manifestIndex,
 												 int partitionSpecId, List *partitionTransforms,
 												 IcebergManifestContentType contentType);
+static bool RewriteManifestForRemoval(IcebergManifest * manifest,
+									  List *removedEntries, bool removeAllEntries,
+									  int64_t snapshotId, IcebergSnapshot * newSnapshot,
+									  const char *metadataLocation, const char *snapshotUUID,
+									  int *manifestIndex, List *allTransforms,
+									  List **finalDataManifestList,
+									  List **finalDeleteManifestList);
 static IcebergSnapshot * CopyIcebergSnapshot(IcebergSnapshot * src);
 static Property * CopyPropertiesArray(Property * src, int length);
 static HTAB *MakePartitionManifestEntryHash(void);
@@ -971,36 +978,14 @@ FinalizeNewSnapshot(IcebergSnapshotBuilder * builder, Oid relationId, const char
 		foreach(manifestCell, manifestList)
 		{
 			IcebergManifest *manifest = lfirst(manifestCell);
-			IcebergManifestContentType content = manifest->content;
-			List	   *manifestEntries =
-				ReadManifestEntries(manifest->manifest_path);
 
-			List	   *deletedManifestEntries =
-				FindAndAdjustDeletedManifestEntries(manifest, manifestEntries, removedEntries,
-													snapshotId, removeAllEntries);
-
-			if (deletedManifestEntries != NIL)
+			if (RewriteManifestForRemoval(manifest, removedEntries, removeAllEntries,
+										  snapshotId, newSnapshot,
+										  metadataLocation, snapshotUUID,
+										  &manifestIndex, allTransforms,
+										  &finalDataManifestList,
+										  &finalDeleteManifestList))
 			{
-				List	   *newManifests =
-					CreateNewManifestsForDeletedEntries(manifestEntries, deletedManifestEntries,
-														newSnapshot, metadataLocation, snapshotUUID,
-														&manifestIndex, manifest->partition_spec_id,
-														allTransforms, content);
-
-				/* remove the old manifest and add the new ones */
-				if (content == ICEBERG_MANIFEST_FILE_CONTENT_DATA)
-				{
-					finalDataManifestList = list_difference_ptr(finalDataManifestList, list_make1(manifest));
-					finalDataManifestList = list_concat(finalDataManifestList, newManifests);
-				}
-				else if (content == ICEBERG_MANIFEST_FILE_CONTENT_DELETES)
-				{
-					finalDeleteManifestList = list_difference_ptr(finalDeleteManifestList, list_make1(manifest));
-					finalDeleteManifestList = list_concat(finalDeleteManifestList, newManifests);
-				}
-				else
-					pg_unreachable();
-
 				createNewSnapshot = true;
 			}
 		}
@@ -1111,6 +1096,104 @@ CreateNewManifestsForDeletedEntries(List *allManifestEntries, List *deletedManif
 								 remainingManifestPath, remainingManifestEntries);
 
 	return list_make2(deleteManifest, remainingManifest);
+}
+
+
+/*
+ * RewriteManifestForRemoval marks the rows belonging to removedEntries (or
+ * every row if removeAllEntries is true) as deleted in the given manifest
+ * and, if any rows were affected, splices the resulting new manifests into
+ * finalDataManifestList / finalDeleteManifestList in place of the old one.
+ *
+ * Returns true iff the manifest was rewritten.
+ *
+ *
+ * Memory management:
+ *
+ * Reading one manifest's entries plus its Partition Field Map can take tens
+ * of MB.  When the caller iterates over thousands of manifests in a single
+ * DELETE, leaving that memory in the caller's context accumulates into
+ * multi-GB peaks.  This function isolates the per-manifest memory in a
+ * private context that is created and destroyed inside the function:
+ *
+ *   - The READ phase (entries + partition field map) is allocated in
+ *     perManifestCtx, which is destroyed before returning.
+ *
+ *   - The WRITE phase (UploadIcebergManifestToURI, the new IcebergManifest
+ *     headers) is run in callerCtx.  This is required, not just convenient:
+ *     UploadIcebergManifestToURI -> GenerateTempFileName registers a
+ *     callback on the current memory context that unlinks the local temp
+ *     file when that context is reset.  The actual S3 upload is deferred
+ *     until commit, so the callback must outlive this function.  Running
+ *     the WRITE phase in callerCtx also means the resulting IcebergManifest
+ *     headers are already in callerCtx and can be appended to the final
+ *     lists directly.
+ *
+ * Callers must not be in perManifestCtx when calling this function -- it
+ * unconditionally restores CurrentMemoryContext to whatever it was on
+ * entry before returning.
+ */
+static bool
+RewriteManifestForRemoval(IcebergManifest * manifest,
+						  List *removedEntries, bool removeAllEntries,
+						  int64_t snapshotId, IcebergSnapshot * newSnapshot,
+						  const char *metadataLocation, const char *snapshotUUID,
+						  int *manifestIndex, List *allTransforms,
+						  List **finalDataManifestList,
+						  List **finalDeleteManifestList)
+{
+	bool		rewritten = false;
+
+	MemoryContext perManifestCtx =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "Iceberg per-manifest memory",
+							  ALLOCSET_DEFAULT_SIZES);
+
+	/* read the manifest's entries into per-manifest memory */
+	MemoryContext callerCtx = MemoryContextSwitchTo(perManifestCtx);
+
+	List	   *manifestEntries = ReadManifestEntries(manifest->manifest_path);
+
+	List	   *deletedManifestEntries =
+		FindAndAdjustDeletedManifestEntries(manifest, manifestEntries, removedEntries,
+											snapshotId, removeAllEntries);
+
+	if (deletedManifestEntries != NIL)
+	{
+		/* write the new manifests in caller memory (see comment above) */
+		MemoryContextSwitchTo(callerCtx);
+
+		IcebergManifestContentType content = manifest->content;
+
+		List	   *newManifests =
+			CreateNewManifestsForDeletedEntries(manifestEntries, deletedManifestEntries,
+												newSnapshot, metadataLocation, snapshotUUID,
+												manifestIndex, manifest->partition_spec_id,
+												allTransforms, content);
+
+		if (content == ICEBERG_MANIFEST_FILE_CONTENT_DATA)
+		{
+			*finalDataManifestList =
+				list_difference_ptr(*finalDataManifestList, list_make1(manifest));
+			*finalDataManifestList =
+				list_concat(*finalDataManifestList, newManifests);
+		}
+		else if (content == ICEBERG_MANIFEST_FILE_CONTENT_DELETES)
+		{
+			*finalDeleteManifestList =
+				list_difference_ptr(*finalDeleteManifestList, list_make1(manifest));
+			*finalDeleteManifestList =
+				list_concat(*finalDeleteManifestList, newManifests);
+		}
+		else
+			pg_unreachable();
+
+		rewritten = true;
+	}
+
+	MemoryContextSwitchTo(callerCtx);
+	MemoryContextDelete(perManifestCtx);
+	return rewritten;
 }
 
 

--- a/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
+++ b/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
@@ -36,6 +36,7 @@
 #include "common/hashfn.h"
 #include "nodes/pg_list.h"
 #include "utils/hsearch.h"
+#include "utils/memutils.h"
 
 
 
@@ -495,6 +496,36 @@ RemoveDeletedManifestEntriesInternal(IcebergManifest * *manifest, IcebergSnapsho
 									 List *allTransforms, IcebergManifestContentType contentType,
 									 const char *metadataLocation, const char *snapshotUUID, int *manifestIndex)
 {
+	/*
+	 * Reading one manifest's entries plus its Partition Field Map can take
+	 * tens of MB on large changelog tables.  When the caller calls us in a
+	 * loop over every manifest in a snapshot, leaving that memory in the
+	 * caller's context would accumulate into multi-GB peaks.
+	 *
+	 * Use two memory contexts:
+	 *
+	 * - callerCtx      : holds the new IcebergManifest header we hand back,
+	 * and the local temp file registered for upload at commit time.
+	 *
+	 * - perManifestCtx : holds the manifest entries we read and the filtered
+	 * list we build from them.  We free this before returning.
+	 *
+	 * The WRITE phase (GenerateRemoteManifestPath,
+	 * UploadIcebergManifestToURI, CreateNewIcebergManifest) must run in
+	 * callerCtx, because UploadIcebergManifestToURI -> GenerateTempFileName
+	 * registers a callback on the current memory context that unlinks the
+	 * local temp file when that context is reset.  The matching upload is
+	 * deferred until commit, so the callback has to outlive this function.
+	 */
+	bool		modified = false;
+
+	MemoryContext perManifestCtx =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "Iceberg per-manifest memory",
+							  ALLOCSET_DEFAULT_SIZES);
+
+	MemoryContext callerCtx = MemoryContextSwitchTo(perManifestCtx);
+
 	List	   *manifestEntries = FetchManifestEntriesFromManifest(*manifest, NULL);
 
 	List	   *newManifestEntries = NIL;
@@ -517,32 +548,31 @@ RemoveDeletedManifestEntriesInternal(IcebergManifest * *manifest, IcebergSnapsho
 	{
 		/* all entries are removed, skip this manifest */
 		*manifest = NULL;
-		return true;
+		modified = true;
 	}
-
-	bool		removedAnyEntry = list_length(newManifestEntries) != list_length(manifestEntries);
-
-	if (!removedAnyEntry)
+	else if (list_length(newManifestEntries) != list_length(manifestEntries))
 	{
-		/* no entries were removed, no modifications made */
-		return false;
+		/* some entries were removed -- write a new manifest in caller memory */
+		MemoryContextSwitchTo(callerCtx);
+
+		char	   *remoteManifestPath =
+			GenerateRemoteManifestPath(metadataLocation,
+									   snapshotUUID,
+									   (*manifestIndex)++, "");
+
+		int64_t		manifestSize = UploadIcebergManifestToURI(newManifestEntries, remoteManifestPath);
+
+		IcebergManifest *newManifest =
+			CreateNewIcebergManifest(currentSnapshot, (*manifest)->partition_spec_id, allTransforms,
+									 manifestSize, contentType, remoteManifestPath, newManifestEntries);
+
+		*manifest = newManifest;
+		modified = true;
 	}
 
-	char	   *remoteManifestPath =
-		GenerateRemoteManifestPath(metadataLocation,
-								   snapshotUUID,
-								   (*manifestIndex)++, "");
-
-	int64_t		manifestSize = UploadIcebergManifestToURI(newManifestEntries, remoteManifestPath);
-
-	IcebergManifest *newManifest =
-		CreateNewIcebergManifest(currentSnapshot, (*manifest)->partition_spec_id, allTransforms,
-								 manifestSize, contentType, remoteManifestPath, newManifestEntries);
-
-	*manifest = newManifest;
-
-	/* some entries were removed, manifest was modified */
-	return true;
+	MemoryContextSwitchTo(callerCtx);
+	MemoryContextDelete(perManifestCtx);
+	return modified;
 }
 
 


### PR DESCRIPTION
When a single statement rewrites many manifests -- a `DELETE` that touches data spanning thousands of manifests, or manifest-merge-on- write compaction -- `pg_lake_iceberg` used to read every manifest's entry list and Partition Field Map into the caller's memory context and never release that memory until the surrounding statement completed.  

On tables with high `INSERT`/`DELETE` churn this produces memory peaks that grow linearly with the manifest count: backend RSS climbs into multi-GB territory from a single in-flight DELETE, with most of it sitting in one SPI Proc context populated by thousands of sibling "Partition Field Map" / "Iceberg partitioned manifest entry hash" sub-contexts.

The effect is amplified in long-running transactions and on backends that anchor replication slots, because the memory cannot be reclaimed until the statement (and any surrounding transaction) completes -- so the peak observed in a `pg_log_backend_memory_contexts` snapshot is also the floor for the rest of the transaction.

This commit introduces a private per-manifest memory context in the two manifest-rewrite paths inside `pg_lake_iceberg`:

  - `FinalizeNewSnapshot`'s row-removal loop (the path that runs for `DELETE` / `TRUNCATE`-style removal).  The per-manifest body is extracted into a focused helper RewriteManifestForRemoval that owns the lifecycle of its own per-manifest context, so the surrounding loop has no memory-context machinery left in it.

  - RemoveDeletedManifestEntriesInternal (manifest-merge-on-write / compaction).  Already operates on one manifest at a time, so the per-manifest context lives directly in that function.

The READ state -- the manifest entries list, Partition Field Map, and transient avro decode allocations -- is allocated in `perManifestCtx `and freed before the helper returns.  After the change, memory used by these loops is O(one manifest) instead of O(N manifests): on tables with thousands of manifests this is the difference between a multi-GB peak and tens of MB per call.

The new IcebergManifest headers and the deferred S3-upload temp files continue to be allocated in the caller's context.  This split is required, not just convenient: `UploadIcebergManifestToURI` calls `GenerateTempFileName`, which registers a cleanup callback on `CurrentMemoryContext` that unlink()s the local temp file when that context is reset; the matching upload is deferred until commit, so the callback has to outlive the per-manifest scope.  The helper docstring spells this invariant out so future contributors see why the WRITE phase must run in the caller's context.

Made-with: Cursor
