### PR TITLE
Streaming writes via pgduck_server RECEIVE protocol

### DIFF
--- a/pg_lake_copy/include/pg_lake/copy/copy_io.h
+++ b/pg_lake_copy/include/pg_lake/copy/copy_io.h
@@ -18,8 +18,11 @@
 #ifndef PG_LAKE_COPY_IO_H
 #define PG_LAKE_COPY_IO_H
 
+#include "libpq-fe.h"
+
 
 void		CopyInputToFile(char *filePath, int columnCount, bool isBinary);
+void		CopyInputToStream(PGconn *streamConn, int columnCount, bool isBinary);
 void		CopyFileToOutput(char *filePath, int columnCount, bool isBinary);
 
 

--- a/pg_lake_copy/src/copy/copy.c
+++ b/pg_lake_copy/src/copy/copy.c
@@ -96,6 +96,8 @@ PgLakeCopyValidityCheckHookType PgLakeCopyValidityCheckHook = NULL;
 static bool IsPgLakeCopy(CopyStmt *copyStmt);
 static bool IsCopyFromStdin(CopyStmt *copyStmt);
 static bool IsCopyToStdout(CopyStmt *copyStmt);
+static int64 StreamingCopyFromStdinPushdown(Oid relationId, char *readQuery,
+											TupleDesc tupleDesc);
 static void ProcessPgLakeCopyFrom(CopyStmt *copyStmt, ParseState *pstate,
 								  Relation relation, Node *whereClause,
 								  uint64 *rowsProcessed);
@@ -449,23 +451,52 @@ ProcessPgLakeCopyFrom(CopyStmt *copyStmt, ParseState *pstate, Relation relation,
 	 */
 	TupleDesc	tupleDesc = BuildTupleDescriptorForRelation(relation, copyStmt->attlist);
 
+	/*
+	 * Compute doCopyPushdown up front so the STDIN block can choose between
+	 * the streaming-write path (when GUC is on AND we'll push the COPY down
+	 * to pgduck) and the file-based path (everything else). For non-pushdown
+	 * COPYs the COPY query is wrapped in TRANSMIT and rows round-trip back
+	 * through PG; that's a different shape than the deferred-INSERT we use
+	 * for streaming, so streaming + non-pushdown still uses the file-based
+	 * path. Document the gap.
+	 */
+	bool		doCopyPushdown = IsCopyFromPushdownable(relation, copyStmt->attlist,
+														whereClause, sourceFormat);
+	bool		useStreamingStdin = StreamingWritesEnabled && IsCopyFromStdin(copyStmt) &&
+		doCopyPushdown;
+
 	if (IsCopyFromStdin(copyStmt))
 	{
-		sourcePath = GenerateTempFileName(TEMP_FILE_PATTERN, ensureCleanup);
+		if (useStreamingStdin)
+		{
+			/*
+			 * Streaming-write path: don't park bytes locally. Use the
+			 * pgduck_server RECEIVE sink-path placeholder; the deferred COPY
+			 * query that AddQueryResultToTableStream builds will pick this up
+			 * and substitute it with the server-local sink path before
+			 * running read_csv() on it.
+			 */
+			sourcePath = pstrdup(PG_LAKE_RECV_PATH_PLACEHOLDER);
+		}
+		else
+		{
+			sourcePath = GenerateTempFileName(TEMP_FILE_PATTERN, ensureCleanup);
 
-		/*
-		 * we send the expected column count to make pedantic clients happy
-		 */
-		int			columnCount = tupleDesc->natts;
+			/*
+			 * we send the expected column count to make pedantic clients
+			 * happy
+			 */
+			int			columnCount = tupleDesc->natts;
 
-		bool		isBinary = true;
+			bool		isBinary = true;
 
-		/*
-		 * We copy the incoming bytes to a file first and then try to convert
-		 * that file. We could perhaps optimize this in the future by copying
-		 * via a named pipe.
-		 */
-		CopyInputToFile(sourcePath, columnCount, isBinary);
+			/*
+			 * We copy the incoming bytes to a file first and then try to
+			 * convert that file. We could perhaps optimize this in the future
+			 * by copying via a named pipe.
+			 */
+			CopyInputToFile(sourcePath, columnCount, isBinary);
+		}
 	}
 
 	/*
@@ -483,9 +514,6 @@ ProcessPgLakeCopyFrom(CopyStmt *copyStmt, ParseState *pstate, Relation relation,
 	 * case. However, we do want explicit casts to avoid writing incorrect
 	 * types.
 	 */
-	bool		doCopyPushdown = IsCopyFromPushdownable(relation, copyStmt->attlist,
-														whereClause, sourceFormat);
-
 	if (!doCopyPushdown)
 		readFlags |= READ_DATA_TRANSMIT;
 	else
@@ -535,6 +563,13 @@ ProcessPgLakeCopyFrom(CopyStmt *copyStmt, ParseState *pstate, Relation relation,
 	 */
 	if (doCopyPushdown)
 	{
+		if (useStreamingStdin)
+		{
+			*rowsProcessed = StreamingCopyFromStdinPushdown(relationId, readQuery,
+															tupleDesc);
+			return;
+		}
+
 		*rowsProcessed = AddQueryResultToTable(relationId, readQuery, tupleDesc, true);
 		return;
 	}
@@ -657,6 +692,38 @@ IsCopyFromPushdownable(Relation relation, List *columnNameList,
 		return false;
 
 	return true;
+}
+
+
+/*
+ * StreamingCopyFromStdinPushdown drives the COPY tablename FROM STDIN
+ * pushdown path when pg_lake_engine.streaming_writes=on.
+ *
+ * Pulled out of ProcessPgLakeCopyFrom so the caller stays small enough
+ * for gcc's clobbered-variable analysis (-Wclobbered) to keep its
+ * pre-streaming behavior on the unrelated TupleDesc helpers below;
+ * inlining a multi-step PG-call sequence into ProcessPgLakeCopyFrom
+ * triggered false-positive clobber warnings on attributeDescriptor /
+ * cleanTupleDesc that don't fire when this branch is its own function.
+ *
+ * No PG_TRY/CATCH: errors here trigger transaction abort; pgduck's
+ * PGDuckClientTransactionCallback recycles the libpq connection and
+ * the in-progress-file record registered inside Start... is cleaned
+ * up by the pre-commit hook on abort.
+ */
+static int64
+StreamingCopyFromStdinPushdown(Oid relationId, char *readQuery, TupleDesc tupleDesc)
+{
+	AddQueryResultStreamHandle *handle =
+		StartAddQueryResultToTableStream(relationId, readQuery, tupleDesc,
+										  /* wrapNativeTypes */ true);
+
+	int			columnCount = tupleDesc->natts;
+	bool		isBinary = true;
+
+	CopyInputToStream(AddQueryResultStreamConnection(handle), columnCount, isBinary);
+
+	return FinishAddQueryResultToTableStream(handle);
 }
 
 

--- a/pg_lake_copy/src/copy/copy_io.c
+++ b/pg_lake_copy/src/copy/copy_io.c
@@ -30,6 +30,7 @@
 #include "storage/fd.h"
 #include "utils/memutils.h"
 
+#include "libpq-fe.h"
 #include "libpq/libpq.h"
 
 #define MAX_READ_SIZE (65536)
@@ -53,6 +54,55 @@ static int	ReceiveDataFromClient(CopyFromStdinState * cstate, char *databuf);
 static void SendCopyBegin(int columnCount, bool isBinary);
 static void SendCopyEnd(void);
 static void SendCopyData(char *sendBuffer, int sendBufferLength);
+
+
+/*
+ * CopyInputToStream is the streaming counterpart of CopyInputToFile.
+ *
+ * Instead of writing the postgres client's COPY-IN bytes to a local file,
+ * forwards them via PQputCopyData on `streamConn`. The caller must have
+ * already opened a libpq COPY-IN stream against pgduck_server (via
+ * OpenCopyInStreamToPGDuck) so streamConn is in COPY-IN-active state.
+ * Uses the same SendCopyInResponseToClient(columnCount, isBinary) the
+ * file-based path uses to tell the client we're ready.
+ *
+ * Caller is responsible for finalizing the libpq stream via
+ * FinishCopyInStreamToPGDuck (or moral equivalent) afterwards.
+ */
+void
+CopyInputToStream(PGconn *streamConn, int columnCount, bool isBinary)
+{
+	CopyFromStdinState cstate = {
+		.fe_msgbuf = makeStringInfo(),
+		.raw_reached_eof = false
+	};
+
+	/* tell the client we are ready for data */
+	SendCopyInResponseToClient(columnCount, isBinary);
+
+	char	   *receiveBuffer = palloc(MAX_READ_SIZE);
+
+	while (!cstate.raw_reached_eof)
+	{
+		unsigned long bytesRead = ReceiveDataFromClient(&cstate, receiveBuffer);
+
+		if (bytesRead > 0)
+		{
+			if (PQputCopyData(streamConn, receiveBuffer, (int) bytesRead) != 1)
+			{
+				ereport(ERROR, (errcode(ERRCODE_CONNECTION_FAILURE),
+								errmsg("failed to forward COPY data to pgduck_server: %s",
+									   PQerrorMessage(streamConn))));
+			}
+		}
+		else if (bytesRead == 0)
+		{
+			break;
+		}
+	}
+
+	pfree(receiveBuffer);
+}
 
 
 /*

--- a/pg_lake_engine/include/pg_lake/csv/csv_writer.h
+++ b/pg_lake_engine/include/pg_lake/csv/csv_writer.h
@@ -18,6 +18,8 @@
 #ifndef CSV_WRITER_H
 #define CSV_WRITER_H
 
+#include "libpq-fe.h"
+
 #include "pg_lake/copy/copy_format.h"
 #include "tcop/dest.h"
 #include "nodes/pg_list.h"
@@ -28,6 +30,22 @@ extern PGDLLEXPORT DestReceiver *CreateCSVDestReceiverExtended(char *filename,
 															   List *copyOptions,
 															   CopyDataFormat targetFormat,
 															   bool sessionLifetime);
+
+/*
+ * Streaming variant: bytes go to a libpq COPY-IN already opened on
+ * `streamConn` (use OpenCopyInStreamToPGDuck() to get there). The caller
+ * is responsible for finalizing the stream via FinishCopyInStreamToPGDuck()
+ * AFTER calling rShutdown on the returned DestReceiver — rShutdown only
+ * flushes the per-row buffer and emits any binary trailer; it deliberately
+ * does NOT call PQputCopyEnd, so callers can still emit additional
+ * CopyData (e.g. for multi-segment writes) before closing. The deferred
+ * query's PGresult is returned by FinishCopyInStreamToPGDuck so callers
+ * can extract row counts / column statistics.
+ */
+extern PGDLLEXPORT DestReceiver *CreateCSVStreamDestReceiver(PGconn *streamConn,
+															 List *copyOptions,
+															 CopyDataFormat targetFormat);
+
 extern PGDLLEXPORT int GetCSVDestReceiverMaxLineSize(DestReceiver *dest);
 extern PGDLLEXPORT uint64 GetCSVDestReceiverFileSize(DestReceiver *dest);
 

--- a/pg_lake_engine/include/pg_lake/pgduck/client.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/client.h
@@ -52,4 +52,27 @@ extern PGDLLEXPORT char *GetSingleValueFromPGDuck(char *query);
 extern PGDLLEXPORT void SendQueryWithParams(PGDuckConnection * pgduckConn, char *queryString,
 											int numParams, const char **parameterValues);
 
+/*
+ * Streaming-write helpers for the RECEIVE protocol prefix on pgduck_server.
+ *
+ * OpenCopyInStreamToPGDuck sends `queryString` (which must begin with
+ * "RECEIVE " and contain '@@PG_LAKE_RECV@@' as the read_csv path
+ * placeholder) and waits for pgduck_server's CopyInResponse. After this
+ * returns, the caller may emit CSV bytes via PQputCopyData on
+ * pgDuckConnection->conn (typically by passing it to
+ * CreateCSVStreamDestReceiver and driving a producer query through it).
+ *
+ * FinishCopyInStreamToPGDuck calls PQputCopyEnd(NULL), waits for the
+ * deferred query's first PGresult, drains the trailing NULL terminator,
+ * and returns the PGresult to the caller. The caller owns it and must
+ * PQclear it. Errors raised by the deferred query (e.g. INSERT failures)
+ * surface here as ereport(ERROR) before returning.
+ *
+ * Both throw on protocol or query errors; the connection is left in an
+ * idle state on success, in an error state on failure.
+ */
+extern PGDLLEXPORT void OpenCopyInStreamToPGDuck(PGDuckConnection * pgDuckConnection,
+												 const char *queryString);
+extern PGDLLEXPORT PGresult *FinishCopyInStreamToPGDuck(PGDuckConnection * pgDuckConnection);
+
 #endif

--- a/pg_lake_engine/include/pg_lake/pgduck/write_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/write_data.h
@@ -23,10 +23,24 @@
 #include "pg_lake/parquet/field.h"
 #include "pg_lake/pgduck/iceberg_validation.h"
 #include "nodes/pg_list.h"
+#include "tcop/dest.h"
 
 /* pg_lake_table.target_row_group_size_mb */
 #define DEFAULT_TARGET_ROW_GROUP_SIZE_MB 512
 extern PGDLLEXPORT int TargetRowGroupSizeMB;
+
+/* pg_lake_engine.streaming_writes */
+extern PGDLLEXPORT bool StreamingWritesEnabled;
+
+/*
+ * Sink-path placeholder substituted server-side by pgduck_server's
+ * RECEIVE handler. Must match SINK_PLACEHOLDER in pgduck_server's
+ * pgsession.c. Streaming-write callers pass this where the file-based
+ * path would pass the local CSV file path; the placeholder is then
+ * embedded inside read_csv('<placeholder>', ...) and pgduck swaps in
+ * the server-local sink path before running the deferred query.
+ */
+#define PG_LAKE_RECV_PATH_PLACEHOLDER "@@PG_LAKE_RECV@@"
 
 typedef enum ParquetVersion
 {
@@ -57,7 +71,42 @@ extern PGDLLEXPORT StatsCollector * WriteQueryResultTo(char *query,
 													   List *leafFields,
 													   IcebergOutOfRangePolicy outOfRangePolicy,
 													   bool wrapNativeTypes);
+/*
+ * BuildCopyToCommandString assembles `COPY (query) TO 'destinationPath'
+ * WITH (format ..., compression ..., return_stats, ...)` for the given
+ * destination format / compression / format options. The same string
+ * builder is used by WriteQueryResultTo (file path), OpenCSVStreamWriter
+ * (streaming), and the streaming AddQueryResultToTable variant in
+ * writable_table.c.
+ */
+extern PGDLLEXPORT char *BuildCopyToCommandString(char *query, char *destinationPath,
+												  CopyDataFormat destinationFormat,
+												  CopyDataCompression destinationCompression,
+												  List *formatOptions,
+												  bool queryHasRowId,
+												  DataFileSchema * schema,
+												  TupleDesc queryTupleDesc,
+												  IcebergOutOfRangePolicy outOfRangePolicy,
+												  bool wrapNativeTypes);
+
 extern PGDLLEXPORT void AppendFields(StringInfo map, DataFileSchema * schema);
 extern PGDLLEXPORT char *TupleDescToColumnMapForWrite(TupleDesc tupleDesc, CopyDataFormat destinationFormat);
 extern PGDLLEXPORT char *TupleDescToProjectionListForWrite(TupleDesc tupleDesc,
 														   CopyDataFormat destinationFormat);
+
+/*
+ * Streaming counterpart of ConvertCSVFileTo. See OpenCSVStreamWriter in
+ * write_data.c for the contract. The struct is opaque to callers.
+ */
+typedef struct CSVStreamWriter CSVStreamWriter;
+
+extern PGDLLEXPORT CSVStreamWriter * OpenCSVStreamWriter(TupleDesc csvTupleDesc,
+														 int maxLineSize,
+														 char *destinationPath,
+														 CopyDataFormat destinationFormat,
+														 CopyDataCompression destinationCompression,
+														 List *formatOptions,
+														 DataFileSchema * schema,
+														 List *leafFields);
+extern PGDLLEXPORT DestReceiver *CSVStreamWriterDestReceiver(CSVStreamWriter * writer);
+extern PGDLLEXPORT StatsCollector * FinishCSVStreamWriter(CSVStreamWriter * writer);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -56,7 +56,7 @@
 typedef enum CopyDest
 {
 	COPY_FILE,					/* to file */
-	/* other options removed, since we only supported COPY_FILE */
+	COPY_STREAM,				/* to libpq COPY IN on streamConn */
 } CopyDest;
 
 /*
@@ -79,6 +79,7 @@ typedef struct CopyToStateData
 	/* low-level state data */
 	CopyDest	copy_dest;		/* type of copy source/destination */
 	FILE	   *copy_file;		/* used if copy_dest == COPY_FILE */
+	PGconn	   *streamConn;		/* used if copy_dest == COPY_STREAM */
 	StringInfo	fe_msgbuf;		/* used for all dests during COPY TO */
 
 	int			file_encoding;	/* file or remote side's character encoding */
@@ -216,8 +217,26 @@ CopySendEndOfRow(CopyToState cstate)
 						 errmsg("could not write to COPY file: %m")));
 			}
 			break;
+		case COPY_STREAM:
+			if (!cstate->opts.binary)
+				CopySendChar(cstate, '\n');
+
+			/*
+			 * PQputCopyData blocks on socket back-pressure when the kernel
+			 * buffer fills, which gives the streaming path natural flow
+			 * control. Returns 1 on success, 0 on async-flow blocked (we use
+			 * sync mode so this shouldn't happen), -1 on error.
+			 */
+			if (PQputCopyData(cstate->streamConn, fe_msgbuf->data,
+							  fe_msgbuf->len) != 1)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_CONNECTION_FAILURE),
+						 errmsg("failed to stream CopyData to pgduck_server: %s",
+								PQerrorMessage(cstate->streamConn))));
+			}
+			break;
 		default:
-			/* we only use COPY to emit files */
 			Assert(false);
 			break;
 	}
@@ -271,7 +290,7 @@ EndCopy(CopyToState cstate)
 		CopySendEndOfRow(cstate);
 	}
 
-	if (cstate->filename != NULL)
+	if (cstate->copy_dest == COPY_FILE && cstate->filename != NULL)
 	{
 		if (cstate->sessionLifetime)
 		{
@@ -287,6 +306,13 @@ EndCopy(CopyToState cstate)
 		}
 	}
 
+	/*
+	 * COPY_STREAM: caller owns the libpq stream and is responsible for
+	 * calling FinishCopyInStreamToPGDuck() (PQputCopyEnd + drain). We
+	 * deliberately do NOT close the stream here so callers can interleave
+	 * multiple writes if needed.
+	 */
+
 	MemoryContextDelete(cstate->rowcontext);
 	MemoryContextDelete(cstate->copycontext);
 }
@@ -301,9 +327,10 @@ CreateCopyToState(char *filename, List *copyOptions)
 {
 	/*
 	 * Prevent write to relative path ... too easy to shoot oneself in the
-	 * foot by overwriting a database file ...
+	 * foot by overwriting a database file ... (filename is NULL for stream
+	 * destinations, which skip this check.)
 	 */
-	if (!is_absolute_path(filename))
+	if (filename != NULL && !is_absolute_path(filename))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_NAME),
 				 errmsg("relative path not allowed for COPY to file")));
@@ -350,7 +377,7 @@ CreateCopyToState(char *filename, List *copyOptions)
 	cstate->fe_msgbuf = makeStringInfo();
 
 	cstate->copy_dest = COPY_FILE;	/* default */
-	cstate->filename = pstrdup(filename);
+	cstate->filename = filename ? pstrdup(filename) : NULL;
 
 	cstate->maxLineSize = 0;
 	cstate->bytes_processed = 0;
@@ -361,7 +388,7 @@ CreateCopyToState(char *filename, List *copyOptions)
 }
 
 /*
- * Setup CopyToState to write to the given file.
+ * Setup CopyToState to write to the given destination (file or stream).
  */
 static void
 StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
@@ -370,49 +397,52 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 
 	MemoryContext oldcontext = MemoryContextSwitchTo(cstate->copycontext);
 
-	/* create the file */
-	mode_t		oumask = umask(S_IWGRP | S_IWOTH);
-
-	PG_TRY();
+	if (cstate->copy_dest == COPY_FILE)
 	{
-		if (cstate->sessionLifetime)
-			cstate->copy_file = fopen(cstate->filename, "w");
-		else
-			cstate->copy_file = AllocateFile(cstate->filename, PG_BINARY_W);
+		/* create the file */
+		mode_t		oumask = umask(S_IWGRP | S_IWOTH);
+
+		PG_TRY();
+		{
+			if (cstate->sessionLifetime)
+				cstate->copy_file = fopen(cstate->filename, "w");
+			else
+				cstate->copy_file = AllocateFile(cstate->filename, PG_BINARY_W);
+		}
+		PG_FINALLY();
+		{
+			umask(oumask);
+		}
+		PG_END_TRY();
+
+		if (cstate->copy_file == NULL)
+		{
+			/* copy errno because ereport subfunctions might change it */
+			int			save_errno = errno;
+
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not open file \"%s\" for writing: %m",
+							cstate->filename),
+					 (save_errno == ENOENT || save_errno == EACCES) ?
+					 errhint("COPY TO instructs the PostgreSQL server process to write a file. "
+							 "You may want a client-side facility such as psql's \\copy.") : 0));
+		}
+
+		struct stat st;
+
+		if (fstat(fileno(cstate->copy_file), &st))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not stat file \"%s\": %m",
+							cstate->filename)));
+
+		if (S_ISDIR(st.st_mode))
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("\"%s\" is a directory", cstate->filename)));
 	}
