### PR TITLE
[release-3.3] Backport #342: fix double pfree of REST catalog access token after OAuth failure

### DIFF
--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -555,7 +555,10 @@ GetRestCatalogAccessToken(bool forceRefreshToken)
 		!TimestampDifferenceExceeds(now, RestCatalogAccessTokenExpiry, MINUTE_IN_MSECS))
 	{
 		if (RestCatalogAccessToken)
+		{
 			pfree(RestCatalogAccessToken);
+			RestCatalogAccessToken = NULL;
+		}
 
 		char	   *accessToken = NULL;
 		int			expiresIn = 0;


### PR DESCRIPTION
## Summary

Cherry-picks #342 (`3df2693` on `main`) onto `release-3.3`.

The fix is a 3-line null-after-free guard in `GetRestCatalogAccessToken()` to avoid a "detected double pfree in TopMemoryContext" warning when `FetchRestCatalogAccessToken()` throws (e.g. HTTP timeout) and the global `RestCatalogAccessToken` is left as a dangling pointer.

## Why backport

`v3.3.3` was tagged on 2026-05-05; #342 merged to `main` on 2026-05-06 and is not present on `release-3.3`. Customers on the 3.3 series running against a flaky/slow REST catalog endpoint will see the warning until this lands.

## Diff

Identical to the upstream fix on `main` — single hunk in `pg_lake_iceberg/src/rest_catalog/rest_catalog.c`. No conflicts during cherry-pick.

```c
		if (RestCatalogAccessToken)
+		{
			pfree(RestCatalogAccessToken);
+			RestCatalogAccessToken = NULL;
+		}
```

Original commit references #328.

## Test plan

- [ ] CI green on `release-3.3`
- [ ] Existing REST catalog tests pass (no behavioural change on happy path; only error-recovery state changes)

Made with [Cursor](https://cursor.com)