### PR TITLE
pg_lake_table: ANALYZE pg_lake catalogs to keep commit-time diff off the N² cliff

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -48,7 +48,8 @@ HTAB	   *GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool ne
 HTAB	   *GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
 												   bool forUpdate, char *orderBy, Snapshot snapshot,
 												   List *partitionTransforms, bool skipColumnStats);
-extern PGDLLEXPORT void LoadColumnStatsForFiles(Oid relationId, List *dataFiles);
+extern PGDLLEXPORT void LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPath,
+												List *dataFiles);
 extern PGDLLEXPORT List *GetPossiblePositionDeleteFilesFromCatalog(Oid relationId, List *sourcePathList,
 																   Snapshot snapshot);
 extern PGDLLEXPORT int64 GetTableSizeFromCatalog(Oid relationId);

--- a/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
+++ b/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
@@ -31,8 +31,25 @@ typedef struct TableMetadataOperationTracker
 	bool		relationDataFileChanged;
 	bool		relationManifestMergeRequested;
 	bool		relationSnapshotExpirationRequested;
+
+	/*
+	 * Number of single-file data-file operations recorded for this relation
+	 * in the current transaction (DATA_FILE_ADD + DATA_FILE_REMOVE). Each
+	 * such op rewrites the pg_lake catalogs that the commit-time diff joins,
+	 * so the count tracks the work the diff will do regardless of direction.
+	 * Used by pg_lake_table.commit_time_analyze_threshold.
+	 */
+	int64		dataFileChangeCount;
+
+	/*
+	 * Set when DATA_FILE_REMOVE_ALL was recorded for this relation. That
+	 * single op typically maps to thousands of catalog deletes, so we force
+	 * commit-time ANALYZE regardless of dataFileChangeCount.
+	 */
+	bool		forceCommitTimeAnalyze;
 }			TableMetadataOperationTracker;
 
+extern PGDLLEXPORT int CommitTimeCatalogAnalyzeThreshold;
 
 extern PGDLLEXPORT void ConsumeTrackedIcebergMetadataChanges(bool isVerbose);
 extern PGDLLEXPORT void PostAllRestCatalogRequests(void);

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -407,17 +407,17 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 
 
 /*
- * LoadColumnStatsForFiles fills in per-column min/max stats for the given
- * data files, targeting only their paths. This lets callers pair a stats-free
- * bulk read (GetTableDataFilesHashFromCatalog with skipColumnStats=true) with
- * a narrow stats load for just the files that actually need them (e.g. the
- * handful of newly added files in a transaction).
+ * LoadColumnStatsForFiles fetches per-column min/max stats for the data files
+ * in dataFiles and appends them to each dataFile->stats.columnStats list.
  *
- * The dataFiles list must contain TableDataFile pointers whose columnStats
- * are currently NIL; this function appends to dataFile->stats.columnStats.
+ * filesByPath is the caller's path -> TableDataFileHashEntry hash (as built
+ * by GetTableDataFilesByPathHashFromCatalog / CreateDataFilesByPathHash);
+ * every TableDataFile in dataFiles must be the &entry->dataFile of an entry
+ * in filesByPath so we can dispatch each SPI result row back to its target
+ * in O(1) instead of walking dataFiles per row.
  */
 void
-LoadColumnStatsForFiles(Oid relationId, List *dataFiles)
+LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPath, List *dataFiles)
 {
 	if (dataFiles == NIL)
 		return;
@@ -482,6 +482,29 @@ LoadColumnStatsForFiles(Oid relationId, List *dataFiles)
 			continue;
 		}
 