-	PG_FINALLY();
-	{
-		umask(oumask);
-	}
-	PG_END_TRY();
-
-	if (cstate->copy_file == NULL)
-	{
-		/* copy errno because ereport subfunctions might change it */
-		int			save_errno = errno;
-
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for writing: %m",
-						cstate->filename),
-				 (save_errno == ENOENT || save_errno == EACCES) ?
-				 errhint("COPY TO instructs the PostgreSQL server process to write a file. "
-						 "You may want a client-side facility such as psql's \\copy.") : 0));
-	}
-
-	struct stat st;
-
-	if (fstat(fileno(cstate->copy_file), &st))
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not stat file \"%s\": %m",
-						cstate->filename)));
-
-	if (S_ISDIR(st.st_mode))
-		ereport(ERROR,
-				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-				 errmsg("\"%s\" is a directory", cstate->filename)));
-
+	/* COPY_STREAM: caller already opened libpq COPY IN; nothing to do here. */
 
 	/* get the attribute names from the tuple descriptor */
 	List	   *attnamelist = TupleDescColumnNameList(tupDesc);
@@ -1173,6 +1203,35 @@ CreateCSVDestReceiverExtended(char *filename, List *copyOptions,
 		(DR_copy *) CreateCSVDestReceiver(filename, copyOptions, targetFormat);
 
 	self->cstate->sessionLifetime = sessionLifetime;
+
+	return (DestReceiver *) self;
+}
+
+
+/*
+ * CreateCSVStreamDestReceiver creates a DestReceiver that streams CSV
+ * bytes via libpq COPY IN on an already-open connection.
+ *
+ * Usage pattern:
+ *   1. Caller opens the COPY-IN stream via OpenCopyInStreamToPGDuck(conn,
+ *      "RECEIVE INSERT INTO ... read_csv('@@PG_LAKE_RECV@@', ...)").
+ *   2. Caller passes conn->conn into this factory; the returned
+ *      DestReceiver writes CSV bytes via PQputCopyData on each row flush.
+ *   3. Caller drives the producer query (e.g. ExecuteQuery) into the
+ *      DestReceiver. rShutdown emits the binary trailer if any but does
+ *      NOT call PQputCopyEnd.
+ *   4. Caller calls FinishCopyInStreamToPGDuck(conn) to send PQputCopyEnd
+ *      and wait for the deferred query's CommandComplete.
+ */
+DestReceiver *
+CreateCSVStreamDestReceiver(PGconn *streamConn, List *copyOptions,
+							CopyDataFormat targetFormat)
+{
+	DR_copy    *self =
+		(DR_copy *) CreateCSVDestReceiver(NULL, copyOptions, targetFormat);
+
+	self->cstate->copy_dest = COPY_STREAM;
+	self->cstate->streamConn = streamConn;
 
 	return (DestReceiver *) self;
 }

--- a/pg_lake_engine/src/init.c
+++ b/pg_lake_engine/src/init.c
@@ -44,6 +44,7 @@
 #include "pg_extension_base/pg_extension_base_ids.h"
 #include "pg_lake/pgduck/cache_worker.h"
 #include "pg_lake/pgduck/client.h"
+#include "pg_lake/pgduck/write_data.h"
 #include "pg_lake/util/s3_writer_utils.h"
 #include "utils/guc.h"
 
@@ -196,6 +197,22 @@ _PG_init(void)
 							   0,
 							   PgLakeStageLocationCheckHook,
 							   NULL, NULL);
+
+	DefineCustomBoolVariable(
+							 "pg_lake_engine.streaming_writes",
+							 gettext_noop("Stream bulk-write CSV bytes to pgduck_server "
+										  "over libpq instead of writing them to a local "
+										  "temp file under PGDATA/pgsql_tmp."),
+							 gettext_noop("Required when pgduck_server runs on a different "
+										  "host than the postgres backend (e.g. as a "
+										  "separate Kubernetes pod) and therefore cannot "
+										  "read PGDATA-relative paths. Off by default to "
+										  "preserve the existing single-host behavior."),
+							 &StreamingWritesEnabled,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
 
 	if (QueryEngineEnabled)
 	{

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -973,3 +973,135 @@ SendQueryWithParams(PGDuckConnection * pgduckConn, char *queryString,
 		elog(ERROR, "could not set single row mode for connection");
 	}
 }
+
+
+/*
+ * OpenCopyInStreamToPGDuck opens a libpq COPY-IN stream against
+ * pgduck_server. queryString must begin with the "RECEIVE " prefix and
+ * contain the '@@PG_LAKE_RECV@@' placeholder; pgduck_server creates a
+ * server-local sink, replaces the placeholder with the sink path, and
+ * sends a CopyInResponse. After this returns the caller may emit CSV
+ * bytes via PQputCopyData on pgDuckConnection->conn.
+ *
+ * On any error (PQsendQuery failure, non-CopyIn response, server-side
+ * sink-creation error) we ereport(ERROR), which will trigger the xact
+ * cleanup that cancels the in-flight query and releases the connection.
+ */
+void
+OpenCopyInStreamToPGDuck(PGDuckConnection * pgDuckConnection, const char *queryString)
+{
+	PGconn	   *conn = pgDuckConnection->conn;
+	PGresult   *result;
+
+	/*
+	 * Use the simple query protocol (PQsendQuery, not PQsendQueryParams)
+	 * because pgduck_server's RECEIVE handler routes through
+	 * process_query_message via the 'Q' message type. PQsendQueryParams uses
+	 * the extended protocol which goes through Parse/Bind/Execute and doesn't
+	 * currently support our RECEIVE prefix.
+	 */
+	if (PQsendQuery(conn, queryString) == 0)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("failed to send RECEIVE query to pgduck_server: %s",
+						PQerrorMessage(conn))));
+	}
+
+	/*
+	 * Use the WaitLatchOrSocket-driven cooperative wait via WaitForResult
+	 * rather than raw PQgetResult here. Raw PQgetResult blocks inside libpq's
+	 * pqWait, which never reaches CHECK_FOR_INTERRUPTS — so neither
+	 * statement_timeout nor postmaster-death detection can fire while we are
+	 * waiting on pgduck. Run #2v hung 4 minutes in this exact state because
+	 * of that. WaitForResult uses the standard pgduck-client wait pattern
+	 * (WL_LATCH_SET | WL_SOCKET_READABLE | WL_EXIT_ON_PM_DEATH +
+	 * PQconsumeInput + CHECK_FOR_INTERRUPTS) so a hang here surfaces as a
+	 * normal psql error within the configured timeout.
+	 */
+	result = WaitForResult(pgDuckConnection);
+	if (result == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("connection to pgduck_server closed before CopyInResponse")));
+	}
+
+	if (PQresultStatus(result) != PGRES_COPY_IN)
+	{
+		char	   *errMsg = pstrdup(PQresultErrorMessage(result));
+		ExecStatusType status = PQresultStatus(result);
+
+		PQclear(result);
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("expected CopyInResponse from pgduck_server, got %s: %s",
+						PQresStatus(status),
+						errMsg ? errMsg : "")));
+	}
+
+	PQclear(result);
+}
+
+
+/*
+ * FinishCopyInStreamToPGDuck closes the COPY-IN stream and waits for
+ * pgduck_server to run the deferred query (the one with the now-finalized
+ * sink path baked in) to completion. Errors raised by the deferred query
+ * surface here. The deferred query's PGresult is returned to the caller,
+ * who owns it and must PQclear it.
+ */
+PGresult *
+FinishCopyInStreamToPGDuck(PGDuckConnection * pgDuckConnection)
+{
+	PGconn	   *conn = pgDuckConnection->conn;
+	PGresult   *result;
+	PGresult   *trailing;
+
+	if (PQputCopyEnd(conn, NULL) != 1)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("failed to send CopyDone to pgduck_server: %s",
+						PQerrorMessage(conn))));
+	}
+
+	/*
+	 * Cooperative wait — see the matching note in OpenCopyInStreamToPGDuck.
+	 * Raw PQgetResult here would mask statement_timeout / SIGINT / postmaster
+	 * death the same way it did before CopyDone.
+	 *
+	 * The first PGresult after CopyDone is the deferred query's response
+	 * (CommandComplete, a result set with rows for COPY ... return_stats, or
+	 * an error). Subsequent PGresults are NULL (end-of-stream); drain them so
+	 * the connection is idle on return.
+	 */
+	result = WaitForResult(pgDuckConnection);
+	if (result == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("connection to pgduck_server closed before deferred query result")));
+	}
+
+	PG_TRY();
+	{
+		ThrowIfPGDuckResultHasError(pgDuckConnection, result);
+	}
+	PG_CATCH();
+	{
+		PQclear(result);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	/*
+	 * Drain trailing NULL terminator. WaitForResult re-checks PQisBusy each
+	 * iteration so a single call here is sufficient — but loop defensively
+	 * in case pgduck sends additional results (e.g. CommandComplete + Z).
+	 */
+	while ((trailing = WaitForResult(pgDuckConnection)) != NULL)
+		PQclear(trailing);
+
+	return result;
+}

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -24,11 +24,13 @@
 #include "commands/defrem.h"
 #include "common/string.h"
 #include "pg_lake/csv/csv_options.h"
+#include "pg_lake/csv/csv_writer.h"
 #include "pg_lake/copy/copy_format.h"
 #include "pg_lake/data_file/data_file_stats.h"
 #include "pg_lake/extensions/postgis.h"
 #include "pg_lake/parquet/field.h"
 #include "pg_lake/parquet/geoparquet.h"
+#include "pg_lake/pgduck/client.h"
 #include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/pgduck/read_data.h"
 #include "pg_lake/pgduck/type.h"
@@ -44,6 +46,10 @@ static DuckDBTypeInfo ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 													 CopyDataFormat destinationFormat);
 static void AppendFieldIdValue(StringInfo map, Field * field, int fieldId);
 static const char *ParquetVersionToString(ParquetVersion version);
+static char *BuildSelectFromCSVQuery(const char *csvFilePath, TupleDesc csvTupleDesc,
+									 int maxLineSize, CopyDataFormat destinationFormat);
+
+/* BuildCopyToCommandString is exposed via write_data.h for the streaming path. */
 
 static DuckDBTypeInfo VARCHAR_TYPE =
 {
@@ -52,6 +58,41 @@ static DuckDBTypeInfo VARCHAR_TYPE =
 
 int			TargetRowGroupSizeMB = DEFAULT_TARGET_ROW_GROUP_SIZE_MB;
 int			DefaultParquetVersion = PARQUET_VERSION_V1;
+
+/*
+ * pg_lake_engine.streaming_writes — opt-in libpq COPY-IN streaming for
+ * bulk-write paths (INSERT/COPY/DELETE). Defined here so the variable
+ * lives next to the other write-side state. The DefineCustomBoolVariable
+ * call is in init.c.
+ *
+ * When false, the existing file-based path is used: rows are written to a
+ * local CSV under $PGDATA/pgsql_tmp and pgduck reads it via read_csv().
+ *
+ * When true, rows are streamed directly to pgduck_server's RECEIVE sink
+ * over libpq, decoupling pgduck_server's filesystem from PGDATA. This is
+ * required when pgduck_server runs on a different host than the postgres
+ * backend (e.g. as a separate Kubernetes pod).
+ */
+bool		StreamingWritesEnabled = false;
+
+/* PG_LAKE_RECV_PATH_PLACEHOLDER is exposed via write_data.h. */
+
+/*
+ * CSVStreamWriter is the streaming counterpart of a CSV temp file +
+ * deferred ConvertCSVFileTo: it owns a libpq COPY-IN stream and a CSV
+ * DestReceiver feeding bytes into it. The destination path / format /
+ * options used to build the deferred RECEIVE query are kept here so we
+ * can reconstruct the StatsCollector once the stream finishes.
+ */
+struct CSVStreamWriter
+{
+	PGDuckConnection *conn;
+	DestReceiver *dest;
+	char	   *destinationPath;
+	CopyDataFormat destinationFormat;
+	DataFileSchema *schema;
+	List	   *leafFields;
+};
 
 
 /*
@@ -68,6 +109,40 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 				 List *formatOptions,
 				 DataFileSchema * schema,
 				 List *leafFields)
+{
+	char	   *innerSelect = BuildSelectFromCSVQuery(csvFilePath, csvTupleDesc,
+													  maxLineSize, destinationFormat);
+	bool		queryHasRowIds = false;
+
+	/*
+	 * CSV data is already clamped by WriteInsertRecord and converted to
+	 * struct for Iceberg
+	 */
+	return WriteQueryResultTo(innerSelect,
+							  destinationPath,
+							  destinationFormat,
+							  destinationCompression,
+							  formatOptions,
+							  queryHasRowIds,
+							  schema,
+							  csvTupleDesc,
+							  leafFields,
+							  ICEBERG_OOR_NONE,
+							  false /* wrapNativeTypes */ );
+}
+
+
+/*
+ * BuildSelectFromCSVQuery builds the inner `SELECT ... FROM read_csv(<path>, ...)`
+ * query that ConvertCSVFileTo wraps with COPY (...) TO ... WITH (...).
+ *
+ * Pulled out so the streaming path (OpenCSVStreamWriter) can build the
+ * same query with the RECEIVE sink-path placeholder substituted for
+ * csvFilePath.
+ */
+static char *
+BuildSelectFromCSVQuery(const char *csvFilePath, TupleDesc csvTupleDesc,
+						int maxLineSize, CopyDataFormat destinationFormat)
 {
 	StringInfoData command;
 
@@ -88,23 +163,7 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 	AppendReadCSVClause(&command, csvFilePath, maxLineSize, columnsMap,
 						InternalCSVOptions(includeHeader));
 
-	bool		queryHasRowIds = false;
-
-	/*
-	 * CSV data is already clamped by WriteInsertRecord and converted to
-	 * struct for Iceberg
-	 */
-	return WriteQueryResultTo(command.data,
-							  destinationPath,
-							  destinationFormat,
-							  destinationCompression,
-							  formatOptions,
-							  queryHasRowIds,
-							  schema,
-							  csvTupleDesc,
-							  leafFields,
-							  ICEBERG_OOR_NONE,
-							  false /* wrapNativeTypes */ );
+	return command.data;
 }
 
 
@@ -125,6 +184,41 @@ WriteQueryResultTo(char *query,
 				   List *leafFields,
 				   IcebergOutOfRangePolicy outOfRangePolicy,
 				   bool wrapNativeTypes)
+{
+	char	   *command = BuildCopyToCommandString(query, destinationPath,
+												   destinationFormat,
+												   destinationCompression,
+												   formatOptions, queryHasRowId,
+												   schema, queryTupleDesc,
+												   outOfRangePolicy, wrapNativeTypes);
+
+	return ExecuteCopyToCommandOnPGDuckConnection(command,
+												  leafFields,
+												  schema,
+												  destinationPath,
+												  destinationFormat);
+}
+
+
+/*
+ * BuildCopyToCommandString wraps `query` in `COPY (...) TO 'destinationPath'
+ * WITH (...)` and returns the command string. Pulled out of
+ * WriteQueryResultTo so the streaming paths (OpenCSVStreamWriter and
+ * StartAddQueryResultToTableStream) can build the same command but with
+ * '@@PG_LAKE_RECV@@' substituted for the read_csv path arg, and then
+ * prefix it with "RECEIVE " before sending.
+ */
+char *
+BuildCopyToCommandString(char *query,
+						 char *destinationPath,
+						 CopyDataFormat destinationFormat,
+						 CopyDataCompression destinationCompression,
+						 List *formatOptions,
+						 bool queryHasRowId,
+						 DataFileSchema * schema,
+						 TupleDesc queryTupleDesc,
+						 IcebergOutOfRangePolicy outOfRangePolicy,
+						 bool wrapNativeTypes)
 {
 	if (outOfRangePolicy != ICEBERG_OOR_NONE)
 	{
@@ -367,11 +461,175 @@ WriteQueryResultTo(char *query,
 	/* end WITH options */
 	appendStringInfoString(&command, ")");
 
-	return ExecuteCopyToCommandOnPGDuckConnection(command.data,
-												  leafFields,
-												  schema,
-												  destinationPath,
-												  destinationFormat);
+	return command.data;
+}
+
+
+/*
+ * OpenCSVStreamWriter is the streaming counterpart of ConvertCSVFileTo:
+ * instead of reading bytes back through a local CSV file, it opens a
+ * libpq COPY-IN stream to pgduck_server's RECEIVE handler with the same
+ * COPY ... TO destination query baked in (with '@@PG_LAKE_RECV@@' as the
+ * read_csv path placeholder), and returns a writer whose ->dest is a CSV
+ * DestReceiver feeding bytes into that stream.
+ *
+ * Caller pattern:
+ *
+ *   writer = OpenCSVStreamWriter(...);
+ *   dest = CSVStreamWriterDestReceiver(writer);
+ *   <drive `dest` from a producer query>
+ *   dest->rShutdown(dest);
+ *   stats = FinishCSVStreamWriter(writer);
+ *
+ * The writer takes ownership of a PGDuckConnection for its lifetime and
+ * releases it in FinishCSVStreamWriter (success or failure).
+ */
+CSVStreamWriter *
+OpenCSVStreamWriter(TupleDesc csvTupleDesc, int maxLineSize,
+					char *destinationPath,
+					CopyDataFormat destinationFormat,
+					CopyDataCompression destinationCompression,
+					List *formatOptions,
+					DataFileSchema * schema,
+					List *leafFields)
+{
+	/* Build the same query as ConvertCSVFileTo, with the RECEIVE placeholder. */
+	char	   *innerSelect = BuildSelectFromCSVQuery(PG_LAKE_RECV_PATH_PLACEHOLDER,
+													  csvTupleDesc,
+													  maxLineSize,
+													  destinationFormat);
+
+	/*
+	 * Wrap with COPY (...) TO 'destinationPath' WITH (...). We use
+	 * outOfRangePolicy = ICEBERG_OOR_NONE / wrapNativeTypes = false to mirror
+	 * ConvertCSVFileTo: the CSV bytes coming from the DestReceiver are
+	 * already clamped / native-converted upstream.
+	 */
+	bool		queryHasRowIds = false;
+	char	   *copyCommand = BuildCopyToCommandString(innerSelect, destinationPath,
+													   destinationFormat,
+													   destinationCompression,
+													   formatOptions,
+													   queryHasRowIds,
+													   schema, csvTupleDesc,
+													   ICEBERG_OOR_NONE,
+													   false /* wrapNativeTypes */ );
+
+	char	   *receiveQuery = psprintf("RECEIVE %s", copyCommand);
+
+	CSVStreamWriter *writer = palloc0(sizeof(CSVStreamWriter));
+
+	writer->destinationPath = destinationPath;
+	writer->destinationFormat = destinationFormat;
+	writer->schema = schema;
+	writer->leafFields = leafFields;
+	writer->conn = GetPGDuckConnection();
+
+	PG_TRY();
+	{
+		OpenCopyInStreamToPGDuck(writer->conn, receiveQuery);
+
+		/*
+		 * The dest receiver uses the same CSV options as ConvertCSVFileTo's
+		 * caller: header included so AppendReadCSVClause's auto-detect /
+		 * columns map matches the bytes we emit.
+		 */
+		bool		includeHeader = true;
+		List	   *copyOptions = InternalCSVOptions(includeHeader);
+
+		writer->dest = CreateCSVStreamDestReceiver(writer->conn->conn,
+												   copyOptions,
+												   destinationFormat);
+	}
+	PG_CATCH();
+	{
+		ReleasePGDuckConnection(writer->conn);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	return writer;
+}
+
+
+/*
+ * CSVStreamWriterDestReceiver returns the DestReceiver that the caller
+ * should drive with rows. The receiver is owned by the writer; do not
+ * call rDestroy on it (FinishCSVStreamWriter handles that).
+ */
+DestReceiver *
+CSVStreamWriterDestReceiver(CSVStreamWriter * writer)
+{
+	return writer->dest;
+}
+
+
+/*
+ * FinishCSVStreamWriter closes the COPY-IN stream, waits for pgduck to
+ * complete the deferred COPY ... TO query, and returns the resulting
+ * StatsCollector built from its result rows (Parquet/Iceberg) or
+ * CommandComplete tag (CSV/JSON), exactly like
+ * ExecuteCopyToCommandOnPGDuckConnection does for the file-based path.
+ *
+ * The caller MUST have called writer->dest->rShutdown(writer->dest)
+ * before invoking this so the per-row buffer is flushed and any binary
+ * trailer is emitted.
+ *
+ * The DestReceiver and the underlying PGDuckConnection are released here
+ * (in both success and failure paths).
+ */
+StatsCollector *
+FinishCSVStreamWriter(CSVStreamWriter * writer)
+{
+	StatsCollector *statsCollector = NULL;
+	PGresult   *result = NULL;
+
+	PG_TRY();
+	{
+		result = FinishCopyInStreamToPGDuck(writer->conn);
+
+		if (writer->destinationFormat == DATA_FORMAT_PARQUET ||
+			writer->destinationFormat == DATA_FORMAT_ICEBERG)
+		{
+			/* DuckDB's COPY ... return_stats returns one row per file. */
+			statsCollector = GetDataFileStatsListFromPGResult(result,
+															  writer->leafFields,
+															  writer->schema);
+		}
+		else
+		{
+			char	   *commandTuples = PQcmdTuples(result);
+			int64		totalRowCount = atoll(commandTuples);
+
+			statsCollector = palloc0(sizeof(StatsCollector));
+			statsCollector->totalRowCount = totalRowCount;
+
+			/* no file is created when 0 rows are copied */
+			if (totalRowCount > 0)
+			{
+				DataFileStats *fileStats =
+					CreateDataFileStatsForDataFile(writer->destinationPath,
+												   totalRowCount, 0,
+												   writer->leafFields);
+
+				statsCollector->dataFileStats = list_make1(fileStats);
+			}
+		}
+	}
+	PG_FINALLY();
+	{
+		if (result != NULL)
+			PQclear(result);
+		if (writer->dest != NULL)
+		{
+			writer->dest->rDestroy(writer->dest);
+			writer->dest = NULL;
+		}
+		ReleasePGDuckConnection(writer->conn);
+	}
+	PG_END_TRY();
+
+	return statsCollector;
 }
 
 

--- a/pg_lake_engine/src/utils/s3_writer_utils.c
+++ b/pg_lake_engine/src/utils/s3_writer_utils.c
@@ -23,9 +23,11 @@
 #include "pg_lake/cleanup/in_progress_files.h"
 #include "pg_lake/pgduck/client.h"
 #include "pg_lake/pgduck/parallel_command.h"
+#include "pg_lake/pgduck/write_data.h"
 #include "pg_lake/util/s3_reader_utils.h"
 #include "pg_lake/util/s3_writer_utils.h"
 #include "pg_lake/util/rel_utils.h"
+#include "storage/fd.h"
 #include "utils/builtins.h"
 #include "utils/hsearch.h"
 #include "utils/memutils.h"
@@ -42,6 +44,7 @@ typedef struct ScheduledUpload
 
 
 static char *CopyLocalFileToS3Command(char *localFileUri, char *s3Uri);
+static void StreamLocalFileToS3(char *localFilePath, char *s3Uri);
 static void ScheduleFileUpload(char *localFile, char *remoteUrl);
 static void InitUploadScheduling(void);
 static void ResetPendingUploads(void);
@@ -72,11 +75,116 @@ ScheduleFileCopyToS3WithCleanup(char *localFilePath, char *s3Uri, bool autoDelet
  * CopyLocalFileToS3 copies the content of a local file to an S3 bucket.
  *
  * Note: If the transaction rolls back this file will not be cleaned up.
+ *
+ * Two implementations: when pg_lake_engine.streaming_writes is on we
+ * stream the file content over libpq via the RECEIVE protocol so
+ * pgduck_server doesn't need to share a filesystem with the postgres
+ * backend. When off we keep the original behaviour of asking pgduck
+ * to read the local path directly via pg_lake_copy_file().
  */
 void
 CopyLocalFileToS3(char *localFilePath, char *s3Uri)
 {
-	ExecuteCommandInPGDuck(CopyLocalFileToS3Command(localFilePath, s3Uri));
+	if (StreamingWritesEnabled)
+		StreamLocalFileToS3(localFilePath, s3Uri);
+	else
+		ExecuteCommandInPGDuck(CopyLocalFileToS3Command(localFilePath, s3Uri));
+}
+
+
+/*
+ * StreamLocalFileToS3 is the streaming-write counterpart of
+ * CopyLocalFileToS3 for non-CSV-shaped intermediate files (iceberg
+ * metadata JSON, manifests, etc).
+ *
+ * Wire shape:
+ *
+ *   client (this code):
+ *     PQsendQuery("RECEIVE SELECT * FROM pg_lake_copy_file('@@PG_LAKE_RECV@@',
+ *                                                          's3://...')")
+ *     -- reads local file in chunks, PQputCopyData each chunk
+ *     PQputCopyEnd
+ *
+ *   pgduck_server:
+ *     CopyInResponse
+ *     -- accepts CopyData into a server-local sink under recv_dir
+ *     CopyDone -> substitute '@@PG_LAKE_RECV@@' with the sink path,
+ *                 run the deferred SELECT (pg_lake_copy_file copies
+ *                 the now-finalized sink file straight to S3)
+ *     CommandComplete
+ *
+ * No new server-side UDF needed: the existing pg_lake_copy_file
+ * (duckdb_pglake/src/fs/functions.cpp:50) takes a local path + an
+ * S3 URI and upload-copies. Pointing it at the RECEIVE sink path
+ * is exactly the same operation it already supports.
+ */
+static void
+StreamLocalFileToS3(char *localFilePath, char *s3Uri)
+{
+	StringInfoData receiveQuery;
+
+	initStringInfo(&receiveQuery);
+	appendStringInfo(&receiveQuery,
+					 "RECEIVE SELECT * FROM pg_lake_copy_file('%s', %s)",
+					 PG_LAKE_RECV_PATH_PLACEHOLDER,
+					 quote_literal_cstr(s3Uri));
+
+	FILE	   *file = AllocateFile(localFilePath, PG_BINARY_R);
+
+	if (file == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open local file \"%s\" for streaming upload: %m",
+						localFilePath)));
+
+	PGDuckConnection *conn = GetPGDuckConnection();
+
+	PG_TRY();
+	{
+		OpenCopyInStreamToPGDuck(conn, receiveQuery.data);
+
+		/*
+		 * 64 KiB read buffer matches CopyInputToFile's MAX_READ_SIZE and is
+		 * well under libpq's CopyData chunk limits. Iceberg metadata files
+		 * are typically <100 KB so this fits in 1-2 chunks; manifests can be
+		 * larger but still small relative to data files.
+		 */
+		char		buffer[65536];
+
+		while (!feof(file))
+		{
+			size_t		bytesRead = fread(buffer, 1, sizeof(buffer), file);
+
+			if (ferror(file))
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("could not read local file \"%s\" for streaming upload: %m",
+								localFilePath)));
+
+			if (bytesRead == 0)
+				break;
+
+			if (PQputCopyData(conn->conn, buffer, (int) bytesRead) != 1)
+				ereport(ERROR,
+						(errcode(ERRCODE_CONNECTION_FAILURE),
+						 errmsg("failed to forward bytes to pgduck_server: %s",
+								PQerrorMessage(conn->conn))));
+		}
+
+		FreeFile(file);
+		file = NULL;
+
+		PGresult   *result = FinishCopyInStreamToPGDuck(conn);
+
+		PQclear(result);
+	}
+	PG_FINALLY();
+	{
+		if (file != NULL)
+			FreeFile(file);
+		ReleasePGDuckConnection(conn);
+	}
+	PG_END_TRY();
 }
 
 
