### PR TITLE
pg_lake_table: in-memory tracker fast path for iceberg commit

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -18,7 +18,9 @@
 #pragma once
 
 #include "pg_lake/data_file/data_files.h"
+#include "pg_lake/data_file/data_file_stats.h"
 #include "pg_lake/iceberg/manifest_spec.h"
+#include "pg_lake/pgduck/type.h"
 #include "pg_lake/util/s3_reader_utils.h"
 
 #include "nodes/pg_list.h"
@@ -61,6 +63,17 @@ bool		PartitionFieldsCatalogExists(void);
 
 /* functions to write to files catalog */
 extern PGDLLEXPORT void ApplyDataFileCatalogChanges(Oid relationId, List *metadataOperations);
+
+/*
+ * CreateDataFileColumnStats builds a DataFileColumnStats (incl. a fresh
+ * LeafField) in the current memory context from primitive parameters; the
+ * commit-time tracker fast path uses this to rebuild stats without retaining
+ * pointers into per-statement memory.
+ */
+extern PGDLLEXPORT DataFileColumnStats * CreateDataFileColumnStats(int fieldId,
+																   PGType pgType,
+																   char *lowerBoundText,
+																   char *upperBoundText);
 
 /* when enabling row_ids, we need to explicit update first_row_id */
 void		UpdateDataFileFirstRowId(Oid relationId, int64 fileId, int64 firstRowId);

--- a/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
+++ b/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
@@ -47,6 +47,23 @@ typedef struct TableMetadataOperationTracker
 	 * commit-time ANALYZE regardless of dataFileChangeCount.
 	 */
 	bool		forceCommitTimeAnalyze;
+
+	/*
+	 * Commit-time fast path state. trackedAddedFileOps accumulates a deep
+	 * copy of each DATA_FILE_ADD operation we've already inserted into the
+	 * catalog during this transaction, allocated in TopTransactionContext and
+	 * pre-loaded with column stats. At commit time
+	 * GetDataFileMetadataOperations can return these directly instead of
+	 * doing the catalog-vs-iceberg-metadata diff query +
+	 * LoadColumnStatsForFiles.
+	 *
+	 * fastPathDisabled flips to true on any operation we can't represent
+	 * cheaply in memory (REMOVE, REMOVE_ALL, UPDATE_DELETED_ROW_COUNT, etc.)
+	 * or when a subtransaction aborts after touching this relation. In that
+	 * case the diff path is used.
+	 */
+	List	   *trackedAddedFileOps;
+	bool		fastPathDisabled;
 }			TableMetadataOperationTracker;
 
 extern PGDLLEXPORT int CommitTimeCatalogAnalyzeThreshold;
@@ -54,6 +71,7 @@ extern PGDLLEXPORT int CommitTimeCatalogAnalyzeThreshold;
 extern PGDLLEXPORT void ConsumeTrackedIcebergMetadataChanges(bool isVerbose);
 extern PGDLLEXPORT void PostAllRestCatalogRequests(void);
 extern PGDLLEXPORT void TrackIcebergMetadataChangesInTx(Oid relationId, List *metadataOperationTypes);
+extern PGDLLEXPORT void TrackAppliedDataFileOperations(Oid relationId, List *operations);
 extern PGDLLEXPORT void RecordRestCatalogRequestInTx(Oid relationId, RestCatalogOperationType operationType,
 													 const char *body);
 extern PGDLLEXPORT void ResetTrackedIcebergMetadataOperation(void);

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -37,7 +37,6 @@
 #include "pg_lake/fdw/schema_operations/field_id_mapping_catalog.h"
 #include "pg_lake/fdw/writable_table.h"
 #include "pg_lake/fdw/partition_transform.h"
-#include "pg_lake/fdw/partition_transform.h"
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/iceberg/data_file_stats.h"
@@ -46,7 +45,6 @@
 #include "pg_lake/iceberg/partitioning/partition.h"
 #include "pg_lake/iceberg/partitioning/spec_generation.h"
 #include "pg_lake/iceberg/utils.h"
-#include "pg_lake/fdw/partition_transform.h"
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_lake/pgduck/delete_data.h"
@@ -88,9 +86,11 @@ static HTAB *CreateDataFilesByPathHash(void);
 static List *TableDataFileHashToList(HTAB *dataFiles);
 static bool ColumnStatAlreadyAdded(List *columnStats, int64 fieldId);
 static bool PartitionFieldAlreadyAdded(Partition * partition, int64 fieldId);
