### PR TITLE
pg_lake_table: bulk-INSERT data file catalog changes

### DIFF
--- a/pg_lake_engine/include/pg_lake/util/array_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/array_utils.h
@@ -27,3 +27,5 @@ extern PGDLLEXPORT List *Int64ArrayToList(ArrayType *array);
 extern PGDLLEXPORT ArrayType *StringListToArray(List *stringList);
 extern PGDLLEXPORT ArrayType *INT16ListToArray(List *stringList);
 extern PGDLLEXPORT ArrayType *OidListToArray(List *oidList);
+extern PGDLLEXPORT ArrayType *MakeArrayFromDatums(Datum *datums, bool *nulls, int count,
+												  Oid elementType);

--- a/pg_lake_engine/src/utils/array_utils.c
+++ b/pg_lake_engine/src/utils/array_utils.c
@@ -66,8 +66,8 @@ INT16ListToArray(List *stringList)
 }
 
 /*
-* OidListToArray converts a list of OIDs to an oid array.
-*/
+ * OidListToArray converts a list of OIDs to an oid array.
+ */
 ArrayType *
 OidListToArray(List *oidList)
 {
@@ -76,7 +76,36 @@ OidListToArray(List *oidList)
 
 
 /*
-* Generic function to convert a list to an array.
+ * MakeArrayFromDatums builds a 1-D PostgreSQL array of `count` elements of
+ * `elementType` from a caller-provided Datum[]. Pass `nulls == NULL` for a
+ * "no nulls in this array" call - construct_md_array treats a NULL bitmap as
+ * all-not-null. Pass a real bool[] of length `count` when any element may be
+ * SQL NULL. Use this whenever ListToArray's "single fixed type, never null"
+ * shape is too narrow.
+ *
+ * Inspired by construct_md_array in src/backend/utils/adt/arrayfuncs.c; this
+ * is a 1-D shortcut that does the get_typlenbyvalalign for the caller. There
+ * is no exported one-liner in core that does exactly this, so the
+ * port-from-postgres-source skill's "reimplement + cite" applies.
+ */
+ArrayType *
+MakeArrayFromDatums(Datum *datums, bool *nulls, int count, Oid elementType)
+{
+	int16		typlen;
+	bool		typbyval;
+	char		typalign;
+	int			dims[1] = {count};
+	int			lbs[1] = {1};
+
+	get_typlenbyvalalign(elementType, &typlen, &typbyval, &typalign);
+
+	return construct_md_array(datums, nulls, 1, dims, lbs,
+							  elementType, typlen, typbyval, typalign);
+}
+
+
+/*
+ * Generic function to convert a list to an array.
 * The 'elementType' should be the type of the elements in the
 * list. Make sure the type is supported by the function.
 */

--- a/pg_lake_table/include/pg_lake/fdw/data_file_stats_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_file_stats_catalog.h
@@ -26,7 +26,4 @@
 #define DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED \
  	PG_LAKE_TABLE_SCHEMA "." PG_LAKE_TABLE_DATA_FILE_COLUMN_STATS_TABLE_NAME
 
-extern void AddDataFileColumnStatsToCatalog(Oid relationId, const char *path, List *columnStatsList);
-extern void AddDataFilePartitionValueToCatalog(Oid relationId, int32 partitionSpecId, int64 fileId,
-											   Partition * partition);
 extern bool DataFileColumnStatsCatalogExists(void);

--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -61,7 +61,6 @@ bool		PartitionFieldsCatalogExists(void);
 
 /* functions to write to files catalog */
 extern PGDLLEXPORT void ApplyDataFileCatalogChanges(Oid relationId, List *metadataOperations);
-int64		GenerateDataFileId(void);
 
 /* when enabling row_ids, we need to explicit update first_row_id */
 void		UpdateDataFileFirstRowId(Oid relationId, int64 fileId, int64 firstRowId);

--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog_internal.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog_internal.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Module-internal contract between data_files_catalog.c (the orchestrator
+ * in ApplyDataFileCatalogChanges) and data_files_catalog_batch.c (the bulk
+ * write path). Not part of the public extension API; do not include from
+ * other modules.
+ */
+
+#pragma once
+
+#include "pg_lake/data_file/data_files.h"
+#include "pg_lake/extensions/pg_lake_table.h"
+
+#include "nodes/pg_list.h"
+
+/*
+ * Per-tx temp table populated by the bulk path with the ids of newly-added
+ * data files that PgLakeAddDataFileHook opted in. Read by the old per-row
+ * catalog code in data_files_catalog.c, written by data_files_catalog_batch.c.
+ */
+#define TX_DATA_FILES_QUALIFIED_TABLE_NAME PG_LAKE_TABLE_SCHEMA "tx_data_file_ids"
+
+/* True when adjacent ops of this type can be collapsed into one bulk SQL. */
+bool		BatchableType(TableMetadataOperationType type);
+
+/* Apply a run of same-typed batchable ops to the files catalog. */
+void		ApplyDataFileBatch(Oid relationId, TableMetadataOperationType type, List *batch);

--- a/pg_lake_table/src/fdw/data_file_stats_catalog.c
+++ b/pg_lake_table/src/fdw/data_file_stats_catalog.c
@@ -32,56 +32,9 @@
 
 
 /*
- * AddDataFileColumnStatsToCatalog inserts column stats for a data file into
- * lake_table.data_file_column_stats.
+ * DataFileColumnStatsCatalogExists checks if the
+ * lake_table.data_file_column_stats catalog exists.
  */
-void
-AddDataFileColumnStatsToCatalog(Oid relationId, const char *path, List *columnStatsList)
-{
-	ListCell   *columnStatsCell = NULL;
-
-	foreach(columnStatsCell, columnStatsList)
-	{
-		DataFileColumnStats *columnStats = lfirst(columnStatsCell);
-
-		/*
-		 * do not insert stats if bounds are empty. (we do not write them to
-		 * iceberg metadata as well)
-		 */
-		if (columnStats->lowerBoundText == NULL)
-		{
-			Assert(columnStats->upperBoundText == NULL);
-			continue;
-		}
-
-		char	   *query =
-			"insert into " DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED " "
-			"(table_name, path, field_id, lower_bound, upper_bound) "
-			"values ($1,$2,$3,$4,$5)";
-
-		DECLARE_SPI_ARGS(5);
-		SPI_ARG_VALUE(1, OIDOID, relationId, false);
-		SPI_ARG_VALUE(2, TEXTOID, path, false);
-		SPI_ARG_VALUE(3, INT8OID, columnStats->leafField.fieldId, false);
-		SPI_ARG_VALUE(4, TEXTOID, columnStats->lowerBoundText, columnStats->lowerBoundText == NULL);
-		SPI_ARG_VALUE(5, TEXTOID, columnStats->upperBoundText, columnStats->upperBoundText == NULL);
-
-		/* switch to schema owner, we assume callers checked permissions */
-		SPI_START_EXTENSION_OWNER(PgLakeTable);
-
-		bool		readOnly = false;
-
-		SPI_EXECUTE(query, readOnly);
-
-		SPI_END();
-	}
-}
-
-
- /*
-  * DataFileColumnStatsCatalogExists checks if the
-  * lake_table.data_file_column_stats catalog exists.
-  */
 bool
 DataFileColumnStatsCatalogExists(void)
 {

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -24,7 +24,6 @@
 #include "catalog/pg_class.h"
 #include "catalog/pg_namespace.h"
 #include "commands/defrem.h"
-#include "commands/sequence.h"
 #include "pg_lake/csv/csv_options.h"
 #include "pg_lake/data_file/data_files.h"
 #include "pg_lake/data_file/data_file_stats.h"
@@ -33,6 +32,7 @@
 #include "pg_lake/extensions/pg_lake_engine.h"
 #include "pg_lake/fdw/catalog/row_id_mappings.h"
 #include "pg_lake/fdw/data_files_catalog.h"
+#include "pg_lake/fdw/data_files_catalog_internal.h"
 #include "pg_lake/fdw/data_file_stats_catalog.h"
 #include "pg_lake/fdw/schema_operations/field_id_mapping_catalog.h"
 #include "pg_lake/fdw/writable_table.h"
@@ -67,8 +67,6 @@
 #include "utils/syscache.h"
 
 #define DELETION_FILE_MAP_TABLE PG_LAKE_TABLE_SCHEMA ".deletion_file_map"
-#define DATA_FILES_ID_SEQUENCE_NAME "files_id_seq"
-#define TX_DATA_FILES_QUALIFIED_TABLE_NAME PG_LAKE_TABLE_SCHEMA "tx_data_file_ids"
 
 
 /* global hook override */
@@ -78,8 +76,6 @@ PgLakeAddDataFileHookType PgLakeAddDataFileHook = NULL;
 static void FillDataFileColumnStats(TableDataFile * dataFile, int64 fieldId, int rowIndex);
 static void FillPartitionFieldFromCatalog(TableDataFile * dataFile, List *partitionTransforms,
 										  int64 partitionFieldId, int rowIndex);
-static int64 AddDataFileToTable(Oid relationId, const char *path, int64 rowCount,
-								int64 fileSize, DataFileContent content, int64 rowIdStart);
 static void AddDeletionFileMapping(Oid relationId, const char *path,
 								   const char *sourcePath);
 static void AddNewRowIdMapping(Oid relationId, const char *path, List *rowIdRanges);
@@ -92,11 +88,12 @@ static HTAB *CreateDataFilesByPathHash(void);
 static List *TableDataFileHashToList(HTAB *dataFiles);
 static bool ColumnStatAlreadyAdded(List *columnStats, int64 fieldId);
 static bool PartitionFieldAlreadyAdded(Partition * partition, int64 fieldId);
-static void CreateTxDataFileIdsTempTableIfNotExists(void);
-static void InsertDataFileIdIntoTransactionTable(int64 fileId);
 static DataFileColumnStats * CreateDataFileColumnStats(int fieldId, PGType pgType,
 													   char *lowerBoundText,
 													   char *upperBoundText);
+static void ApplySingleOp(Oid relationId, TableMetadataOperation * operation);
+static List *CollectAdjacentOpsOfType(List *operations, ListCell **cursor,
+									  TableMetadataOperationType runType);
 
 /*
  * GetTableDataFilesFromCatalog returns a list of TableDataFile for each data and deletion file
@@ -922,62 +919,6 @@ GetTotalDeletedRowCountFromCatalog(Oid relationId)
 
 
 /*
- * AddDataFileToTable inserts a new file URL into lake_table.files
- *
- * content indicates whether this is a data file or deletion file.
- *
- * For deletion files, deletedFrom indicates which file we are deleting from (can
- * be NULL if deleting from multiple files/unknown).
- */
-static int64
-AddDataFileToTable(Oid relationId, const char *path, int64 rowCount, int64 fileSize,
-				   DataFileContent content, int64 rowIdStart)
-{
-	char	   *query =
-		"insert into " DATA_FILES_TABLE_QUALIFIED " "
-		"(id, table_name, path, row_count, file_size, content, first_row_id) "
-		"values ($1,$2,$3,$4,$5,$6,$7)";
-
-	int64		fileId = GenerateDataFileId();
-
-	DECLARE_SPI_ARGS(7);
-	SPI_ARG_VALUE(1, INT8OID, fileId, false);
-	SPI_ARG_VALUE(2, OIDOID, relationId, false);
-	SPI_ARG_VALUE(3, TEXTOID, path, false);
-	SPI_ARG_VALUE(4, INT8OID, rowCount, false);
-	SPI_ARG_VALUE(5, INT8OID, fileSize, false);
-	SPI_ARG_VALUE(6, INT4OID, (int) content, false);
-	SPI_ARG_VALUE(7, INT8OID, rowIdStart, rowIdStart == INVALID_ROW_ID);
-
-	/* switch to schema owner, we assume callers checked permissions */
-	SPI_START_EXTENSION_OWNER(PgLakeTable);
-
-	bool		readOnly = false;
-
-	SPI_EXECUTE(query, readOnly);
-
-	SPI_END();
-
-	return fileId;
-}
-
-
-/*
- * GenerateDataFileId returns a unique file number that can be used for insertion
- * into files.
- */
-int64
-GenerateDataFileId(void)
-{
-	bool		missingOk = false;
-	Oid			namespaceId = get_namespace_oid(PG_LAKE_TABLE_SCHEMA, missingOk);
-	Oid			sequenceId = get_relname_relid(DATA_FILES_ID_SEQUENCE_NAME, namespaceId);
-
-	return nextval_internal(sequenceId, false);
-}
-
-
-/*
  * AddDeletionFileMapping inserts a new deletion file -> source file mapping
  * that indicates the deletion file has at least 1 deletion from the source
  * file.
@@ -1301,216 +1242,126 @@ DataFilesPartitionValuesCatalogExists(void)
 
 
 /*
- * CreateTxDataFileIdsTempTableIfNotExists creates a temporary table
- * to track data file IDs that are being added in the current transaction.
- *
- * PostgreSQL forbids CREATE TEMP TABLE under SECURITY_RESTRICTED_OPERATION,
- * so we use the SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS variant
- * which omits the restricted-op flag.  The search_path lockdown stays in
- * effect; the DDL is a fixed string with no caller-supplied input.
- */
-static void
-CreateTxDataFileIdsTempTableIfNotExists(void)
-{
-	const char *query =
-		"create temporary table if not exists " TX_DATA_FILES_QUALIFIED_TABLE_NAME " "
-		"(id bigint primary key) USING heap ON COMMIT DELETE ROWS;";
-
-	SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS(PgLakeTable);
-
-	bool		readOnly = false;
-
-	SPI_execute(query, readOnly, 0);
-
-	SPI_END();
-}
-
-
-/*
- * InsertDataFileIdIntoTransactionTable records the data file IDs, that are being
- * added in the current transaction, into tx's temporary table.
- * It creates the table if it does not exist yet.
- */
-static void
-InsertDataFileIdIntoTransactionTable(int64 fileId)
-{
-	CreateTxDataFileIdsTempTableIfNotExists();
-
-	char	   *query =
-		"insert into " TX_DATA_FILES_QUALIFIED_TABLE_NAME " "
-		"(id) "
-		"values ($1)";
-
-	DECLARE_SPI_ARGS(1);
-	SPI_ARG_VALUE(1, INT8OID, fileId, false);
-
-	SPI_START_EXTENSION_OWNER(PgLakeTable);
-
-	bool		readOnly = false;
-
-	SPI_EXECUTE(query, readOnly);
-
-	SPI_END();
-}
-
-
-/*
- * ApplyDataFileCatalogChanges is the main work horse for metadata operations
- * on the files catalog.
+ * Drive the files-catalog write phase for one transaction's metadata ops.
+ * Coalesces adjacent runs of one batchable type into one bulk SQL; everything
+ * else goes one op at a time through ApplySingleOp.
  */
 void
 ApplyDataFileCatalogChanges(Oid relationId, List *metadataOperations)
 {
-	ListCell   *operationCell = NULL;
+	/*
+	 * Walk ops in their original order. We must never coalesce across a
+	 * non-ADD op: an ADD followed by a REMOVE/UPDATE/ADD_DELETE_MAPPING on
+	 * the same path needs the ADD already visible in lake_table.files, and
+	 * pulling non-adjacent ADDs into one INSERT would silently reorder ops
+	 * across non-ADDs. Hence the alternating-phase loop here.
+	 */
+	ListCell   *opCell = list_head(metadataOperations);
 
-	foreach(operationCell, metadataOperations)
+	while (opCell != NULL)
 	{
-		TableMetadataOperation *operation = lfirst(operationCell);
+		TableMetadataOperation *currentOp = lfirst(opCell);
+		TableMetadataOperationType runType = currentOp->type;
 
-		switch (operation->type)
+		if (BatchableType(runType))
 		{
-			case DATA_FILE_ADD:
-				{
-					int64		fileId = AddDataFileToTable(relationId,
-															operation->path,
-															operation->dataFileStats.rowCount,
-															operation->dataFileStats.fileSize,
-															operation->content,
-															operation->dataFileStats.rowIdStart);
+			/*
+			 * Hot path: a partitioned bulk INSERT emits a long run of
+			 * DATA_FILE_ADDs that collapses to one INSERT per catalog inside
+			 * ApplyDataFileBatch.
+			 */
+			List	   *adjacentOps = CollectAdjacentOpsOfType(metadataOperations,
+															   &opCell, runType);
 
-					/* add column stats only for data files */
-					List	   *columnStats = operation->dataFileStats.columnStats;
-
-					if (operation->content == CONTENT_DATA && columnStats != NIL)
-						AddDataFileColumnStatsToCatalog(relationId,
-														operation->path,
-														columnStats);
-
-					/*
-					 * Add partition values only for data files. Even if the
-					 * table is not partitioned, we record the partition spec
-					 * id as the table might be partitioned in the future.
-					 *
-					 * For non-partitioned tables, if the table has never been
-					 * partitioned, we record the partition spec id as 0,
-					 * which is the default spec id for non-partitioned
-					 * tables. If the table has been partitioned before, and
-					 * now it is not, we record the partition spec id as the
-					 * current/largest spec id.
-					 */
-					if (operation->partition != NULL &&
-						operation->partition->fields_length > 0 &&
-						(operation->content == CONTENT_DATA ||
-						 operation->content == CONTENT_POSITION_DELETES))
-					{
-						AddDataFilePartitionValueToCatalog(relationId,
-														   operation->partitionSpecId,
-														   fileId,
-														   operation->partition);
-					}
-
-					if (PgLakeAddDataFileHook)
-					{
-						if (operation->content == CONTENT_DATA && PgLakeAddDataFileHook())
-							/* add the file ID to the transaction's temp table */
-							InsertDataFileIdIntoTransactionTable(fileId);
-					}
-					break;
-				}
-
-			case DATA_FILE_ADD_DELETE_MAPPING:
-				AddDeletionFileMapping(relationId,
-									   operation->path,
-									   operation->deletedFrom);
-				break;
-
-			case DATA_FILE_ADD_ROW_ID_MAPPING:
-				AddNewRowIdMapping(relationId,
-								   operation->path,
-								   operation->rowIdRanges);
-				break;
-
-			case DATA_FILE_REMOVE:
-				RemoveDataFileFromTable(relationId, operation->path);
-				break;
-			case DATA_FILE_REMOVE_ALL:
-			case DATA_FILE_DROP_TABLE:
-				RemoveAllDataFilesFromCatalog(relationId);
-				break;
-			case DATA_FILE_UPDATE_DELETED_ROW_COUNT:
-				UpdateDeletedRowCount(relationId,
-									  operation->path,
-									  operation->dataFileStats.deletedRowCount);
-				break;
-
-			case DATA_FILE_MERGE_MANIFESTS:
-			case EXPIRE_OLD_SNAPSHOTS:
-			case TABLE_CREATE:
-			case TABLE_DDL:
-			case TABLE_PARTITION_BY:
-				/* no-op for non-iceberg tables */
-				/* we don't do anything for EXPIRE_OLD_SNAPSHOTS */
-				break;
-
-			default:
-				elog(ERROR, "unsupported operation (%d) on data file catalog",
-					 operation->type);
+			ApplyDataFileBatch(relationId, runType, adjacentOps);
+			list_free(adjacentOps);
+		}
+		else
+		{
+			ApplySingleOp(relationId, currentOp);
+			opCell = lnext(metadataOperations, opCell);
 		}
 	}
 }
 
 
 /*
-* AddDataFileColumnStatsToCatalog inserts the column stats for a data file
- * into the catalog.
+ * Consume adjacent operations whose type equals runType starting at *cursor,
+ * advancing *cursor past them.  Returns the consumed ops as a new list, which
+ * the caller is expected to list_free().
  */
-void
-AddDataFilePartitionValueToCatalog(Oid relationId, int32 partitionSpecId, int64 fileId,
-								   Partition * partition)
+static List *
+CollectAdjacentOpsOfType(List *operations, ListCell **cursor,
+						 TableMetadataOperationType runType)
 {
-	Assert(partition != NULL);
-	Assert(partition->fields_length > 0);
-	Assert(partition->fields != NULL);
-	Assert(partitionSpecId != DEFAULT_SPEC_ID);
+	List	   *adjacentOps = NIL;
 
-	/* we might be adding a file to an old partition spec */
-	List	   *transforms = AllPartitionTransformList(relationId);
-
-	/* switch to schema owner, we assume callers checked permissions */
-	SPI_START_EXTENSION_OWNER(PgLakeTable);
-
-	for (size_t fieldIndex = 0; fieldIndex < partition->fields_length; fieldIndex++)
+	while (*cursor != NULL)
 	{
-		PartitionField *partitionField = &partition->fields[fieldIndex];
+		TableMetadataOperation *op = lfirst(*cursor);
 
-		bool		errorIfMissing = true;
+		if (op->type != runType)
+			break;
 
-		IcebergPartitionTransform *transform =
-			FindPartitionTransformById(transforms, partitionField->field_id, errorIfMissing);
-
-		const char *partitionValue =
-			SerializePartitionValueToPGText(partitionField->value,
-											partitionField->value_length,
-											transform);
-
-		char	   *query =
-			"INSERT INTO " DATA_FILE_PARTITION_VALUES_TABLE_QUALIFIED " "
-			"(table_name, id, partition_field_id, value) "
-			"VALUES ($1,$2,$3,$4)";
-
-		DECLARE_SPI_ARGS(4);
-
-		SPI_ARG_VALUE(1, OIDOID, relationId, false);
-		SPI_ARG_VALUE(2, INT8OID, fileId, false);
-		SPI_ARG_VALUE(3, INT4OID, partitionField->field_id, false);
-		SPI_ARG_VALUE(4, TEXTOID, partitionValue, partitionValue == NULL);
-
-		bool		readOnly = false;
-
-		SPI_EXECUTE(query, readOnly);
+		adjacentOps = lappend(adjacentOps, op);
+		*cursor = lnext(operations, *cursor);
 	}
+	return adjacentOps;
+}
 
-	SPI_END();
+
+/* Apply one non-batchable metadata op to the files catalog. */
+static void
+ApplySingleOp(Oid relationId, TableMetadataOperation * operation)
+{
+	switch (operation->type)
+	{
+		case DATA_FILE_ADD_DELETE_MAPPING:
+			AddDeletionFileMapping(relationId,
+								   operation->path,
+								   operation->deletedFrom);
+			break;
+
+		case DATA_FILE_ADD_ROW_ID_MAPPING:
+			AddNewRowIdMapping(relationId,
+							   operation->path,
+							   operation->rowIdRanges);
+			break;
+
+		case DATA_FILE_REMOVE:
+			RemoveDataFileFromTable(relationId, operation->path);
+			break;
+		case DATA_FILE_REMOVE_ALL:
+		case DATA_FILE_DROP_TABLE:
+			RemoveAllDataFilesFromCatalog(relationId);
+			break;
+		case DATA_FILE_UPDATE_DELETED_ROW_COUNT:
+			UpdateDeletedRowCount(relationId,
+								  operation->path,
+								  operation->dataFileStats.deletedRowCount);
+			break;
+
+		case DATA_FILE_MERGE_MANIFESTS:
+		case EXPIRE_OLD_SNAPSHOTS:
+		case TABLE_CREATE:
+		case TABLE_DDL:
+		case TABLE_PARTITION_BY:
+
+			/*
+			 * no-op on the files catalog (EXPIRE_OLD_SNAPSHOTS and the DDL
+			 * types don't touch lake_table.files)
+			 */
+			break;
+
+		case DATA_FILE_ADD:
+			/* Routed via ApplyDataFileBatch by the outer loop. */
+			Assert(false);
+			break;
+
+		default:
+			elog(ERROR, "unsupported operation (%d) on data file catalog",
+				 operation->type);
+	}
 }
 
 

--- a/pg_lake_table/src/fdw/data_files_catalog_batch.c
+++ b/pg_lake_table/src/fdw/data_files_catalog_batch.c
@@ -1,0 +1,688 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Bulk write path for lake_table.files and its satellite catalogs. Used by
+ * ApplyDataFileCatalogChanges (data_files_catalog.c) to collapse a run of
+ * adjacent same-typed metadata ops into one INSERT per catalog instead of
+ * N per-row SPI calls. Today only DATA_FILE_ADD is bulked; the dispatcher
+ * ApplyDataFileBatch is structured so adjacent DATA_FILE_REMOVE etc. can
+ * slot in later without touching the orchestrator.
+ */
+
+#include "postgres.h"
+
+#include "pg_extension_base/extension_ids.h"
+#include "pg_extension_base/spi_helpers.h"
+#include "pg_lake/data_file/data_files.h"
+#include "pg_lake/data_file/data_file_stats.h"
+#include "pg_lake/extensions/pg_lake_table.h"
+#include "pg_lake/fdw/data_files_catalog.h"
+#include "pg_lake/fdw/data_files_catalog_internal.h"
+#include "pg_lake/fdw/data_file_stats_catalog.h"
+#include "pg_lake/fdw/partition_transform.h"
+#include "pg_lake/iceberg/partitioning/partition.h"
+#include "pg_lake/iceberg/partitioning/spec_generation.h"
+#include "pg_lake/partitioning/partition_spec_catalog.h"
+#include "pg_lake/util/array_utils.h"
+
+#include "executor/spi.h"
+#include "utils/builtins.h"
+#include "utils/dynahash.h"
+
+/* path -> int64 file id, built from RETURNING output of ExecInsertDataFiles */
+typedef struct FileIdHashEntry
+{
+	char		path[MAX_S3_PATH_LENGTH];
+	int64		fileId;
+}			FileIdHashEntry;
+
+/* caller-above-callee forward decls for the statics below */
+static void FlushDataFileAddBatch(Oid relationId, List *addOps);
+static HTAB *BulkInsertDataFiles(Oid relationId, List *addOps);
+static HTAB *ExecInsertDataFiles(Oid relationId, int fileCount,
+								 ArrayType *pathArray, ArrayType *rowCountArray,
+								 ArrayType *fileSizeArray, ArrayType *contentArray,
+								 ArrayType *firstRowIdArray);
+static void BulkInsertDataFileColumnStats(Oid relationId, List *addOps);
+static int	AppendColumnStatsForFile(TableMetadataOperation * operation,
+									 int statIndex, Datum *pathDatums,
+									 Datum *fieldIdDatums, Datum *lowerDatums,
+									 bool *lowerNulls, Datum *upperDatums,
+									 bool *upperNulls);
+static void ExecInsertDataFileColumnStats(Oid relationId, ArrayType *pathArray,
+										  ArrayType *fieldIdArray,
+										  ArrayType *lowerArray,
+										  ArrayType *upperArray);
+static void BulkInsertDataFilePartitionValues(Oid relationId, List *addOps,
+											  HTAB *pathToFileId);
+static int	AppendPartitionValuesForFile(TableMetadataOperation * operation,
+										 int64 fileId, List *transforms,
+										 int partitionRowIndex,
+										 Datum *fileIdDatums,
+										 Datum *partitionFieldIdDatums,
+										 Datum *valueDatums, bool *valueNulls);
+static void ExecInsertDataFilePartitionValues(Oid relationId,
+											  ArrayType *fileIdArray,
+											  ArrayType *partitionFieldIdArray,
+											  ArrayType *valueArray);
+static bool AddOpHasPartitionValues(TableMetadataOperation * operation);
+static void BulkInsertTrackedFileIds(List *addOps, HTAB *pathToFileId);
+static void ExecInsertTrackedFileIds(ArrayType *fileIdArray);
+static void CreateTxDataFileIdsTempTableIfNotExists(void);
+#ifdef USE_ASSERT_CHECKING
+static void AssertAllOpsAreType(List *ops, TableMetadataOperationType type);
+#endif
+
+
+/* Dispatch a run of same-typed ops to the right per-type bulk SQL. */
+void
+ApplyDataFileBatch(Oid relationId, TableMetadataOperationType type, List *batch)
+{
+	if (batch == NIL)
+		return;
+
+	Assert(BatchableType(type));
+
+	switch (type)
+	{
+		case DATA_FILE_ADD:
+			FlushDataFileAddBatch(relationId, batch);
+			break;
+		default:
+
+			/*
+			 * Future bulk paths slot in as new cases here, e.g. a run of
+			 * DATA_FILE_REMOVE collapsing to: DELETE FROM lake_table.files
+			 * WHERE table_name = $1 AND path = ANY($2::text[]). When you add
+			 * a case, also flip BatchableType to enable it.
+			 */
+			Assert(false);
+	}
+}
+
+
+/* True iff adjacent ops of this type can be collapsed into one bulk SQL. */
+bool
+BatchableType(TableMetadataOperationType type)
+{
+	/*
+	 * Only DATA_FILE_ADD today. Adjacent DATA_FILE_REMOVE is the obvious next
+	 * case; ApplyDataFileBatch holds the matching SQL sketch.
+	 */
+	return type == DATA_FILE_ADD;
+}
+
+
+/*
+ * Apply a run of DATA_FILE_ADD ops via bulk INSERTs into the three lake_table
+ * catalogs (files, data_file_column_stats, data_file_partition_values) plus
+ * the optional tx_data_file_ids temp table when PgLakeAddDataFileHook opts
+ * in. Pays O(catalogs) SPI round trips instead of O(files * (1 + columns +
+ * partition_fields)).
+ */
+static void
+FlushDataFileAddBatch(Oid relationId, List *addOps)
+{
+	if (addOps == NIL)
+		return;
+
+#ifdef USE_ASSERT_CHECKING
+	AssertAllOpsAreType(addOps, DATA_FILE_ADD);
+#endif
+
+	/*
+	 * BulkInsertDataFiles runs first; RETURNING captures the
+	 * sequence-assigned ids into a path->id hash. The downstream helpers use
+	 * that hash for O(1) id lookup instead of JOINing back to
+	 * lake_table.files.
+	 */
+	HTAB	   *pathToFileId = BulkInsertDataFiles(relationId, addOps);
+
+	BulkInsertDataFileColumnStats(relationId, addOps);
+	BulkInsertDataFilePartitionValues(relationId, addOps, pathToFileId);
+	BulkInsertTrackedFileIds(addOps, pathToFileId);
+	hash_destroy(pathToFileId);
+}
+
+
+/*
+ * Build parallel arrays from addOps and bulk-insert them into lake_table.files.
+ * Returns a path->int64 HTAB of sequence-assigned file ids (via RETURNING).
+ * Caller must hash_destroy() the returned table when done.
+ */
+static HTAB *
+BulkInsertDataFiles(Oid relationId, List *addOps)
+{
+	int			fileCount = list_length(addOps);
+
+	Assert(fileCount > 0);
+
+	Datum	   *pathDatums = palloc(sizeof(Datum) * fileCount);
+	Datum	   *rowCountDatums = palloc(sizeof(Datum) * fileCount);
+	Datum	   *fileSizeDatums = palloc(sizeof(Datum) * fileCount);
+	Datum	   *contentDatums = palloc(sizeof(Datum) * fileCount);
+	Datum	   *firstRowIdDatums = palloc(sizeof(Datum) * fileCount);
+	bool	   *firstRowIdNulls = palloc(sizeof(bool) * fileCount);
+	int			fileIndex = 0;
+	ListCell   *operationCell = NULL;
+
+	foreach(operationCell, addOps)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+		int64		firstRowId = operation->dataFileStats.rowIdStart;
+
+		pathDatums[fileIndex] = CStringGetTextDatum(operation->path);
+		rowCountDatums[fileIndex] = Int64GetDatum(operation->dataFileStats.rowCount);
+		fileSizeDatums[fileIndex] = Int64GetDatum(operation->dataFileStats.fileSize);
+		contentDatums[fileIndex] = Int32GetDatum((int) operation->content);
+		firstRowIdNulls[fileIndex] = (firstRowId == INVALID_ROW_ID);
+		firstRowIdDatums[fileIndex] = Int64GetDatum(firstRowId);
+
+		fileIndex++;
+	}
+	Assert(fileIndex == fileCount);
+
+	ArrayType  *pathArray = MakeArrayFromDatums(pathDatums, NULL, fileCount, TEXTOID);
+	ArrayType  *rowCountArray = MakeArrayFromDatums(rowCountDatums, NULL, fileCount, INT8OID);
+	ArrayType  *fileSizeArray = MakeArrayFromDatums(fileSizeDatums, NULL, fileCount, INT8OID);
+	ArrayType  *contentArray = MakeArrayFromDatums(contentDatums, NULL, fileCount, INT4OID);
+	ArrayType  *firstRowIdArray = MakeArrayFromDatums(firstRowIdDatums, firstRowIdNulls,
+													  fileCount, INT8OID);
+
+	return ExecInsertDataFiles(relationId, fileCount, pathArray, rowCountArray,
+							   fileSizeArray, contentArray, firstRowIdArray);
+}
+
+
+/*
+ * INSERT into lake_table.files via unnest and return a path->id HTAB built
+ * from the RETURNING clause. fileCount is the number of rows inserted.
+ * Must be called outside any SPI session.
+ * Caller must hash_destroy() the returned table when done.
+ */
+static HTAB *
+ExecInsertDataFiles(Oid relationId, int fileCount, ArrayType *pathArray,
+					ArrayType *rowCountArray, ArrayType *fileSizeArray,
+					ArrayType *contentArray, ArrayType *firstRowIdArray)
+{
+	MemoryContext callerCxt = CurrentMemoryContext;
+
+	/*
+	 * RETURNING id, path captures sequence-assigned ids so downstream helpers
+	 * can do O(1) hash lookups instead of JOINing back to lake_table.files.
+	 *
+	 * No ::text[] / ::int8[] casts on the $N placeholders: SPI_ARG_VALUE
+	 * already declares each parameter's type to the planner.
+	 *
+	 * Multi-argument unnest in FROM is SQL syntax, not a resolvable
+	 * pg_catalog.unnest(...) overload, so keep unnest unqualified here.
+	 */
+	char	   *query =
+		"INSERT INTO " DATA_FILES_TABLE_QUALIFIED " "
+		"(table_name, path, row_count, file_size, content, first_row_id) "
+		"SELECT $1, path, row_count, file_size, content, first_row_id "
+		"FROM unnest($2, $3, $4, $5, $6) "
+		"AS t(path, row_count, file_size, content, first_row_id) "
+		"RETURNING id, path";
+
+	DECLARE_SPI_ARGS(6);
+	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+	SPI_ARG_VALUE(2, TEXTARRAYOID, pathArray, false);
+	SPI_ARG_VALUE(3, INT8ARRAYOID, rowCountArray, false);
+	SPI_ARG_VALUE(4, INT8ARRAYOID, fileSizeArray, false);
+	SPI_ARG_VALUE(5, INT4ARRAYOID, contentArray, false);
+	SPI_ARG_VALUE(6, INT8ARRAYOID, firstRowIdArray, false);
+
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+	SPI_EXECUTE(query, /* readOnly = */ false);
+
+	HASHCTL		hashCtl;
+
+	memset(&hashCtl, 0, sizeof(hashCtl));
+	hashCtl.keysize = MAX_S3_PATH_LENGTH;
+	hashCtl.entrysize = sizeof(FileIdHashEntry);
+	hashCtl.hcxt = callerCxt;
+
+	HTAB	   *pathToFileId = hash_create("inserted file ids by path",
+										   fileCount * 2,
+										   &hashCtl,
+										   HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
+
+	for (int fileIndex = 0; fileIndex < fileCount; fileIndex++)
+	{
+		bool		idIsNull;
+		bool		pathIsNull;
+
+		/* column 1 = id (int8), column 2 = path (text) */
+		int64		fileId = GET_SPI_VALUE(INT8OID, fileIndex, 1, &idIsNull);
+		char	   *path = GET_SPI_VALUE(TEXTOID, fileIndex, 2, &pathIsNull);
+
+		Assert(!idIsNull && !pathIsNull);
+
+		bool		found;
+		FileIdHashEntry *entry = (FileIdHashEntry *)
+			hash_search(pathToFileId, path, HASH_ENTER, &found);
+
+		Assert(!found);			/* each path is unique in lake_table.files */
+		entry->fileId = fileId;
+	}
+
+	SPI_END();
+
+	return pathToFileId;
+}
+
+
+/*
+ * Build parallel arrays from addOps and bulk-insert column stats into
+ * lake_table.data_file_column_stats. Rows with NULL bounds are skipped
+ * entirely, matching the per-row helper.
+ */
+static void
+BulkInsertDataFileColumnStats(Oid relationId, List *addOps)
+{
+	int			statCapacity = 0;
+	ListCell   *operationCell = NULL;
+
+	foreach(operationCell, addOps)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+
+		if (operation->content != CONTENT_DATA)
+			continue;
+
+		statCapacity += list_length(operation->dataFileStats.columnStats);
+	}
+
+	if (statCapacity == 0)
+		return;
+
+	Datum	   *pathDatums = palloc(sizeof(Datum) * statCapacity);
+	Datum	   *fieldIdDatums = palloc(sizeof(Datum) * statCapacity);
+	Datum	   *lowerDatums = palloc(sizeof(Datum) * statCapacity);
+	bool	   *lowerNulls = palloc(sizeof(bool) * statCapacity);
+	Datum	   *upperDatums = palloc(sizeof(Datum) * statCapacity);
+	bool	   *upperNulls = palloc(sizeof(bool) * statCapacity);
+	int			statIndex = 0;
+
+	foreach(operationCell, addOps)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+
+		if (operation->content != CONTENT_DATA)
+			continue;
+
+		statIndex = AppendColumnStatsForFile(operation, statIndex,
+											 pathDatums, fieldIdDatums,
+											 lowerDatums, lowerNulls,
+											 upperDatums, upperNulls);
+	}
+	Assert(statIndex <= statCapacity);
+
+	if (statIndex == 0)
+		return;
+
+	ArrayType  *pathArray = MakeArrayFromDatums(pathDatums, NULL, statIndex, TEXTOID);
+	ArrayType  *fieldIdArray = MakeArrayFromDatums(fieldIdDatums, NULL, statIndex, INT8OID);
+	ArrayType  *lowerArray = MakeArrayFromDatums(lowerDatums, lowerNulls, statIndex, TEXTOID);
+	ArrayType  *upperArray = MakeArrayFromDatums(upperDatums, upperNulls, statIndex, TEXTOID);
+
+	ExecInsertDataFileColumnStats(relationId, pathArray, fieldIdArray,
+								  lowerArray, upperArray);
+}
+
+
+/*
+ * Append column stats for one file to the parallel arrays starting at
+ * statIndex. Skips stats with NULL bounds (same as per-row behavior).
+ * Returns the updated statIndex.
+ */
+static int
+AppendColumnStatsForFile(TableMetadataOperation * operation, int statIndex,
+						 Datum *pathDatums, Datum *fieldIdDatums,
+						 Datum *lowerDatums, bool *lowerNulls,
+						 Datum *upperDatums, bool *upperNulls)
+{
+	ListCell   *statsCell = NULL;
+
+	foreach(statsCell, operation->dataFileStats.columnStats)
+	{
+		DataFileColumnStats *columnStats = lfirst(statsCell);
+
+		/*
+		 * Match the per-row code: skip rows with NULL bounds entirely rather
+		 * than emitting (NULL, NULL).
+		 */
+		if (columnStats->lowerBoundText == NULL)
+		{
+			Assert(columnStats->upperBoundText == NULL);
+			continue;
+		}
+
+		pathDatums[statIndex] = CStringGetTextDatum(operation->path);
+		fieldIdDatums[statIndex] = Int64GetDatum(columnStats->leafField.fieldId);
+		lowerDatums[statIndex] = CStringGetTextDatum(columnStats->lowerBoundText);
+		lowerNulls[statIndex] = false;
+		upperDatums[statIndex] = (columnStats->upperBoundText != NULL)
+			? CStringGetTextDatum(columnStats->upperBoundText)
+			: (Datum) 0;
+		upperNulls[statIndex] = (columnStats->upperBoundText == NULL);
+
+		statIndex++;
+	}
+
+	return statIndex;
+}
+
+
+/* INSERT into lake_table.data_file_column_stats via unnest. */
+static void
+ExecInsertDataFileColumnStats(Oid relationId, ArrayType *pathArray,
+							  ArrayType *fieldIdArray, ArrayType *lowerArray,
+							  ArrayType *upperArray)
+{
+	/*
+	 * See ExecInsertDataFiles: multi-arg unnest cannot be
+	 * pg_catalog-qualified.
+	 */
+	char	   *query =
+		"INSERT INTO " DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED " "
+		"(table_name, path, field_id, lower_bound, upper_bound) "
+		"SELECT $1, path, field_id, lower_bound, upper_bound "
+		"FROM unnest($2, $3, $4, $5) "
+		"AS t(path, field_id, lower_bound, upper_bound)";
+
+	DECLARE_SPI_ARGS(5);
+	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+	SPI_ARG_VALUE(2, TEXTARRAYOID, pathArray, false);
+	SPI_ARG_VALUE(3, INT8ARRAYOID, fieldIdArray, false);
+	SPI_ARG_VALUE(4, TEXTARRAYOID, lowerArray, false);
+	SPI_ARG_VALUE(5, TEXTARRAYOID, upperArray, false);
+
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+	SPI_EXECUTE(query, /* readOnly = */ false);
+	SPI_END();
+}
+
+
+/*
+ * Build parallel arrays from addOps and bulk-insert into
+ * lake_table.data_file_partition_values. File ids are resolved via
+ * pathToFileId (built from RETURNING in ExecInsertDataFiles).
+ * AllPartitionTransformList is called once per batch rather than per file.
+ */
+static void
+BulkInsertDataFilePartitionValues(Oid relationId, List *addOps, HTAB *pathToFileId)
+{
+	int			partitionRowCapacity = 0;
+	ListCell   *operationCell = NULL;
+
+	foreach(operationCell, addOps)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+
+		if (AddOpHasPartitionValues(operation))
+			partitionRowCapacity += operation->partition->fields_length;
+	}
+
+	if (partitionRowCapacity == 0)
+		return;
+
+	/*
+	 * Per-row helper called AllPartitionTransformList once per file; hoist
+	 * the lookup to once per batch.
+	 */
+	List	   *transforms = AllPartitionTransformList(relationId);
+
+	Datum	   *fileIdDatums = palloc(sizeof(Datum) * partitionRowCapacity);
+	Datum	   *partitionFieldIdDatums = palloc(sizeof(Datum) * partitionRowCapacity);
+	Datum	   *valueDatums = palloc(sizeof(Datum) * partitionRowCapacity);
+	bool	   *valueNulls = palloc(sizeof(bool) * partitionRowCapacity);
+	int			partitionRowIndex = 0;
+
+	foreach(operationCell, addOps)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+
+		if (!AddOpHasPartitionValues(operation))
+			continue;
+
+		Assert(operation->partitionSpecId != DEFAULT_SPEC_ID);
+
+		FileIdHashEntry *entry = (FileIdHashEntry *)
+			hash_search(pathToFileId, operation->path, HASH_FIND, NULL);
+
+		Assert(entry != NULL);
+
+		partitionRowIndex = AppendPartitionValuesForFile(operation, entry->fileId,
+														 transforms,
+														 partitionRowIndex,
+														 fileIdDatums,
+														 partitionFieldIdDatums,
+														 valueDatums, valueNulls);
+	}
+	Assert(partitionRowIndex == partitionRowCapacity);
+
+	ArrayType  *fileIdArray = MakeArrayFromDatums(fileIdDatums, NULL,
+												  partitionRowIndex, INT8OID);
+	ArrayType  *partitionFieldIdArray = MakeArrayFromDatums(partitionFieldIdDatums, NULL,
+															partitionRowIndex, INT4OID);
+	ArrayType  *valueArray = MakeArrayFromDatums(valueDatums, valueNulls,
+												 partitionRowIndex, TEXTOID);
+
+	ExecInsertDataFilePartitionValues(relationId, fileIdArray,
+									  partitionFieldIdArray, valueArray);
+}
+
+
+/*
+ * Append one row per partition field for a single file to the parallel arrays
+ * starting at partitionRowIndex. Returns the updated partitionRowIndex.
+ */
+static int
+AppendPartitionValuesForFile(TableMetadataOperation * operation, int64 fileId,
+							 List *transforms, int partitionRowIndex,
+							 Datum *fileIdDatums, Datum *partitionFieldIdDatums,
+							 Datum *valueDatums, bool *valueNulls)
+{
+	int			fieldCount = (int) operation->partition->fields_length;
+
+	for (int fieldIndex = 0; fieldIndex < fieldCount; fieldIndex++)
+	{
+		PartitionField *partitionField = &operation->partition->fields[fieldIndex];
+		bool		errorIfMissing = true;
+
+		IcebergPartitionTransform *transform =
+			FindPartitionTransformById(transforms, partitionField->field_id,
+									   errorIfMissing);
+
+		const char *partitionValue =
+			SerializePartitionValueToPGText(partitionField->value,
+											partitionField->value_length,
+											transform);
+
+		fileIdDatums[partitionRowIndex] = Int64GetDatum(fileId);
+		partitionFieldIdDatums[partitionRowIndex] = Int32GetDatum(partitionField->field_id);
+		if (partitionValue == NULL)
+		{
+			valueDatums[partitionRowIndex] = (Datum) 0;
+			valueNulls[partitionRowIndex] = true;
+		}
+		else
+		{
+			valueDatums[partitionRowIndex] = CStringGetTextDatum(partitionValue);
+			valueNulls[partitionRowIndex] = false;
+		}
+
+		partitionRowIndex++;
+	}
+
+	return partitionRowIndex;
+}
+
+
+/* INSERT into lake_table.data_file_partition_values via unnest. */
+static void
+ExecInsertDataFilePartitionValues(Oid relationId, ArrayType *fileIdArray,
+								  ArrayType *partitionFieldIdArray,
+								  ArrayType *valueArray)
+{
+	/*
+	 * See ExecInsertDataFiles: multi-arg unnest cannot be
+	 * pg_catalog-qualified.
+	 */
+	char	   *query =
+		"INSERT INTO " DATA_FILE_PARTITION_VALUES_TABLE_QUALIFIED " "
+		"(table_name, id, partition_field_id, value) "
+		"SELECT $1, id, partition_field_id, value "
+		"FROM unnest($2, $3, $4) "
+		"AS t(id, partition_field_id, value)";
+
+	DECLARE_SPI_ARGS(4);
+	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+	SPI_ARG_VALUE(2, INT8ARRAYOID, fileIdArray, false);
+	SPI_ARG_VALUE(3, INT4ARRAYOID, partitionFieldIdArray, false);
+	SPI_ARG_VALUE(4, TEXTARRAYOID, valueArray, false);
+
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+	SPI_EXECUTE(query, /* readOnly = */ false);
+	SPI_END();
+}
+
+
+/* Only DATA and POSITION_DELETES content can carry partition values. */
+static bool
+AddOpHasPartitionValues(TableMetadataOperation * operation)
+{
+	if (operation->partition == NULL)
+		return false;
+	if (operation->partition->fields_length == 0)
+		return false;
+	if (operation->content != CONTENT_DATA &&
+		operation->content != CONTENT_POSITION_DELETES)
+		return false;
+	return true;
+}
+
+
+/*
+ * Collect file ids opted in by PgLakeAddDataFileHook and insert them into
+ * the tx-scoped temp table. The hook fires once per CONTENT_DATA op; ids are
+ * resolved via pathToFileId rather than a JOIN to lake_table.files.
+ */
+static void
+BulkInsertTrackedFileIds(List *addOps, HTAB *pathToFileId)
+{
+	if (PgLakeAddDataFileHook == NULL)
+		return;
+
+	/*
+	 * Lazy palloc: most batches won't have any hook-tracked files (the hook
+	 * only fires for CONTENT_DATA ops and only when the sibling extension
+	 * opts in). Defer the allocation to the first hit so partition-only or
+	 * deletes-only runs don't pay for an array they'll never use.
+	 */
+	int			fileCount = list_length(addOps);
+	Datum	   *fileIdDatums = NULL;
+	int			trackedFileCount = 0;
+	ListCell   *operationCell = NULL;
+
+	foreach(operationCell, addOps)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+
+		if (operation->content != CONTENT_DATA)
+			continue;
+		if (!PgLakeAddDataFileHook())
+			continue;
+
+		if (fileIdDatums == NULL)
+			fileIdDatums = palloc(sizeof(Datum) * fileCount);
+
+		FileIdHashEntry *entry = (FileIdHashEntry *)
+			hash_search(pathToFileId, operation->path, HASH_FIND, NULL);
+
+		Assert(entry != NULL);
+		fileIdDatums[trackedFileCount++] = Int64GetDatum(entry->fileId);
+	}
+
+	if (trackedFileCount == 0)
+		return;
+
+	CreateTxDataFileIdsTempTableIfNotExists();
+
+	ArrayType  *fileIdArray = MakeArrayFromDatums(fileIdDatums, NULL,
+												  trackedFileCount, INT8OID);
+
+	ExecInsertTrackedFileIds(fileIdArray);
+}
+
+
+/* INSERT into the tx-scoped temp table via unnest. */
+static void
+ExecInsertTrackedFileIds(ArrayType *fileIdArray)
+{
+	char	   *query =
+		"INSERT INTO " TX_DATA_FILES_QUALIFIED_TABLE_NAME " (id) "
+		"SELECT id FROM pg_catalog.unnest($1) AS t(id)";
+
+	DECLARE_SPI_ARGS(1);
+	SPI_ARG_VALUE(1, INT8ARRAYOID, fileIdArray, false);
+
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+	SPI_EXECUTE(query, /* readOnly = */ false);
+	SPI_END();
+}
+
+
+/*
+ * Lazily create the per-tx tracker temp table; rows are auto-dropped at COMMIT.
+ *
+ * PostgreSQL forbids CREATE TEMP TABLE under SECURITY_RESTRICTED_OPERATION,
+ * so we use the SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS variant which
+ * omits the restricted-op flag.  The search_path lockdown stays in effect;
+ * the DDL is a fixed string with no caller-supplied input.
+ */
+static void
+CreateTxDataFileIdsTempTableIfNotExists(void)
+{
+	const char *query =
+		"create temporary table if not exists " TX_DATA_FILES_QUALIFIED_TABLE_NAME " "
+		"(id bigint primary key) USING heap ON COMMIT DELETE ROWS;";
+
+	SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS(PgLakeTable);
+	SPI_execute(query, /* readOnly = */ false, 0);
+	SPI_END();
+}
+
+
+#ifdef USE_ASSERT_CHECKING
+/* Belt-and-suspenders: every op in a batch should already be of `type`. */
+static void
+AssertAllOpsAreType(List *ops, TableMetadataOperationType type)
+{
+	ListCell   *opCell = NULL;
+
+	foreach(opCell, ops)
+	{
+		TableMetadataOperation *operation = lfirst(opCell);
+
+		Assert(operation->type == type);
+	}
+}
+#endif