@@ -167,12 +275,21 @@ ResetPendingUploads(void)
 
 
 /*
- * FinishAllUploads completes all of the pending uploads in parallel using
- * a state machine approach.
+ * FinishAllUploads completes all of the pending uploads.
  *
- * Each upload connection progresses through states independently, with up to
- * pg_lake_engine.max_parallel_file_uploads (default 8) connections active
- * concurrently.
+ * File-based path (StreamingWritesEnabled=false): builds a list of
+ * pg_lake_copy_file(local, s3) commands and runs them in parallel, up
+ * to pg_lake_engine.max_parallel_file_uploads (default 8) concurrent
+ * connections.
+ *
+ * Streaming path (StreamingWritesEnabled=true): runs StreamLocalFileToS3
+ * for each upload sequentially. Sequential is OK here — the deferred
+ * uploads are iceberg metadata files (JSON / Avro manifests, all small,
+ * typically <10 per transaction), and parallelizing the streaming
+ * variant would require multiple libpq COPY-IN sessions, which adds
+ * complexity for marginal wins on this workload. Bulk-write CSV data
+ * files (the much larger transfers) go through the dedicated streaming
+ * dest receivers in patches 0004-0006, not through here.
  */
 void
 FinishAllUploads(void)
@@ -180,23 +297,33 @@ FinishAllUploads(void)
 	if (PendingUploads == NULL)
 		return;
 
-	/* build command list */
-	List	   *commandList = NIL;
+	HASH_SEQ_STATUS status;
 	ScheduledUpload *upload = NULL;
 
-	HASH_SEQ_STATUS status;
-
-	hash_seq_init(&status, PendingUploads);
-
-	while ((upload = hash_seq_search(&status)) != NULL)
+	if (StreamingWritesEnabled)
 	{
-		char	   *command = CopyLocalFileToS3Command(upload->localFile,
-													   upload->remoteUrl);
+		hash_seq_init(&status, PendingUploads);
 
-		commandList = lappend(commandList, command);
+		while ((upload = hash_seq_search(&status)) != NULL)
+			StreamLocalFileToS3(upload->localFile, upload->remoteUrl);
 	}
+	else
+	{
+		/* build command list */
+		List	   *commandList = NIL;
 
-	ExecuteCommandsInParallelInPGDuck(commandList, MaxParallelFileUploads);
+		hash_seq_init(&status, PendingUploads);
+
+		while ((upload = hash_seq_search(&status)) != NULL)
+		{
+			char	   *command = CopyLocalFileToS3Command(upload->localFile,
+														   upload->remoteUrl);
+
+			commandList = lappend(commandList, command);
+		}
+
+		ExecuteCommandsInParallelInPGDuck(commandList, MaxParallelFileUploads);
+	}
 
 	MemoryContextDelete(UploadSchedulingContext);
 }

--- a/pg_lake_table/include/pg_lake/fdw/writable_table.h
+++ b/pg_lake_table/include/pg_lake/fdw/writable_table.h
@@ -17,8 +17,11 @@
 
 #pragma once
 
+#include "access/tupdesc.h"
 #include "nodes/pg_list.h"
 #include "utils/relcache.h"
+#include "pg_lake/copy/copy_format.h"
+#include "pg_lake/data_file/data_file_stats.h"
 #include "pg_lake/data_file/data_files.h"
 
 /* by default, we switch to copy-on-write if 20% or more of a file is deleted */
@@ -48,6 +51,18 @@ typedef enum DataFileModificationType
 
 	/* new data file (Parquet) */
 	ADD_DATA_FILE,
+
+	/*
+	 * Streaming-write variant: deletions from a single data file where the
+	 * intermediate CSV was streamed directly into the destination Parquet
+	 * position-delete file (no local CSV ever existed). `deleteFile` points
+	 * at the precomputed Parquet path on object storage and `fileStats`
+	 * carries its DuckDB return_stats. ApplyPrecomputedDeleteFile consumes
+	 * this; the file-based ApplyDeleteFile path is bypassed (and so is its
+	 * copy-on-write threshold check — see ApplyPrecomputedDeleteFile for
+	 * the rationale).
+	 */
+	ADD_DELETION_FILE_PRECOMPUTED,
 }			DataFileModificationType;
 
 /*
@@ -121,6 +136,68 @@ extern PGDLLEXPORT List *PrepareCSVInsertion(Oid relationId, char *insertCSV, in
 											 int64 reservedRowIdStart, int maximumLineSize,
 											 DataFileSchema * schema);
 
+/*
+ * Two-phase variant of PrepareCSVInsertion exposed for the streaming-write
+ * path: callers compute the destination prefix / format / options up front
+ * (BeginCSVInsertion), drive the CSV bytes themselves (e.g. via
+ * OpenCSVStreamWriter), then build modifications from a precomputed
+ * StatsCollector (BuildCSVInsertionModifications). EndCSVInsertion releases
+ * the relation lock.
+ *
+ * The struct is opaque to callers; access the destination prefix / format /
+ * options via the accessor functions below.
+ */
+typedef struct CSVInsertionContext CSVInsertionContext;
+
+extern PGDLLEXPORT CSVInsertionContext * BeginCSVInsertion(Oid relationId,
+														   int64 reservedRowIdStart,
+														   DataFileSchema * schema);
+extern PGDLLEXPORT List *BuildCSVInsertionModifications(CSVInsertionContext * ctx,
+														StatsCollector * statsCollector,
+														int64 rowCount);
+extern PGDLLEXPORT void EndCSVInsertion(CSVInsertionContext * ctx);
+
+/* accessors for the streaming-write call sites */
+extern PGDLLEXPORT TupleDesc CSVInsertionContextTupleDescriptor(CSVInsertionContext * ctx);
+extern PGDLLEXPORT char *CSVInsertionContextDestinationPath(CSVInsertionContext * ctx);
+extern PGDLLEXPORT CopyDataFormat CSVInsertionContextFormat(CSVInsertionContext * ctx);
+extern PGDLLEXPORT CopyDataCompression CSVInsertionContextCompression(CSVInsertionContext * ctx);
+extern PGDLLEXPORT List *CSVInsertionContextOptions(CSVInsertionContext * ctx);
+extern PGDLLEXPORT DataFileSchema * CSVInsertionContextSchema(CSVInsertionContext * ctx);
+extern PGDLLEXPORT List *CSVInsertionContextLeafFields(CSVInsertionContext * ctx);
+
 extern PGDLLEXPORT int64 AddQueryResultToTable(Oid relationId, char *readQuery,
 											   TupleDesc queryTupleDesc,
 											   bool wrapNativeTypes);
+
+/*
+ * Streaming-write variant of AddQueryResultToTable.
+ *
+ * StartAddQueryResultToTableStream prepares destination metadata, builds
+ *   COPY (readQuery) TO '<parquet>' WITH (...), prefixes "RECEIVE " (with
+ *   '@@PG_LAKE_RECV@@' substituted for the read_csv path arg in
+ *   readQuery), and opens a libpq COPY-IN stream against pgduck_server.
+ *   Returns an opaque handle.
+ *
+ * AddQueryResultStreamConnection returns the libpq connection the
+ *   caller should forward CSV bytes over (e.g. via CopyInputToStream).
+ *
+ * FinishAddQueryResultToTableStream calls PQputCopyEnd, waits for the
+ *   deferred COPY query to complete, applies the resulting metadata
+ *   changes to the table, and returns the number of inserted rows.
+ *   Releases the underlying pgduck connection (success or failure).
+ *
+ * Callers of these helpers MUST use '@@PG_LAKE_RECV@@' as the read_csv
+ * path arg in readQuery; see write_data.c for why and pgduck_server's
+ * pgsession.c for the substitution.
+ */
+typedef struct AddQueryResultStreamHandle AddQueryResultStreamHandle;
+
+extern PGDLLEXPORT AddQueryResultStreamHandle *
+StartAddQueryResultToTableStream(Oid relationId, char *readQuery,
+								 TupleDesc queryTupleDesc, bool wrapNativeTypes);
+
+extern PGDLLEXPORT struct pg_conn *AddQueryResultStreamConnection(AddQueryResultStreamHandle * handle);
+
+extern PGDLLEXPORT int64
+			FinishAddQueryResultToTableStream(AddQueryResultStreamHandle * handle);

--- a/pg_lake_table/src/fdw/multi_data_file_dest.c
+++ b/pg_lake_table/src/fdw/multi_data_file_dest.c
@@ -26,6 +26,7 @@
 #include "pg_lake/csv/csv_writer.h"
 #include "pg_lake/data_file/data_file_stats.h"
 #include "pg_lake/fdw/data_files_catalog.h"
+#include "pg_lake/iceberg/partitioning/partition.h"
 #include "pg_lake/fdw/multi_data_file_dest.h"
 #include "pg_lake/fdw/writable_table.h"
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"
@@ -60,8 +61,20 @@ typedef struct MultiDataFileUploadDestReceiver
 	/* function pointers for the active CSV DestReceiver */
 	DestReceiver *currentDest;
 
-	/* current CSV file */
+	/*
+	 * File-based path: temp CSV that the active DestReceiver writes into,
+	 * later consumed by ConvertCSVFileTo. NULL when streaming.
+	 */
 	char	   *currentFilePath;
+
+	/*
+	 * Streaming path (StreamingWritesEnabled): holds the per-file insertion
+	 * context (relation lock, dataFilePrefix, format, options, schema, ...)
+	 * and the CSV stream writer that owns the libpq COPY-IN connection. Both
+	 * NULL on the file-based path.
+	 */
+	CSVInsertionContext *currentInsertCtx;
+	CSVStreamWriter *currentStreamWriter;
 
 	/* current number of rows in the CSV file */
 	int64		currentRowCount;
@@ -177,6 +190,12 @@ CreateMultiDataFileDestReceiver(Oid relationId,
 
 /*
  * CreateChildDestReceiver creates the DestReceiver for the current file.
+ *
+ * When pg_lake_engine.streaming_writes is on, we open a libpq COPY-IN
+ * stream to pgduck_server (via OpenCSVStreamWriter) instead of writing
+ * to a local temp CSV file. The active DestReceiver in that case is the
+ * stream's CSV writer; its rotated lifetime is FinishCSVStreamWriter +
+ * EndCSVInsertion in FlushChildDestReceiver.
  */
 static void
 CreateChildDestReceiver(MultiDataFileUploadDestReceiver * self)
@@ -184,15 +203,44 @@ CreateChildDestReceiver(MultiDataFileUploadDestReceiver * self)
 	/* use the same memory context that was used to create the DestReceiver */
 	MemoryContext oldContext = MemoryContextSwitchTo(self->childContext);
 
-	/* we currently use CSV as a universal intermediate format */
-	bool		includeHeader = true;
-	List	   *copyOptions = InternalCSVOptions(includeHeader);
-	char	   *tempFilePath = GenerateTempFileName("lake_table_insert", true);
-
 	self->currentRowCount = 0;
-	self->currentFilePath = tempFilePath;
-	self->currentDest = CreateCSVDestReceiver(tempFilePath, copyOptions,
-											  self->targetFormat);
+
+	if (StreamingWritesEnabled)
+	{
+		/*
+		 * Open the per-file context up front (relation lock, dataFilePrefix,
+		 * format, options, schema, ...) and pass those into
+		 * OpenCSVStreamWriter so the deferred RECEIVE query targets the same
+		 * destination ConvertCSVFileTo would have.
+		 */
+		self->currentInsertCtx = BeginCSVInsertion(self->relationId,
+												   self->currentRowIdStart,
+												   self->schema);
+
+		self->currentStreamWriter =
+			OpenCSVStreamWriter(CSVInsertionContextTupleDescriptor(self->currentInsertCtx),
+								 /* maxLineSize */ -1,
+								CSVInsertionContextDestinationPath(self->currentInsertCtx),
+								CSVInsertionContextFormat(self->currentInsertCtx),
+								CSVInsertionContextCompression(self->currentInsertCtx),
+								CSVInsertionContextOptions(self->currentInsertCtx),
+								CSVInsertionContextSchema(self->currentInsertCtx),
+								CSVInsertionContextLeafFields(self->currentInsertCtx));
+
+		self->currentDest = CSVStreamWriterDestReceiver(self->currentStreamWriter);
+		self->currentFilePath = NULL;
+	}
+	else
+	{
+		/* we currently use CSV as a universal intermediate format */
+		bool		includeHeader = true;
+		List	   *copyOptions = InternalCSVOptions(includeHeader);
+		char	   *tempFilePath = GenerateTempFileName("lake_table_insert", true);
+
+		self->currentFilePath = tempFilePath;
+		self->currentDest = CreateCSVDestReceiver(tempFilePath, copyOptions,
+												  self->targetFormat);
+	}
 
 	self->currentDest->rStartup(self->currentDest, self->operation, self->tupleDesc);
 
@@ -212,13 +260,37 @@ FlushChildDestReceiver(MultiDataFileUploadDestReceiver * self)
 	/* do conversion in a memory context that is about to be destroyed */
 	MemoryContext oldContext = MemoryContextSwitchTo(self->childContext);
 
-	List	   *insertModifications =
-		PrepareCSVInsertion(self->relationId,
-							self->currentFilePath,
-							self->currentRowCount,
-							self->currentRowIdStart,
-							GetCSVDestReceiverMaxLineSize(self->currentDest),
-							self->schema);
+	List	   *insertModifications;
+
+	if (self->currentStreamWriter != NULL)
+	{
+		/*
+		 * Streaming path: the deferred COPY ... TO query has already written
+		 * the destination file(s). FinishCSVStreamWriter waits for it to
+		 * complete and returns the resulting StatsCollector, which
+		 * BuildCSVInsertionModifications turns into the same
+		 * DataFileModification list PrepareCSVInsertion would.
+		 */
+		StatsCollector *statsCollector =
+			FinishCSVStreamWriter(self->currentStreamWriter);
+
+		insertModifications = BuildCSVInsertionModifications(self->currentInsertCtx,
+															 statsCollector,
+															 self->currentRowCount);
+		EndCSVInsertion(self->currentInsertCtx);
+		self->currentStreamWriter = NULL;
+		self->currentInsertCtx = NULL;
+	}
+	else
+	{
+		insertModifications =
+			PrepareCSVInsertion(self->relationId,
+								self->currentFilePath,
+								self->currentRowCount,
+								self->currentRowIdStart,
+								GetCSVDestReceiverMaxLineSize(self->currentDest),
+								self->schema);
+	}
 
 	/* make sure we preserve the list of data file modifications */
 	MemoryContextSwitchTo(self->parentContext);
@@ -234,7 +306,23 @@ FlushChildDestReceiver(MultiDataFileUploadDestReceiver * self)
 		copyModification->insertedRowCount = modification->insertedRowCount;
 
 		copyModification->partitionSpecId = self->currentPartitionSpecId;
-		copyModification->partition = modification->partition;
+
+		/*
+		 * partition is a pointer into childContext, which we are about to
+		 * MemoryContextReset() at the bottom of this function. Any downstream
+		 * consumer of self->modifications (notably ApplyDataFileModifications
+		 * during PRE_COMMIT, in another transaction's worth of execution)
+		 * will dereference it. Deep-copy under parentContext so the pointer
+		 * remains valid.
+		 *
+		 * NULL guard: CopyPartition unconditionally dereferences
+		 * partition->fields_length and segfaults on NULL. Unpartitioned
+		 * tables produce NULL modification->partition; preserve that as NULL
+		 * in the copy.
+		 */
+		copyModification->partition = (modification->partition != NULL)
+			? CopyPartition(modification->partition)
+			: NULL;
 		copyModification->fileStats = DeepCopyDataFileStats(modification->fileStats);
 
 		/*
@@ -259,8 +347,17 @@ FlushChildDestReceiver(MultiDataFileUploadDestReceiver * self)
 
 	MemoryContextSwitchTo(oldContext);
 
-	self->currentDest->rDestroy(self->currentDest);
-	self->currentDest = NULL;
+	if (self->currentDest != NULL)
+	{
+		/*
+		 * Streaming path's dest is owned by the (now-freed) stream writer;
+		 * for the file-based path we destroy it explicitly.
+		 */
+		if (self->currentFilePath != NULL)
+			self->currentDest->rDestroy(self->currentDest);
+		self->currentDest = NULL;
+	}
+	self->currentFilePath = NULL;
 
 	/* release all memory allocated for child DestReceiver, and the temp file */
 	MemoryContextReset(self->childContext);