+		TableDataFileHashEntry *entry =
+			(TableDataFileHashEntry *) hash_search(filesByPath, path,
+												   HASH_FIND, NULL);
+
+		if (entry == NULL)
+		{
+			/*
+			 * Stats row points at a path that isn't in the caller's hash.
+			 * Shouldn't happen given the WHERE path = ANY($2) filter, but
+			 * tolerate it to avoid crashing on a corrupt catalog.
+			 */
+			MemoryContextSwitchTo(spiContext);
+			continue;
+		}
+
+		TableDataFile *dataFile = &entry->dataFile;
+
+		if (ColumnStatAlreadyAdded(dataFile->stats.columnStats, fieldId))
+		{
+			MemoryContextSwitchTo(spiContext);
+			continue;
+		}
+
 		bool		isPgTypeNull = false;
 		bool		isPgTypeModNull = false;
 
@@ -505,29 +528,10 @@ LoadColumnStatsForFiles(Oid relationId, List *dataFiles)
 		if (!isUpperBoundNull)
 			upperBoundText = TextDatumGetCString(upperBoundDatum);
 
-		/*
-		 * Walk the caller's list to find the matching struct. dataFiles is
-		 * expected to be small (typically 1-2 entries per transaction), so a
-		 * linear search is fine and avoids an extra pointer-valued hash.
-		 */
-		ListCell   *lc = NULL;
+		DataFileColumnStats *columnStats =
+			CreateDataFileColumnStats(fieldId, pgType, lowerBoundText, upperBoundText);
 
-		foreach(lc, dataFiles)
-		{
-			TableDataFile *dataFile = lfirst(lc);
-
-			if (strcmp(dataFile->path, path) != 0)
-				continue;
-
-			if (ColumnStatAlreadyAdded(dataFile->stats.columnStats, fieldId))
-				break;
-
-			DataFileColumnStats *columnStats =
-				CreateDataFileColumnStats(fieldId, pgType, lowerBoundText, upperBoundText);
-
-			dataFile->stats.columnStats = lappend(dataFile->stats.columnStats, columnStats);
-			break;
-		}
+		dataFile->stats.columnStats = lappend(dataFile->stats.columnStats, columnStats);
 
 		MemoryContextSwitchTo(spiContext);
 	}

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -489,12 +489,16 @@ LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPath, List *dataFiles)
 		if (entry == NULL)
 		{
 			/*
-			 * Stats row points at a path that isn't in the caller's hash.
-			 * Shouldn't happen given the WHERE path = ANY($2) filter, but
-			 * tolerate it to avoid crashing on a corrupt catalog.
+			 * SPI filters with WHERE s.path = ANY($2), so every returned row
+			 * should resolve through filesByPath (built from the same path
+			 * set). A miss is an internal inconsistency (catalog vs in-memory
+			 * map), not a user error.
 			 */
-			MemoryContextSwitchTo(spiContext);
-			continue;
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("internal error: column stats row does not map to any tracked data file path"),
+					 errdetail("SPI returned statistics for path \"%s\", field_id %lld, relation OID %u, but that path is missing from the caller's path-to-file hash (the query was restricted with WHERE path = ANY($2)). This usually indicates inconsistent lake_table.data_file_column_stats data or an extension bug.",
+							   path, (long long) fieldId, relationId)));
 		}
 
 		TableDataFile *dataFile = &entry->dataFile;

--- a/pg_lake_table/src/init.c
+++ b/pg_lake_table/src/init.c
@@ -44,6 +44,7 @@
 #include "pg_lake/util/s3_file_utils.h"
 #include "pg_lake/test/hide_lake_objects.h"
 #include "pg_lake/transaction/transaction_hooks.h"
+#include "pg_lake/transaction/track_iceberg_metadata_changes.h"
 #include "utils/guc.h"
 
 #define GUC_STANDARD 0
@@ -153,6 +154,20 @@ _PG_init(void)
 							 NULL,
 							 NULL);
 