### PR DESCRIPTION

**Empirical (LOAD only):** same fixed parquet per `COPY`, partitioned Iceberg table, **one transaction**, local PG17 + MinIO. Baseline = `okalaci/batch_delete_in_progress_files` tip immediately before this change.

| Workload | Baseline LOAD | With this change | Δ |
|----------|---------------|------------------|---|
| 24k files (60 × 400 rows/file) | 427.8 s | 414.2 s | −3.2% |
| 100k files (250 × 400 rows/file) | 2411.1 s | 1939.6 s | −19.5% |

*SQL `COMMIT` wall time is dominated by manifest/metadata work outside `ApplyDataFileCatalogChanges`, so it is not a useful signal for this change and is omitted.*

Previously, `ApplyDataFileCatalogChanges` in `data_files_catalog.c` walked the metadata operation list and applied each `DATA_FILE_ADD` with three per-row helpers (`AddDataFileToTable`, `AddDataFileColumnStatsToCatalog`, `AddDataFilePartitionValueToCatalog`). For *N* files with *C* stat columns and *P* partition fields each, that was **N × (1 + C + P + 1)** SPI calls plus **N** redundant `AllPartitionTransformList()` lookups.

This change **collapses contiguous `DATA_FILE_ADD` runs** into **four** bulk inserts of the shape `INSERT … SELECT … FROM unnest(…)`, implemented in `data_files_catalog_batch.c`:

