### PR TITLE
Optimize pre-commit by avoiding to read stats of unchanged files

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -44,10 +44,11 @@ extern PGDLLEXPORT List *GetTableDataFilesFromCatalog(Oid relationId, bool dataO
 													  bool forUpdate, char *orderBy, Snapshot snapshot);
 HTAB	   *GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
 											 bool forUpdate, char *orderBy, Snapshot snapshot,
-											 List *partitionTransforms);
+											 List *partitionTransforms, bool skipColumnStats);
 HTAB	   *GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
 												   bool forUpdate, char *orderBy, Snapshot snapshot,
-												   List *partitionTransforms);
+												   List *partitionTransforms, bool skipColumnStats);
+extern PGDLLEXPORT void LoadColumnStatsForFiles(Oid relationId, List *dataFiles);
 extern PGDLLEXPORT List *GetPossiblePositionDeleteFilesFromCatalog(Oid relationId, List *sourcePathList,
 																   Snapshot snapshot);
 extern PGDLLEXPORT int64 GetTableSizeFromCatalog(Oid relationId);

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -113,7 +113,8 @@ GetTableDataFilesFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
 	HTAB	   *dataFilesHash = GetTableDataFilesHashFromCatalog(relationId, dataOnly,
 																 newFilesOnly, forUpdate,
 																 orderBy, snapshot,
-																 partitionTransforms);
+																 partitionTransforms,
+																 false /* skipColumnStats */ );
 
 	List	   *dataFiles = TableDataFileHashToList(dataFilesHash);
 
@@ -130,11 +131,15 @@ GetTableDataFilesFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
  * If newFilesOnly is true, only data files that are added in the current transaction are returned.
  * If orderBy is not null, it is used to sort results.
  * If snapshot is set, it is used for the query.
+ * If skipColumnStats is true, the per-column min/max stats are not loaded.
+ * Callers that only need file-level info (path, id, row count, partition) can
+ * pass true to avoid the expensive join against data_file_column_stats; stats
+ * can be loaded on demand for a subset of files via LoadColumnStatsForFiles().
  */
 HTAB *
 GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
 								 bool forUpdate, char *orderBy, Snapshot snapshot,
-								 List *partitionTransforms)
+								 List *partitionTransforms, bool skipColumnStats)
 {
 	MemoryContext callerContext = CurrentMemoryContext;
 
@@ -153,12 +158,21 @@ GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnl
 						    /* 5 */ "f.file_size, "
 						    /* 6 */ "f.deleted_row_count, "
 						    /* 7 */ "f.updated_time, "
-						    /* 8 */ "f.first_row_id, "
-						    /* 9 */ "sma.field_id, "
-						    /* 10 */ "sma.field_pg_type, "
-						    /* 11 */ "sma.field_pg_typemod, "
-						    /* 12 */ "sma.lower_bound, "
-						    /* 13 */ "sma.upper_bound, "
+						    /* 8 */ "f.first_row_id, ");
+
+	if (!skipColumnStats)
+		appendStringInfoString(&metadataQuery,
+							    /* 9 */ "sma.field_id, "
+							    /* 10 */ "sma.field_pg_type, "
+							    /* 11 */ "sma.field_pg_typemod, "
+							    /* 12 */ "sma.lower_bound, "
+							    /* 13 */ "sma.upper_bound, ");
+	else
+		appendStringInfoString(&metadataQuery,
+							   "NULL::bigint, NULL::oid, NULL::int4, "
+							   "NULL::text, NULL::text, ");
+
+	appendStringInfoString(&metadataQuery,
 						    /* 14 */ "p.partition_field_id, "
 						    /* 15 */ "p.partition_field_name, "
 						    /* 16 */ "p.value, "
@@ -188,15 +202,18 @@ GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnl
 						   "LEFT JOIN (" DATA_FILE_PARTITION_VALUES_TABLE_QUALIFIED
 						   " JOIN " PARTITION_FIELDS_TABLE_QUALIFIED
 						   " USING (table_name, partition_field_id) "
-						   ") p USING (table_name, id) "
-						   "LEFT JOIN ("
-						   DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED " s "
-						   "JOIN " MAPPING_TABLE_NAME
-						   " m USING (table_name, field_id) "
-						   "JOIN pg_attribute a ON (a.attrelid OPERATOR(pg_catalog.=) m.table_name "
-						   "                       AND a.attnum   OPERATOR(pg_catalog.=) m.pg_attnum "
-						   "                       AND NOT a.attisdropped)"
-						   ") sma USING (table_name, path)");
+						   ") p USING (table_name, id) ");
+
+	if (!skipColumnStats)
+		appendStringInfoString(&metadataQuery,
+							   "LEFT JOIN ("
+							   DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED " s "
+							   "JOIN " MAPPING_TABLE_NAME
+							   " m USING (table_name, field_id) "
+							   "JOIN pg_attribute a ON (a.attrelid OPERATOR(pg_catalog.=) m.table_name "
+							   "                       AND a.attnum   OPERATOR(pg_catalog.=) m.pg_attnum "
+							   "                       AND NOT a.attisdropped)"
+							   ") sma USING (table_name, path)");
 
 
 	if (orderBy != NULL)
