### PR TITLE
pg_lake_table: O(1) hash dispatch in LoadColumnStatsForFiles

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -48,7 +48,8 @@ HTAB	   *GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool ne
 HTAB	   *GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnly,
 												   bool forUpdate, char *orderBy, Snapshot snapshot,
 												   List *partitionTransforms, bool skipColumnStats);
-extern PGDLLEXPORT void LoadColumnStatsForFiles(Oid relationId, List *dataFiles);
+extern PGDLLEXPORT void LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPath,
+												List *dataFiles);
 extern PGDLLEXPORT List *GetPossiblePositionDeleteFilesFromCatalog(Oid relationId, List *sourcePathList,
 																   Snapshot snapshot);
 extern PGDLLEXPORT int64 GetTableSizeFromCatalog(Oid relationId);

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -407,17 +407,17 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 
 
 /*
- * LoadColumnStatsForFiles fills in per-column min/max stats for the given
- * data files, targeting only their paths. This lets callers pair a stats-free
- * bulk read (GetTableDataFilesHashFromCatalog with skipColumnStats=true) with
- * a narrow stats load for just the files that actually need them (e.g. the
- * handful of newly added files in a transaction).
+ * LoadColumnStatsForFiles fetches per-column min/max stats for the data files
+ * in dataFiles and appends them to each dataFile->stats.columnStats list.
  *
- * The dataFiles list must contain TableDataFile pointers whose columnStats
- * are currently NIL; this function appends to dataFile->stats.columnStats.
+ * filesByPath is the caller's path -> TableDataFileHashEntry hash (as built
+ * by GetTableDataFilesByPathHashFromCatalog / CreateDataFilesByPathHash);
+ * every TableDataFile in dataFiles must be the &entry->dataFile of an entry
+ * in filesByPath so we can dispatch each SPI result row back to its target
+ * in O(1) instead of walking dataFiles per row.
  */
 void
-LoadColumnStatsForFiles(Oid relationId, List *dataFiles)
+LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPath, List *dataFiles)
 {
 	if (dataFiles == NIL)
 		return;
@@ -482,6 +482,29 @@ LoadColumnStatsForFiles(Oid relationId, List *dataFiles)
 			continue;
 		}
 
+		TableDataFileHashEntry *entry =
+			(TableDataFileHashEntry *) hash_search(filesByPath, path,
+												   HASH_FIND, NULL);
+
+		if (entry == NULL)
+		{
+			/*
+			 * Stats row points at a path that isn't in the caller's hash.
+			 * Shouldn't happen given the WHERE path = ANY($2) filter, but
+			 * tolerate it to avoid crashing on a corrupt catalog.
+			 */
+			MemoryContextSwitchTo(spiContext);
+			continue;
+		}
+
+		TableDataFile *dataFile = &entry->dataFile;
+
+		if (ColumnStatAlreadyAdded(dataFile->stats.columnStats, fieldId))
+		{
+			MemoryContextSwitchTo(spiContext);
+			continue;
+		}
+
 		bool		isPgTypeNull = false;
 		bool		isPgTypeModNull = false;
 
@@ -505,29 +528,10 @@ LoadColumnStatsForFiles(Oid relationId, List *dataFiles)
 		if (!isUpperBoundNull)
 			upperBoundText = TextDatumGetCString(upperBoundDatum);
 
-		/*
-		 * Walk the caller's list to find the matching struct. dataFiles is
-		 * expected to be small (typically 1-2 entries per transaction), so a
-		 * linear search is fine and avoids an extra pointer-valued hash.
-		 */
-		ListCell   *lc = NULL;
+		DataFileColumnStats *columnStats =
+			CreateDataFileColumnStats(fieldId, pgType, lowerBoundText, upperBoundText);
 
-		foreach(lc, dataFiles)
-		{
-			TableDataFile *dataFile = lfirst(lc);
-
-			if (strcmp(dataFile->path, path) != 0)
-				continue;
-
-			if (ColumnStatAlreadyAdded(dataFile->stats.columnStats, fieldId))
-				break;
-
-			DataFileColumnStats *columnStats =
-				CreateDataFileColumnStats(fieldId, pgType, lowerBoundText, upperBoundText);
-
-			dataFile->stats.columnStats = lappend(dataFile->stats.columnStats, columnStats);
-			break;
-		}
+		dataFile->stats.columnStats = lappend(dataFile->stats.columnStats, columnStats);
 
 		MemoryContextSwitchTo(spiContext);
 	}

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -489,12 +489,16 @@ LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPath, List *dataFiles)
 		if (entry == NULL)
 		{
 			/*
-			 * Stats row points at a path that isn't in the caller's hash.
-			 * Shouldn't happen given the WHERE path = ANY($2) filter, but
-			 * tolerate it to avoid crashing on a corrupt catalog.
+			 * SPI filters with WHERE s.path = ANY($2), so every returned row
+			 * should resolve through filesByPath (built from the same path
+			 * set). A miss is an internal inconsistency (catalog vs in-memory
+			 * map), not a user error.
 			 */
-			MemoryContextSwitchTo(spiContext);
-			continue;
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("internal error: column stats row does not map to any tracked data file path"),
+					 errdetail("SPI returned statistics for path \"%s\", field_id %lld, relation OID %u, but that path is missing from the caller's path-to-file hash (the query was restricted with WHERE path = ANY($2)). This usually indicates inconsistent lake_table.data_file_column_stats data or an extension bug.",
+							   path, (long long) fieldId, relationId)));
 		}
 
 		TableDataFile *dataFile = &entry->dataFile;

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1153,7 +1153,7 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	 * manifest DELETE entry carries only the path — so this is bounded by
 	 * the actual write size rather than by total files in the changelog.
 	 */
-	LoadColumnStatsForFiles(opTracker->relationId, addedFiles);
+	LoadColumnStatsForFiles(opTracker->relationId, currentFilesMap, addedFiles);
 
 	/*
 	 * We have found the new files that are added since the last metadata


### PR DESCRIPTION
`LoadColumnStatsForFiles`  is called once at commit time from `GetDataFileMetadataOperations`
 with the list of files added in the transaction. For each `(path, field_id)` row returned by the SPI query against `lake_table.data_file_column_stats` it has to find the matching caller-owned `TableDataFile*` and append a `DataFileColumnStats` to its `stats.columnStats` list.

The previous implementation walked the entire dataFiles list per result row with strcmp:
```C
    foreach(lc, dataFiles)
    {
        TableDataFile *dataFile = lfirst(lc);
        if (strcmp(dataFile->path, path) != 0)
            continue;
        ...
        break;
    }
```

That comment ("typically 1-2 entries per transaction") was true for small interactive workloads but is dramatically wrong for any append- heavy iceberg write: an Iceberg table partitioned on `(client_id, month(ordered_date))` over a year of data lands tens of thousands of files per transaction, and each file has ~6 columns worth of stats. The fill loop is then `N files` * `(N * C)` inner iterations -- quadratic in the number of files.

Fix: the caller `GetDataFileMetadataOperations` already builds a `path` -> `TableDataFile` hash for the diff. Thread that hash through to `LoadColumnStatsForFiles` and dispatch each SPI row to its target file with one hash_search(HASH_FIND).


The 14x commit drop is the targeted win. Empirical, 60 batches x 400 files = 24000 files in one tx, local PG17
+ MinIO, on top of the previous ANALYZE + threshold commits:
```
  step               threshold-gate   this commit
  -----------------+-----------------+-------------
  COMMIT              47.7 s           3.5 s
```
