### PR TITLE
Allow external extensions to register objects to hide from installcheck

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -78,7 +78,9 @@ runs:
 
     - name: Install the test extensions
       shell: bash
-      run: make -C pg_extension_base prepare-check
+      run: |
+        make -C pg_extension_base prepare-check
+        make -C pg_lake_table prepare-check
 
     - name: Upload postgres-${{ inputs.pg_version }} artifacts for ${{ inputs.container_os }}
       uses: actions/upload-artifact@v4

--- a/pg_lake_table/Makefile
+++ b/pg_lake_table/Makefile
@@ -38,6 +38,21 @@ $(EXTENSION)--1.0.sql: $(EXTENSION).sql
 	cat $^ > $@
 
 
+pg_lake_table-test:
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/
+
+install-pg_lake_table-test: pg_lake_table-test
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/ install
+
+uninstall-pg_lake_table-test:
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/ uninstall
+
+clean-pg_lake_table-test:
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/ clean
+
+prepare-check: install install-pg_lake_table-test
+finish-check: uninstall-pg_lake_table-test
+
 # Custom target for running Python tests
 .PHONY: check
 check:

--- a/pg_lake_table/include/pg_lake/test/hide_lake_objects.h
+++ b/pg_lake_table/include/pg_lake/test/hide_lake_objects.h
@@ -19,7 +19,10 @@
 
 #include "postgres.h"
 
+#include "pg_extension_base/extension_ids.h"
+
 extern bool HideObjectsCreatedByLake;
 
 extern bool HideObjectsCreatedByLakeFromCatalogTables(Node *node, void *context);
 extern void DisableLocallyHideObjectsCreatedByLakeWhenAlreadyEnabled(void);
+extern PGDLLEXPORT void RegisterHideableExtension(CachedExtensionIds * extension);

--- a/pg_lake_table/src/test/hide_lake_objects.c
+++ b/pg_lake_table/src/test/hide_lake_objects.c
@@ -29,6 +29,7 @@
 #include "catalog/pg_attrdef.h"
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_class.h"
+#include "catalog/pg_default_acl.h"
 #include "catalog/pg_depend.h"
 #include "catalog/pg_enum.h"
 #include "catalog/pg_event_trigger.h"
@@ -98,6 +99,15 @@ typedef struct ReferencedObject
  */
 bool		HideObjectsCreatedByLake = false;
 
+/*
+ * List of externally-registered CachedExtensionIds * whose objects should also
+ * be hidden from catalog queries when HideObjectsCreatedByLake is on.  The
+ * builtin pg_lake suite is handled directly in IsExtensionObjectCreatedByLake;
+ * this list lets other extensions opt in at _PG_init time without having to
+ * edit hide_lake_objects.c.
+ */
+static List *ExternalHideableExtensions = NIL;
+
 
 PG_FUNCTION_INFO_V1(is_object_created_by_lake);
 
@@ -128,6 +138,7 @@ is_object_created_by_lake(PG_FUNCTION_ARGS)
 		case AccessMethodRelationId:
 		case AttrDefaultRelationId:
 		case ConstraintRelationId:
+		case DefaultAclRelationId:
 		case EventTriggerRelationId:
 		case ForeignServerRelationId:
 		case ForeignDataWrapperRelationId:
@@ -233,6 +244,7 @@ HideObjectsCreatedByLakeFromCatalogTables(Node *node, void *context)
 				case AttrDefaultRelationId:
 				case AttributeRelationId:
 				case ConstraintRelationId:
+				case DefaultAclRelationId:
 				case EnumRelationId:
 				case EventTriggerRelationId:
 				case ForeignDataWrapperRelationId:
@@ -576,5 +588,43 @@ IsExtensionObjectCreatedByLake(ObjectAddress extensionAddress)
 		return true;
 	}
 
+	ListCell   *lc;
+
+	foreach(lc, ExternalHideableExtensions)
+	{
+		CachedExtensionIds *ext = (CachedExtensionIds *) lfirst(lc);
+
+		if (IsExtensionCreated(ext) && extensionAddress.objectId == ExtensionId(ext))
+			return true;
+	}
+
 	return false;
+}
+
+
+/*
+ * RegisterHideableExtension adds an extension to the list of externally-
+ * registered extensions whose objects should be hidden from catalog queries
+ * when HideObjectsCreatedByLake is on.  Intended to be called from an
+ * extension's _PG_init once it has created its CachedExtensionIds.
+ *
+ * The registration is stored in TopMemoryContext so it survives across
+ * statements, and is idempotent: registering the same extension twice is a
+ * no-op.
+ */
+void
+RegisterHideableExtension(CachedExtensionIds * extension)
+{
+	if (extension == NULL)
+		return;
+
+	if (!HideObjectsCreatedByLake)
+		return;
+
+	MemoryContext oldContext = MemoryContextSwitchTo(TopMemoryContext);
+
+	if (!list_member_ptr(ExternalHideableExtensions, extension))
+		ExternalHideableExtensions = lappend(ExternalHideableExtensions, extension);
+
+	MemoryContextSwitchTo(oldContext);
 }