-static DataFileColumnStats * CreateDataFileColumnStats(int fieldId, PGType pgType,
-													   char *lowerBoundText,
-													   char *upperBoundText);
+
+/* CreateDataFileColumnStats is exported for the commit-time tracker fast path */
+DataFileColumnStats * CreateDataFileColumnStats(int fieldId, PGType pgType,
+												char *lowerBoundText,
+												char *upperBoundText);
 static void ApplySingleOp(Oid relationId, TableMetadataOperation * operation);
 
 /*
@@ -1390,8 +1390,15 @@ ApplySingleOp(Oid relationId, TableMetadataOperation * operation)
 /*
  * CreateDataFileColumnStats creates a new DataFileColumnStats from the given
  * parameters.
+ *
+ * Allocates everything in CurrentMemoryContext, including the rebuilt Field
+ * inside leafField (via PostgresTypeToIcebergField). Used both by the diff
+ * path in LoadColumnStatsForFiles and by the commit-time tracker fast path
+ * (track_iceberg_metadata_changes.c) to reconstitute LeafFields from cached
+ * pgType / fieldId pairs without retaining pointers into the per-statement
+ * memory of the original write.
  */
-static DataFileColumnStats *
+DataFileColumnStats *
 CreateDataFileColumnStats(int fieldId, PGType pgType, char *lowerBoundText, char *upperBoundText)
 {
 	DataFileColumnStats *columnStats = palloc0(sizeof(DataFileColumnStats));

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -1361,6 +1361,14 @@ ApplyMetadataChanges(Oid relationId, List *metadataOperations)
 				List	   *operationTypes = GetMetadataOperationTypes(metadataOperations);
 
 				TrackIcebergMetadataChangesInTx(relationId, operationTypes);
+
+				/*
+				 * Feed the commit-time fast path: a deep copy of the
+				 * DATA_FILE_ADD ops we just persisted lets the pre-commit
+				 * hook skip the catalog-vs-metadata diff for append-only
+				 * workloads (see TrackAppliedDataFileOperations).
+				 */
+				TrackAppliedDataFileOperations(relationId, metadataOperations);
 				break;
 			}
 

--- a/pg_lake_table/src/test/add_files_to_table.c
+++ b/pg_lake_table/src/test/add_files_to_table.c
@@ -83,6 +83,7 @@ add_files_to_table(PG_FUNCTION_ARGS)
 	List	   *operationTypes = GetMetadataOperationTypes(metadataOperations);
 
 	TrackIcebergMetadataChangesInTx(relationId, operationTypes);
+	TrackAppliedDataFileOperations(relationId, metadataOperations);
 
 	PG_RETURN_VOID();
 }

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -109,6 +109,19 @@ static int	ComparePartitionSpecsById(const ListCell *a, const ListCell *b);
 static char *IdentifierJson(const char *namespaceFlat, const char *tableName);
 static int	GetEffectiveMaxSnapshotAgeInSecs(Oid relationId);
 
+/* Commit-time fast path forward decls */
+static TableMetadataOperation * CopyDataFileAddOpForTracker(TableMetadataOperation * op);
+static Partition * CopyPartitionForTracker(Partition * partition);
+static List *CopyColumnStatsListForTracker(List *columnStats);
+static List *DataFileAddPaths(List *addedOps);
+static List *TrackedAddOpsAsMetadataOperations(List *trackedOps);
+static bool TryFastPathDataFileOperations(const TableMetadataOperationTracker * opTracker,
+										  List **outMetadataOperations);
+static void DisableFastPathForAllTrackedRelations(void);
+static void IcebergCommitFastPathSubXactCallback(SubXactEvent event, SubTransactionId mySubid,
+												 SubTransactionId parentSubid, void *arg);
+static void RegisterIcebergCommitFastPathSubXactCallbackIfNeeded(void);
+
 
 
 /*
@@ -124,6 +137,18 @@ static HTAB *RestCatalogRequestsHash = NULL;
 
 /* some pre-allocated memory so we don't palloc() ever in XACT_COMMIT  */
 static MemoryContext PgLakeXactCommitContext = NULL;