@@ -354,15 +371,17 @@ GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnl
 /*
  * GetTableDataFilesByPathHashFromCatalog retrieves the data files for a given table
  * and returns a hash table indexed by file path.
+ *
+ * See GetTableDataFilesHashFromCatalog for the meaning of skipColumnStats.
  */
 HTAB *
 GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
 									   bool forUpdate, char *orderBy, Snapshot snapshot,
-									   List *partitionTransforms)
+									   List *partitionTransforms, bool skipColumnStats)
 {
 	HTAB	   *filesById = GetTableDataFilesHashFromCatalog(relationId, dataOnly, newFilesOnly,
 															 forUpdate, orderBy, snapshot,
-															 partitionTransforms);
+															 partitionTransforms, skipColumnStats);
 
 	HTAB	   *filesByPath = CreateDataFilesByPathHash();
 
@@ -384,6 +403,136 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 	}
 
 	return filesByPath;
+}
+
+
+/*
+ * LoadColumnStatsForFiles fills in per-column min/max stats for the given
+ * data files, targeting only their paths. This lets callers pair a stats-free
+ * bulk read (GetTableDataFilesHashFromCatalog with skipColumnStats=true) with
+ * a narrow stats load for just the files that actually need them (e.g. the
+ * handful of newly added files in a transaction).
+ *
+ * The dataFiles list must contain TableDataFile pointers whose columnStats
+ * are currently NIL; this function appends to dataFile->stats.columnStats.
+ */
+void
+LoadColumnStatsForFiles(Oid relationId, List *dataFiles)
+{
+	if (dataFiles == NIL)
+		return;
+
+	MemoryContext callerContext = CurrentMemoryContext;
+
+	List	   *pathList = NIL;
+	ListCell   *fileCell = NULL;
+
+	foreach(fileCell, dataFiles)
+	{
+		TableDataFile *dataFile = lfirst(fileCell);
+
+		pathList = lappend(pathList, dataFile->path);
+	}
+
+	char	   *query =
+		"select "
+		 /* 1 */ "s.path, "
+		 /* 2 */ "s.field_id, "
+		 /* 3 */ "m.field_pg_type, "
+		 /* 4 */ "m.field_pg_typemod, "
+		 /* 5 */ "s.lower_bound, "
+		 /* 6 */ "s.upper_bound "
+		"from " DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED " s "
+		"JOIN " MAPPING_TABLE_NAME " m USING (table_name, field_id) "
+		"JOIN pg_attribute a ON (a.attrelid OPERATOR(pg_catalog.=) m.table_name "
+		"                        AND a.attnum   OPERATOR(pg_catalog.=) m.pg_attnum "
+		"                        AND NOT a.attisdropped) "
+		"where s.table_name OPERATOR(pg_catalog.=) $1 "
+		"  AND s.path       OPERATOR(pg_catalog.=) ANY($2)";
+
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+
+	DECLARE_SPI_ARGS(2);
+	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+	SPI_ARG_VALUE(2, TEXTARRAYOID, StringListToArray(pathList), false);
+
+	bool		readOnly = false;
+
+	SPI_EXECUTE(query, readOnly);
+
+	for (int rowIndex = 0; rowIndex < SPI_processed; rowIndex++)
+	{
+		MemoryContext spiContext = MemoryContextSwitchTo(callerContext);
+
+		bool		isPathNull = false;
+		char	   *path = GET_SPI_VALUE(TEXTOID, rowIndex, 1, &isPathNull);
+
+		if (isPathNull)
+		{
+			MemoryContextSwitchTo(spiContext);
+			continue;
+		}
+
+		bool		isFieldIdNull = false;
+		int64		fieldId = GET_SPI_VALUE(INT8OID, rowIndex, 2, &isFieldIdNull);
+
+		if (isFieldIdNull)
+		{
+			MemoryContextSwitchTo(spiContext);
+			continue;
+		}
+
+		bool		isPgTypeNull = false;
+		bool		isPgTypeModNull = false;
+
+		PGType		pgType = {
+			.postgresTypeOid = GET_SPI_VALUE(OIDOID, rowIndex, 3, &isPgTypeNull),
+			.postgresTypeMod = GET_SPI_VALUE(INT4OID, rowIndex, 4, &isPgTypeModNull)
+		};
+
+		char	   *lowerBoundText = NULL;
+		char	   *upperBoundText = NULL;
+
+		bool		isLowerBoundNull = false;
+		Datum		lowerBoundDatum = GET_SPI_DATUM(rowIndex, 5, &isLowerBoundNull);
+
+		if (!isLowerBoundNull)
+			lowerBoundText = TextDatumGetCString(lowerBoundDatum);
+
+		bool		isUpperBoundNull = false;
+		Datum		upperBoundDatum = GET_SPI_DATUM(rowIndex, 6, &isUpperBoundNull);
+
+		if (!isUpperBoundNull)
+			upperBoundText = TextDatumGetCString(upperBoundDatum);
+
+		/*
+		 * Walk the caller's list to find the matching struct. dataFiles is
+		 * expected to be small (typically 1-2 entries per transaction), so a
+		 * linear search is fine and avoids an extra pointer-valued hash.
+		 */
+		ListCell   *lc = NULL;
+
+		foreach(lc, dataFiles)
+		{
+			TableDataFile *dataFile = lfirst(lc);
+
+			if (strcmp(dataFile->path, path) != 0)
+				continue;
+
+			if (ColumnStatAlreadyAdded(dataFile->stats.columnStats, fieldId))
+				break;
+
+			DataFileColumnStats *columnStats =
+				CreateDataFileColumnStats(fieldId, pgType, lowerBoundText, upperBoundText);
+
+			dataFile->stats.columnStats = lappend(dataFile->stats.columnStats, columnStats);
+			break;
+		}
+
+		MemoryContextSwitchTo(spiContext);
+	}
+
+	SPI_END();
 }
 
 

