### PR TITLE
Bump polaris version from 1.2 to 1.5.0

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -52,7 +52,10 @@ runs:
       id: cache_polaris
       name: Cache Polaris
       with:
-        key: polaris-${{ inputs.container_os }}-${{ hashFiles('test_common/rest_catalog/Makefile') }}
+        # Key includes polaris/version.txt so that a submodule-only bump
+        # (without touching the Makefile) still invalidates the jar cache
+        # and forces a real rebuild against the new Polaris version.
+        key: polaris-${{ inputs.container_os }}-${{ hashFiles('test_common/rest_catalog/Makefile', 'test_common/rest_catalog/polaris/version.txt') }}
         path: |
           /home/postgres/pgsql-${{ inputs.pg_version }}/bin/polaris-admin.jar
           /home/postgres/pgsql-${{ inputs.pg_version }}/bin/polaris-server.jar

--- a/pg_lake_iceberg/tests/pytests/test_polaris_conn.py
+++ b/pg_lake_iceberg/tests/pytests/test_polaris_conn.py
@@ -1,3 +1,6 @@
+import subprocess
+from pathlib import Path
+
 from utils_pytest import *
 from helpers.polaris import *
 
@@ -12,6 +15,63 @@ def test_polaris_catalog_running(pg_conn, polaris_session, installcheck):
     url = f"http://{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}/api/catalog/v1/config?warehouse={server_params.PG_DATABASE}"
     resp = polaris_session.get(url, timeout=1)
     assert resp.ok, f"Polaris is not running: {resp.status_code} {resp.text}"
