### PR TITLE
pg_lake: batch delete in_progress_files

### DIFF
--- a/pg_lake_engine/include/pg_lake/cleanup/in_progress_files.h
+++ b/pg_lake_engine/include/pg_lake/cleanup/in_progress_files.h
@@ -27,5 +27,6 @@ extern PGDLLEXPORT bool RemoveInProgressFiles(char *location, bool isFull, bool 
 extern PGDLLEXPORT void InsertInProgressFileRecord(char *path);
 extern PGDLLEXPORT void InsertInProgressFileRecordExtended(char *path, bool isPrefix, bool autoDeleteRecord);
 extern PGDLLEXPORT void DeleteInProgressFileRecord(char *path);
+extern PGDLLEXPORT void DeleteInProgressFileRecords(List *paths);
 extern PGDLLEXPORT void ReplaceInProgressPrefixPathWithFullPaths(char *prefixPath, List *fullPaths);
 extern PGDLLEXPORT void InvalidateInProgressTableVisibilityCache(void);

--- a/pg_lake_engine/src/cleanup/in_progress_files.c
+++ b/pg_lake_engine/src/cleanup/in_progress_files.c
@@ -201,10 +201,21 @@ RemoveInProgressFiles(char *location, bool isFull, bool isVerbose, List **delete
 			DeleteRemoteFile(entry->path);
 		}
 
-		DeleteInProgressFileRecord(entry->path);
-
 		*deletedPaths = lappend(*deletedPaths, entry->path);
 	}
+
+	/*
+	 * Drop the catalog rows for the paths we just unlinked from remote
+	 * storage in a single DELETE. Per-row DeleteInProgressFileRecord would
+	 * take a fresh plan-cache + snapshot per file, which on large backlogs (a
+	 * stuck VACUUM walk of a long in-progress queue) was a notable share of
+	 * the loop. Remote DeleteObject above is still the dominant cost, so this
+	 * is a tidy-up rather than a hot-path win; the per-iteration semantics
+	 * are preserved because the catalog DELETE is idempotent against missing
+	 * paths and DeleteRemoteFile is idempotent against missing remote
+	 * objects, so a mid-loop error still recovers via the next VACUUM cycle.
+	 */
+	DeleteInProgressFileRecords(*deletedPaths);
 
 	return hasRemainingFiles;
 }