+	DefineCustomIntVariable("pg_lake_table.commit_time_analyze_threshold",
+							"Number of data-file ADD/REMOVE ops in one transaction "
+							"that triggers commit-time ANALYZE on the pg_lake catalogs. "
+							"REMOVE_ALL always triggers ANALYZE.",
+							NULL,
+							&CommitTimeCatalogAnalyzeThreshold,
+							1000,
+							1,
+							INT_MAX,
+							PGC_USERSET,
+							GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
 
 	DefineCustomIntVariable("pg_lake_table.copy_on_write_threshold",
 							"Determines the percentage of deleted rows in a file "

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -83,11 +83,14 @@ typedef struct RestCatalogRequestPerTable
 	List	   *tableModifyRequests;
 }			RestCatalogRequestPerTable;
 
+/* GUC: see pg_lake_table.commit_time_analyze_threshold in init.c. */
+int			CommitTimeCatalogAnalyzeThreshold = 1000;
+
 static void ApplyTrackedIcebergMetadataChanges(bool isVerbose);
 static void RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operationType);
 static void InitTableMetadataTrackerHashIfNeeded(void);
 static void InitRestCatalogRequestsHashIfNeeded(void);
-static bool AnyTrackedRelationChangedDataFiles(HTAB *trackedRelations);
+static bool ShouldRunCommitTimeAnalyze(HTAB *trackedRelations);
 static void EnsureFreshStatsForCommitTimeDiff(void);
 static HTAB *CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata);
 static void FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
@@ -494,8 +497,12 @@ RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operat
 			break;
 		case DATA_FILE_ADD:
 		case DATA_FILE_REMOVE:
+			opTracker->relationDataFileChanged = true;
+			opTracker->dataFileChangeCount++;
+			break;
 		case DATA_FILE_REMOVE_ALL:
 			opTracker->relationDataFileChanged = true;
+			opTracker->forceCommitTimeAnalyze = true;
 			break;
 		case DATA_FILE_MERGE_MANIFESTS:
 			opTracker->relationManifestMergeRequested = true;
@@ -729,10 +736,11 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 	 * pick an N^2 nested loop for a query whose result is comfortably
 	 * hash-join-able, blowing commit time up by orders of magnitude.
 	 *
-	 * Only worth doing if at least one tracked relation actually has data
-	 * file changes — DDL-only or noop trackers skip the diff entirely.
+	 * Gated by pg_lake_table.commit_time_analyze_threshold: DDL-only or noop
+	 * trackers skip the diff entirely, and small inserts skip ANALYZE because
+	 * the cliff only matters once the catalogs hold many rows.
 	 */
-	if (AnyTrackedRelationChangedDataFiles(trackedRelations))
+	if (ShouldRunCommitTimeAnalyze(trackedRelations))
 	{
 		EnsureFreshStatsForCommitTimeDiff();
 	}
@@ -842,28 +850,37 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 
 
 /*
- * AnyTrackedRelationChangedDataFiles returns true if at least one tracked
- * relation has data-file changes that will trigger the commit-time diff
- * query. We use this to gate the upfront ANALYZE: DDL-only or noop trackers
- * shouldn't pay even the few-ms ANALYZE cost.
+ * ShouldRunCommitTimeAnalyze decides whether ANALYZE is worth running
+ * before the per-table data-file diff query. It says yes when:
+ *
+ *   - any tracked relation saw DATA_FILE_REMOVE_ALL (one op, but maps
+ *     to thousands of catalog deletes — always blow away stale stats), or
+ *   - the total number of single-file ADD/REMOVE ops across all tracked
+ *     relations reaches pg_lake_table.commit_time_analyze_threshold.
+ *
+ * Small commits (a handful of files) skip ANALYZE entirely so they don't
+ * pay its non-incremental resampling cost on every transaction.
  */
 static bool