| # | Function | What it does |
|---|----------|----------------|
| 1 | `BulkInsertDataFiles` | One insert into `lake_table.files`; ids from `files_id_seq` default |
| 2 | `BulkInsertDataFileColumnStats` | One insert into `lake_table.data_file_column_stats` with nullable lower/upper arrays |
| 3 | `BulkInsertDataFilePartitionValues` | One insert joining `unnest(…)` to `files_pkey` on `(table_name, path)`; `AllPartitionTransformList()` once per batch |
| 4 | `BulkInsertTrackedFileIds` | One insert joining `unnest(…)` to `files_pkey` when `PgLakeAddDataFileHook` opted in |

`ApplyDataFileCatalogChanges` is now an **alternating-phase loop**: it flushes a run of same-type ops through `FlushBatch` (today only `DATA_FILE_ADD`; structured so adjacent `DATA_FILE_REMOVE` can follow later) and applies non-batchable ops one at a time via `ApplySingleOp`. Order between adds and other op types matches the old per-row behavior.

**Layout:** bulk helpers live in `data_files_catalog_batch.c`; private contract in `data_files_catalog_internal.h` (`BatchableType`, `FlushBatch`, `TX_DATA_FILES_QUALIFIED_TABLE_NAME`). `data_files_catalog.c` keeps the public orchestrator and `ApplySingleOp`.