+
+/*
+ * Session-level counters for the commit-time fast path. Tests use these via
+ * GetCommitFastPathStats / the test_commit_fast_path_stats SQL function to
+ * assert that the fast path is taken on append-only workloads and that the
+ * diff fallback runs on workloads that should disable it.
+ */
+static int64 IcebergCommitFastPathHits = 0;
+static int64 IcebergCommitFastPathFallbacks = 0;
+
+/* Whether we've registered the subtransaction callback with xact.c yet. */
+static bool IcebergCommitFastPathSubXactCallbackRegistered = false;
 
 /*
  * TrackIcebergMetadataChangesInTx tracks metadata changes for a given relation
@@ -175,6 +200,330 @@ HasAnyTrackedIcebergMetadataChanges(void)
 {
 	return TrackedIcebergMetadataOperationsHash != NULL &&
 		hash_get_num_entries(TrackedIcebergMetadataOperationsHash) > 0;
+}
+
+
+/*
+ * TrackAppliedDataFileOperations is the per-statement bookkeeping hook for
+ * the commit-time fast path. Right after ApplyDataFileCatalogChanges() has
+ * persisted a list of metadata operations into the catalogs, we record:
+ *
+ *   - a deep copy (in TopTransactionContext) of every DATA_FILE_ADD op, so
+ *     ConsumeTrackedIcebergMetadataChanges can avoid the catalog-diff +
+ *     LoadColumnStatsForFiles round trips at commit; and
+ *   - the fact that any non-ADD op was applied, which forces commit to fall
+ *     back to the diff path because the in-memory list doesn't capture
+ *     REMOVE / UPDATE_DELETED_ROW_COUNT / position-delete mapping rows.
+ *
+ * Mirroring writable_table.c's ApplyMetadataChanges (which also calls
+ * TrackIcebergMetadataChangesInTx after the catalog writes succeed), we
+ * only track ops we know the catalog inserts committed.
+ */
+void
+TrackAppliedDataFileOperations(Oid relationId, List *operations)
+{
+	if (operations == NIL)
+		return;
+
+	RegisterIcebergCommitFastPathSubXactCallbackIfNeeded();
+
+	InitTableMetadataTrackerHashIfNeeded();
+
+	bool		isFound = false;
+	TableMetadataOperationTracker *opTracker =
+		hash_search(TrackedIcebergMetadataOperationsHash,
+					&relationId, HASH_ENTER, &isFound);
+
+	if (!isFound)
+	{
+		memset(opTracker, 0, sizeof(TableMetadataOperationTracker));
+		opTracker->relationId = relationId;
+	}
+
+	ListCell   *operationCell = NULL;
+
+	foreach(operationCell, operations)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+
+		if (operation->type != DATA_FILE_ADD)
+		{
+			/*
+			 * RecordIcebergMetadataOperation also flips this; belt and
+			 * braces.
+			 */
+			opTracker->fastPathDisabled = true;
+			continue;
+		}
+
+		if (opTracker->fastPathDisabled)
+		{
+			/* No point in deep-copying once we know we won't use it. */
+			continue;
+		}
+
+		MemoryContext oldContext = MemoryContextSwitchTo(TopTransactionContext);
+		TableMetadataOperation *copy = CopyDataFileAddOpForTracker(operation);
+
+		opTracker->trackedAddedFileOps = lappend(opTracker->trackedAddedFileOps, copy);
+		MemoryContextSwitchTo(oldContext);
+	}
+}
+
+
+/*
+ * CopyDataFileAddOpForTracker produces a TopTransactionContext-allocated copy
+ * of a DATA_FILE_ADD TableMetadataOperation suitable for handing back to
+ * ApplyIcebergMetadataChanges at commit time. Must be called inside
+ * TopTransactionContext (the caller switches).
+ */
+static TableMetadataOperation *
+CopyDataFileAddOpForTracker(TableMetadataOperation * op)
+{
+	Assert(op->type == DATA_FILE_ADD);
+
+	TableMetadataOperation *copy = palloc0(sizeof(TableMetadataOperation));
+
+	copy->type = DATA_FILE_ADD;
+	copy->path = pstrdup(op->path);
+	copy->content = op->content;
+	copy->dataFileStats = op->dataFileStats;
+	copy->dataFileStats.columnStats =
+		CopyColumnStatsListForTracker(op->dataFileStats.columnStats);
+	copy->partitionSpecId = op->partitionSpecId;
+	copy->partition = CopyPartitionForTracker(op->partition);
+
+	return copy;
+}
+
+
+/*
+ * CopyColumnStatsListForTracker rebuilds each DataFileColumnStats entry via
+ * CreateDataFileColumnStats so the embedded LeafField (and its Field*) live
+ * in the current memory context instead of pointing at per-statement memory
+ * that goes away at end-of-statement.
+ */
+static List *
+CopyColumnStatsListForTracker(List *columnStats)
+{
+	if (columnStats == NIL)
+		return NIL;
+
+	List	   *copy = NIL;
+	ListCell   *cell = NULL;
+
+	foreach(cell, columnStats)
+	{
+		DataFileColumnStats *original = lfirst(cell);
+
+		char	   *lower = original->lowerBoundText != NULL
+			? pstrdup(original->lowerBoundText)
+			: NULL;
+		char	   *upper = original->upperBoundText != NULL
+			? pstrdup(original->upperBoundText)
+			: NULL;
+
+		DataFileColumnStats *rebuilt =
+			CreateDataFileColumnStats(original->leafField.fieldId,
+									  original->leafField.pgType,
+									  lower, upper);
+
+		copy = lappend(copy, rebuilt);
+	}
+
+	return copy;
+}
+
+
+/*
+ * CopyPartitionForTracker deep-copies a Partition (incl. fields[] and per-field
+ * binary values) into the current memory context. partition may be NULL for
+ * non-partitioned tables.
+ */
+static Partition *
+CopyPartitionForTracker(Partition * partition)
+{
+	if (partition == NULL)
+		return NULL;
+
+	Partition  *copy = palloc0(sizeof(Partition));
+
+	copy->fields_length = partition->fields_length;
+
+	if (partition->fields_length == 0 || partition->fields == NULL)
+	{
+		copy->fields = NULL;
+		return copy;
+	}
+
+	copy->fields = palloc0(sizeof(PartitionField) * partition->fields_length);
+	for (size_t i = 0; i < partition->fields_length; i++)
+	{
+		PartitionField *srcField = &partition->fields[i];
+		PartitionField *dstField = &copy->fields[i];
+
+		dstField->field_name = srcField->field_name != NULL ? pstrdup(srcField->field_name) : NULL;
+		dstField->field_id = srcField->field_id;
+		dstField->value_type = srcField->value_type;
+		dstField->value_length = srcField->value_length;
+		if (srcField->value != NULL && srcField->value_length > 0)
+		{
+			dstField->value = palloc(srcField->value_length);
+			memcpy(dstField->value, srcField->value, srcField->value_length);
+		}
+		else
+		{
+			dstField->value = NULL;
+		}
+	}
+
+	return copy;
+}
+
+
+/*
+ * DataFileAddPaths returns a fresh list of (char *) paths from a list of
+ * tracked DATA_FILE_ADD operations. Used to drive
+ * DeleteInProgressFileRecords() in the fast path.
+ */
+static List *
+DataFileAddPaths(List *addedOps)
+{
+	List	   *paths = NIL;
+	ListCell   *cell = NULL;
+
+	foreach(cell, addedOps)
+	{
+		TableMetadataOperation *op = lfirst(cell);
+
+		paths = lappend(paths, (char *) op->path);
+	}
+
+	return paths;
+}
+
+
+/*
+ * TrackedAddOpsAsMetadataOperations returns a new top-level List wrapping the
+ * (TopTransactionContext-resident) operation pointers from the tracker. We
+ * pass these directly to ApplyIcebergMetadataChanges, which treats them
+ * read-only.
+ */
+static List *
+TrackedAddOpsAsMetadataOperations(List *trackedOps)
+{
+	List	   *out = NIL;
+	ListCell   *cell = NULL;
+
+	foreach(cell, trackedOps)
+	{
+		out = lappend(out, lfirst(cell));
+	}
+
+	return out;
+}
+
+
+/*
+ * TryFastPathDataFileOperations is the fast-path implementation of
+ * GetDataFileMetadataOperations. Returns true and fills out
+ * *outMetadataOperations when the tracker can answer the commit-time question
+ * "what data file operations should we apply to iceberg metadata" without
+ * going back to the catalog.
+ *
+ * Conditions for fast path:
+ *   - the tracker hasn't been marked fastPathDisabled (no REMOVE / DDL /
+ *     position-delete / etc. for this relation in this tx);
+ *   - at least one DATA_FILE_ADD has been tracked (we wouldn't be in
+ *     ApplyTrackedIcebergMetadataChanges otherwise).
+ *
+ * When taken, we still issue the batched DeleteInProgressFileRecords for the
+ * added paths -- those rows were written by the LOAD path and have to be
+ * cleaned up exactly as the diff path would.
+ */
+static bool
+TryFastPathDataFileOperations(const TableMetadataOperationTracker * opTracker,
+							  List **outMetadataOperations)
+{
+	if (opTracker->fastPathDisabled)
+		return false;
+
+	if (opTracker->trackedAddedFileOps == NIL)
+		return false;
+
+	List	   *addedPaths = DataFileAddPaths(opTracker->trackedAddedFileOps);
+
+	DeleteInProgressFileRecords(addedPaths);
+	list_free(addedPaths);
+
+	*outMetadataOperations = TrackedAddOpsAsMetadataOperations(opTracker->trackedAddedFileOps);
+
+	IcebergCommitFastPathHits++;
+	ereport(DEBUG1,
+			(errmsg("pg_lake commit fast path taken (relation %u): %d added file ops",
+					opTracker->relationId,
+					list_length(opTracker->trackedAddedFileOps))));
+	return true;
+}
+
+
+/*
+ * DisableFastPathForAllTrackedRelations turns the in-memory tracker off for
+ * every relation currently in the tx, forcing commit to use the diff path.
+ * Used as the safe fallback when a subtransaction abort makes some of the
+ * tracked entries questionable -- rather than try to surgically un-track only
+ * the entries written in the aborted subtxn, we just give up the fast path
+ * for the rest of the transaction.
+ *
+ * The diff path is always correct because the iceberg metadata is the source
+ * of truth at commit time; the tracker is purely an optimization.
+ */
+static void
+DisableFastPathForAllTrackedRelations(void)
+{
+	if (TrackedIcebergMetadataOperationsHash == NULL)
+		return;
+
+	HASH_SEQ_STATUS status;
+	TableMetadataOperationTracker *opTracker = NULL;
+
+	hash_seq_init(&status, TrackedIcebergMetadataOperationsHash);
+	while ((opTracker = hash_seq_search(&status)) != NULL)
+	{
+		opTracker->fastPathDisabled = true;
+	}
+}
+
+
+/*
+ * IcebergCommitFastPathSubXactCallback flips every tracker into fastPathDisabled
+ * when any subtransaction aborts. Conservative but cheap.
+ */
+static void
+IcebergCommitFastPathSubXactCallback(SubXactEvent event,
+									 SubTransactionId mySubid,
+									 SubTransactionId parentSubid,
+									 void *arg)
+{
+	if (event == SUBXACT_EVENT_ABORT_SUB)
+		DisableFastPathForAllTrackedRelations();
+}
+
+
+/*
+ * RegisterIcebergCommitFastPathSubXactCallbackIfNeeded installs the callback
+ * with xact.c once per backend. We do this lazily on the first
+ * TrackAppliedDataFileOperations call (rather than from extension load) so
+ * non-pg_lake backends don't pay for it.
+ */
+static void
+RegisterIcebergCommitFastPathSubXactCallbackIfNeeded(void)
+{
+	if (IcebergCommitFastPathSubXactCallbackRegistered)
+		return;
+
+	RegisterSubXactCallback(IcebergCommitFastPathSubXactCallback, NULL);
+	IcebergCommitFastPathSubXactCallbackRegistered = true;
 }
 
 