--- a/pg_lake_table/tests/pytests/test_hide_registered_extension.py
+++ b/pg_lake_table/tests/pytests/test_hide_registered_extension.py
@@ -1,0 +1,50 @@
+import pytest
+from utils_pytest import *
+
+
+@pytest.fixture(scope="module")
+def hideable_extension(superuser_conn, extension):
+    run_command(
+        "CREATE EXTENSION IF NOT EXISTS pg_lake_table_test_hideable CASCADE",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command(
+        "DROP EXTENSION IF EXISTS pg_lake_table_test_hideable CASCADE", superuser_conn
+    )
+    superuser_conn.commit()
+
+
+@pytest.mark.parametrize("hide_enabled", [True, False])
+def test_registered_extension_objects_visibility(
+    superuser_conn, hideable_extension, hide_enabled
+):
+    """Objects from an extension that called RegisterHideableExtension()
+    should be hidden or visible depending on hide_objects_created_by_lake."""
+
+    guc_value = "true" if hide_enabled else "false"
+    run_command(
+        f"SET pg_lake_table.hide_objects_created_by_lake TO {guc_value}",
+        superuser_conn,
+    )
+
+    expected = 0 if hide_enabled else 1
+
+    result = run_query(
+        "SELECT count(*) FROM pg_namespace WHERE nspname = 'test_hideable_nsp'",
+        superuser_conn,
+    )
+    assert result[0][0] == expected
+
+    result = run_query(
+        """SELECT count(*) FROM pg_proc p
+           JOIN pg_namespace n ON p.pronamespace = n.oid
+           WHERE n.nspname = 'test_hideable_nsp' AND p.proname = 'test_func'""",
+        superuser_conn,
+    )
+    assert result[0][0] == expected
+
+    superuser_conn.rollback()

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/Makefile
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/Makefile
@@ -1,0 +1,15 @@
+EXTENSION = pg_lake_table_test_hideable
+
+MODULE_big = $(EXTENSION)
+
+DATA = $(EXTENSION)--1.0.sql
+SOURCES := $(wildcard src/*.c)
+OBJS := $(patsubst %.c,%.o,$(sort $(SOURCES)))
+
+PG_CPPFLAGS = -Iinclude -I../../../include -I../../../../pg_extension_base/include -std=gnu99
+override CFLAGS := $(filter-out -Wdeclaration-after-statement,$(CFLAGS))
+
+PG_CONFIG ?= pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+USE_PGXS=1
+include $(PGXS)

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable--1.0.sql
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable--1.0.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA test_hideable_nsp;
+
+CREATE FUNCTION test_hideable_nsp.test_func()
+ RETURNS int
+ LANGUAGE sql
+AS $$ SELECT 1 $$;

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
@@ -1,0 +1,7 @@
+comment = 'Test extension for RegisterHideableExtension'
+default_version = '1.0'
+module_pathname = '$libdir/pg_lake_table_test_hideable'
+relocatable = false
+requires = 'pg_extension_base,pg_lake_table'
+schema = pg_catalog
+#!shared_preload_libraries

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/src/pg_lake_table_test_hideable.c
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/src/pg_lake_table_test_hideable.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test extension that registers itself as hideable via
+ * RegisterHideableExtension().  Used by test_hide_registered_extension.py
+ * to verify that externally-registered extensions have their objects
+ * filtered from catalog queries when hide_objects_created_by_lake is on.
+ */
+#include "postgres.h"
+#include "fmgr.h"
+#include "miscadmin.h"
+
+#include "nodes/nodes.h"
+#include "pg_extension_base/extension_ids.h"
+#include "pg_lake/test/hide_lake_objects.h"
+
+PG_MODULE_MAGIC;
+
+static CachedExtensionIds * TestHideable;
+
+void		_PG_init(void);
+
+/*
+ * Must be loaded via shared_preload_libraries so that
+ * RegisterHideableExtension() runs before any queries are planned.
+ */
+void
+_PG_init(void)
+{
+	if (!process_shared_preload_libraries_in_progress)
+	{
+		ereport(ERROR,
+				(errmsg("pg_lake_table_test_hideable can only be loaded via shared_preload_libraries"),
+				 errhint("Add pg_extension_base to shared_preload_libraries.")));
+	}
+
+	TestHideable = CreateExtensionIdsCache("pg_lake_table_test_hideable",
+										   NULL, NULL);
+	RegisterHideableExtension(TestHideable);
+}


### PR DESCRIPTION
  ## Summary

  - Adds RegisterHideableExtension() so extensions outside the pg_lake suite can opt their objects into the hide-from-installcheck mechanism from their own _PG_init(),
  without editing hide_lake_objects.c
  - Registration is a no-op when hide_objects_created_by_lake is off, keeping production paths untouched
  - Adds DefaultAclRelationId to the set of filtered catalog tables (pg_default_acl entries from ALTER DEFAULT PRIVILEGES on lake-owned schemas now stay hidden)
  - Includes a test extension (pg_lake_table_test_hideable) that exercises the registration path end-to-end

  ## Test plan

  - New parametrized pytest (test_hide_registered_extension.py) verifies objects are hidden when GUC is on and visible when off
  - Test extension registers via RegisterHideableExtension() in _PG_init(), creates a schema and function as test objects
  - CI builds and installs the test extension via make -C pg_lake_table prepare-check