### Intentional simplifications

1. **Only `DATA_FILE_ADD` is batched.** On a non-add op we flush pending adds first, so ordering vs. other ops matches the old code. Within a batch, multi-argument `unnest()` in `FROM` iterates in lockstep so `$2[i]`, `$3[i]`, … share one output row (no `WITH ORDINALITY` needed; downstream inserts join on `(table_name, path)`, not on position).

2. **`PgLakeAddDataFileHook()`** is still invoked once per `CONTENT_DATA` file (hook may inspect per-file state); paths where it returns true are batched into one insert into the tx-scoped temp table.

3. **Column stats:** empty / NULL-bound stats still **skip the row entirely** (same as before), not `(NULL, NULL)` catalog rows.

### Removed / moved

Per-row helpers `AddDataFileToTable`, `InsertDataFileIdIntoTransactionTable`, `AddDataFileColumnStatsToCatalog`, `AddDataFilePartitionValueToCatalog`, and `GenerateDataFileId` are no longer reachable and were removed. `MakeArrayFromDatums` was moved to `pg_lake_engine` (`util/array_utils`) for reuse.

The LOAD win **scales with file count**: on the order of ~280k SPI calls per `ApplyDataFileCatalogChanges` invocation collapse into **four** inserts, and the gap widens as the in-transaction catalog grows.

Co-authored-by: Cursor <cursoragent@cursor.com>