--- a/pg_lake_table/src/fdw/position_delete_dest.c
+++ b/pg_lake_table/src/fdw/position_delete_dest.c
@@ -125,7 +125,8 @@ CreatePositionDeleteDestReceiver(Oid relationId)
 	List	   *allTransforms = AllPartitionTransformList(relationId);
 
 	self->dataFilesHash =
-		GetTableDataFilesHashFromCatalog(relationId, true, false, false, NULL, NULL, allTransforms);
+		GetTableDataFilesHashFromCatalog(relationId, true, false, false, NULL, NULL, allTransforms,
+										 false /* skipColumnStats */ );
 
 	/* construct a tuple table slot for position deletes */
 	TupleDesc	deleteTupleDesc = CreatePositionDeleteTupleDesc();

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1003,6 +1003,13 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	/*
 	 * get current state of data files, which are not applied to metadata yet,
 	 * from catalog
+	 *
+	 * We skip per-column min/max stats on this read. The diff against the
+	 * last-pushed metadata below (FindChangedFilesSinceMetadata) only looks
+	 * at paths, and stats are only needed for the small subset of newly added
+	 * files — loaded in a targeted follow-up call below. On large
+	 * changelogs this avoids materializing one SPI row per (file × stats
+	 * column) just to diff paths.
 	 */
 	bool		dataOnly = false;
 	bool		newFilesOnly = false;