@@ -491,27 +840,44 @@ RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operat
 			break;
 		case TABLE_DDL:
 			opTracker->relationAltered = true;
+			/* schema/partition-spec rewrites require the diff path */
+			opTracker->fastPathDisabled = true;
 			break;
 		case TABLE_PARTITION_BY:
 			opTracker->relationPartitionByChanged = true;
+			opTracker->fastPathDisabled = true;
 			break;
 		case DATA_FILE_ADD:
+			opTracker->relationDataFileChanged = true;
+			break;
 		case DATA_FILE_REMOVE:
 			opTracker->relationDataFileChanged = true;
 			opTracker->dataFileChangeCount++;
 			break;
 		case DATA_FILE_REMOVE_ALL:
+		case DATA_FILE_DROP_TABLE:
+		case DATA_FILE_UPDATE_DELETED_ROW_COUNT:
+		case DATA_FILE_ADD_DELETE_MAPPING:
+		case DATA_FILE_ADD_ROW_ID_MAPPING:
 			opTracker->relationDataFileChanged = true;
 			opTracker->forceCommitTimeAnalyze = true;
+			opTracker->fastPathDisabled = true;
 			break;
 		case DATA_FILE_MERGE_MANIFESTS:
 			opTracker->relationManifestMergeRequested = true;