+
+
+def test_polaris_jar_matches_expected_version(pg_conn, polaris_session, installcheck):
+    """
+    Assert the installed polaris-admin.jar reports the same version that
+    test_common/rest_catalog/Makefile's JAR_VERSION declares -- i.e. the
+    version the install step actually copied into $PG_BINDIR.
+
+    Guards against a CI cache-key regression where the cached jars from
+    an earlier Polaris pin are served while the Makefile/submodule have
+    moved on, making every other Polaris test silently exercise the
+    wrong server version.
+
+    We read JAR_VERSION from the Makefile rather than the submodule's
+    polaris/version.txt because the test job only checks out the parent
+    repo (no submodule init); the Makefile is always present and is
+    what physically named the jar that the install step cp'd.
+    """
+    if installcheck:
+        return
+
+    # repo root: .../<repo>/pg_lake_iceberg/tests/pytests/<this file>
+    repo_root = Path(__file__).resolve().parents[3]
+    makefile = repo_root / "test_common" / "rest_catalog" / "Makefile"
+    expected_version = None
+    for raw_line in makefile.read_text().splitlines():
+        line = raw_line.strip()
+        if line.startswith("JAR_VERSION="):
+            expected_version = line.split("=", 1)[1].strip()
+            break
+    assert expected_version, (
+        f"could not parse JAR_VERSION=... from {makefile}; "
+        "expected a line like 'JAR_VERSION=1.5.0'"
+    )
+
+    pg_bindir = subprocess.run(
+        ["pg_config", "--bindir"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    polaris_admin_jar = Path(pg_bindir) / "polaris-admin.jar"
+    assert polaris_admin_jar.exists(), f"missing {polaris_admin_jar}"
+
+    proc = subprocess.run(
+        ["java", "-jar", str(polaris_admin_jar), "--version"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    output = (proc.stdout or "") + (proc.stderr or "")
+
+    assert expected_version in output, (
+        f"polaris-admin.jar version mismatch: expected {expected_version!r} "
+        f"(from JAR_VERSION in {makefile}); java --version "
+        f"exit={proc.returncode}, output:\n{output}"
+    )
 
 
 def test_polaris_catalog_test_http_get(
@@ -47,7 +107,12 @@ def test_polaris_catalog_test_namespace_and_policy(
     url = f"http://{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}/api/catalog/v1/{server_params.PG_DATABASE}/namespaces"
     token = get_polaris_access_token()
 
-    namespace_name = "prod/team_a"
+    # Apache Polaris 1.4+ rejects '/' in entity names with HTTP 400
+    # ("Entity name must not contain '/'"), so use an underscore here.
+    # The test still exercises lake_iceberg.url_encode() on a name with
+    # non-trivial characters (letters, digits, underscore are all
+    # percent-encoding-safe but the helper is exercised regardless).
+    namespace_name = "prod_team_a"
     url_encoded_namespace_name = run_query(
         f"SELECT lake_iceberg.url_encode('{namespace_name}')", pg_conn
     )[0][0]

--- a/pg_lake_table/tests/pytests/test_polaris_catalog.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog.py
@@ -36,11 +36,16 @@ def test_polaris_catalog_running(pg_conn, s3, polaris_session, installcheck):
     assert resp.ok, f"Polaris is not running: {resp.status_code} {resp.text}"
 
 
+# Apache Polaris 1.4+ rejects '/' in entity names with HTTP 400
+# ("Entity name must not contain '/'"). Until pg_lake maps Postgres
+# schema names that contain '/' to multi-level Iceberg namespaces
+# (or otherwise encodes them server-acceptably), we cannot include '/'
+# in test data that goes through the REST catalog.
 namespaces = [
     "regular_name",
-    "regular..!!**(());;//??::@@&&==++$$,,#name",
+    "regular..!!**(())..;;..??::@@&&==++$$,,#name",
     "Special-Table!_With.Multiple_Uses_Of@Chars#-Here~And*Here!name",
-    "!~*();/?:@&=+$,#",
+    "!~*().?:@&=+$,#",
 ]
 
 

--- a/test_common/rest_catalog/Makefile
+++ b/test_common/rest_catalog/Makefile
@@ -8,9 +8,7 @@ PG_SHAREDIR := $(shell $(PG_CONFIG) --sharedir)
 USE_PGXS=1
 include $(PGXS)
 
-# change to trigger CI cache
-# for Polaris version changes
-JAR_VERSION=1.2.0
+JAR_VERSION=1.5.0
 
 # Polaris build and install
 all:
@@ -18,8 +16,8 @@ all:
 
 install:
 	cp polaris/gradlew $(PG_BINDIR)/. && \
-	cp polaris/runtime/admin/build/polaris-admin-$(JAR_VERSION)-incubating-runner.jar $(PG_BINDIR)/polaris-admin.jar && \
-	cp polaris/runtime/server/build/polaris-server-$(JAR_VERSION)-incubating-runner.jar $(PG_BINDIR)/polaris-server.jar
+	cp polaris/runtime/admin/build/polaris-admin-$(JAR_VERSION)-runner.jar $(PG_BINDIR)/polaris-admin.jar && \
+	cp polaris/runtime/server/build/polaris-server-$(JAR_VERSION)-runner.jar $(PG_BINDIR)/polaris-server.jar
 
 clean:
 	cd polaris && ./gradlew clean


### PR DESCRIPTION
Move the Apache Polaris REST-catalog submodule from `apache-polaris-1.2.0-incubating` to `apache-polaris-1.5.0` (released 2026-05-18) so the REST-catalog integration is exercised against the current release.

## Changes

- **`test_common/rest_catalog/polaris`** - submodule pointer to `apache-polaris-1.5.0`.
- **`test_common/rest_catalog/Makefile`** - bump `JAR_VERSION` to `1.5.0` and drop the `-incubating` suffix from the install paths (Polaris graduated from the Apache Incubator after 1.2, so the artifact name changed from `polaris-{admin,server}-X-incubating-runner.jar` to `polaris-{admin,server}-X-runner.jar`).
- **`.github/actions/build-and-install/action.yml`** - include `test_common/rest_catalog/polaris/version.txt` in the `cache_polaris` key alongside the Makefile, so that a future submodule-only bump (no Makefile change) invalidates the jar cache and triggers a real rebuild against the new pin.
- **`pg_lake_iceberg/tests/pytests/test_polaris_conn.py`** - add `test_polaris_jar_matches_expected_version`. It invokes the installed `polaris-admin.jar` with `--version` and asserts the reported version matches `JAR_VERSION` in the Makefile. Belt-and-suspenders for the cache-key change above: if a stale cached jar is ever served while the Makefile has moved on, this test fails loudly instead of letting the rest of the Polaris suite silently exercise the wrong server version. The Makefile is the source of truth (rather than the submodule's `version.txt`) because the `test_check` CI jobs only check out the parent repo without initialising submodules.
- **`pg_lake_iceberg/tests/pytests/test_polaris_conn.py`** and **`pg_lake_table/tests/pytests/test_polaris_catalog.py`** - drop `/` from polaris entity names in test data. Polaris 1.4+ rejects entity names containing `/` with HTTP 400 (`"Entity name must not contain '/'"`) as part of stricter validation tightening. The affected entries (`namespace_name = "prod/team_a"` in `test_polaris_conn.py`, and two namespaces in the parameterized list in `test_polaris_catalog.py`) are replaced with `.` / `_` variants that keep the rest of the special-character coverage intact. End users with `/` in Postgres schema names that they map to Polaris namespaces are tracked separately for a proper multi-level-namespace fix in pg_lake.

## Verification

Verified locally against Polaris 1.5.0 (pgduck_server + Moto):

- `pg_lake_iceberg/tests/pytests/test_polaris_conn.py` - 5/5 pass (incl. the new `test_polaris_jar_matches_expected_version`).
- `pg_lake_table/tests/pytests/test_polaris_catalog.py` - 48/48 pass.
- Sample of `pg_lake_table/tests/pytests/test_polaris_catalog_writable.py` (basic_flow, ddl, drop_table, complex_transaction, base_types, add_drop_columns) - 7/7 pass.

After `make install-rest_catalog`, the install step produces `polaris-{admin,server}-1.5.0-runner.jar` (no `-incubating`) and `java -jar polaris-admin.jar --version` reports `1.5.0`.

CI on this branch is fully green (64/64 checks).

Co-authored-by: Cursor <cursoragent@cursor.com>