### PR TITLE
Fix double pfree of REST catalog access token after OAuth failure

### DIFF
--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -555,7 +555,10 @@ GetRestCatalogAccessToken(bool forceRefreshToken)
 		!TimestampDifferenceExceeds(now, RestCatalogAccessTokenExpiry, MINUTE_IN_MSECS))
 	{
 		if (RestCatalogAccessToken)
+		{
 			pfree(RestCatalogAccessToken);
+			RestCatalogAccessToken = NULL;
+		}
 
 		char	   *accessToken = NULL;
 		int			expiresIn = 0;


### PR DESCRIPTION
  ## Summary
  - Fixes dangling pointer in `GetRestCatalogAccessToken()` that causes double pfree warnings after a REST catalog OAuth token request fails (HTTP timeout, network error,
   etc.)
  - The fix NULLs `RestCatalogAccessToken` immediately after `pfree()`, so if `FetchRestCatalogAccessToken()` throws an error, subsequent retry calls see NULL and skip
  the free

  ## Root Cause
  1. `GetRestCatalogAccessToken()` calls `pfree(RestCatalogAccessToken)` (line 558)
  2. `FetchRestCatalogAccessToken()` throws ERROR (e.g. HTTP 0 / timeout)
  3. Exception unwinds past the reassignment on line 565, leaving `RestCatalogAccessToken` as a dangling pointer
  4. Vacuum PG_CATCH handles the error, but doesn't reset the token pointer
  5. Next call to `GetRestCatalogAccessToken()` sees non-NULL, pfrees the already-freed memory → "detected double pfree in TopMemoryContext"

  ## Test plan
  - [x] Verify the fix compiles
  - [ ] Reproduce by simulating REST catalog timeout during vacuum (e.g. block network to catalog endpoint)
  - [ ] Confirm no "double pfree" warnings after the fix

  Fixes #328