@@ -285,6 +382,12 @@ StartDestReceiver(DestReceiver *dest, int operation, TupleDesc tupleDesc)
 /*
  * ReceiveSlot is called when a slot is received. We pass it on to the child
  * DestReceiver, and rotate to a new file if the file size exceeds the threshold.
+ *
+ * The temp-file size threshold only matters for the file-based path; for
+ * the streaming path the bytes are flowing over libpq into pgduck_server,
+ * which handles its own file-size splitting via the file_size_bytes COPY
+ * option. Rotating mid-stream would close the deferred query and force a
+ * separate RECEIVE round-trip per chunk for no benefit.
  */
 static bool
 ReceiveSlot(TupleTableSlot *slot, DestReceiver *dest)
@@ -298,7 +401,8 @@ ReceiveSlot(TupleTableSlot *slot, DestReceiver *dest)
 
 	self->currentRowCount++;
 
-	if (GetCSVDestReceiverFileSize(self->currentDest) > self->maxWriteTempFileSizeMB * MB_BYTES)
+	if (self->currentStreamWriter == NULL &&
+		GetCSVDestReceiverFileSize(self->currentDest) > self->maxWriteTempFileSizeMB * MB_BYTES)
 		FlushChildDestReceiver(self);
 
 	return result;

--- a/pg_lake_table/src/fdw/pg_lake_table.c
+++ b/pg_lake_table/src/fdw/pg_lake_table.c
@@ -82,7 +82,10 @@
 #include "pg_lake/fdw/update_tracking.h"
 #include "pg_lake/fdw/writable_table.h"
 #include "pg_lake/fdw/multi_data_file_dest.h"
+#include "pg_lake/cleanup/in_progress_files.h"
+#include "pg_lake/fdw/schema_operations/register_field_ids.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/iceberg_field.h"
 #include "pg_lake/iceberg/operations/manifest_merge.h"
 #include "pg_lake/partitioning/partition_by_parser.h"
 #include "pg_lake/partitioning/partitioned_dest_receiver.h"
@@ -214,9 +217,32 @@ typedef struct PgLakeFileModifyState
 	/* number of not-deleted rows in the source file */
 	int64		liveRowCount;
 
-	/* DestReceiver for deletions in case of UPDATE/DELETE */
+	/*
+	 * DestReceiver for deletions in case of UPDATE/DELETE.
+	 *
+	 * File-based path (StreamingWritesEnabled=false): deleteDest is a CSV
+	 * DestReceiver writing to deleteFile (a local temp under pgsql_tmp). The
+	 * file is later read by ApplyDeleteFile via ConvertCSVFileTo or
+	 * PerformDeleteFromParquet.
+	 *
+	 * Streaming-write path (StreamingWritesEnabled=true): deleteDest is
+	 * lazily set on the first row received for this source file. Until then
+	 * it stays NULL (along with deleteStreamWriter); `deleteFile` holds the
+	 * precomputed Parquet position-delete path and the deleteStream* fields
+	 * hold the metadata needed to open the stream. Lazy because we don't want
+	 * to open a libpq stream / write an empty Parquet for every source file
+	 * when only some have matching rows.
+	 *
+	 * deleteStreamWriter owns the libpq connection and is finalized in
+	 * end_foreign_modify (or on error). It's NULL on the file-based path.
+	 */
 	DestReceiver *deleteDest;
 	char	   *deleteFile;
+	CSVStreamWriter *deleteStreamWriter;
+	TupleDesc	deleteStreamTupleDesc;
+	DataFileSchema *deleteStreamSchema;
+	CopyDataCompression deleteStreamCompression;
+	List	   *deleteStreamLeafFields;
 
 	/* number of rows modified by UPDATE/DELETE */
 	int64		modifiedRowCount;
@@ -245,6 +271,29 @@ typedef struct PgLakeModifyState
 
 	/* slot used for position deletes */
 	TupleTableSlot *deleteSlot;
+
+	/*
+	 * Long-lived memory context for the per-file deleteStreamWriter
+	 * allocations made by the lazy-open in DeleteSingleRow.
+	 *
+	 * Without this, OpenCSVStreamWriter palloc's the writer + dest in
+	 * whatever CurrentMemoryContext the executor set up at
+	 * postgresExecForeignDelete/Update entry — typically a per-tuple
+	 * context whose chunks get reset or sibling-reused before
+	 * FinishForeignModify runs. The chunk gets re-allocated as a postgres
+	 * List by a later lappend in GetDataFileStatsListFromPGResult, and
+	 * writer->dest->rDestroy jumps into garbage → SIGSEGV.
+	 *
+	 * Mirrors the pattern in multi_data_file_dest.c::CreateChildDestReceiver,
+	 * which switches to its own childContext before the OpenCSVStreamWriter
+	 * call.
+	 *
+	 * Created lazily (only when DELETE/UPDATE) by create_foreign_modify as a
+	 * sub-context of CurrentMemoryContext at that time, which is the FDW
+	 * state's per-statement context — outlives all rows and survives until
+	 * FinishForeignModify completes.
+	 */
+	MemoryContext deleteStreamMemoryContext;
 
 	/* files that are scanned during UPDATE/DELETE */
 	List	   *fileModifyStates;
@@ -2354,9 +2403,49 @@ DeleteSingleRow(PgLakeModifyState * fmstate, ItemPointer ctid)
 	PgLakeFileModifyState *fileModifyState =
 		list_nth(fmstate->fileModifyStates, fileIndex);
 
-	if (fileModifyState->deleteDest == NULL)
-		/* not tracking deletions for this file, which is fully deleted */
+	if (fileModifyState->deleteFile == NULL)
+	{
+		/* not tracking deletions for this file (allRowsMatch shortcut) */
+		Assert(fileModifyState->deleteDest == NULL);
 		return;
+	}
+
+	/*
+	 * Lazy-open the streaming dest receiver on the first row for this source
+	 * file. We don't open up front because many source files in a scan may
+	 * end up with no matching rows, and an empty stream would still write an
+	 * empty Parquet on flush. See create_foreign_modify for where the stash
+	 * fields are populated.
+	 */
+	if (fileModifyState->deleteDest == NULL && StreamingWritesEnabled)
+	{
+		Assert(fileModifyState->deleteStreamWriter == NULL);
+
+		/*
+		 * Allocate the writer + dest + cstate in
+		 * fmstate->deleteStreamMemoryContext, not whatever per-tuple context
+		 * the executor handed us. Without this switch the chunks get reset /
+		 * sibling-reused before FinishForeignModify runs and
+		 * writer->dest->rDestroy jumps into garbage. See the field comment in
+		 * struct PgLakeModifyState.
+		 */
+		MemoryContext oldContext =
+			MemoryContextSwitchTo(fmstate->deleteStreamMemoryContext);
+
+		fileModifyState->deleteStreamWriter =
+			OpenCSVStreamWriter(fileModifyState->deleteStreamTupleDesc,
+								 /* maxLineSize */ -1,
+								fileModifyState->deleteFile,
+								DATA_FORMAT_PARQUET,
+								fileModifyState->deleteStreamCompression,
+								 /* formatOptions */ NIL,
+								fileModifyState->deleteStreamSchema,
+								fileModifyState->deleteStreamLeafFields);
+		fileModifyState->deleteDest =
+			CSVStreamWriterDestReceiver(fileModifyState->deleteStreamWriter);
+
+		MemoryContextSwitchTo(oldContext);
+	}
 
 	/* construct a (filename,position,...) delete record */
 	PrepareDeletionSlot(fileModifyState, fileRowNumber, fmstate->deleteSlot);