-AnyTrackedRelationChangedDataFiles(HTAB *trackedRelations)
+ShouldRunCommitTimeAnalyze(HTAB *trackedRelations)
 {
 	HASH_SEQ_STATUS status;
 	TableMetadataOperationTracker *opTracker;
+	int64		totalChanges = 0;
 
 	hash_seq_init(&status, trackedRelations);
 	while ((opTracker = hash_seq_search(&status)) != NULL)
 	{
-		if (opTracker->relationDataFileChanged)
+		if (opTracker->forceCommitTimeAnalyze)
 		{
 			hash_seq_term(&status);
 			return true;
 		}
+
+		totalChanges += opTracker->dataFileChangeCount;
 	}
 
-	return false;
+	return totalChanges >= CommitTimeCatalogAnalyzeThreshold;
 }
 
 

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -22,6 +22,7 @@
 
 #include "pg_lake/cleanup/in_progress_files.h"
 #include "pg_lake/data_file/data_files.h"
+#include "pg_lake/fdw/data_file_stats_catalog.h"
 #include "pg_lake/fdw/data_files_catalog.h"
 #include "pg_lake/fdw/partition_transform.h"
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"
@@ -40,6 +41,8 @@
 #include "pg_lake/util/s3_writer_utils.h"
 #include "pg_lake/util/url_encode.h"
 #include "pg_lake/parsetree/options.h"
+#include "pg_extension_base/spi_helpers.h"
+#include "executor/spi.h"
 #include "commands/defrem.h"
 #include "foreign/foreign.h"
 #include "utils/builtins.h"
@@ -84,6 +87,8 @@ static void ApplyTrackedIcebergMetadataChanges(bool isVerbose);
 static void RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operationType);
 static void InitTableMetadataTrackerHashIfNeeded(void);
 static void InitRestCatalogRequestsHashIfNeeded(void);
+static bool AnyTrackedRelationChangedDataFiles(HTAB *trackedRelations);
+static void EnsureFreshStatsForCommitTimeDiff(void);
 static HTAB *CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata);
 static void FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
 										  List **addedFiles, List **removedFilePaths);
@@ -714,6 +719,24 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 		return;
 	}
 
+	/*
+	 * Refresh catalog stats before we run the per-table data-file diff query.
+	 * The diff joins lake_table.files against the partition-value and
+	 * column-stats catalogs; autovacuum does not fire inside an open
+	 * transaction, so on workloads that insert tens of thousands of files in
+	 * one tx the planner's pg_class.reltuples is wildly stale by the time
+	 * GetDataFileMetadataOperations runs. With stale stats the planner can
+	 * pick an N^2 nested loop for a query whose result is comfortably
+	 * hash-join-able, blowing commit time up by orders of magnitude.
+	 *
+	 * Only worth doing if at least one tracked relation actually has data
+	 * file changes — DDL-only or noop trackers skip the diff entirely.
+	 */
+	if (AnyTrackedRelationChangedDataFiles(trackedRelations))
+	{
+		EnsureFreshStatsForCommitTimeDiff();
+	}
+
 	HASH_SEQ_STATUS status;
 	TableMetadataOperationTracker *opTracker;
 
@@ -815,6 +838,83 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 	INJECTION_POINT_COMPAT("after-apply-iceberg-changes");
 
 	ExternalHeavyAssertsOnIcebergMetadataChange();