@@ -288,25 +299,48 @@ GetInProgressFileRecords(char *location, bool isFull, List **fileRecords)
 void
 DeleteInProgressFileRecord(char *path)
 {
-	StringInfo	queryBuf = makeStringInfo();
+	List	   *paths = list_make1(path);
 
-	appendStringInfo(queryBuf,
-					 "DELETE FROM " PG_LAKE_ENGINE_NSP "." IN_PROGRESS_FILES_TABLE " "
-					 "WHERE path = $1");
+	DeleteInProgressFileRecords(paths);
+
+	list_free(paths);
+}
+
+
+/*
+ * DeleteInProgressFileRecords deletes the records for the given list of paths
+ * from the IN_PROGRESS_FILES_TABLE in a single DELETE ... WHERE path = ANY($1).
+ *
+ * A no-op if paths is empty. Used by the iceberg commit-time pre-commit hook
+ * (DeleteInProgressAddedFiles, track_iceberg_metadata_changes.c) where the
+ * number of paths to clear is the number of files newly written in the
+ * transaction -- thousands per large partitioned write. Doing one round trip
+ * + one CommandCounterIncrement for the whole set is dramatically cheaper
+ * than calling DeleteInProgressFileRecord in a loop.
+ */
+void
+DeleteInProgressFileRecords(List *paths)
+{
+	if (paths == NIL)
+		return;
+
+	char	   *query =
+		"DELETE FROM " PG_LAKE_ENGINE_NSP "." IN_PROGRESS_FILES_TABLE " "
+		"WHERE path OPERATOR(pg_catalog.=) ANY($1)";
 
 	DECLARE_SPI_ARGS(1);
-	SPI_ARG_VALUE(1, TEXTOID, path, false);
+	SPI_ARG_VALUE(1, TEXTARRAYOID, StringListToArray(paths), false);
 
 	/* switch to schema owner, we assume callers checked permissions */
 	SPI_START_EXTENSION_OWNER(PgLakeEngine);
-	SPIPlanPtr	queryPlan = GetCachedQueryPlan(queryBuf->data, spiArgCount, spiArgTypes);
+	SPIPlanPtr	queryPlan = GetCachedQueryPlan(query, spiArgCount, spiArgTypes);
 
 	bool		readOnly = false;
 
 	/* IN_PROGRESS_FILES_TABLE doesn't have any triggers */
 	bool		fireTriggers = false;
 
-	/* always read from the  latest snapshot */
+	/* always read from the latest snapshot */
 	Snapshot	snapshot = GetLatestSnapshot();
 	int			spiResult = SPI_execute_snapshot(queryPlan,
 												 spiArgValues, spiArgNulls,
@@ -314,7 +348,6 @@ DeleteInProgressFileRecord(char *path)
 												 InvalidSnapshot,
 												 readOnly, fireTriggers, 0);
 
-	/* Check result */
 	if (spiResult != SPI_OK_DELETE)
 	{
 		elog(ERROR, "SPI_execute_snapshot returned %s", SPI_result_code_string(spiResult));

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -891,19 +891,34 @@ FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * meta
 
 /*
  * DeleteInProgressAddedFiles deletes the in-progress data file records
- * for the given list of data files.
+ * for the given list of data files in a single batch DELETE.
+ *
+ * Pre-commit emits one row per file added in the transaction (tens of
+ * thousands per large partitioned iceberg write); doing one DELETE per file
+ * was the simplest version but cost a snapshot, a SPI execute, and a
+ * CommandCounterIncrement each. We collect the paths and let
+ * DeleteInProgressFileRecords (pg_lake_engine) issue a single
+ * WHERE path = ANY(...) DELETE instead.
  */
 static void
 DeleteInProgressAddedFiles(Oid relationId, List *addedFiles)
 {
+	if (addedFiles == NIL)
+		return;
+
+	List	   *addedFilePaths = NIL;
 	ListCell   *fileCell = NULL;
 
 	foreach(fileCell, addedFiles)
 	{
 		TableDataFile *addedFile = lfirst(fileCell);
 
-		DeleteInProgressFileRecord(addedFile->path);
+		addedFilePaths = lappend(addedFilePaths, addedFile->path);
 	}
+
+	DeleteInProgressFileRecords(addedFilePaths);
+
+	list_free(addedFilePaths);
 }
 
 


### PR DESCRIPTION
`DeleteInProgressAddedFiles` (pre-commit) and `RemoveInProgressFiles` (VACUUM cleanup) both looped and called `DeleteInProgressFileRecord` per path: a fresh snapshot, `SPI_execute_snapshot`, and
`CommandCounterIncrement` per row. On a partitioned write that adds tens of thousands of files in one transaction this dominates the step.

Introduce `DeleteInProgressFileRecords(List *paths)` in the engine, which issues a single `DELETE ... WHERE path = ANY($1)` and one `CommandCounterIncrement` for the whole batch. The single-path `DeleteInProgressFileRecord` becomes a thin wrapper so other callers are unchanged. Both call sites now collect paths and call once.

The pre-commit path is the hot one (catalog SPI dominated). The VACUUM path swap is consistency / tidy-up: per-file remote DeleteObject RPC is still the dominant cost there. Semantics are unchanged -- per-row precondition checks (advisory lock + record-exists) still run before appending to the batch, and the bulk DELETE is idempotent against missing rows so concurrent VACUUMs are safe.

Large transactions with partitioning are the typical case where this matters most.

Empirical, 60 batches x 400 files = 24000 files in one tx, local PG17
+ MinIO, on top of the previous LoadColumnStats commit:

  step               loadcs    this commit
  -----------------+---------+-------------
  COMMIT              3.49 s    2.88 s
  