@@ -2735,13 +2824,29 @@ WriteDeleteRecord(PgLakeFileModifyState * fileModifyState,
 	deleteDest->receiveSlot(deleteSlot, deleteDest);
 	fileModifyState->modifiedRowCount++;
 
-	if (fileModifyState->modifiedRowCount == fileModifyState->liveRowCount)
+	if (fileModifyState->modifiedRowCount == fileModifyState->liveRowCount &&
+		fileModifyState->deleteStreamWriter == NULL)
 	{
 		/*
-		 * All rows are deleted, we do not actually need a delete file. Delete
-		 * it now to free up disk space.
+		 * File-based path only: all rows in this source file are being
+		 * deleted, so we don't need a deletion file. Drop the local CSV temp
+		 * file to free up disk space and let FinishForeignModify emit an
+		 * ADD_DELETION_FILE_FROM_CSV with deleteFile=NULL — downstream
+		 * ApplyDeleteFile handles that as "remove the source file"
+		 * (liveRowCount==0).
 		 *
-		 * We'll just pass on the modified row count.
+		 * The streaming path (deleteStreamWriter != NULL) MUST NOT take this
+		 * branch: rDestroy mid-stream pfree\'s the DR_copy chunk and the
+		 * still-non-NULL deleteStreamWriter then points at freed memory;
+		 * FinishForeignModify\'s FinishCSVStreamWriter would hit a
+		 * use-after-free + ApplyPrecomputedDeleteFile would receive a NULL
+		 * deleteFile.
+		 *
+		 * For the streaming path, just let WriteDeleteRecord keep
+		 * accumulating rows; the resulting parquet position-delete file will
+		 * cover all rows in the source, which is semantically equivalent
+		 * (iceberg readers see a fully-deleted source via the position-delete
+		 * merge).
 		 */
 		fileModifyState->deleteDest->rShutdown(fileModifyState->deleteDest);
 		fileModifyState->deleteDest->rDestroy(fileModifyState->deleteDest);
@@ -2873,12 +2978,43 @@ FinishForeignModify(PgLakeModifyState * fmstate)
 
 		DataFileModification *modification = palloc0(sizeof(DataFileModification));
 
-		modification->type = ADD_DELETION_FILE_FROM_CSV;
-		modification->sourcePath = TextDatumGetCString(fileModifyState->pathDatum);
-		modification->sourceRowCount = fileModifyState->sourceRowCount;
-		modification->liveRowCount = fileModifyState->liveRowCount;
-		modification->deleteFile = fileModifyState->deleteFile;
-		modification->deletedRowCount = fileModifyState->modifiedRowCount;
+		if (fileModifyState->deleteStreamWriter != NULL)
+		{
+			/*
+			 * Streaming-write path: close the COPY-IN stream, wait for
+			 * pgduck's deferred COPY ... TO 'parquet_path' to complete, and
+			 * grab the resulting per-file stats. The Parquet position- delete
+			 * file already exists on object storage at this point.
+			 *
+			 * ApplyPrecomputedDeleteFile will stitch it into the metadata
+			 * (always merge-on-read for streaming; see writable_table.c).
+			 */
+			StatsCollector *statsCollector =
+				FinishCSVStreamWriter(fileModifyState->deleteStreamWriter);
+
+			fileModifyState->deleteStreamWriter = NULL;
+			fileModifyState->deleteDest = NULL;
+
+			Assert(list_length(statsCollector->dataFileStats) == 1);
+			DataFileStats *stats = linitial(statsCollector->dataFileStats);
+
+			modification->type = ADD_DELETION_FILE_PRECOMPUTED;
+			modification->sourcePath = TextDatumGetCString(fileModifyState->pathDatum);
+			modification->sourceRowCount = fileModifyState->sourceRowCount;
+			modification->liveRowCount = fileModifyState->liveRowCount;
+			modification->deleteFile = fileModifyState->deleteFile;
+			modification->deletedRowCount = fileModifyState->modifiedRowCount;
+			modification->fileStats = stats;
+		}
+		else
+		{
+			modification->type = ADD_DELETION_FILE_FROM_CSV;
+			modification->sourcePath = TextDatumGetCString(fileModifyState->pathDatum);
+			modification->sourceRowCount = fileModifyState->sourceRowCount;
+			modification->liveRowCount = fileModifyState->liveRowCount;
+			modification->deleteFile = fileModifyState->deleteFile;
+			modification->deletedRowCount = fileModifyState->modifiedRowCount;
+		}
 
 		modifications = lappend(modifications, modification);
 	}
@@ -3505,6 +3641,17 @@ create_foreign_modify(Relation rel,
 
 	if (operation == CMD_UPDATE || operation == CMD_DELETE)
 	{
+		/*
+		 * Long-lived memory context for the deleteStreamWriter per-file
+		 * allocations. See the field comment in struct PgLakeModifyState for
+		 * the full reasoning. Created as a sub of CurrentMemoryContext (the
+		 * FDW state context) so it outlives all per-tuple resets.
+		 */
+		fmstate->deleteStreamMemoryContext =
+			AllocSetContextCreate(CurrentMemoryContext,
+								  "PgLakeDeleteStreamWriter",
+								  ALLOCSET_DEFAULT_SIZES);
+
 		/* Find the ctid resjunk column in the subplan's result */
 		Plan	   *subPlan = outerPlanState(mtstate)->plan;
 
@@ -3573,6 +3720,66 @@ create_foreign_modify(Relation rel,
 					 * remaining rows in the data file.
 					 */
 					fileModifyState->modifiedRowCount = fileModifyState->liveRowCount;
+				}
+				else if (StreamingWritesEnabled)
+				{
+					/*
+					 * Streaming-write path: precompute the Parquet
+					 * position-delete file path now and stash the args needed
+					 * to open a CSVStreamWriter targeting it. The actual
+					 * stream open is deferred to the first ExecForeignDelete
+					 * touching this source file (see the lazy-open block
+					 * above WriteDeleteRecord).
+					 *
+					 * Why deferred: ExecForeignDelete is dispatched per row
+					 * based on the row's ctid -> source file mapping. Many
+					 * source files in a scan may end up with zero matching
+					 * rows, and we don't want to open a libpq stream (and
+					 * write an empty Parquet) for those.
+					 *
+					 * We always go merge-on-read here; copy-on-write is
+					 * file-based-only for now (see
+					 * ApplyPrecomputedDeleteFile).
+					 */
+					ForeignTable *foreignTable = GetForeignTable(relationId);
+					CopyDataFormat tableFormat;
+					CopyDataCompression tableCompression;
+					PgLakeTableType tableType = GetPgLakeTableType(relationId);
+
+					FindDataFormatAndCompression(tableType, NULL,
+												 foreignTable->options,
+												 &tableFormat, &tableCompression);
+
+					char	   *deletionFilePath =
+						GenerateDataFileNameForTable(relationId, true);
+
+					/*
+					 * Mirror the in-progress-file tracking that
+					 * ApplyDeleteFile's merge-on-read branch does for the
+					 * file-based path so a transaction abort still cleans up
+					 * partial Parquet writes.
+					 */
+					bool		isPrefix = false;
+					bool		isIcebergTable =
+						IsPgLakeIcebergForeignTableById(relationId);
+					bool		autoDeleteRecord = !isIcebergTable;
+
+					InsertInProgressFileRecordExtended(deletionFilePath, isPrefix,
+													   autoDeleteRecord);
+
+					fileModifyState->deleteFile = deletionFilePath;
+					fileModifyState->deleteStreamTupleDesc =
+						fmstate->deleteSlot->tts_tupleDescriptor;
+					fileModifyState->deleteStreamSchema =
+						CreatePositionDeleteDataFileSchema();
+					fileModifyState->deleteStreamCompression = tableCompression;
+					fileModifyState->deleteStreamLeafFields =
+						GetLeafFieldsForTable(relationId);
+
+					/*
+					 * deleteDest stays NULL until the lazy-open block fires.
+					 * WriteDeleteRecord guards on this.
+					 */
 				}
 				else
 				{

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -101,6 +101,11 @@ static List *ApplyInsertFile(Relation rel, char *insertFile, int64 rowCount,
 static List *ApplyDeleteFile(Relation rel, char *sourcePath, int64 sourceRowCount,
 							 int64 liveRowCount, char *deleteFile, int64 deletedRowCount,
 							 int64 *totalPositionDeletedRows);
+static List *ApplyPrecomputedDeleteFile(Relation rel, char *sourcePath,
+										int64 sourceRowCount, int64 liveRowCount,
+										char *deleteFile, int64 deletedRowCount,
+										DataFileStats * deletionFileStats,
+										int64 *totalPositionDeletedRows);
 static List *GetDataFilePathsFromStatsList(List *dataFileStats);
 static List *GetNewFileOpsFromFileStats(Oid relationId, List *dataFileStats,
 										int32 partitionSpecId, Partition * partition, int64 rowCount,
@@ -210,6 +215,203 @@ ApplyInsertFile(Relation rel, char *insertFile, int64 rowCount,
 
 
 /*
+ * CSVInsertionContext bundles the per-target metadata that PrepareCSVInsertion
+ * computes once (relation lock, format/compression, options, dataFilePrefix,
+ * etc.) so both the file-based and streaming-write paths can share the
+ * "build modifications from a StatsCollector" tail.
+ */
+struct CSVInsertionContext
+{
+	Relation	relation;
+	TupleDesc	tupleDescriptor;
+	CopyDataFormat format;
+	CopyDataCompression compression;
+	List	   *options;		/* possibly with file_size_bytes appended */
+	DataFileSchema *schema;
+	List	   *leafFields;
+	char	   *dataFilePrefix;
+	bool		isPrefix;
+	bool		isIcebergTable;
+	bool		splitFilesBySize;
+	int64		reservedRowIdStart;
+};
+
+
+/*
+ * BeginCSVInsertion takes RowExclusiveLock on the relation, computes the
+ * destination prefix / format / options the same way PrepareCSVInsertion
+ * always has, and registers an in-progress-file record so a transaction
+ * abort can clean up partial writes. The caller (PrepareCSVInsertion or a
+ * streaming-write driver) then either runs ConvertCSVFileTo against
+ * dataFilePrefix or opens a CSVStreamWriter to it.
+ *
+ * EndCSVInsertion (must be called) drops the relation lock.
+ */
+CSVInsertionContext *
+BeginCSVInsertion(Oid relationId, int64 reservedRowIdStart, DataFileSchema * schema)
+{
+	CSVInsertionContext *ctx = palloc0(sizeof(CSVInsertionContext));
+
+	ctx->relation = table_open(relationId, RowExclusiveLock);
+	ctx->tupleDescriptor = RelationGetDescr(ctx->relation);
+	ctx->reservedRowIdStart = reservedRowIdStart;
+	ctx->schema = schema;
+
+	ForeignTable *foreignTable = GetForeignTable(relationId);
+
+	ctx->options = foreignTable->options;
+
+	PgLakeTableType tableType = GetPgLakeTableType(relationId);
+
+	FindDataFormatAndCompression(tableType, NULL, ctx->options, &ctx->format,
+								 &ctx->compression);
+
+	/*
+	 * We currently only support splitting Parquet files, to not complicate
+	 * the row counting.
+	 */
+	ctx->splitFilesBySize = TargetFileSizeMB > 0 &&
+		FormatUsesParquet(ctx->format) &&
+		reservedRowIdStart == 0;
+
+	/*
+	 * When target_file_size_mb is non-0 (512MB by default), we use the
+	 * file_size_bytes option in DuckDB COPY to split the file. The files may
+	 * not be exactly the desired size; some guess work is involved.
+	 */
+	if (ctx->splitFilesBySize)
+	{
+		ctx->options = lappend(ctx->options,
+							   CreateFileSizeBytesOption(TargetFileSizeMB));
+
+		/* extension will be added automatically when using file_size_bytes */
+		ctx->isPrefix = true;
+	}
+
+	ctx->dataFilePrefix = GenerateDataFileNameForTable(relationId, !ctx->isPrefix);
+	ctx->isIcebergTable = IsPgLakeIcebergForeignTableById(relationId);
+
+	bool		autoDeleteRecord = !ctx->isIcebergTable;
+
+	InsertInProgressFileRecordExtended(ctx->dataFilePrefix, ctx->isPrefix,
+									   autoDeleteRecord);
+
+	ctx->leafFields = GetLeafFieldsForTable(relationId);
+
+	return ctx;
+}
+
+
+/*
+ * BuildCSVInsertionModifications turns a StatsCollector (from either
+ * ConvertCSVFileTo or FinishCSVStreamWriter) into the
+ * ADD_DATA_FILE-typed DataFileModification list that
+ * ApplyDataFileModifications consumes. Same as PrepareCSVInsertion's tail
+ * before the table_close; pulled out so both write paths share it.
+ */
+List *
+BuildCSVInsertionModifications(CSVInsertionContext * ctx,
+							   StatsCollector * statsCollector,
+							   int64 rowCount)
+{
+	Oid			relationId = RelationGetRelid(ctx->relation);
+
+	ApplyColumnStatsModeForAllFileStats(relationId, statsCollector->dataFileStats);
+
+	if (!ctx->splitFilesBySize && statsCollector->dataFileStats == NIL)
+	{
+		DataFileStats *stats = palloc0(sizeof(DataFileStats));
+
+		stats->dataFilePath = ctx->dataFilePrefix;
+		stats->rowCount = rowCount;
+		statsCollector->dataFileStats = list_make1(stats);
+	}
+
+	/*
+	 * when we defer deletion of in-progress files, we need to replace the
+	 * prefix paths with full paths. At precommit hook, we delete persisted
+	 * files from in-progress
+	 */
+	if (ctx->isPrefix && ctx->isIcebergTable)
+		ReplaceInProgressPrefixPathWithFullPaths(ctx->dataFilePrefix,
+												 GetDataFilePathsFromStatsList(statsCollector->dataFileStats));
+
+	/* build a DataFileModification for each new data file */
+	List	   *modifications = NIL;
+	ListCell   *dataFileStatsCell = NULL;
+
+	foreach(dataFileStatsCell, statsCollector->dataFileStats)
+	{
+		DataFileStats *stats = lfirst(dataFileStatsCell);
+		DataFileModification *modification = palloc0(sizeof(DataFileModification));
+
+		modification->type = ADD_DATA_FILE;
+		modification->insertFile = stats->dataFilePath;
+		modification->insertedRowCount = stats->rowCount;
+		modification->reservedRowIdStart = ctx->reservedRowIdStart;
+		modification->fileStats = stats;
+
+		modifications = lappend(modifications, modification);
+	}
+
+	return modifications;
+}
+
+
+/*
+ * EndCSVInsertion drops the RowExclusiveLock taken in BeginCSVInsertion.
+ */
+void
+EndCSVInsertion(CSVInsertionContext * ctx)
+{
+	table_close(ctx->relation, NoLock);
+}
+
+
+TupleDesc
+CSVInsertionContextTupleDescriptor(CSVInsertionContext * ctx)
+{
+	return ctx->tupleDescriptor;
+}
+
+char *
+CSVInsertionContextDestinationPath(CSVInsertionContext * ctx)
+{
+	return ctx->dataFilePrefix;
+}
+
+CopyDataFormat
+CSVInsertionContextFormat(CSVInsertionContext * ctx)
+{
+	return ctx->format;
+}
+
+CopyDataCompression
+CSVInsertionContextCompression(CSVInsertionContext * ctx)
+{
+	return ctx->compression;
+}
+
+List *
+CSVInsertionContextOptions(CSVInsertionContext * ctx)
+{
+	return ctx->options;
+}
+
+DataFileSchema *
+CSVInsertionContextSchema(CSVInsertionContext * ctx)
+{
+	return ctx->schema;
+}
+
+List *
+CSVInsertionContextLeafFields(CSVInsertionContext * ctx)
+{
+	return ctx->leafFields;
+}
+
+
+/*
  * PrepareCSVInsertion converts a given CSV file to the table's format (e.g. Parquet)
  * the table's location (e.g. s3://mybucket/mytable/).
  *
@@ -220,105 +422,17 @@ PrepareCSVInsertion(Oid relationId, char *insertCSV, int64 rowCount,
 					int64 reservedRowIdStart, int maximumLineSize,
 					DataFileSchema * schema)
 {
-	Relation	relation = table_open(relationId, RowExclusiveLock);
-	ForeignTable *foreignTable = GetForeignTable(relationId);
-	TupleDesc	tupleDescriptor = RelationGetDescr(relation);
+	CSVInsertionContext *ctx = BeginCSVInsertion(relationId, reservedRowIdStart, schema);
 
-	List	   *options = foreignTable->options;
-
-	CopyDataFormat format;
-	CopyDataCompression compression;
-	PgLakeTableType tableType = GetPgLakeTableType(relationId);
-
-	FindDataFormatAndCompression(tableType, NULL, options, &format, &compression);
-
-	bool		isPrefix = false;
-
-	/*
-	 * We currently only support splitting Parquet files, to not complicate
-	 * the row counting.
-	 */
-	bool		splitFilesBySize =
-		TargetFileSizeMB > 0 &&
-		FormatUsesParquet(format) &&
-		reservedRowIdStart == 0;
-
-	/*
-	 * When target_file_size_mb is non-0 (512MB by default), we use the
-	 * file_size_bytes option in DuckDB COPY to split the file.
-	 *
-	 * The files may not be exactly the desired size; some guess work is
-	 * involved.
-	 */
-	if (splitFilesBySize)
-	{
-		options = lappend(options, CreateFileSizeBytesOption(TargetFileSizeMB));
-
-		/* extension will be added automatically when using file_size_bytes */
-		isPrefix = true;
-	}
-
-	char	   *dataFilePrefix = GenerateDataFileNameForTable(relationId, !isPrefix);
-
-	/* we defer deletion of in-progress data files only for Iceberg tables */
-	bool		isIcebergTable = IsPgLakeIcebergForeignTableById(relationId);
-	bool		autoDeleteRecord = !isIcebergTable;
-
-	InsertInProgressFileRecordExtended(dataFilePrefix, isPrefix, autoDeleteRecord);
-
-	List	   *leafFields = GetLeafFieldsForTable(relationId);
-
-	/* convert insert file to a new file in table format */
 	StatsCollector *statsCollector =
-		ConvertCSVFileTo(insertCSV,
-						 tupleDescriptor,
-						 maximumLineSize,
-						 dataFilePrefix,
-						 format,
-						 compression,
-						 options,
-						 schema,
-						 leafFields);
+		ConvertCSVFileTo(insertCSV, ctx->tupleDescriptor, maximumLineSize,
+						 ctx->dataFilePrefix, ctx->format, ctx->compression,
+						 ctx->options, ctx->schema, ctx->leafFields);
 
-	ApplyColumnStatsModeForAllFileStats(relationId, statsCollector->dataFileStats);
+	List	   *modifications = BuildCSVInsertionModifications(ctx, statsCollector,
+															   rowCount);
 
-	if (!splitFilesBySize && statsCollector->dataFileStats == NIL)
-	{
-		DataFileStats *stats = palloc0(sizeof(DataFileStats));
-
-		stats->dataFilePath = dataFilePrefix;
-		stats->rowCount = rowCount;
-		statsCollector->dataFileStats = list_make1(stats);
-	}
-
-	/*
-	 * when we defer deletion of in-progress files, we need to replace the
-	 * prefix paths with full paths. At precommit hook, we delete persisted
-	 * files from in-progress
-	 */
-	if (isPrefix && isIcebergTable)
-		ReplaceInProgressPrefixPathWithFullPaths(dataFilePrefix, GetDataFilePathsFromStatsList(statsCollector->dataFileStats));
-
-	/* build a DataFileModification for each new data file */
-	List	   *modifications = NIL;
-	ListCell   *dataFileStatsCell = NULL;
-
-	foreach(dataFileStatsCell, statsCollector->dataFileStats)
-	{
-		DataFileStats *stats = lfirst(dataFileStatsCell);
-
-		DataFileModification *modification = palloc0(sizeof(DataFileModification));
-
-		modification->type = ADD_DATA_FILE;
-		modification->insertFile = stats->dataFilePath;
-		modification->insertedRowCount = stats->rowCount;
-		modification->reservedRowIdStart = reservedRowIdStart;
-		modification->fileStats = stats;
-
-		modifications = lappend(modifications, modification);
-	}
-
-	table_close(relation, NoLock);
+	EndCSVInsertion(ctx);
 
 	return modifications;
 }
@@ -648,6 +762,84 @@ ApplyDeleteFile(Relation rel, char *sourcePath, int64 sourceRowCount, int64 live
 		elog(ERROR, "deleted row count " INT64_FORMAT " exceeds live row count " INT64_FORMAT,
 			 deletedRowCount, liveRowCount);
 	}
+
+	return metadataOperations;
+}
+
+
+/*
+ * ApplyPrecomputedDeleteFile is the streaming-write counterpart of
+ * ApplyDeleteFile's merge-on-read branch.
+ *
+ * The caller (a streaming-write call site like pg_lake_table.c's DELETE
+ * path with pg_lake_engine.streaming_writes=on) has already streamed the
+ * (file_path, row_position) records into a Parquet position-delete file
+ * on object storage and captured its DuckDB return_stats. Here we just
+ * stitch that precomputed file into the table metadata.
+ *
+ * Compared with the file-based ApplyDeleteFile, this function:
+ *
+ * - Skips the copy_on_write_threshold check. COW reads the source file +
+ *   the delete CSV via DuckDB and JOINs them to write a new data file
+ *   (PerformDeleteFromParquet). The streaming path doesn't have a CSV to
+ *   feed PerformDeleteFromParquet — only a Parquet position-delete file.
+ *   We could teach PerformDeleteFromParquet to accept Parquet input, but
+ *   that's a separate change; for now streaming always uses merge-on-read.
+ *   This is a pure perf trade-off (compaction will rewrite eventually).
+ * - Skips the all-rows-deleted shortcut (RemoveDataFileOperation). Same
+ *   reason: by the time we get here the streaming caller has already
+ *   committed to writing a delete file. If every row is deleted,
+ *   merge-on-read still works — it just produces a position-delete file that wipes
+ *   the source. Compaction handles cleanup.
+ */
+static List *
+ApplyPrecomputedDeleteFile(Relation rel, char *sourcePath, int64 sourceRowCount,
+						   int64 liveRowCount, char *deleteFile, int64 deletedRowCount,
+						   DataFileStats * deletionFileStats,
+						   int64 *totalPositionDeletedRows)
+{
+	if (deletedRowCount == 0)
+		return NIL;
+
+	/* same invariants as ApplyDeleteFile */
+	Assert(liveRowCount <= sourceRowCount);
+	Assert(deletedRowCount <= liveRowCount);
+	Assert(sourceRowCount > 0);
+
+	Oid			relationId = RelationGetRelid(rel);
+	uint64		totalDeletedRowCount =
+		deletedRowCount + sourceRowCount - liveRowCount;
+
+	ApplyColumnStatsModeForAllFileStats(relationId,
+										list_make1(deletionFileStats));
+
+	ereport(WriteLogLevel, (errmsg("adding deletion file %s with " INT64_FORMAT " rows",
+								   deleteFile, deletedRowCount)));
+
+	int32		partitionSpecId = DEFAULT_SPEC_ID;
+	List	   *transforms = AllPartitionTransformList(relationId);
+	Partition  *partition =
+		GetDataFilePartition(relationId, transforms, sourcePath, &partitionSpecId);
+
+	List	   *metadataOperations = NIL;
+
+	TableMetadataOperation *addDeletionFileOperation =
+		AddDataFileOperation(deleteFile, CONTENT_POSITION_DELETES,
+							 deletionFileStats, partition, partitionSpecId);
+
+	metadataOperations = lappend(metadataOperations, addDeletionFileOperation);
+
+	TableMetadataOperation *delMapOperation =
+		AddDeleteMappingOperation(deleteFile, sourcePath);
+
+	metadataOperations = lappend(metadataOperations, delMapOperation);
+
+	TableMetadataOperation *updateOperation =
+		UpdateDeletedRowCountOperation(sourcePath, totalDeletedRowCount);
+
+	metadataOperations = lappend(metadataOperations, updateOperation);
+
+	*totalPositionDeletedRows += deletedRowCount;
 
 	return metadataOperations;
 }
@@ -1080,6 +1272,241 @@ PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryT
 
 
 /*
+ * AddQueryResultStreamHandle holds the state needed to span the lifetime
+ * of a streaming AddQueryResultToTable call: the libpq connection
+ * (already opened with the deferred RECEIVE COPY query) and the
+ * preallocated table metadata (destination prefix, format/compression,
+ * schema, in-progress tracking) so we can build the same modifications
+ * the file-based AddQueryResultToTable produces once the stream finishes.
+ */
+struct AddQueryResultStreamHandle
+{
+	PGDuckConnection *conn;
+
+	/* table-level state */
+	Oid			relationId;
+	bool		hasRowIds;
+	int32		partitionSpecId;
+	Partition  *partition;
+
+	/* destination state (mirrors PrepareToAddQueryResultToTable) */
+	CopyDataFormat format;
+	CopyDataCompression compression;
+	List	   *leafFields;
+	DataFileSchema *schema;
+	char	   *newDataFilePath;
+	bool		isPrefix;
+	bool		isIcebergTable;
+};
+
+
+/*
+ * StartAddQueryResultToTableStream is the streaming-write counterpart of
+ * AddQueryResultToTable. See the doc comment in writable_table.h for the
+ * caller contract.
+ */
+AddQueryResultStreamHandle *
+StartAddQueryResultToTableStream(Oid relationId, char *readQuery,
+								 TupleDesc queryTupleDesc, bool wrapNativeTypes)
+{
+	Assert(queryTupleDesc != NULL && queryTupleDesc->natts > 0);
+
+	/*
+	 * COPY/INSERT .. SELECT pushdown is never exercised for partitioned
+	 * tables (same Assert as AddQueryResultToTable).
+	 */
+	Assert(GetIcebergTablePartitionByOption(relationId) == NULL);
+
+	AddQueryResultStreamHandle *handle =
+		palloc0(sizeof(AddQueryResultStreamHandle));
+
+	handle->relationId = relationId;
+	handle->partition = NULL;
+	handle->partitionSpecId = GetCurrentSpecId(relationId);
+	Assert(handle->partitionSpecId == DEFAULT_SPEC_ID);
+
+	ForeignTable *foreignTable = GetForeignTable(relationId);
+
+	handle->hasRowIds = GetBoolOption(foreignTable->options, "row_ids", false);
+
+	/* Mirror PrepareToAddQueryResultToTable for destination state. */
+	PgLakeTableProperties properties = GetPgLakeTableProperties(relationId);
+	List	   *options = properties.options;
+
+	handle->format = properties.format;
+	handle->compression = properties.compression;
+
+	/*
+	 * Splitting is allowed for the streaming path too; pgduck's COPY
+	 * file_size_bytes will produce one Parquet per split server-side.
+	 */
+	bool		allowSplit = true;
+	bool		splitFilesBySize = allowSplit && TargetFileSizeMB > 0 &&
+		FormatUsesParquet(handle->format);
+
+	handle->isPrefix = splitFilesBySize;
+
+	if (splitFilesBySize)
+		options = lappend(options, CreateFileSizeBytesOption(TargetFileSizeMB));
+
+	handle->newDataFilePath =
+		GenerateDataFileNameForTable(relationId, !handle->isPrefix);
+	handle->schema = GetDataFileSchemaForTable(relationId);
+	handle->isIcebergTable = IsPgLakeIcebergForeignTableById(relationId);
+	handle->leafFields = GetLeafFieldsForTable(relationId);
+
+	bool		autoDeleteRecord = !handle->isIcebergTable;
+
+	InsertInProgressFileRecordExtended(handle->newDataFilePath, handle->isPrefix,
+									   autoDeleteRecord);
+
+	IcebergOutOfRangePolicy outOfRangePolicy =
+		GetIcebergOutOfRangePolicyForTable(relationId);
+	bool		queryHasRowId = false;
+
+	/*
+	 * Build the same COPY (...) TO ... WITH (...) command WriteQueryResultTo
+	 * would build, then prefix RECEIVE so pgduck knows to wait for COPY-IN
+	 * bytes before running it.
+	 */
+	char	   *copyCommand = BuildCopyToCommandString(readQuery,
+													   handle->newDataFilePath,
+													   handle->format,
+													   handle->compression,
+													   options, queryHasRowId,
+													   handle->schema, queryTupleDesc,
+													   outOfRangePolicy,
+													   wrapNativeTypes);
+	char	   *receiveQuery = psprintf("RECEIVE %s", copyCommand);
+
+	handle->conn = GetPGDuckConnection();
+
+	PG_TRY();
+	{
+		OpenCopyInStreamToPGDuck(handle->conn, receiveQuery);
+	}
+	PG_CATCH();
+	{
+		ReleasePGDuckConnection(handle->conn);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	return handle;
+}
+
+
+PGconn *
+AddQueryResultStreamConnection(AddQueryResultStreamHandle * handle)
+{
+	return handle->conn->conn;
+}
+
+
+int64
+FinishAddQueryResultToTableStream(AddQueryResultStreamHandle * handle)
+{
+	int64		rowsProcessed = 0;
+	StatsCollector *statsCollector = NULL;
+	PGresult   *result = NULL;
+
+	PG_TRY();
+	{
+		result = FinishCopyInStreamToPGDuck(handle->conn);
+
+		if (handle->format == DATA_FORMAT_PARQUET ||
+			handle->format == DATA_FORMAT_ICEBERG)
+		{
+			statsCollector = GetDataFileStatsListFromPGResult(result,
+															  handle->leafFields,
+															  handle->schema);
+		}
+		else
+		{
+			char	   *commandTuples = PQcmdTuples(result);
+			int64		totalRowCount = atoll(commandTuples);
+
+			statsCollector = palloc0(sizeof(StatsCollector));
+			statsCollector->totalRowCount = totalRowCount;
+
+			if (totalRowCount > 0)
+			{
+				DataFileStats *fileStats =
+					CreateDataFileStatsForDataFile(handle->newDataFilePath,
+												   totalRowCount, 0,
+												   handle->leafFields);
+
+				statsCollector->dataFileStats = list_make1(fileStats);
+			}
+		}
+	}
+	PG_FINALLY();
+	{
+		if (result != NULL)
+			PQclear(result);
+		ReleasePGDuckConnection(handle->conn);
+	}
+	PG_END_TRY();
+
+	if (statsCollector->totalRowCount == 0)
+	{
+		/* mirror PrepareToAddQueryResultToTable's empty-result handling */
+		TimestampTz orphanedAt = GetCurrentTransactionStartTimestamp();
+
+		InsertDeletionQueueRecordExtended(handle->newDataFilePath,
+										  handle->isPrefix ? InvalidOid : handle->relationId,
+										  orphanedAt, handle->isPrefix);
+		return 0;
+	}
+
+	ApplyColumnStatsModeForAllFileStats(handle->relationId,
+										statsCollector->dataFileStats);
+
+	bool		isVerbose = false;
+	List	   *newFiles = NIL;
+	List	   *newFileOps =
+		GetNewFileOpsFromFileStats(handle->relationId,
+								   statsCollector->dataFileStats,
+								   handle->partitionSpecId, handle->partition,
+								   statsCollector->totalRowCount,
+								   isVerbose, &newFiles);
+
+	if (handle->isPrefix && handle->isIcebergTable)
+		ReplaceInProgressPrefixPathWithFullPaths(handle->newDataFilePath, newFiles);
+
+	List	   *metadataOperations = NIL;
+
+	metadataOperations = list_concat(metadataOperations, newFileOps);
+
+	ListCell   *newFileCell = NULL;
+
+	foreach(newFileCell, newFileOps)
+	{
+		TableMetadataOperation *addOp = lfirst(newFileCell);
+		int64		rowCount = addOp->dataFileStats.rowCount;
+
+		if (handle->hasRowIds && rowCount > 0)
+		{
+			RowIdRangeMapping *rowIdRange =
+				CreateRowIdRangeForNewFile(handle->relationId, rowCount, 0);
+
+			TableMetadataOperation *rowIdMappingOp =
+				AddRowIdMappingOperation(addOp->path, list_make1(rowIdRange));
+
+			metadataOperations = lappend(metadataOperations, rowIdMappingOp);
+			addOp->dataFileStats.rowIdStart = rowIdRange->rowStartId;
+		}
+
+		rowsProcessed += rowCount;
+	}
+
+	ApplyMetadataChanges(handle->relationId, metadataOperations);
+
+	return rowsProcessed;
+}
+
+
+/*
  * AddQueryResultToTable adds the result of a pgduck query to the table.
  *
  * Pass wrapNativeTypes=true when the source data is a raw DuckDB query
@@ -1314,6 +1741,23 @@ ApplyDataFileModifications(Relation rel, List *modifications)
 								modification->deleteFile,
 								modification->deletedRowCount,
 								&totalPositionDeletedRows);
+		}
+
+		else if (modification->type == ADD_DELETION_FILE_PRECOMPUTED)
+		{
+			Assert(modification->sourcePath != NULL);
+			Assert(modification->deleteFile != NULL);
+			Assert(modification->fileStats != NULL);
+
+			modificationOperations =
+				ApplyPrecomputedDeleteFile(rel,
+										   modification->sourcePath,
+										   modification->sourceRowCount,
+										   modification->liveRowCount,
+										   modification->deleteFile,
+										   modification->deletedRowCount,
+										   modification->fileStats,
+										   &totalPositionDeletedRows);
 		}
 
 		else if (modification->type == ADD_DATA_FILE)

--- a/pgduck_server/include/command_line/command_line.h
+++ b/pgduck_server/include/command_line/command_line.h
@@ -33,6 +33,16 @@ typedef struct
 	char	   *unix_socket_directory;
 	char	   *unix_socket_group;
 	int			unix_socket_permissions;
+
+	/*
+	 * Comma-separated list of TCP addresses to bind on (PostgreSQL-style
+	 * semantics). Empty string or NULL means TCP is disabled (default) and
+	 * pgduck_server only listens on the Unix domain socket. Examples:
+	 * "0.0.0.0"     listen on all IPv4 interfaces "0.0.0.0,::"  listen on all
+	 * IPv4 + all IPv6 interfaces "127.0.0.1"   loopback only The TCP port is
+	 * the same `port` field used for the Unix socket suffix.
+	 */
+	char	   *listen_addresses;
 	unsigned int port;
 	unsigned int max_clients;
 	char	   *memory_limit;
@@ -46,6 +56,12 @@ typedef struct
 	bool		debug;
 	char	   *init_file_path;
 	char	   *pidfile_path;
+
+	/*
+	 * Base directory for RECEIVE-query sinks (libpq COPY-IN landing files).
+	 * Defaults to <cache_dir>/recv when unset; overridable via --recv-dir.
+	 */
+	char	   *recv_dir;
 }			CommandLineOptions;
 
 CommandLineOptions parse_arguments(int argc, char *argv[]);

--- a/pgduck_server/include/pgserver/pgserver.h
+++ b/pgduck_server/include/pgserver/pgserver.h
@@ -24,13 +24,30 @@
 #define PGDUCK_PG_SERVER_H
 
 /*
+ * Maximum number of TCP listening sockets we'll bind. Each address in
+ * --listen_addresses can resolve to multiple addrinfos (rare; usually
+ * one per family), so we size for headroom over typical configs like
+ * "0.0.0.0,::".
+ */
+#define MAX_TCP_LISTEN_SOCKETS 16
+
+/*
  * PGServer represents an instance of a PostgreSQL wire compatible
  * server.
  */
 typedef struct PGServer
 {
 	int			listeningPort;
-	int			listeningSocket;
+	int			listeningSocket;	/* Unix domain socket */
+
+	/*
+	 * TCP listening sockets (one per resolved address from
+	 * --listen_addresses). numTcpSockets == 0 when TCP is disabled (the
+	 * default), in which case the server only accepts Unix-socket connections —
+	 * preserving backwards-compatible behavior.
+	 */
+	int			tcpSockets[MAX_TCP_LISTEN_SOCKETS];
+	int			numTcpSockets;
 
 	char		unixSocketDir[MAXPGPATH];
 	char		unixSocketPath[MAXPGPATH];
@@ -48,6 +65,7 @@ extern int	pgserver_init(PGServer * pgServer,
 						  char *unixSocketPath,
 						  char *unixSocketOwningGroup,
 						  int unixSocketPermissions,
+						  char *tcpListenAddresses,
 						  int port);
 extern int	pgserver_run(PGServer * pgServer);
 extern void pgserver_destroy(PGServer * pgServer);

--- a/pgduck_server/include/pgsession/pgsession.h
+++ b/pgduck_server/include/pgsession/pgsession.h
@@ -28,6 +28,9 @@
 
 #include "duckdb/duckdb.h"
 
+/* forward declaration; full definition lives in pgsession/recv_sink.h */
+typedef struct ReceiveSink ReceiveSink;
+
 #define DUCKPG_SERVER_VERSION "16.4.DuckPG"
 
 /*
@@ -175,6 +178,19 @@ typedef struct PGSession
 
 	int			lastReportedSendErrno;	/* needed to make pgsession_flush
 										 * thread-safe */
+
+	/*
+	 * RECEIVE-query state.
+	 *
+	 * When a query begins with the "RECEIVE " prefix, we send the client a
+	 * CopyInResponse, accept CopyData messages into activeRecvSink, and defer
+	 * running the actual DuckDB query until CopyDone arrives. While
+	 * deferredQueryString is non-NULL the session is in COPY-IN-active state
+	 * and only 'd' / 'c' / 'f' messages are valid.
+	 */
+	ReceiveSink *activeRecvSink;
+	char	   *deferredQueryString;
+	ResponseFormat deferredResponseFormat;
 }			PGSession;
 
 /* per-client entrance point for the pgsession logic */

--- a/pgduck_server/include/pgsession/recv_sink.h
+++ b/pgduck_server/include/pgsession/recv_sink.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Receive sink: a per-RECEIVE-query landing area on pgduck_server's local
+ * filesystem.
+ *
+ * The RECEIVE query prefix (mirror of TRANSMIT) lets pg_lake clients stream
+ * bytes via libpq COPY IN, instead of writing to a shared filesystem under
+ * the Postgres backend's PGDATA. The bytes land in a sink owned by
+ * pgduck_server, and the sink path is what gets passed to DuckDB's
+ * read_csv() etc. This decouples pgduck_server's filesystem from the
+ * client's PGDATA, which is a hard requirement when pgduck_server runs in
+ * a different pod/host than the Postgres backend (e.g. on Kubernetes).
+ *
+ * v1 stages received bytes to a regular file in a private base directory.
+ * Future versions may use a FIFO so DuckDB can consume the stream in
+ * parallel with the client upload, but the file approach is simpler and
+ * sufficient for typical CDC batch sizes (tens of MB).
+ */
+#ifndef PGDUCK_RECV_SINK_H
+#define PGDUCK_RECV_SINK_H
+
+#include "c.h"
+#include <stddef.h>
+
+typedef struct ReceiveSink ReceiveSink;
+
+/*
+ * Initialize the global receive directory. Creates it (mode 0700) if
+ * missing and unlinks any stale files left over from a prior run. Must be
+ * called once at startup, before any sink is created. Repeated calls
+ * replace the configured path.
+ *
+ * Returns 0 on success, -1 on error (with errno set and the failure
+ * already logged).
+ */
+int			recv_sink_global_init(const char *base_dir);
+
+/*
+ * Returns the configured base directory, or NULL if recv_sink has not been
+ * initialized.
+ */
+const char *recv_sink_global_dir(void);
+
+/*
+ * Create a new sink. Allocates a unique path under the global recv
+ * directory, opens it for writing (mode 0600), and returns the sink. The
+ * caller owns the sink and must call recv_sink_destroy() when done.
+ *
+ * Returns NULL on error (with errno set).
+ */
+ReceiveSink *recv_sink_create(void);
+
+/*
+ * Path of the sink file. Stable from create() through destroy(). DuckDB
+ * should open this path for reading.
+ */
+const char *recv_sink_path(const ReceiveSink * sink);
+
+/*
+ * Append bytes to the sink. Performs a full write (handles partial writes
+ * and EINTR). Returns 0 on success, -1 on error.
+ */
+int			recv_sink_write(ReceiveSink * sink, const char *data, size_t len);
+
+/*
+ * Close the sink for writing. After this call, the sink path is readable
+ * by DuckDB and reads will see EOF after all written bytes. Idempotent.
+ * Returns 0 on success, -1 on error.
+ */
+int			recv_sink_finalize(ReceiveSink * sink);
+
+/*
+ * Destroy the sink: close the file if still open, unlink the path, and
+ * free memory. Always succeeds; safe to call with NULL.
+ */
+void		recv_sink_destroy(ReceiveSink * sink);
+
+#endif							/* PGDUCK_RECV_SINK_H */

--- a/pgduck_server/src/command_line/command_line.c
+++ b/pgduck_server/src/command_line/command_line.c
@@ -57,7 +57,8 @@ print_usage()
 	printf(" --unix_socket_directory <path>		Specify the unix socket directory, default is %s\n", DEFAULT_UNIX_DOMAIN_PATH);
 	printf(" --unix_socket_group <group name>	Specify the unix socket group owner, default is \"%s\"\n", DEFAULT_UNIX_DOMAIN_GROUP);
 	printf(" --unix_socket_permissions <mask>	Specify the unix socket (chmod) permissions, default is %o\n", DEFAULT_UNIX_DOMAIN_PERMISSIONS);
-	printf(" --port <port>                 		Specify the port number, default is %d\n", DEFAULT_PORT);
+	printf(" --listen_addresses <addrs>		Comma-separated TCP addresses to listen on (e.g. \"0.0.0.0,::\"). Default: empty (Unix socket only)\n");
+	printf(" --port <port>                 		Specify the port number (used for both Unix socket suffix and TCP listener), default is %d\n", DEFAULT_PORT);
 	printf(" --max_clients <max_clients>		Specify the maximum allowed clients, default is %d\n", DEFAULT_MAX_CLIENTS);
 	printf(" --memory_limit=<memory_limit>		Optionally specify the maximum memory of pgduck_server similar to DuckDB's memory_limit, the default is 80 percent of the system memory\n");
 	printf(" --continue_on_oom                  If out of memory error occurs, continue operating\n");
@@ -66,6 +67,7 @@ print_usage()
 	printf(" --check_cli_params_only       		Only check the cli arguments, do not run the server\n");
 	printf(" --init_file_path <path>			Execute all statements in this file on start-up\n");
 	printf(" --cache_dir                    	Specify the directory to use to cache remote files (from S3)\n");
+	printf(" --recv_dir <path>                  Base dir for RECEIVE-query landing files; default <cache_dir>/recv or /tmp/pgduck_recv\n");
 	printf(" --extensions_dir <path>			Install and load extensions in the specified directory\n");
 	printf(" --pidfile <path>					Write the pid of this program to the given path\n");
 	printf(" --no_extension_install             Disable extension installation\n");
@@ -85,6 +87,7 @@ parse_arguments(int argc, char *argv[])
 		.unix_socket_directory = DEFAULT_UNIX_DOMAIN_PATH,
 		.unix_socket_group = DEFAULT_UNIX_DOMAIN_GROUP,
 		.unix_socket_permissions = DEFAULT_UNIX_DOMAIN_PERMISSIONS,
+		.listen_addresses = NULL,
 		.port = DEFAULT_PORT,
 		.max_clients = DEFAULT_MAX_CLIENTS,
 		.memory_limit = NULL,
@@ -97,6 +100,7 @@ parse_arguments(int argc, char *argv[])
 		.extensions_dir = NULL,
 		.no_extension_install = false,
 		.debug = false,
+		.recv_dir = NULL,
 	};
 	int			opt;
 	int			option_index = 0;
@@ -108,6 +112,7 @@ parse_arguments(int argc, char *argv[])
 		{"unix_socket_directory", required_argument, NULL, 'U'},
 		{"unix_socket_group", required_argument, NULL, 'G'},
 		{"unix_socket_permissions", required_argument, NULL, 'm'},
+		{"listen_addresses", required_argument, NULL, 'A'},
 		{"port", required_argument, NULL, 'P'},
 		{"max_clients", required_argument, NULL, 'M'},
 		{"memory_limit", required_argument, NULL, 'l'},
@@ -120,10 +125,11 @@ parse_arguments(int argc, char *argv[])
 		{"init_file_path", required_argument, NULL, 'i'},
 		{"pidfile", required_argument, NULL, 'p'},
 		{"debug", no_argument, NULL, 'd'},
+		{"recv_dir", required_argument, NULL, 'R'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "cvhU:P:M:D:l:L:p:d", long_options, &option_index)) != -1)
+	while ((opt = getopt_long(argc, argv, "cvhU:A:P:M:D:l:L:p:dR:", long_options, &option_index)) != -1)
 	{
 		switch (opt)
 		{
@@ -142,6 +148,15 @@ parse_arguments(int argc, char *argv[])
 				break;
 			case 'G':
 				options.unix_socket_group = strdup(optarg);
+				break;
+			case 'A':
+
+				/*
+				 * Empty string is allowed and disables TCP listening (same as
+				 * not passing the flag at all). Any non-empty value is
+				 * treated as a comma-separated list of addresses to bind on.
+				 */
+				options.listen_addresses = strdup(optarg);
 				break;
 			case 'l':
 				if (optarg)
@@ -251,6 +266,9 @@ parse_arguments(int argc, char *argv[])
 				break;
 			case 'p':
 				options.pidfile_path = strdup(optarg);
+				break;
+			case 'R':
+				options.recv_dir = strdup(optarg);
 				break;
 			case '?':
 				print_usage();

--- a/pgduck_server/src/main.c
+++ b/pgduck_server/src/main.c
@@ -22,6 +22,8 @@
  */
 #include <stdio.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "c.h"
 #include "postgres_fe.h"
@@ -32,6 +34,7 @@
 #include "pgserver/pgserver.h"
 #include "pgserver/client_threadpool.h"
 #include "pgsession/pgsession.h"
+#include "pgsession/recv_sink.h"
 #include "duckdb/duckdb.h"
 #include "utils/pidfile.h"
 
@@ -74,6 +77,47 @@ main(int argc, char *argv[])
 
 	pgclient_threadpool_init(options.max_clients);
 
+	/*
+	 * Resolve and initialize the RECEIVE-query landing directory.
+	 *
+	 * Default precedence: --recv_dir > <cache_dir>/recv > /tmp/pgduck_recv.
+	 * The directory is created (mode 0700) and any stale files from a prior
+	 * run are unlinked.
+	 */
+	{
+		char	   *recv_dir = options.recv_dir;
+		char	   *resolved = NULL;
+
+		if (recv_dir == NULL)
+		{
+			if (options.cache_dir != NULL)
+			{
+				size_t		len = strlen(options.cache_dir) + sizeof("/recv");
+
+				resolved = malloc(len);
+				if (resolved == NULL)
+				{
+					PGDUCK_SERVER_ERROR("out of memory deriving recv_dir");
+					return STATUS_ERROR;
+				}
+				snprintf(resolved, len, "%s/recv", options.cache_dir);
+				recv_dir = resolved;
+			}
+			else
+			{
+				recv_dir = "/tmp/pgduck_recv";
+			}
+		}
+
+		if (recv_sink_global_init(recv_dir) != 0)
+		{
+			free(resolved);
+			return STATUS_ERROR;
+		}
+		PGDUCK_SERVER_LOG("RECEIVE-query landing dir: %s", recv_dir);
+		free(resolved);
+	}
+
 	PGServer	pgServer;
 
 	srand(time(NULL));
@@ -82,6 +126,7 @@ main(int argc, char *argv[])
 					  options.unix_socket_directory,
 					  options.unix_socket_group,
 					  options.unix_socket_permissions,
+					  options.listen_addresses,
 					  options.port) != STATUS_OK)
 		return STATUS_ERROR;
 

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -26,13 +26,19 @@
 #include "postgres_fe.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
 #include <common/ip.h>
 #include <pthread.h>
 #include <signal.h>
 #include <sys/fcntl.h>
 #include <sys/file.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <utime.h>
 #include <grp.h>
@@ -68,6 +74,10 @@ static int	create_and_bind_unix_socket(PGServer * server, char *unixSocketPath,
 										char *unixSocketOwningGroup,
 										int unixSocketPermissions,
 										int port);
+static int	create_and_bind_tcp_sockets(PGServer * server,
+										char *tcpListenAddresses,
+										int port);
+static int	bind_one_tcp_addr(PGServer * server, const char *address, int port);
 static int	acquire_domain_socket_lock_file(PGServer * server, int port);
 static int	set_unix_socket_permissions(char *unixSocketPath, char *groupName,
 										int permissionsMask);
@@ -75,18 +85,24 @@ static int	pgserver_create_client_thread(const PgClientThreadInitState * initSta
 static void *pgclient_thread_main(void *arg);
 static void pgclient_thread_cleanup(void *arg);
 static void touch_internal_files(PGServer * pgServer, time_t now);
+static int	dispatch_accepted_client(PGServer * pgServer, int listeningSocket);
 
 /*
  * pgserver_create initializes a PostgreSQL wire compatible server
- * and starts listening on the given port.
+ * and starts listening on the given port. Always creates the Unix
+ * domain socket; additionally binds TCP sockets when
+ * `tcpListenAddresses` is non-NULL and non-empty.
  */
 int
 pgserver_init(PGServer * pgServer,
 			  char *unixSocketPath,
 			  char *unixSocketOwningGroup,
 			  int unixSocketPermissions,
+			  char *tcpListenAddresses,
 			  int port)
 {
+	pgServer->numTcpSockets = 0;
+
 	if (create_and_bind_unix_socket(pgServer,
 									unixSocketPath,
 									unixSocketOwningGroup,
@@ -94,12 +110,181 @@ pgserver_init(PGServer * pgServer,
 									port) != 0)
 		return STATUS_ERROR;
 
+	if (tcpListenAddresses != NULL && tcpListenAddresses[0] != '\0')
+	{
+		if (create_and_bind_tcp_sockets(pgServer, tcpListenAddresses, port) != STATUS_OK)
+			return STATUS_ERROR;
+	}
+
 	pgServer->listeningPort = port;
 	pgServer->startFunction = pgsession_handle_connection;
 	pgServer->last_touch_time = time(NULL);
 
-	PGDUCK_SERVER_LOG("pgduck_server is running with pid: %d", getpid());
+	PGDUCK_SERVER_LOG("pgduck_server is running with pid: %d (unix=%s, tcp_listeners=%d)",
+					  getpid(), pgServer->unixSocketPath, pgServer->numTcpSockets);
 
+	return STATUS_OK;
+}
+
+/*
+ * Bind a TCP listening socket per resolved address. `tcpListenAddresses`
+ * is a comma-separated list of addresses (e.g., "0.0.0.0,::") with
+ * PostgreSQL-style semantics. Each address is resolved via
+ * pg_getaddrinfo_all and bound on the same `port` as the Unix socket.
+ *
+ * On any failure, errors logged and STATUS_ERROR returned. Caller is
+ * responsible for cleanup; pgserver_destroy closes whatever sockets
+ * were successfully created.
+ */
+static int
+create_and_bind_tcp_sockets(PGServer * server, char *tcpListenAddresses, int port)
+{
+	char	   *list_copy = strdup(tcpListenAddresses);
+
+	if (list_copy == NULL)
+	{
+		PGDUCK_SERVER_ERROR("could not strdup listen_addresses: %m");
+		return STATUS_ERROR;
+	}
+
+	char	   *saveptr = NULL;
+	char	   *token = strtok_r(list_copy, ",", &saveptr);
+
+	while (token != NULL)
+	{
+		/* trim leading whitespace */
+		while (*token == ' ' || *token == '\t')
+			token++;
+
+		/* trim trailing whitespace */
+		size_t		len = strlen(token);
+
+		while (len > 0 && (token[len - 1] == ' ' || token[len - 1] == '\t'))
+			token[--len] = '\0';
+
+		if (*token != '\0')
+		{
+			if (bind_one_tcp_addr(server, token, port) != STATUS_OK)
+			{
+				free(list_copy);
+				return STATUS_ERROR;
+			}
+		}
+
+		token = strtok_r(NULL, ",", &saveptr);
+	}
+
+	free(list_copy);
+
+	if (server->numTcpSockets == 0)
+	{
+		PGDUCK_SERVER_ERROR("listen_addresses set but no TCP sockets bound �63� empty value?");
+		return STATUS_ERROR;
+	}
+
+	return STATUS_OK;
+}
+
+/*
+ * Resolve a single address (e.g., "0.0.0.0", "::", "127.0.0.1") and bind
+ * a TCP listening socket on it. May produce more than one socket if the
+ * resolver returns multiple addrinfos; each is added to server->tcpSockets.
+ */
+static int
+bind_one_tcp_addr(PGServer * server, const char *address, int port)
+{
+	struct addrinfo hint;
+
+	MemSet(&hint, 0, sizeof(hint));
+	hint.ai_family = AF_UNSPEC;
+	hint.ai_flags = AI_PASSIVE | AI_NUMERICHOST;
+	hint.ai_socktype = SOCK_STREAM;
+
+	char		portStr[16];
+
+	snprintf(portStr, sizeof(portStr), "%d", port);
+
+	struct addrinfo *addrs = NULL;
+	int			ret = pg_getaddrinfo_all(address, portStr, &hint, &addrs);
+
+	if (ret != STATUS_OK || addrs == NULL)
+	{
+		PGDUCK_SERVER_ERROR("could not translate address \"%s\" port %d: %s",
+							address, port,
+							ret != STATUS_OK ? gai_strerror(ret) : "no addresses returned");
+		if (addrs)
+			pg_freeaddrinfo_all(hint.ai_family, addrs);
+		return STATUS_ERROR;
+	}
+
+	for (struct addrinfo *a = addrs; a != NULL; a = a->ai_next)
+	{
+		if (server->numTcpSockets >= MAX_TCP_LISTEN_SOCKETS)
+		{
+			PGDUCK_SERVER_ERROR("too many TCP listen addresses (max %d)",
+								MAX_TCP_LISTEN_SOCKETS);
+			pg_freeaddrinfo_all(hint.ai_family, addrs);
+			return STATUS_ERROR;
+		}
+
+		int			sock = socket(a->ai_family, SOCK_STREAM, 0);
+
+		if (sock == PGINVALID_SOCKET)
+		{
+			PGDUCK_SERVER_ERROR("could not create TCP socket for \"%s\": %m", address);
+			pg_freeaddrinfo_all(hint.ai_family, addrs);
+			return STATUS_ERROR;
+		}
+
+		int			one = 1;
+
+		/* SO_REUSEADDR avoids "address already in use" after a restart */
+		if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) < 0)
+		{
+			PGDUCK_SERVER_ERROR("setsockopt(SO_REUSEADDR) on \"%s\": %m", address);
+			close(sock);
+			pg_freeaddrinfo_all(hint.ai_family, addrs);
+			return STATUS_ERROR;
+		}
+
+		/*
+		 * For dual-stack hosts, bind IPv6 sockets to v6-only so we can
+		 * separately bind 0.0.0.0 without conflict (matches PG's behavior).
+		 */
+		if (a->ai_family == AF_INET6 &&
+			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one)) < 0)
+		{
+			PGDUCK_SERVER_ERROR("setsockopt(IPV6_V6ONLY) on \"%s\": %m", address);
+			close(sock);
+			pg_freeaddrinfo_all(hint.ai_family, addrs);
+			return STATUS_ERROR;
+		}
+
+		if (bind(sock, a->ai_addr, a->ai_addrlen) < 0)
+		{
+			PGDUCK_SERVER_ERROR("could not bind TCP socket on \"%s\" port %d: %m",
+								address, port);
+			close(sock);
+			pg_freeaddrinfo_all(hint.ai_family, addrs);
+			return STATUS_ERROR;
+		}
+
+		const int	listenQueueSize = MaxThreads;
+
+		if (listen(sock, listenQueueSize) < 0)
+		{
+			PGDUCK_SERVER_ERROR("listen() on TCP socket for \"%s\": %m", address);
+			close(sock);
+			pg_freeaddrinfo_all(hint.ai_family, addrs);
+			return STATUS_ERROR;
+		}
+
+		server->tcpSockets[server->numTcpSockets++] = sock;
+		PGDUCK_SERVER_LOG("pgduck_server listening on TCP %s:%d (fd=%d)",
+						  address, port, sock);
+	}
+
+	pg_freeaddrinfo_all(hint.ai_family, addrs);
 	return STATUS_OK;
 }
 