@@ -1011,7 +1018,8 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	Snapshot	snapshot = GetTransactionSnapshot();
 
 	HTAB	   *currentFilesMap = GetTableDataFilesByPathHashFromCatalog(opTracker->relationId, dataOnly, newFilesOnly,
-																		 forUpdate, orderBy, snapshot, allTransforms);
+																		 forUpdate, orderBy, snapshot, allTransforms,
+																		 true /* skipColumnStats */ );
 
 	/* get last pushed metadata */
 	IcebergTableMetadata *lastMetadata = GetLastPushedIcebergMetadata(opTracker);
@@ -1021,6 +1029,14 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	List	   *removedFilePaths = NIL;
 
 	FindChangedFilesSinceMetadata(currentFilesMap, lastMetadata, &addedFiles, &removedFilePaths);
+
+	/*
+	 * Now that we know which files are newly added, load per-column stats
+	 * targeted to just those paths. Removed files don't need stats — the
+	 * manifest DELETE entry carries only the path — so this is bounded by
+	 * the actual write size rather than by total files in the changelog.
+	 */
+	LoadColumnStatsForFiles(opTracker->relationId, addedFiles);
 
 	/*
 	 * We have found the new files that are added since the last metadata

--- a/pg_lake_table/tests/pytests/test_pg_lake_iceberg_stats.py
+++ b/pg_lake_table/tests/pytests/test_pg_lake_iceberg_stats.py
@@ -764,6 +764,70 @@ def test_nan_double_converted_numeric_column_stats(
     pg_conn.rollback()
 
 
+def test_column_stats_roundtrip_into_iceberg_manifest(
+    pg_conn, extension, app_user, s3, with_default_location, stats_catalog_permission
+):
+    """
+    Regression test for the PRE_COMMIT split-read in
+    GetDataFileMetadataOperations: the bulk catalog scan skips column stats
+    and a targeted LoadColumnStatsForFiles() reloads them for just the files
+    that are newly added in this transaction. A bug in that split — wrong
+    path matching, dedup logic, or NULL handling — would silently drop
+    bounds from the Iceberg manifest even though lake_table.data_file_column_stats
+    still has the row. We exercise that by reading the manifest directly
+    across multiple commits (each commit is a separate PRE_COMMIT pass that
+    must hit its own path through LoadColumnStatsForFiles) and confirming
+    bounds for every file and every column.
+    """
+    run_command(
+        """
+        CREATE TABLE stats_roundtrip (a int, b text, c bigint)
+        USING iceberg WITH (column_stats_mode = 'full');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # First commit: a file with multiple rows -> non-trivial min/max.
+    run_command(
+        "INSERT INTO stats_roundtrip VALUES (1, 'aaa', 100), (5, 'zzz', 500);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Second commit: another file on a path the commit hook has never seen.
+    run_command(
+        "INSERT INTO stats_roundtrip VALUES (10, 'mmm', 1000);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    stats = run_query(
+        "SELECT sequence_number, lower_bounds, upper_bounds "
+        "FROM lake_iceberg.data_file_stats("
+        "  (SELECT metadata_location FROM iceberg_tables "
+        "   WHERE table_name = 'stats_roundtrip')"
+        ") ORDER BY sequence_number;",
+        pg_conn,
+    )
+
+    # One manifest entry per commit, in order. int columns come back as ints,
+    # text columns as strings (see test_pg_lake_iceberg_table_skip_min_max for
+    # precedent).
+    assert stats == [
+        [1, {"1": 1, "2": "aaa", "3": 100}, {"1": 5, "2": "zzz", "3": 500}],
+        [2, {"1": 10, "2": "mmm", "3": 1000}, {"1": 10, "2": "mmm", "3": 1000}],
+    ], (
+        f"Manifest bounds do not match what was inserted. Got {stats}. "
+        "If some field_ids are missing from the lower_bounds/upper_bounds "
+        "dicts, the targeted stats load is dropping (path, field_id) rows "
+        "for some combination."
+    )
+
+    run_command("DROP TABLE stats_roundtrip", pg_conn)
+    pg_conn.commit()
+
+
 @pytest.fixture(scope="module")
 def stats_catalog_permission(app_user, superuser_conn, extension, s3):
     run_command(


### PR DESCRIPTION
When the number of data files gets large, pre-commit gets sluggish due to reading column statistics, but the pre-commit only needs stats for newly added files. 