+}
+
+
+/*
+ * AnyTrackedRelationChangedDataFiles returns true if at least one tracked
+ * relation has data-file changes that will trigger the commit-time diff
+ * query. We use this to gate the upfront ANALYZE: DDL-only or noop trackers
+ * shouldn't pay even the few-ms ANALYZE cost.
+ */
+static bool
+AnyTrackedRelationChangedDataFiles(HTAB *trackedRelations)
+{
+	HASH_SEQ_STATUS status;
+	TableMetadataOperationTracker *opTracker;
+
+	hash_seq_init(&status, trackedRelations);
+	while ((opTracker = hash_seq_search(&status)) != NULL)
+	{
+		if (opTracker->relationDataFileChanged)
+		{
+			hash_seq_term(&status);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/*
+ * EnsureFreshStatsForCommitTimeDiff runs ANALYZE on the high-cardinality
+ * pg_lake_table catalogs that the commit-time data-file diff joins:
+ *
+ *   - lake_table.files
+ *   - lake_table.data_file_partition_values
+ *   - lake_table.data_file_column_stats
+ *
+ * Autovacuum cannot run inside the current transaction, so on a tx that
+ * has just inserted many thousand rows into these catalogs the planner's
+ * estimate of their size is whatever it was at the start of the tx
+ * (often zero, for a freshly created iceberg table, or stale for one
+ * with frequent DROP/CREATE churn). The diff query
+ * GetTableDataFilesHashFromCatalog joins files LEFT JOIN
+ * data_file_partition_values, and LoadColumnStatsForFiles joins
+ * data_file_column_stats against pg_attribute via field_id_mappings.
+ * With wrong row estimates the planner happily picks nested loops, which
+ * become quadratic as the catalogs grow within the transaction.
+ *
+ * The lower-cardinality catalogs (partition_fields, field_id_mappings)
+ * are intentionally skipped: they're small enough that even bad
+ * estimates don't change plan shape, and analyzing them per-commit adds
+ * latency without observable benefit.
+ *
+ * Cost: ANALYZE samples up to default_statistics_target * 300 rows; on
+ * these catalogs that's well under 50ms total even when there's nothing
+ * to do, which is why the caller gates this on AnyTrackedRelationChangedDataFiles().
+ */
+static void
+EnsureFreshStatsForCommitTimeDiff(void)
+{
+	const char *cmd =
+		"ANALYZE "
+		DATA_FILES_TABLE_QUALIFIED ", "
+		DATA_FILE_PARTITION_VALUES_TABLE_QUALIFIED ", "
+		DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED;
+
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+
+	int			spiStatus = SPI_execute(cmd, false /* readOnly */ , 0);
+
+	if (spiStatus < 0)
+		ereport(ERROR,
+				(errmsg("pg_lake: ANALYZE on commit-time catalogs failed"),
+				 errdetail("SPI_execute(\"%s\") returned %s",
+						   cmd, SPI_result_code_string(spiStatus))));
+
+	SPI_END();
 }
 
 

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1153,7 +1153,7 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	 * manifest DELETE entry carries only the path — so this is bounded by
 	 * the actual write size rather than by total files in the changelog.
 	 */
-	LoadColumnStatsForFiles(opTracker->relationId, addedFiles);
+	LoadColumnStatsForFiles(opTracker->relationId, currentFilesMap, addedFiles);
 
 	/*
 	 * We have found the new files that are added since the last metadata


### PR DESCRIPTION
Two commits, both gating the same problem: the commit-time diff query joins three `lake_table` catalogs that the same tx has been bulk-inserting into, but `autovacuum` can't run inside an open tx, so the planner's `reltuples` is stale (often 0 on a freshly created table) and it picks an N² nested loop on a query that's comfortably hash-joinable. 

On 24k files in one tx that's hours.

1. ANALYZE `pg_lake` catalogs before commit-time diff — adds a cheap SPI ANALYZE lake_table.files, `lake_table.data_file_partition_values`, `lake_table.data_file_column_stats` before `GetDataFileMetadataOperations` runs. Gated on at least one tracked relation actually changing data files, so DDL-only trackers don't pay it.

2. gate commit-time ANALYZE on data-file change count — adds hidden GUC `pg_lake_table.commit_time_analyze_threshold` (default 1000) so small commits skip `ANALYZE` (its cost is non-incremental and amortizes badly on hot-loop workloads). `DATA_FILE_REMOVE_ALL` (e.g., TRUNCATE/DROP) forces `ANALYZE` regardless because that one op fans out to thousands of catalog deletes.

Bench, 60 × 400 = 24k files in one tx, local PG17 + MinIO:

```
                 main       this PR
COMMIT           2505.8 s   47.7 s     ~52x
LOAD (60 COPYs)   946.8 s   907.7 s    unchanged
```