@@ -410,7 +595,94 @@ enable_shutdown_signals(void)
 
 
 /*
+ * dispatch_accepted_client -- accept() one client on a ready listening
+ * socket and hand it off to a worker thread. Returns STATUS_OK if the
+ * client was accepted (success or backpressured-rejected) and the loop
+ * should continue, or STATUS_ERROR for a fatal error that should cause
+ * the server to exit. EINTR during accept() is treated as benign and
+ * returns STATUS_OK.
+ */
+static int
+dispatch_accepted_client(PGServer * pgServer, int listeningSocket)
+{
+	PGClient   *client = (PGClient *) pg_malloc0(sizeof(PGClient));
+	socklen_t	clientAddrLen = sizeof(client->clientAddress);
+
+	client->clientSocket =
+		accept(listeningSocket,
+			   (struct sockaddr *) &client->clientAddress, &clientAddrLen);
+
+	if (client->clientSocket < 0)
+	{
+		int			save_errno = errno;
+
+		pg_free(client);
+
+		/*
+		 * EINTR can come from our shutdown handler (running == 0) or from
+		 * unrelated sources like a debugger attaching (ptrace). Either way,
+		 * just continue — the while-condition handles shutdown.
+		 *
+		 * EAGAIN/EWOULDBLOCK shouldn't normally happen on a listening socket
+		 * we just learned was readable via poll(), but be defensive.
+		 */
+		if (save_errno == EINTR || save_errno == EAGAIN ||
+			save_errno == EWOULDBLOCK)
+			return STATUS_OK;
+
+		PGDUCK_SERVER_ERROR("Could not accept the client on fd %d: %s",
+							listeningSocket, strerror(save_errno));
+		return STATUS_ERROR;
+	}
+
+	/* first check if we have available threads */
+	int			threadIndex = pgclient_threadpool_reserve_slot(client);
+
+	if (threadIndex == InvalidThreadIndex)
+	{
+		PGDUCK_SERVER_LOG("A new client rejected as it exceeds %d clients", MaxAllowedClients);
+
+		/* TODO: send error message to the client */
+		close(client->clientSocket);
+		pg_free(client);
+		return STATUS_OK;
+	}
+
+	/* state to pass into pgclient_thread_main and pgclient_thread_cleanup */
+	PgClientThreadInitState *initState =
+		(PgClientThreadInitState *) pg_malloc0(sizeof(PgClientThreadInitState));
+
+	initState->threadIndex = threadIndex;
+	initState->startFunction = pgServer->startFunction;
+	initState->pgClient = client;
+
+	if (disable_shutdown_signals() != STATUS_OK)
+		exit(STATUS_ERROR);
+
+	if (pgserver_create_client_thread(initState) != OK)
+	{
+		PGDUCK_SERVER_ERROR("Thread creation failed for client %d", client->clientSocket);
+
+		close(client->clientSocket);
+		pg_free(client);
+		pg_free(initState);
+		pgclient_threadpool_free_slot(threadIndex);
+	}
+
+	if (enable_shutdown_signals() != STATUS_OK)
+		exit(STATUS_ERROR);
+
+	return STATUS_OK;
+}
+
+/*
  * pgserver_run is the main loop for the PostgreSQL wire compatible server.
+ *
+ * Polls across all listening sockets (Unix domain socket plus any TCP
+ * listeners configured via --listen_addresses). When any becomes
+ * readable, accepts the client there and dispatches via the thread
+ * pool. Touches lock/socket files periodically so /tmp cleaners don't
+ * eat them.
  */
 int
 pgserver_run(PGServer * pgServer)