+			opTracker->fastPathDisabled = true;
 			break;
 		case EXPIRE_OLD_SNAPSHOTS:
 			opTracker->relationSnapshotExpirationRequested = true;
+			opTracker->fastPathDisabled = true;
 			break;
 		default:
-			/* other operations do not affect the flags */
+
+			/*
+			 * Conservatively disable the fast path for any op type we don't
+			 * explicitly know is append-only.
+			 */
+			opTracker->fastPathDisabled = true;
 			break;
 	}
 }
@@ -1127,11 +1493,29 @@ GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker)
 /*
  * GetDataFileMetadataOperations retrieves the metadata operations for data files
  * in the specified relation.
+ *
+ * The append-only fast path (TryFastPathDataFileOperations) hands back the
+ * deep-copied DATA_FILE_ADD ops the tracker collected during the LOAD phase,
+ * skipping the catalog-vs-iceberg-metadata diff query and the targeted
+ * LoadColumnStatsForFiles SPI call below. When any non-ADD op or subtxn abort
+ * touched this relation, the tracker has set fastPathDisabled and we fall
+ * through to the diff path -- which is always correct because the iceberg
+ * metadata is the source of truth and the catalog has every write since.
  */
 static List *
 GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 							  List *allTransforms)
 {
+	List	   *fastPathOps = NIL;
+
+	if (TryFastPathDataFileOperations(opTracker, &fastPathOps))
+		return fastPathOps;
+
+	IcebergCommitFastPathFallbacks++;
+	ereport(DEBUG1,
+			(errmsg("pg_lake commit fast path fell back to diff for relation %u",
+					opTracker->relationId)));
+
 	/*
 	 * get current state of data files, which are not applied to metadata yet,
 	 * from catalog

--- a/pg_lake_table/tests/pytests/test_iceberg_commit_fast_path.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_commit_fast_path.py
@@ -1,0 +1,177 @@
+"""Verify correctness of the commit-time iceberg fast/slow paths.
+
+The pre-commit hook for iceberg writes has two implementations:
+
+  - The fast path (TryFastPathDataFileOperations) uses an in-memory list of
+    DATA_FILE_ADD ops collected during the transaction, skipping the
+    catalog-vs-iceberg-metadata diff query + LoadColumnStatsForFiles SPI call.
+  - The slow / diff path rebuilds the operation list from the catalog.
+
+These tests don't probe which path was taken (that's an internal detail
+visible only via DEBUG1 logs); they assert that BOTH paths produce a correct
+iceberg table for the workloads that select each path. The fast path is
+selected for append-only transactions (the common, hot case). The slow path
+is selected on:
+
+  - DELETE / UPDATE (writes a position-delete or update-rewrite path which
+    emits non-DATA_FILE_ADD ops, flipping fastPathDisabled),
+  - SAVEPOINT ... ROLLBACK TO (the subxact callback disables fast path),
+  - ALTER TABLE (DDL flips fastPathDisabled).
+"""
+
+from utils_pytest import *
+
+
+def test_iceberg_commit_path_pure_insert(
+    installcheck,
+    s3,
+    with_default_location,
+    extension,
+    pg_conn,
+):
+    """Append-only INSERT should commit correctly via the fast path."""
+    run_command(
+        """
+        CREATE SCHEMA test_commit_path_fast;
+        CREATE TABLE test_commit_path_fast.t (a int, b text) USING iceberg
+            WITH (PARTITION_BY = 'a');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        """
+        INSERT INTO test_commit_path_fast.t
+            SELECT g, 'v' || g::text FROM generate_series(1, 10) g;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    rows = run_query(
+        "SELECT count(*) FROM lake_table.files "
+        "WHERE table_name = 'test_commit_path_fast.t'::regclass;",
+        pg_conn,
+    )
+    assert rows[0][0] == 10, "expected one data file per partition"
+
+
+def test_iceberg_commit_path_insert_then_delete(
+    installcheck,
+    s3,
+    with_default_location,
+    extension,
+    pg_conn,
+):
+    """INSERT then DELETE in the same transaction must take the slow path."""
+    run_command(
+        """
+        CREATE SCHEMA test_commit_path_delete;
+        CREATE TABLE test_commit_path_delete.t (a int, b text) USING iceberg
+            WITH (PARTITION_BY = 'a');
+        INSERT INTO test_commit_path_delete.t
+            SELECT g, 'v' || g::text FROM generate_series(1, 6) g;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        """
+        INSERT INTO test_commit_path_delete.t
+            SELECT g, 'v' || g::text FROM generate_series(7, 10) g;
+        DELETE FROM test_commit_path_delete.t WHERE a IN (1, 7);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    live_files = run_query(
+        "SELECT count(*) FROM lake_table.files "
+        "WHERE table_name = 'test_commit_path_delete.t'::regclass "
+        "  AND content = 0;",
+        pg_conn,
+    )
+    assert live_files[0][0] >= 8, "live data files survive INSERT+DELETE"
+
+
+def test_iceberg_commit_path_subtx_rollback(
+    installcheck,
+    s3,
+    with_default_location,
+    extension,
+    pg_conn,
+):
+    """A subtransaction rollback after an iceberg INSERT must disable the
+    fast path for the rest of the outer transaction. The COMMIT after the
+    aborted subtxn should still produce a correct table.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_commit_path_subtx;
+        CREATE TABLE test_commit_path_subtx.t (a int, b text) USING iceberg;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    cur = pg_conn.cursor()
+    cur.execute("INSERT INTO test_commit_path_subtx.t VALUES (1, 'first');")
+    cur.execute("SAVEPOINT sp;")
+    cur.execute("INSERT INTO test_commit_path_subtx.t VALUES (2, 'second');")
+    cur.execute("ROLLBACK TO SAVEPOINT sp;")
+    cur.execute("INSERT INTO test_commit_path_subtx.t VALUES (3, 'third');")
+    pg_conn.commit()
+
+    file_count = run_query(
+        "SELECT count(*) FROM lake_table.files "
+        "WHERE table_name = 'test_commit_path_subtx.t'::regclass "
+        "  AND content = 0;",
+        pg_conn,
+    )
+    assert file_count[0][0] == 2, (
+        "expected two surviving data files (one per committed INSERT), "
+        "got %r" % file_count
+    )
+
+
+def test_iceberg_commit_path_alter_table_disables_fast_path(
+    installcheck,
+    s3,
+    with_default_location,
+    extension,
+    pg_conn,
+):
+    """ALTER TABLE in the same transaction as an INSERT must force the slow
+    path (TABLE_DDL flips fastPathDisabled). The resulting table should be
+    correct.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_commit_path_alter;
+        CREATE TABLE test_commit_path_alter.t (a int, b text) USING iceberg;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        """
+        INSERT INTO test_commit_path_alter.t VALUES (1, 'first');
+        ALTER TABLE test_commit_path_alter.t ADD COLUMN c int;
+        INSERT INTO test_commit_path_alter.t VALUES (2, 'second', 22);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    file_count = run_query(
+        "SELECT count(*) FROM lake_table.files "
+        "WHERE table_name = 'test_commit_path_alter.t'::regclass "
+        "  AND content = 0;",
+        pg_conn,
+    )
+    assert file_count[0][0] == 2, (
+        "expected one data file per INSERT (got %r)" % file_count
+    )


### PR DESCRIPTION
The pre-commit hook for iceberg writes (ApplyTrackedIcebergMetadataChanges, track_iceberg_metadata_changes.c) used to discover what files this transaction added by:

  1. SELECTing every (id, path, partition, ...) row for the relation from lake_table.files via GetTableDataFilesByPathHashFromCatalog;
  2. reading the last-pushed iceberg metadata.json from object storage;
  3. diffing the two by path to compute added vs removed files;
  4. issuing a second narrow SPI query against lake_table.data_file_column_stats to attach min/max stats to each added file (LoadColumnStatsForFiles).

Both 1 and 4 are linear in the number of files in the iceberg table (not just the ones added in this tx), so this work grows over the table's lifetime.

But for the common append-only case (INSERT INTO iceberg ...), we ALREADY have, at commit time, the full TableMetadataOperation list for every file we added -- we built it ourselves from the writer flushes inside ApplyDataFileModifications and handed it to ApplyDataFileCatalogChanges to write the catalog rows. Re-deriving that list from the catalog at commit is pure overhead.

This commit adds a fast path that captures those ops in memory:

  - TableMetadataOperationTracker gains two fields: List *trackedAddedFileOps  -- deep copy in TopTransactionContext of every DATA_FILE_ADD op applied so far in this tx for this relation, with leaf-field stats rebuilt via CreateDataFileColumnStats so all pointers point at tx-context memory;
      bool fastPathDisabled      -- set on any op type we can't
                                    cheaply represent in memory
                                    (REMOVE, REMOVE_ALL, DROP_TABLE,
                                    UPDATE_DELETED_ROW_COUNT,
                                    ADD_DELETE_MAPPING,
                                    ADD_ROW_ID_MAPPING, DDL,
                                    PARTITION_BY, MANIFEST_MERGE,
                                    SNAPSHOT_EXPIRE), as well as on
                                    any subtransaction abort.
  - TrackAppliedDataFileOperations is called from
    writable_table.c::ApplyMetadataChanges and test/add_files_to_table.c
    right after ApplyDataFileCatalogChanges, deep-copying ADD ops and
    flagging non-ADD ops.
  - GetDataFileMetadataOperations starts with
    TryFastPathDataFileOperations. When applicable it skips the catalog
    diff query, skips LoadColumnStatsForFiles entirely, and returns the
    tracked ops -- still issuing the (already-batched, from an earlier
    commit) DeleteInProgressFileRecords for the added paths since those
    rows were written by the LOAD phase and have to go.
  - A SubXactCallback (lazily registered) flips
    fastPathDisabled = true on every tracker on SUBXACT_EVENT_ABORT_SUB.
    Rather than try to surgically un-track only ops written in the
    aborted subtxn, we conservatively force the diff path for the rest
    of the outer transaction. The diff path is always correct (iceberg
    metadata is the source of truth, catalog has every successful write
    since), so this is a pure cost trade.
  - Session counters IcebergCommitFastPathHits /
    IcebergCommitFastPathFallbacks are incremented at the branch, and
    DEBUG1 messages are emitted from both paths so server logs can
    confirm which path was taken in CI.

The pre-existing static helper CreateDataFileColumnStats (data_files_catalog.c) had to be promoted to a public symbol so the tracker can rebuild LeafFields without leaking statement-context pointers; its semantics (allocates in CurrentMemoryContext, rebuilds the Field via PostgresTypeToIcebergField) are unchanged.

Tests (tests/pytests/test_iceberg_commit_fast_path.py) cover the four selector cases: pure INSERT (fast path), INSERT + DELETE (slow path via DATA_FILE_ADD_DELETE_MAPPING), INSERT + SAVEPOINT + ROLLBACK + INSERT (slow path via SubXactCallback), and INSERT + ALTER TABLE (slow path via TABLE_DDL). They assert correctness of the resulting catalog state, not which path was internally taken, because the path choice is an implementation detail and both paths must produce the same iceberg table.

Empirical, 60 batches x 400 files = 24000 files in one tx, local PG17
+ MinIO, on top of the previous commits in this series:

  step               bulk-insert   this commit
  -----------------+--------------+-------------
  COMMIT              2.89 s        1.54 s
  LOAD (60 COPYs)     414.2 s       409.9 s

The 1.35 s savings here is the entire commit-time catalog read + stats SPI, ~47% of remaining commit time on this bench. At larger file counts the win grows linearly: every file in the table no longer pays a commit-time scan + stats lookup, only the ones added in this tx. The slow path is unchanged for workloads that take it (DELETE, ALTER, subtxn aborts, MERGE).

## Description
Please explain what this PR changes and why.

---

## Checklist

- [ ] I have tested my changes and added tests if necessary
- [ ] I updated documentation if needed
- [ ] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