@@ -418,92 +690,71 @@ pgserver_run(PGServer * pgServer)
 	if (install_shutdown_signal_handlers() != STATUS_OK)
 		return STATUS_ERROR;
 
+	struct pollfd fds[1 + MAX_TCP_LISTEN_SOCKETS];
+	int			nfds = 0;
+
+	fds[nfds].fd = pgServer->listeningSocket;
+	fds[nfds].events = POLLIN;
+	nfds++;
+
+	for (int i = 0; i < pgServer->numTcpSockets; i++)
+	{
+		fds[nfds].fd = pgServer->tcpSockets[i];
+		fds[nfds].events = POLLIN;
+		nfds++;
+	}
+
 	while (running)
 	{
-		PGClient   *client = (PGClient *) pg_malloc0(sizeof(PGClient));
-		socklen_t	clientAddrLen = sizeof(client->clientAddress);
+		/* Reset revents before each poll(). */
+		for (int i = 0; i < nfds; i++)
+			fds[i].revents = 0;
 
-		client->clientSocket =
-			accept(pgServer->listeningSocket,
-				   (struct sockaddr *) &client->clientAddress, &clientAddrLen);
+		/*
+		 * Use a 10-second timeout so the touch-internal-files maintenance
+		 * runs even when no clients connect for a long time. Previously the
+		 * code relied on pg_lake_manage_cache() generating a connection every
+		 * ~10s; we don't want to depend on that for the multi-socket path.
+		 */
+		int			r = poll(fds, nfds, 10 * 1000);
 
-		if (client->clientSocket < 0)
+		if (r < 0)
 		{
-			int			save_errno = errno;
+			if (errno == EINTR)
+				continue;		/* shutdown signal or unrelated; let the
+								 * while-condition decide */
 
-			pg_free(client);
-
-			/*
-			 * EINTR can come from our shutdown handler (running == 0) or from
-			 * unrelated sources like a debugger attaching (ptrace). In either
-			 * case, just retry the loop — the while-condition takes care of
-			 * the shutdown case.
-			 */
-			if (save_errno == EINTR)
-				continue;
-
-			PGDUCK_SERVER_ERROR("Could not accept the client: %s",
-								strerror(save_errno));
-
-			/*
-			 * TODO: We can probably recover from this error, but lets handle
-			 * errors gracefully in the future.
-			 */
-			exit(STATUS_ERROR);
+			PGDUCK_SERVER_ERROR("poll() failed: %s", strerror(errno));
+			return STATUS_ERROR;
 		}
 
 		/*
-		 * Touch Unix socket and lock files every 58 minutes, to ensure that
-		 * they are not removed by overzealous /tmp-cleaning tasks.  We assume
-		 * no one runs cleaners with cutoff times of less than an hour ...
-		 *
-		 * Note that normally you'd expect this code to run even if there are
-		 * no clients, but we are not doing that. When there are no clients,
-		 * we are blocked on the accept() system call. We currently rely on
-		 * the fact that every 10 seconds, pg_lake_manage_cache() is called,
-		 * guarantees that there is at least one new client.
+		 * Touch every 58 minutes regardless of activity. (Same logic as
+		 * before, but invoked from the poll loop instead of the inline accept
+		 * path.)
 		 */
 		time_t		now = time(NULL);
 
 		if (now - pgServer->last_touch_time >= 58 * SECS_PER_MINUTE)
 			touch_internal_files(pgServer, now);
 
-		/* first check if we have available threads */
-		int			threadIndex = pgclient_threadpool_reserve_slot(client);
+		if (r == 0)
+			continue;			/* timeout — go back to poll */
 
-		if (threadIndex == InvalidThreadIndex)
+		for (int i = 0; i < nfds; i++)
 		{
-			PGDUCK_SERVER_LOG("A new client rejected as it exceeds %d clients", MaxAllowedClients);
+			if (!(fds[i].revents & POLLIN))
+				continue;
 
-			/* TODO: send error message to the client */
-			close(client->clientSocket);
-			pg_free(client);
-			continue;
+			if (dispatch_accepted_client(pgServer, fds[i].fd) != STATUS_OK)
+			{
+				/*
+				 * TODO: be more graceful — for now keep the original
+				 * exit-on-fatal-accept-error behavior.
+				 */
+				exit(STATUS_ERROR);
+			}
 		}
-
-		/* state to pass into pgclient_thread_main and pgclient_thread_cleanup */
-		PgClientThreadInitState *initState =
-			(PgClientThreadInitState *) pg_malloc0(sizeof(PgClientThreadInitState));
-
-		initState->threadIndex = threadIndex;
-		initState->startFunction = pgServer->startFunction;
-		initState->pgClient = client;
-
-		if (disable_shutdown_signals() != STATUS_OK)
-			exit(STATUS_ERROR);
-
-		if (pgserver_create_client_thread(initState) != OK)
-		{
-			PGDUCK_SERVER_ERROR("Thread creation failed for client %d", client->clientSocket);
-
-			close(client->clientSocket);
-			pg_free(client);
-			pg_free(initState);
-			pgclient_threadpool_free_slot(threadIndex);
-		}
-
-		if (enable_shutdown_signals() != STATUS_OK)
-			exit(STATUS_ERROR);
 	}
 
 	return STATUS_OK;
@@ -526,9 +777,21 @@ pgserver_run(PGServer * pgServer)
 void
 pgserver_destroy(PGServer * pgServer)
 {
-	PGDUCK_SERVER_LOG("Shutting down: closing listening socket");
-	closesocket(pgServer->listeningSocket);
-	pgServer->listeningSocket = -1;
+	PGDUCK_SERVER_LOG("Shutting down: closing listening sockets");
+	if (pgServer->listeningSocket >= 0)
+	{
+		closesocket(pgServer->listeningSocket);
+		pgServer->listeningSocket = -1;
+	}
+	for (int i = 0; i < pgServer->numTcpSockets; i++)
+	{
+		if (pgServer->tcpSockets[i] >= 0)
+		{
+			closesocket(pgServer->tcpSockets[i]);
+			pgServer->tcpSockets[i] = -1;
+		}
+	}
+	pgServer->numTcpSockets = 0;
 
 	int			interrupted = pgclient_threadpool_cancel_all();
 

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -53,6 +53,7 @@
 #include "pgsession/pgsession.h"
 #include "pgsession/pgsession_io.h"
 #include "pgsession/pqformat.h"
+#include "pgsession/recv_sink.h"
 #include "utils/pgduck_log_utils.h"
 #include "utils/pg_log_utils.h"
 
@@ -68,6 +69,25 @@
  */
 #define TRANSMIT_PREFIX "transmit "
 #define TRANSMIT_PREFIX_LENGTH (strlen(TRANSMIT_PREFIX))
+
+/*
+ * RECEIVE-prefix detection (mirror of TRANSMIT, but for the input side).
+ *
+ * RECEIVE queries stage CopyData bytes streamed from the client into a
+ * server-local sink. Once the client sends CopyDone, the actual query
+ * (with SINK_PLACEHOLDER replaced by the sink path) runs against DuckDB.
+ *
+ * Form expected from clients:
+ *   "RECEIVE INSERT INTO foo SELECT * FROM read_csv('@@PG_LAKE_RECV@@', ...)"
+ *
+ * The placeholder is replaced exactly once; the substituted string is
+ * what gets passed to duckdb_query().
+ */
+#define RECEIVE_PREFIX "receive "
+#define RECEIVE_PREFIX_LENGTH (strlen(RECEIVE_PREFIX))
+
+#define SINK_PLACEHOLDER "'@@PG_LAKE_RECV@@'"
+#define SINK_PLACEHOLDER_LENGTH (strlen(SINK_PLACEHOLDER))
 
 /*
  * Convenience macro for pgsession_handle_connection to terminate
@@ -116,7 +136,17 @@ static int	process_parse_message(PGSession * pgSession, StringInfo inputMessage)
 static int	process_bind_message(PGSession * pgSession, StringInfo inputMessage);
 static int	process_execute_message(PGSession * pgSession, StringInfo inputMessage);
 
+static int	process_copy_data(PGSession * pgSession, StringInfo inputMessage);
+static int	process_copy_done(PGSession * pgSession, StringInfo inputMessage);
+static int	process_copy_fail(PGSession * pgSession, StringInfo inputMessage);
+static int	pgsession_send_copy_in_response(PGSession * pgSession);
+static char *substitute_sink_placeholder(const char *queryString,
+										 const char *sinkPath,
+										 char **errorMessageOut);
+static void recv_session_reset(PGSession * pgSession);
+
 static bool is_transmit_query(const char *queryString);
+static bool is_receive_query(const char *queryString);
 
 /* global flag on whether to exit on OOM */
 int			oom_is_fatal = true;
@@ -219,7 +249,13 @@ pgsession_handle_connection(void *input)
 					/* simple query */
 					check(process_query_message(&pgSession, &inputMessage), pgSession, "failed to process query message");
 
-					sendReadyForQuery = true;
+					/*
+					 * If process_query_message entered COPY-IN-active state
+					 * (RECEIVE prefix), defer ReadyForQuery until CopyDone /
+					 * CopyFail completes the deferred query.
+					 */
+					if (pgSession.activeRecvSink == NULL)
+						sendReadyForQuery = true;
 					break;
 				}
 
@@ -313,16 +349,48 @@ pgsession_handle_connection(void *input)
 				}
 
 			case 'd':
+				{
+					/* CopyData: only valid while a RECEIVE is in flight */
+					if (pgSession.activeRecvSink == NULL)
+					{
+						char	   *errorMessage = "unexpected CopyData message; no RECEIVE in progress";
+
+						check(pgsession_send_postgres_error(&pgSession, ERROR, errorMessage), pgSession, errorMessage);
+						break;
+					}
+					check(process_copy_data(&pgSession, &inputMessage), pgSession, "failed to process CopyData message");
+					break;
+				}
+
 			case 'c':
+				{
+					/* CopyDone: finalize the sink and run the deferred query */
+					if (pgSession.activeRecvSink == NULL)
+					{
+						char	   *errorMessage = "unexpected CopyDone message; no RECEIVE in progress";
+
+						check(pgsession_send_postgres_error(&pgSession, ERROR, errorMessage), pgSession, errorMessage);
+						sendReadyForQuery = true;
+						break;
+					}
+					check(process_copy_done(&pgSession, &inputMessage), pgSession, "failed to process CopyDone message");
+					sendReadyForQuery = true;
+					break;
+				}
+
 			case 'f':
 				{
-					/* d: copy data */
-					/* c: copy done */
-					/* f: copy fail */
-					char	   *errorMessage = "COPY command not yet supported in the protocol";
+					/* CopyFail: client aborted the upload */
+					if (pgSession.activeRecvSink == NULL)
+					{
+						char	   *errorMessage = "unexpected CopyFail message; no RECEIVE in progress";
 
-					check(pgsession_send_postgres_error(&pgSession, ERROR, errorMessage), pgSession, errorMessage);
-
+						check(pgsession_send_postgres_error(&pgSession, ERROR, errorMessage), pgSession, errorMessage);
+						sendReadyForQuery = true;
+						break;
+					}
+					check(process_copy_fail(&pgSession, &inputMessage), pgSession, "failed to process CopyFail message");
+					sendReadyForQuery = true;
 					break;
 				}
 
@@ -382,9 +450,82 @@ process_query_message(PGSession * pgSession, StringInfo inputMessage)
 						pgSession->pgClient->clientSocket, queryString);
 
 	ResponseFormat responseFormat = {
-		.isTransmit = is_transmit_query(queryString)
+		.isTransmit = false
 	};
 
+	if (is_receive_query(queryString))
+	{
+		ReceiveSink *sink;
+		char	   *substituted;
+		char	   *substituteError = NULL;
+
+		/* Strip RECEIVE prefix. */
+		queryString += RECEIVE_PREFIX_LENGTH;
+
+		/*
+		 * RECEIVE may be combined with TRANSMIT (e.g. INSERT ... RETURNING) —
+		 * honor both prefixes.
+		 */
+		if (is_transmit_query(queryString))
+		{
+			responseFormat.isTransmit = true;
+			queryString += TRANSMIT_PREFIX_LENGTH;
+		}
+
+		sink = recv_sink_create();
+		if (sink == NULL)
+		{
+			char	   *err = "failed to create RECEIVE sink";
+
+			return pgsession_send_postgres_error(pgSession, ERROR, err);
+		}
+
+		substituted = substitute_sink_placeholder(queryString, recv_sink_path(sink), &substituteError);
+		if (substituted == NULL)
+		{
+			recv_sink_destroy(sink);
+			return pgsession_send_postgres_error(pgSession, ERROR, substituteError);
+		}
+
+		pgSession->activeRecvSink = sink;
+		pgSession->deferredQueryString = substituted;
+		pgSession->deferredResponseFormat = responseFormat;
+
+		if (!IsOK(pgsession_send_copy_in_response(pgSession)))
+		{
+			recv_session_reset(pgSession);
+			return COMM_ERROR;
+		}
+
+		/*
+		 * pgsession_send_copy_in_response only queues 5 bytes into the send
+		 * buffer; pq_endmessage / pgsession_put_bytes don't flush unless the
+		 * buffer fills. The outer pgsession_handle_connection loop only
+		 * flushes inside the `if (sendReadyForQuery)` branch, which is
+		 * skipped for RECEIVE (we leave activeRecvSink set so the loop stays
+		 * in COPY-IN-active state). Without this explicit flush the
+		 * CopyInResponse never reaches the client and the client's
+		 * PQgetResult blocks forever waiting for it — exactly what hung the
+		 * streaming-writes smoke at run #2v through #2y.
+		 */
+		if (!IsOK(pgsession_flush(pgSession)))
+		{
+			recv_session_reset(pgSession);
+			return COMM_ERROR;
+		}
+
+		/* Validate we read all the bytes from the original Q message. */
+		if (!IsOK(pq_getmsgend(inputMessage)))
+		{
+			recv_session_reset(pgSession);
+			return COMM_ERROR;
+		}
+
+		/* Stay in COPY-IN-active state; CopyDone runs the deferred query. */
+		return OK;
+	}
+
+	responseFormat.isTransmit = is_transmit_query(queryString);
 	if (responseFormat.isTransmit)
 	{
 		/* Skip the prefix by directly adding its length to the pointer */
@@ -1096,6 +1237,9 @@ pgsession_init(PGSession * pgSession, PGClient * pgClient)
 static int
 pgsession_destroy(PGSession * pgSession)
 {
+	/* clean up any in-flight RECEIVE state */
+	recv_session_reset(pgSession);
+
 	pg_free(pgSession->pqSendBuffer);
 	duckdb_session_destroy(&pgSession->duckSession);
 	return OK;
@@ -1130,4 +1274,238 @@ static bool
 is_transmit_query(const char *queryString)
 {
 	return strncasecmp(queryString, TRANSMIT_PREFIX, TRANSMIT_PREFIX_LENGTH) == 0;
+}
+
+
+/*
+ * is_receive_query returns whether the given query string starts with
+ * "receive ".
+ *
+ * RECEIVE queries land CopyData bytes streamed from the client into a
+ * server-local sink, and run the substituted query (with the sink path
+ * baked in) once the client sends CopyDone.
+ */
+static bool
+is_receive_query(const char *queryString)
+{
+	return strncasecmp(queryString, RECEIVE_PREFIX, RECEIVE_PREFIX_LENGTH) == 0;
+}
+
+
+/*
+ * Substitute exactly one occurrence of SINK_PLACEHOLDER in queryString
+ * with a single-quoted SQL literal containing sinkPath. Returns a
+ * malloc'd string (caller frees via pg_free) or NULL on error.
+ *
+ * sinkPath is generated by recv_sink and never contains a single quote;
+ * we still defensively reject the case in case future code changes that.
+ */
+static char *
+substitute_sink_placeholder(const char *queryString, const char *sinkPath, char **errorMessageOut)
+{
+	const char *first;
+	const char *second;
+	size_t		pathLen;
+	size_t		prefixLen;
+	size_t		suffixLen;
+	size_t		resultLen;
+	char	   *result;
+	char	   *p;
+
+	*errorMessageOut = NULL;
+
+	if (strchr(sinkPath, '\'') != NULL)
+	{
+		*errorMessageOut = "RECEIVE sink path must not contain single quote";
+		return NULL;
+	}
+
+	first = strstr(queryString, SINK_PLACEHOLDER);
+	if (first == NULL)
+	{
+		*errorMessageOut = "RECEIVE query must contain placeholder '@@PG_LAKE_RECV@@' exactly once";
+		return NULL;
+	}
+	second = strstr(first + SINK_PLACEHOLDER_LENGTH, SINK_PLACEHOLDER);
+	if (second != NULL)
+	{
+		*errorMessageOut = "RECEIVE query must contain placeholder '@@PG_LAKE_RECV@@' exactly once";
+		return NULL;
+	}
+
+	prefixLen = (size_t) (first - queryString);
+	suffixLen = strlen(first + SINK_PLACEHOLDER_LENGTH);
+	pathLen = strlen(sinkPath);
+	/* prefix + ' + path + ' + suffix + NUL */
+	resultLen = prefixLen + 1 + pathLen + 1 + suffixLen + 1;
+	result = pg_malloc(resultLen);
+	p = result;
+
+	memcpy(p, queryString, prefixLen);
+	p += prefixLen;
+	*p++ = '\'';
+	memcpy(p, sinkPath, pathLen);
+	p += pathLen;
+	*p++ = '\'';
+	memcpy(p, first + SINK_PLACEHOLDER_LENGTH, suffixLen);
+	p += suffixLen;
+	*p = '\0';
+
+	return result;
+}
+
+
+/*
+ * Send a CopyInResponse ('G') message: text format, zero columns. DuckDB
+ * consumes opaque bytes via read_csv() once we land them in the sink.
+ */
+static int
+pgsession_send_copy_in_response(PGSession * pgSession)
+{
+	StringInfoData buf;
+
+	pq_beginmessage(&buf, 'G');
+	pq_sendbyte(&buf, 0);		/* PG_WIRE_TEXT_FORMAT */
+	pq_sendint16(&buf, 0);		/* zero columns */
+	return pq_endmessage(pgSession, &buf);
+}
+
+
+/*
+ * Tear down per-RECEIVE state. Idempotent.
+ */
+static void
+recv_session_reset(PGSession * pgSession)
+{
+	if (pgSession->activeRecvSink != NULL)
+	{
+		recv_sink_destroy(pgSession->activeRecvSink);
+		pgSession->activeRecvSink = NULL;
+	}
+	if (pgSession->deferredQueryString != NULL)
+	{
+		pg_free(pgSession->deferredQueryString);
+		pgSession->deferredQueryString = NULL;
+	}
+}
+
+
+/*
+ * Append the CopyData payload to the active sink.
+ */
+static int
+process_copy_data(PGSession * pgSession, StringInfo inputMessage)
+{
+	int			payloadLen;
+	const char *payload;
+
+	payloadLen = inputMessage->len - inputMessage->cursor;
+	if (payloadLen < 0)
+		return COMM_ERROR;
+
+	payload = pq_getmsgbytes(inputMessage, payloadLen);
+	if (payload == NULL)
+		return COMM_ERROR;
+
+	if (recv_sink_write(pgSession->activeRecvSink, payload, (size_t) payloadLen) != 0)
+	{
+		char	   *errorMessage = "failed to write RECEIVE bytes to local sink";
+
+		recv_session_reset(pgSession);
+		return pgsession_send_postgres_error(pgSession, ERROR, errorMessage);
+	}
+
+	return OK;
+}
+
+
+/*
+ * Finalize the sink and run the deferred query against DuckDB.
+ *
+ * Mirrors the success/error handling at the bottom of process_query_message
+ * so that fatal DuckDB errors still terminate the server process and
+ * reportable errors flow back to the client as 'E' messages.
+ */
+static int
+process_copy_done(PGSession * pgSession, StringInfo inputMessage)
+{
+	int			status;
+	DuckDBStatus duckStatus;
+	char	   *errorMessage = NULL;
+	ResponseFormat responseFormat;
+	char	   *queryString;
+
+	if (!IsOK(pq_getmsgend(inputMessage)))
+	{
+		recv_session_reset(pgSession);
+		return COMM_ERROR;
+	}
+
+	if (recv_sink_finalize(pgSession->activeRecvSink) != 0)
+	{
+		char	   *err = "failed to finalize RECEIVE sink";
+
+		recv_session_reset(pgSession);
+		return pgsession_send_postgres_error(pgSession, ERROR, err);
+	}
+
+	queryString = pgSession->deferredQueryString;
+	responseFormat = pgSession->deferredResponseFormat;
+
+	PGDUCK_SERVER_DEBUG("connection %d running deferred RECEIVE query: %s",
+						pgSession->pgClient->clientSocket, queryString);
+
+	duckStatus = duckdb_session_run_command(&pgSession->duckSession, queryString,
+											&responseFormat, &errorMessage);
+
+	/* Tear down RECEIVE state regardless of outcome. */
+	recv_session_reset(pgSession);
+
+	if (duckStatus == DUCKDB_SUCCESS)
+		return OK;
+
+	if (IS_REPORTABLE_DUCKDB_ERROR(duckStatus))
+	{
+		status = handle_pgsession_error_message(duckStatus, pgSession, errorMessage);
+		pfree(errorMessage);
+		if (IS_FATAL_DUCKDB_STATUS(duckStatus))
+			exit(EXIT_FAILURE);
+		return status;
+	}
+
+	/* error has been logged already; disconnect */
+	return COMM_ERROR;
+}
+
+
+/*
+ * Discard the sink and surface the client's failure reason as an error.
+ */
+static int
+process_copy_fail(PGSession * pgSession, StringInfo inputMessage)
+{
+	const char *clientReason;
+	char	   *errMsg;
+	size_t		len;
+	int			status;
+
+	clientReason = pq_getmsgstring(inputMessage);
+	if (clientReason == NULL)
+		clientReason = "(no reason given)";
+
+	if (!IsOK(pq_getmsgend(inputMessage)))
+	{
+		recv_session_reset(pgSession);
+		return COMM_ERROR;
+	}
+
+	len = strlen("RECEIVE aborted by client: ") + strlen(clientReason) + 1;
+	errMsg = pg_malloc(len);
+	snprintf(errMsg, len, "RECEIVE aborted by client: %s", clientReason);
+
+	recv_session_reset(pgSession);
+
+	status = pgsession_send_postgres_error(pgSession, ERROR, errMsg);
+	pg_free(errMsg);
+	return status;
 }

--- a/pgduck_server/src/pgsession/pgsession_io.c
+++ b/pgduck_server/src/pgsession/pgsession_io.c
@@ -270,16 +270,41 @@ pgsession_read_startup_packet(PGSession * pgSession)
 	else if (proto == NEGOTIATE_SSL_CODE || proto == NEGOTIATE_GSS_CODE)
 	{
 		/*
-		 * We currently only support unix-domain sockets, and SSL is not
-		 * supported over unix domain sockets.
+		 * Standard PostgreSQL protocol: when a client sends an SSLRequest or
+		 * GSSENCRequest packet and the server doesn't support that encryption
+		 * mode, the server replies with a single 'N' byte and the client
+		 * either falls back to plaintext (sslmode=prefer / gssencmode=prefer,
+		 * the libpq defaults) or aborts (require). Just closing the
+		 * connection — which we used to do here — looks like a transient
+		 * failure to libpq, not a "no SSL" signal, so the prefer-fallback
+		 * retry never fires and the connection just dies.
+		 *
+		 * We don't support either encryption method (the original code was
+		 * Unix-socket-only, where no libpq ever sends these packets; with the
+		 * TCP listener added by the 0001 patch these can now arrive). Reply
+		 * 'N' and recurse to read the real startup packet.
 		 *
 		 * For pg-hackers discussion on this topic:
 		 * https://www.postgresql.org/message-id/flat/49CA2524.5010809%40gmx.net
 		 */
-		PGDUCK_SERVER_ERROR("server does not support SSL or GSSAPI: %u", proto);
+		char		negResponse = 'N';
 
 		pg_free(startupPacketBuf);
-		return EOF;
+
+		if (!IsOK(pgsession_put_bytes(pgSession, &negResponse, 1)) ||
+			!IsOK(pgsession_flush(pgSession)))
+		{
+			PGDUCK_SERVER_ERROR("failed to send no-SSL/GSSAPI byte");
+			return EOF;
+		}
+
+		/*
+		 * Now wait for the real StartupPacket. Tail-recurse so error handling
+		 * stays DRY; the recursion is bounded by the startup protocol (at
+		 * most one of SSL+GSSAPI request before the actual startup, and
+		 * clients don't repeat).
+		 */
+		return pgsession_read_startup_packet(pgSession);
 	}
 	else if (proto != PG_PROTOCOL(3, 0))
 	{

--- a/pgduck_server/src/pgsession/recv_sink.c
+++ b/pgduck_server/src/pgsession/recv_sink.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Receive sink implementation. See pgsession/recv_sink.h for the
+ * conceptual overview.
+ *
+ * The sink is a regular file under a server-private base directory. Each
+ * client connection gets its own sink at most one at a time; the path is
+ * unique per (pid, monotonic seq, time) tuple and the directory is mode
+ * 0700 to keep other local users out. Stale files from a crashed prior
+ * run are swept on startup.
+ */
+#include "pgsession/recv_sink.h"
+
+#include "c.h"
+#include "common/fe_memutils.h"
+#include "utils/pgduck_log_utils.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+struct ReceiveSink
+{
+	char	   *path;
+	int			fd;				/* -1 once finalized or destroyed */
+};
+
+static char *globalBaseDir = NULL;
+static pthread_mutex_t sinkSeqLock = PTHREAD_MUTEX_INITIALIZER;
+static unsigned long sinkSeq = 0;
+
+static int	sweep_directory(const char *dir);
+static int	mkdir_p(const char *path);
+
+int
+recv_sink_global_init(const char *base_dir)
+{
+	struct stat st;
+
+	if (base_dir == NULL || base_dir[0] == '\0')
+	{
+		errno = EINVAL;
+		PGDUCK_SERVER_ERROR("recv_sink_global_init: empty base_dir");
+		return -1;
+	}
+
+	/*
+	 * mkdir -p semantics: the derived default <cache_dir>/recv often runs
+	 * before <cache_dir> exists (DuckDB creates it lazily on first cache
+	 * write), so a plain mkdir would fail with ENOENT.
+	 */
+	if (mkdir_p(base_dir) != 0)
+	{
+		PGDUCK_SERVER_ERROR("could not create recv dir %s: %s",
+							base_dir, strerror(errno));
+		return -1;
+	}
+
+	if (stat(base_dir, &st) != 0)
+	{
+		PGDUCK_SERVER_ERROR("could not stat recv dir %s: %s",
+							base_dir, strerror(errno));
+		return -1;
+	}
+	if (!S_ISDIR(st.st_mode))
+	{
+		PGDUCK_SERVER_ERROR("recv dir %s is not a directory", base_dir);
+		errno = ENOTDIR;
+		return -1;
+	}
+
+	/*
+	 * Tighten permissions even on a pre-existing directory; we are the only
+	 * intended writer/reader.
+	 */
+	if ((st.st_mode & 0777) != 0700)
+	{
+		if (chmod(base_dir, 0700) != 0)
+		{
+			PGDUCK_SERVER_ERROR("could not chmod recv dir %s to 0700: %s",
+								base_dir, strerror(errno));
+			return -1;
+		}
+	}
+
+	(void) sweep_directory(base_dir);
+
+	if (globalBaseDir != NULL)
+		free(globalBaseDir);
+	globalBaseDir = strdup(base_dir);
+	if (globalBaseDir == NULL)
+	{
+		PGDUCK_SERVER_ERROR("out of memory recording recv dir");
+		return -1;
+	}
+
+	return 0;
+}
+
+const char *
+recv_sink_global_dir(void)
+{
+	return globalBaseDir;
+}
+
+/*
+ * Recursive mkdir, like `mkdir -p`. Tolerates pre-existing leaf and
+ * intermediate directories. Returns 0 on success; -1 with errno set on
+ * any other failure.
+ */
+static int
+mkdir_p(const char *path)
+{
+	char	   *tmp;
+	size_t		len;
+	char	   *p;
+
+	if (path == NULL || path[0] == '\0')
+	{
+		errno = EINVAL;
+		return -1;
+	}
+
+	len = strlen(path);
+	tmp = strdup(path);
+	if (tmp == NULL)
+		return -1;
+
+	/* Strip trailing slash so the final-component mkdir below isn't a no-op. */
+	if (tmp[len - 1] == '/')
+		tmp[len - 1] = '\0';
+
+	for (p = tmp + 1; *p != '\0'; p++)
+	{
+		if (*p == '/')
+		{
+			*p = '\0';
+			if (mkdir(tmp, 0700) != 0 && errno != EEXIST)
+			{
+				int			saved_errno = errno;
+
+				free(tmp);
+				errno = saved_errno;
+				return -1;
+			}
+			*p = '/';
+		}
+	}
+	if (mkdir(tmp, 0700) != 0 && errno != EEXIST)
+	{
+		int			saved_errno = errno;
+
+		free(tmp);
+		errno = saved_errno;
+		return -1;
+	}
+	free(tmp);
+	return 0;
+}
+
+/*
+ * Best-effort sweep: unlink every regular file in dir. Subdirectories are
+ * left alone (we never create any). Failures are logged but not fatal —
+ * worst case is we leak a few KB of stale files until the next sweep.
+ */
+static int
+sweep_directory(const char *dir)
+{
+	DIR		   *d;
+	struct dirent *de;
+	int			removed = 0;
+	int			failed = 0;
+
+	d = opendir(dir);
+	if (d == NULL)
+	{
+		PGDUCK_SERVER_WARN("could not open recv dir %s for sweep: %s",
+						   dir, strerror(errno));
+		return -1;
+	}
+
+	while ((de = readdir(d)) != NULL)
+	{
+		char		path[PATH_MAX];
+
+		if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0)
+			continue;
+
+		snprintf(path, sizeof(path), "%s/%s", dir, de->d_name);
+		if (unlink(path) == 0)
+			removed++;
+		else
+			failed++;
+	}
+	closedir(d);
+
+	if (removed > 0 || failed > 0)
+		PGDUCK_SERVER_LOG("recv dir sweep: removed %d, failed %d",
+						  removed, failed);
+
+	return 0;
+}
+
+ReceiveSink *
+recv_sink_create(void)
+{
+	ReceiveSink *sink;
+	char	   *path = NULL;
+	int			fd;
+	unsigned long seq;
+	pid_t		pid = getpid();
+
+	if (globalBaseDir == NULL)
+	{
+		PGDUCK_SERVER_ERROR("recv_sink not initialized");
+		errno = EINVAL;
+		return NULL;
+	}
+
+	pthread_mutex_lock(&sinkSeqLock);
+	seq = ++sinkSeq;
+	pthread_mutex_unlock(&sinkSeqLock);
+
+	if (asprintf(&path, "%s/recv_%d_%lu_%lld",
+				 globalBaseDir, (int) pid, seq,
+				 (long long) time(NULL)) < 0)
+	{
+		PGDUCK_SERVER_ERROR("could not format recv path: %s", strerror(errno));
+		return NULL;
+	}
+
+	/*
+	 * O_EXCL guards against any pre-existing file collision (the seq is
+	 * monotonic per process so a collision implies an attacker placed a file
+	 * there; refuse to use it).
+	 */
+	fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+	if (fd < 0)
+	{
+		PGDUCK_SERVER_ERROR("could not create recv file %s: %s",
+							path, strerror(errno));
+		free(path);
+		return NULL;
+	}
+
+	sink = pg_malloc(sizeof(*sink));
+	sink->path = path;
+	sink->fd = fd;
+	return sink;
+}
+
+const char *
+recv_sink_path(const ReceiveSink * sink)
+{
+	return sink ? sink->path : NULL;
+}
+
+int
+recv_sink_write(ReceiveSink * sink, const char *data, size_t len)
+{
+	if (sink == NULL || sink->fd < 0)
+	{
+		errno = EBADF;
+		return -1;
+	}
+
+	while (len > 0)
+	{
+		ssize_t		n = write(sink->fd, data, len);
+
+		if (n < 0)
+		{
+			if (errno == EINTR)
+				continue;
+			PGDUCK_SERVER_ERROR("recv sink write failed on %s: %s",
+								sink->path, strerror(errno));
+			return -1;
+		}
+		data += n;
+		len -= (size_t) n;
+	}
+	return 0;
+}
+
+int
+recv_sink_finalize(ReceiveSink * sink)
+{
+	if (sink == NULL || sink->fd < 0)
+		return 0;
+
+	if (close(sink->fd) != 0)
+	{
+		PGDUCK_SERVER_ERROR("could not close recv sink %s: %s",
+							sink->path, strerror(errno));
+		sink->fd = -1;
+		return -1;
+	}
+	sink->fd = -1;
+	return 0;
+}
+
+void
+recv_sink_destroy(ReceiveSink * sink)
+{
+	if (sink == NULL)
+		return;
+
+	if (sink->fd >= 0)
+		(void) close(sink->fd);
+	if (sink->path != NULL)
+	{
+		(void) unlink(sink->path);
+		free(sink->path);
+	}
+	pg_free(sink);
+}


### PR DESCRIPTION
# Streaming writes via pgduck_server RECEIVE protocol

## What this PR adds

An opt-in path for pg_lake's bulk-write operations (INSERT, UPDATE,
DELETE, COPY FROM STDIN, iceberg metadata uploads) to push bytes
directly to `pgduck_server` over libpq COPY-IN, instead of writing
them to a shared filesystem under `$PGDATA/pgsql_tmp` and asking
pgduck to read them back via `read_csv()`.

Activated by setting `pg_lake_engine.streaming_writes = on`
(default `off`).

## Why

The existing pg_lake design assumes postgres and `pgduck_server`
share a filesystem — the standard sidecar deployment puts both in
the same pod, talking via a Unix socket on a shared
`$PGDATA`-relative path. That layout breaks every bulk-write path
under deployment models where postgres and pgduck don't share a
filesystem:

- Operator-managed Kubernetes deployments (e.g. CloudNativePG, where
  the `Cluster` CR overrides the pod's `command:` and doesn't allow
  arbitrary sidecar containers).
- Multi-host setups where postgres and pgduck run on different
  machines.
- Anywhere a co-located sidecar isn't practical for ops or security
  reasons.

In all of these, today's pg_lake hits a "no such file or directory"
in `pgduck_server` when the bulk-write path's CSV temp lives on a
filesystem the server can't see.

This PR makes pg_lake work in those topologies by routing the bulk-
write data through libpq COPY-IN to a server-local sink on
`pgduck_server`, decoupling the two processes' filesystems.

## How it works

`pgduck_server` learns a new `RECEIVE <inner-query>` query prefix.
When the server sees `RECEIVE …`:

1. Picks a server-local sink path under `--recv_dir`.
2. Substitutes the `'@@PG_LAKE_RECV@@'` token in the inner query
   (which appears exactly once, already wrapped in single quotes
   so it stands in for a string-literal argument — e.g.
   `read_csv('@@PG_LAKE_RECV@@', …)`) with a single-quoted SQL
   literal containing the sink path. The sink path is generated
   server-side and never contains a single quote; the substitution
   defensively rejects any path that does, rather than attempting
   to escape, which keeps the SQL-quoting story trivial to audit.
3. Sends `CopyInResponse` to the client; accepts `CopyData` chunks
   into the sink.
4. On `CopyDone`, runs the deferred inner query (which
   read_csv()'s from the sink) and streams its results back via the
   normal `PGresult` flow.

On the client side, `pg_lake_engine` adds a `CSVStreamWriter`
primitive that builds the same `COPY (…) TO …` command pg_lake
already uses for the file-based path, prefixes it with `RECEIVE`,
opens a libpq COPY-IN, and exposes a `DestReceiver` that the FDW
callers drive with rows.

The INSERT, UPDATE, DELETE, COPY-FROM-STDIN, and iceberg-metadata
upload paths in `pg_lake_table` / `pg_lake_copy` / `pg_lake_engine`
all switch transparently to the streaming path when the GUC is on.

## Structure

This PR is two commits:

1. **pgduck_server: add RECEIVE protocol for streaming COPY-IN sink.**
   Self-contained: TCP listener, `RECEIVE` prefix handling,
   `recv_sink` module, SSL-negotiate-byte handling, explicit flush
   after `CopyInResponse`. Reviewable independently — nothing in
   `pg_lake_*` changes here.
2. **pg_lake: streaming writes for INSERT, UPDATE, DELETE, COPY,
   and iceberg metadata.** Adds `CSVStreamWriter` plumbing in
   `pg_lake_engine`, then adopts it in the `pg_lake_table` /
   `pg_lake_copy` / iceberg-metadata callsites. Gated behind the
   new `pg_lake_engine.streaming_writes` GUC.

Patch 2 builds and runs cleanly against a tree with only patch 1
applied — though it doesn't do much without patch 1's server-side
support.

## Compatibility

- **Default off.** Existing deployments are unaffected.
- **No data layout or catalog changes.** Iceberg tables produced
  via the streaming path are byte-identical to those produced via
  the file-based path. The streaming path is a transport choice,
  not a representation choice.
- **No SQL surface changes.** Same INSERT / UPDATE / DELETE /
  COPY / CREATE TABLE syntax.
- **Existing file-based paths unchanged.** No regressions for
  shared-filesystem topologies.
- **Unix-socket transport remains supported.** `pgduck_server` only
  starts a TCP listener if `--listen_addresses` is set; the
  Unix-socket default behavior is preserved.

## Testing

Tested against a CDC-shape workload (200 mixed INSERT/UPDATE/DELETE
events with `COMMIT` per event, ~10s per event, ~50 minutes of
continuous write activity) on a GKE deployment with `pgduck_server`
in a separate pod from postgres. Final verification: 10 back-to-back
soak runs with full instrumentation across the writer's entire
lifetime — zero correctness issues detected.

The companion `cdc-stream.sql` / `cdc-stream-polaris.sql` regression
fixtures in our local stack exercise the I+D+U mix that the
streaming path needs to handle correctly. Happy to upstream those
test fixtures separately if useful for CI.

## Operational notes

- The `RECEIVE` query prefix is only recognized in libpq's simple-
  query protocol (because it needs the server-side prefix detection
  that the extended-query protocol doesn't surface). Clients using
  `PQsendQueryParams` keep going through the existing path.
- This PR does **not** add a per-stream byte cap on sink size;
  disk usage is currently bounded only by the underlying filesystem.
  Adding a `--recv_max_bytes` cap would be a small follow-up.
- `WaitForResult` is used (not raw `PQgetResult`) so that
  `statement_timeout` / SIGINT / postmaster-death fire promptly
  while the backend is waiting on pgduck — typical libpq calls
  don't observe `statement_timeout` because they sit below
  `CHECK_FOR_INTERRUPTS`.

