### PR TITLE
Lock down extension-owner SPI / direct-call sites

### DIFF
--- a/pg_extension_base/include/pg_extension_base/spi_helpers.h
+++ b/pg_extension_base/include/pg_extension_base/spi_helpers.h
@@ -155,13 +155,31 @@
  * This requires the caller to have ExtensionOwnerId() available
  * (from pg_extension_base/extension_ids.h).
  *
+ * Because the SPI queries that follow are evaluated as the extension owner
+ * (which often coincides with the bootstrap superuser), we lock down the
+ * search-path to pg_catalog,pg_temp and add SECURITY_RESTRICTED_OPERATION
+ * so that:
+ *   - unqualified references in our SPI queries (operators like ->, casts
+ *     like ::jsonb, set-returning functions like jsonb_array_elements) cannot
+ *     be hijacked by overloads the calling user placed in their search_path,
+ *   - SET, RESET, role changes, and other side-effecting commands the caller
+ *     might smuggle in via parameters are rejected.
+ *
+ * GUC_ACTION_SAVE causes AtEOXact_GUC (via RESET_QUERY_TRACKING in SPI_END)
+ * to restore the prior search_path even if the SPI block raises.
+ *
  * Usage: SPI_START_EXTENSION_OWNER(PgLakeTable)
  */
 #define SPI_START_EXTENSION_OWNER(Extension) \
 	SPI_START_VARS() \
 	GetUserIdAndSecContext(&_savedUserId, &_savedSecurityContext); \
-	SetUserIdAndSecContext(ExtensionOwnerId(Extension), SECURITY_LOCAL_USERID_CHANGE); \
+	SetUserIdAndSecContext(ExtensionOwnerId(Extension), \
+						   SECURITY_LOCAL_USERID_CHANGE | \
+						   SECURITY_RESTRICTED_OPERATION); \
 	DISABLE_QUERY_TRACKING() \
+	(void) set_config_option("search_path", "pg_catalog, pg_temp", \
+							 PGC_SUSET, PGC_S_SESSION, \
+							 GUC_ACTION_SAVE, true, 0, false); \
 	SPI_connect();
 
 #define SPI_END() \
@@ -169,5 +187,39 @@
 		SetUserIdAndSecContext(_savedUserId, _savedSecurityContext); \
 	RESET_QUERY_TRACKING(); \
 	SPI_finish();
+
+/*
+ * BEGIN_EXTENSION_OWNER_CONTEXT / END_EXTENSION_OWNER_CONTEXT are the non-SPI
+ * counterparts to SPI_START_EXTENSION_OWNER / SPI_END. Use them when running
+ * direct PostgreSQL operations (DefineSequence, RemoveRelations, setval(),
+ * etc.) under the extension owner's identity, where the SPI machinery is not
+ * involved.
+ *
+ * They apply the same SECURITY_RESTRICTED_OPERATION + pinned search_path
+ * lockdown as the SPI variant, so that unqualified function/operator lookups
+ * in any indirectly-invoked SQL (sequence default expressions, RLS policies,
+ * etc.) cannot be hijacked via the caller's search_path, and the called
+ * operation cannot smuggle in SET / role changes.
+ *
+ * Usage:
+ *     BEGIN_EXTENSION_OWNER_CONTEXT(PgLakeTable);
+ *     ... direct calls ...
+ *     END_EXTENSION_OWNER_CONTEXT();
+ */
+#define BEGIN_EXTENSION_OWNER_CONTEXT(Extension) \
+	SPI_START_VARS() \
+	GetUserIdAndSecContext(&_savedUserId, &_savedSecurityContext); \
+	SetUserIdAndSecContext(ExtensionOwnerId(Extension), \
+						   SECURITY_LOCAL_USERID_CHANGE | \
+						   SECURITY_RESTRICTED_OPERATION); \
+	int			_extOwnerGUCNestLevel = NewGUCNestLevel(); \
+	(void) set_config_option("search_path", "pg_catalog, pg_temp", \
+							 PGC_SUSET, PGC_S_SESSION, \
+							 GUC_ACTION_SAVE, true, 0, false);
+
+#define END_EXTENSION_OWNER_CONTEXT() \
+	AtEOXact_GUC(true, _extOwnerGUCNestLevel); \
+	if (_savedUserId != InvalidOid) \
+		SetUserIdAndSecContext(_savedUserId, _savedSecurityContext);
 
 #endif

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -162,15 +162,6 @@ RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose)
 static void
 RemoveDeletionQueuePathsFromCatalog(List *filePaths)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
-
 	ArrayType  *failedRemovalPathsArray = StringListToArray(filePaths);
 
 	char	   *query =
@@ -181,15 +172,14 @@ RemoveDeletionQueuePathsFromCatalog(List *filePaths)
 
 	SPI_ARG_VALUE(1, TEXTARRAYOID, failedRemovalPathsArray, false);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -200,14 +190,6 @@ RemoveDeletionQueuePathsFromCatalog(List *filePaths)
 static void
 IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
 	ArrayType  *failedRemovalPathsArray = StringListToArray(failedRemovalPaths);
 	bool		readOnly = false;
 
@@ -220,13 +202,12 @@ IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
 
 	SPI_ARG_VALUE(1, TEXTARRAYOID, failedRemovalPathsArray, false);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	SPI_EXECUTE(updateQuery, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -237,14 +218,6 @@ IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
 List *
 GetDeletionQueueRecords(Oid relationId, bool isFull)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
 	MemoryContext callerContext = CurrentMemoryContext;
 	List	   *result = NIL;
 
@@ -290,7 +263,8 @@ GetDeletionQueueRecords(Oid relationId, bool isFull)
 					 ") "
 					 "SELECT path, orphaned_at, retry_count, is_prefix FROM del");
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
@@ -314,8 +288,6 @@ GetDeletionQueueRecords(Oid relationId, bool isFull)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return result;
 }
@@ -351,14 +323,6 @@ void
 InsertDeletionQueueRecordExtended(char *path, Oid relationId, TimestampTz orphanedAt,
 								  bool isPrefix)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
 	char	   *query =
 		"insert into " DELETION_QUEUE_TABLE " "
 		"(path, table_name, orphaned_at, is_prefix) "
@@ -370,13 +334,12 @@ InsertDeletionQueueRecordExtended(char *path, Oid relationId, TimestampTz orphan
 	SPI_ARG_VALUE(3, TIMESTAMPTZOID, orphanedAt, orphanedAt == 0);
 	SPI_ARG_VALUE(4, BOOLOID, isPrefix, false);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }

--- a/pg_lake_engine/src/cleanup/in_progress_files.c
+++ b/pg_lake_engine/src/cleanup/in_progress_files.c
@@ -221,14 +221,6 @@ GetInProgressFileRecords(char *location, bool isFull, List **fileRecords)
 
 	*fileRecords = NIL;
 
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeEngine),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
 	MemoryContext callerContext = CurrentMemoryContext;
 
 	/* filter anything under "location" */
@@ -252,7 +244,8 @@ GetInProgressFileRecords(char *location, bool isFull, List **fileRecords)
 						 "    LIMIT " PG_LAKE_TOSTRING(PER_LOOP_IN_PROGRESS_FILE_CLEANUP_LIMIT));
 	}
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeEngine);
 
 	bool		readOnly = false;
 
@@ -274,8 +267,6 @@ GetInProgressFileRecords(char *location, bool isFull, List **fileRecords)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	if (isFull)
 	{
@@ -307,14 +298,7 @@ DeleteInProgressFileRecord(char *path)
 	SPI_ARG_VALUE(1, TEXTOID, path, false);
 
 	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeEngine),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeEngine);
 	SPIPlanPtr	queryPlan = GetCachedQueryPlan(queryBuf->data, spiArgCount, spiArgTypes);
 
 	bool		readOnly = false;
@@ -337,8 +321,6 @@ DeleteInProgressFileRecord(char *path)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	CommandCounterIncrement();
 }
@@ -497,14 +479,7 @@ InsertInProgressFileRecordExtended(char *path, bool isPrefix, bool autoDeleteRec
 
 
 	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeEngine),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeEngine);
 
 	bool		readOnly = false;
 
@@ -516,8 +491,6 @@ InsertInProgressFileRecordExtended(char *path, bool isPrefix, bool autoDeleteRec
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	/*
 	 * Huh? We just inserted the record, why are we removing it?
@@ -728,14 +701,7 @@ FileInProgressRecordExists(char *path)
 	SPI_ARG_VALUE(1, TEXTOID, path, false);
 
 	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeEngine),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeEngine);
 	SPIPlanPtr	queryPlan = GetCachedQueryPlan(queryBuf->data, spiArgCount, spiArgTypes);
 
 	bool		readOnly = true;
@@ -767,8 +733,6 @@ FileInProgressRecordExists(char *path)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return exists;
 }

--- a/pg_lake_iceberg/src/iceberg/catalog.c
+++ b/pg_lake_iceberg/src/iceberg/catalog.c
@@ -48,13 +48,6 @@ static void ErrorIfSameTableExistsInExternalCatalog(Oid relationId);
 void
 InsertInternalIcebergCatalogTable(Oid relationId, const char *metadataLocation, bool hasCustomLocation)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	/* first, make sure a table with the same info doesn't exist */
 	ErrorIfSameTableExistsInExternalCatalog(relationId);
 
@@ -70,15 +63,13 @@ InsertInternalIcebergCatalogTable(Oid relationId, const char *metadataLocation, 
 	SPI_ARG_VALUE(2, TEXTOID, metadataLocation, metadataLocation == NULL);
 	SPI_ARG_VALUE(3, BOOLOID, hasCustomLocation, false);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query->data, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -95,18 +86,11 @@ HasCustomLocation(Oid relationId)
 					 "SELECT has_custom_location FROM %s WHERE table_name OPERATOR(pg_catalog.=) $1",
 					 ICEBERG_INTERNAL_CATALOG_TABLE_QUALIFIED);
 
-	/* add context security etc */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	DECLARE_SPI_ARGS(1);
 
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = true;
 
@@ -117,8 +101,6 @@ HasCustomLocation(Oid relationId)
 	bool		hasCustomLocation = GET_SPI_VALUE(BOOLOID, 0, 1, &isNull);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	/*
 	 * If it is null, it means the table is created before we introduced the
@@ -154,7 +136,7 @@ ErrorIfSameTableExistsInExternalCatalog(Oid relationId)
 	SPI_ARG_VALUE(2, TEXTOID, schemaName, false);
 	SPI_ARG_VALUE(3, TEXTOID, tableName, false);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = true;
 
@@ -181,13 +163,6 @@ void
 InsertExternalIcebergCatalogTable(const char *catalogName, const char *tableNamespace,
 								  const char *tableName, const char *metadataLocation)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
@@ -201,16 +176,13 @@ InsertExternalIcebergCatalogTable(const char *catalogName, const char *tableName
 	SPI_ARG_VALUE(2, TEXTOID, tableNamespace, false);
 	SPI_ARG_VALUE(3, TEXTOID, tableName, false);
 	SPI_ARG_VALUE(4, TEXTOID, metadataLocation, false);
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query->data, readOnly);
 
 	SPI_END();
-
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -221,13 +193,6 @@ InsertExternalIcebergCatalogTable(const char *catalogName, const char *tableName
 void
 DeleteInternalIcebergCatalogTable(Oid relationId)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
@@ -239,15 +204,13 @@ DeleteInternalIcebergCatalogTable(Oid relationId)
 
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query->data, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 /*
@@ -257,12 +220,6 @@ DeleteInternalIcebergCatalogTable(Oid relationId)
 void
 DeleteExternalIcebergCatalogTable(char *catalogName, char *schemaName, char *tableName)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
@@ -278,15 +235,13 @@ DeleteExternalIcebergCatalogTable(char *catalogName, char *schemaName, char *tab
 	SPI_ARG_VALUE(3, TEXTOID, tableName, false);
 
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query->data, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 /*
@@ -301,13 +256,6 @@ DeleteExternalIcebergCatalogTable(char *catalogName, char *schemaName, char *tab
 List *
 GetAllInternalIcebergRelationIds(void)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	MemoryContext oldcontext = CurrentMemoryContext;
 	StringInfo	query = makeStringInfo();
 
@@ -317,7 +265,7 @@ GetAllInternalIcebergRelationIds(void)
 					 "c ON t.table_name OPERATOR(pg_catalog.=) c.oid;",
 					 ICEBERG_INTERNAL_CATALOG_TABLE_QUALIFIED);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = true;
 
@@ -339,8 +287,6 @@ GetAllInternalIcebergRelationIds(void)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return relationIds;
 }
@@ -552,13 +498,6 @@ RelationExistsInTheIcebergCatalog(Oid relationId)
 static char *
 GetIcebergCatalogColumnInternal(Oid relationId, char *columnName, bool forUpdate, bool errorIfNotFound)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	MemoryContext oldcontext = CurrentMemoryContext;
 	StringInfo	query = makeStringInfo();
 
@@ -575,7 +514,7 @@ GetIcebergCatalogColumnInternal(Oid relationId, char *columnName, bool forUpdate
 	DECLARE_SPI_ARGS(1);
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
@@ -590,7 +529,6 @@ GetIcebergCatalogColumnInternal(Oid relationId, char *columnName, bool forUpdate
 	else if (SPI_processed == 0)
 	{
 		SPI_END();
-		SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 		return NULL;
 	}
@@ -606,8 +544,6 @@ GetIcebergCatalogColumnInternal(Oid relationId, char *columnName, bool forUpdate
 
 	SPI_END();
 
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
-
 	return metadataLocation;
 }
 
@@ -615,13 +551,6 @@ void
 UpdateExternalCatalogMetadataLocation(char *catalogName, char *schemaName, char *tableName, const char *metadataLocation,
 									  const char *previousMetadataLocation)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
@@ -639,15 +568,13 @@ UpdateExternalCatalogMetadataLocation(char *catalogName, char *schemaName, char 
 	SPI_ARG_VALUE(4, TEXTOID, schemaName, false);
 	SPI_ARG_VALUE(5, TEXTOID, tableName, false);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query->data, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 /*
@@ -659,13 +586,6 @@ void
 UpdateInternalCatalogMetadataLocation(Oid relationId, const char *metadataLocation,
 									  const char *previousMetadataLocation)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
@@ -679,15 +599,13 @@ UpdateInternalCatalogMetadataLocation(Oid relationId, const char *metadataLocati
 	SPI_ARG_VALUE(2, TEXTOID, previousMetadataLocation, (previousMetadataLocation == NULL));
 	SPI_ARG_VALUE(3, OIDOID, relationId, false);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query->data, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 /*
@@ -697,28 +615,19 @@ UpdateInternalCatalogMetadataLocation(Oid relationId, const char *metadataLocati
 void
 UpdateAllInternalIcebergTablesToReadOnly(void)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
 					 "UPDATE %s SET read_only = true; ",
 					 ICEBERG_INTERNAL_CATALOG_TABLE_QUALIFIED);
 
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_execute(query->data, readOnly, 0);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 /*

--- a/pg_lake_table/src/ddl/drop_table.c
+++ b/pg_lake_table/src/ddl/drop_table.c
@@ -378,13 +378,7 @@ CheckIfTypeIsUsedInIcebergTable(Oid typeId)
 
 
 	/* set the user context */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	/* SPI_END will rollback this setting to previous value */
 	PreventCitusTableVisibility();
@@ -408,8 +402,6 @@ CheckIfTypeIsUsedInIcebergTable(Oid typeId)
 	bool		exists = GET_SPI_VALUE(BOOLOID, 0, 1, &isNull);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return exists;
 }

--- a/pg_lake_table/src/fdw/data_file_stats_catalog.c
+++ b/pg_lake_table/src/fdw/data_file_stats_catalog.c
@@ -54,13 +54,6 @@ AddDataFileColumnStatsToCatalog(Oid relationId, const char *path, List *columnSt
 			continue;
 		}
 
-		/* switch to schema owner, we assume callers checked permissions */
-		Oid			savedUserId = InvalidOid;
-		int			savedSecurityContext = 0;
-
-		GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-		SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 		char	   *query =
 			"insert into " DATA_FILE_COLUMN_STATS_TABLE_QUALIFIED " "
 			"(table_name, path, field_id, lower_bound, upper_bound) "
@@ -73,15 +66,14 @@ AddDataFileColumnStatsToCatalog(Oid relationId, const char *path, List *columnSt
 		SPI_ARG_VALUE(4, TEXTOID, columnStats->lowerBoundText, columnStats->lowerBoundText == NULL);
 		SPI_ARG_VALUE(5, TEXTOID, columnStats->upperBoundText, columnStats->upperBoundText == NULL);
 
-		SPI_START();
+		/* switch to schema owner, we assume callers checked permissions */
+		SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 		bool		readOnly = false;
 
 		SPI_EXECUTE(query, readOnly);
 
 		SPI_END();
-
-		SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 	}
 }
 

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -749,13 +749,6 @@ GetPossiblePositionDeleteFilesFromCatalog(Oid relationId, List *sourcePathList, 
 	if (sourcePathList == NIL)
 		return NIL;
 
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 	MemoryContext callerContext = CurrentMemoryContext;
 
 	char	   *query =
@@ -765,7 +758,8 @@ GetPossiblePositionDeleteFilesFromCatalog(Oid relationId, List *sourcePathList, 
 		"where table_name OPERATOR(pg_catalog.=) $1 "
 		"and deleted_from OPERATOR(pg_catalog.=) ANY($2)";
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	DECLARE_SPI_ARGS(2);
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
@@ -818,8 +812,6 @@ GetPossiblePositionDeleteFilesFromCatalog(Oid relationId, List *sourcePathList, 
 
 	SPI_END();
 
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
-
 	return result;
 }
 
@@ -836,13 +828,6 @@ GetTableSizeFromCatalog(Oid relationId)
 {
 	int64		tableSize = 0;
 
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 	/* cast sum result to bigint to avoid returning numeric */
 	char	   *metadataQuery =
 		"select "
@@ -850,10 +835,11 @@ GetTableSizeFromCatalog(Oid relationId)
 		"from " DATA_FILES_TABLE_QUALIFIED " "
 		"where table_name OPERATOR(pg_catalog.=) $1";
 
-	SPI_START();
-
 	DECLARE_SPI_ARGS(1);
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = true;
 
@@ -873,8 +859,6 @@ GetTableSizeFromCatalog(Oid relationId)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return tableSize;
 }
@@ -941,13 +925,6 @@ static int64
 AddDataFileToTable(Oid relationId, const char *path, int64 rowCount, int64 fileSize,
 				   DataFileContent content, int64 rowIdStart)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 	char	   *query =
 		"insert into " DATA_FILES_TABLE_QUALIFIED " "
 		"(id, table_name, path, row_count, file_size, content, first_row_id) "
@@ -964,15 +941,14 @@ AddDataFileToTable(Oid relationId, const char *path, int64 rowCount, int64 fileS
 	SPI_ARG_VALUE(6, INT4OID, (int) content, false);
 	SPI_ARG_VALUE(7, INT8OID, rowIdStart, rowIdStart == INVALID_ROW_ID);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return fileId;
 }
@@ -1002,13 +978,6 @@ static void
 AddDeletionFileMapping(Oid relationId, const char *deletionFilePath,
 					   const char *dataFilePath)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 	char	   *query =
 		"insert into " DELETION_FILE_MAP_TABLE " "
 		"(table_name, path, deleted_from) "
@@ -1019,15 +988,14 @@ AddDeletionFileMapping(Oid relationId, const char *deletionFilePath,
 	SPI_ARG_VALUE(2, TEXTOID, deletionFilePath, false);
 	SPI_ARG_VALUE(3, TEXTOID, dataFilePath, false);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -1104,13 +1072,6 @@ GetFileIdForPath(Oid relationId, const char *path)
 static void
 UpdateDeletedRowCount(Oid relationId, const char *path, int64 deletedRowCount)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 	char	   *query =
 		"update " DATA_FILES_TABLE_QUALIFIED " "
 		"set deleted_row_count = $3 "
@@ -1121,15 +1082,14 @@ UpdateDeletedRowCount(Oid relationId, const char *path, int64 deletedRowCount)
 	SPI_ARG_VALUE(2, TEXTOID, path, false);
 	SPI_ARG_VALUE(3, INT8OID, deletedRowCount, false);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -1167,13 +1127,6 @@ UpdateDataFileFirstRowId(Oid relationId, int64 fileId, int64 firstRowId)
 static void
 RemoveDataFileFromTable(Oid relationId, const char *path)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 	/*
 	 * A deletion file can delete from 1 or more data files. When adding a
 	 * deletion file, we also store mappings to each of the data files it
@@ -1233,15 +1186,14 @@ RemoveDataFileFromTable(Oid relationId, const char *path)
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 	SPI_ARG_VALUE(2, TEXTOID, path, false);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -1252,13 +1204,6 @@ RemoveDataFileFromTable(Oid relationId, const char *path)
 static void
 RemoveAllDataFilesFromCatalog(Oid relationId)
 {
-	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
 	char	   *query =
 		"delete from " DATA_FILES_TABLE_QUALIFIED " "
 		"where table_name OPERATOR(pg_catalog.=) $1";
@@ -1266,15 +1211,14 @@ RemoveAllDataFilesFromCatalog(Oid relationId)
 	DECLARE_SPI_ARGS(1);
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 
-	SPI_START();
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -1520,13 +1464,7 @@ AddDataFilePartitionValueToCatalog(Oid relationId, int32 partitionSpecId, int64 
 	List	   *transforms = AllPartitionTransformList(relationId);
 
 	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
-
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	for (size_t fieldIndex = 0; fieldIndex < partition->fields_length; fieldIndex++)
 	{
@@ -1560,8 +1498,6 @@ AddDataFilePartitionValueToCatalog(Oid relationId, int32 partitionSpecId, int64 
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 

--- a/pg_lake_table/src/fdw/row_ids.c
+++ b/pg_lake_table/src/fdw/row_ids.c
@@ -25,6 +25,8 @@
 #include "catalog/pg_class.h"
 #include "commands/sequence.h"
 #include "commands/tablecmds.h"
+#include "pg_extension_base/extension_ids.h"
+#include "pg_extension_base/spi_helpers.h"
 #include "pg_lake/csv/csv_options.h"
 #include "pg_lake/extensions/pg_lake_table.h"
 #include "pg_lake/fdw/catalog/row_id_mappings.h"
@@ -101,11 +103,7 @@ void
 CreateRelationRowIdSequence(Oid relationId)
 {
 	/* create sequence as superuser */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
+	BEGIN_EXTENSION_OWNER_CONTEXT(PgLakeTable);
 
 	RangeVar   *sequenceName = RowIdSequenceGetRangeVar(relationId);
 
@@ -128,7 +126,7 @@ CreateRelationRowIdSequence(Oid relationId)
 
 	CommandCounterIncrement();
 
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
+	END_EXTENSION_OWNER_CONTEXT();
 }
 
 
@@ -181,16 +179,12 @@ DropRowIdSequenceForRelation(Oid relationId)
 	dropStmt->removeType = OBJECT_SEQUENCE;
 	dropStmt->missing_ok = true;
 
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
+	BEGIN_EXTENSION_OWNER_CONTEXT(PgLakeTable);
 
 	/* a sequence is a type of relation */
 	RemoveRelations(dropStmt);
 
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
+	END_EXTENSION_OWNER_CONTEXT();
 }
 
 
@@ -214,11 +208,7 @@ CreateRowIdRangeForNewFile(Oid relationId, int64 rowCount, int64 rowIdStart)
 	Assert(rowCount > 0);
 
 	/* setval checks permissions, so switch to superuser */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
+	BEGIN_EXTENSION_OWNER_CONTEXT(PgLakeTable);
 
 	if (rowIdStart == 0)
 	{
@@ -250,7 +240,7 @@ CreateRowIdRangeForNewFile(Oid relationId, int64 rowCount, int64 rowIdStart)
 	rowIdRange->rowStartNum = 0;
 	rowIdRange->numRows = rowCount;
 
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
+	END_EXTENSION_OWNER_CONTEXT();
 
 	return rowIdRange;
 }
@@ -287,11 +277,7 @@ StartReservingRowIdRange(Oid icebergRelationId)
 void
 FinishReservingRowIdRange(Oid icebergRelation, int64 rowIdOffset, int64 rowCount)
 {
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable), SECURITY_LOCAL_USERID_CHANGE);
+	BEGIN_EXTENSION_OWNER_CONTEXT(PgLakeTable);
 
 	Oid			sequenceOid = FindRelationRowIdSequence(icebergRelation);
 
@@ -307,7 +293,7 @@ FinishReservingRowIdRange(Oid icebergRelation, int64 rowIdOffset, int64 rowCount
 	/* Release the sequence relation lock */
 	UnlockRelationOid(sequenceOid, ExclusiveLock);
 
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
+	END_EXTENSION_OWNER_CONTEXT();
 }
 
 

--- a/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
+++ b/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
@@ -78,13 +78,6 @@ GetRegisteredFieldForAttributes(Oid relationId, List *attrNos)
 
 	List	   *fields = NIL;
 
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	/*
 	 * Now, with SPI select from field_id_mappings (relation_id, pg_attnum)
 	 */
@@ -104,7 +97,8 @@ GetRegisteredFieldForAttributes(Oid relationId, List *attrNos)
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 	SPI_ARG_VALUE(2, INT2ARRAYOID, INT16ListToArray(attrNos), false);
 
-	SPI_START();
+	/* switch to schema owner */
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	/*
 	 * Although this is a read-only query, we need the execution to use the
@@ -138,9 +132,6 @@ GetRegisteredFieldForAttributes(Oid relationId, List *attrNos)
 	MemoryContextSwitchTo(spiContext);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
-
 
 	return fields;
 
@@ -446,13 +437,6 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 
 	MemoryContext currentContext = CurrentMemoryContext;
 
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
@@ -503,7 +487,8 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 
-	SPI_START();
+	/* switch to schema owner */
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	/*
 	 * Although this is a read-only query, we need the execution to use the
@@ -551,9 +536,6 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 
 	SPI_END();
 
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
-
-
 	return leafFields;
 }
 
@@ -564,13 +546,6 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 void
 UpdateRegisteredFieldWriteDefaultForAttribute(Oid relationId, AttrNumber attNum, const char *writeDefault)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	/*
 	 * Now, with SPI select from field_id_mappings (relation_id, pg_attnum)
 	 */
@@ -589,7 +564,8 @@ UpdateRegisteredFieldWriteDefaultForAttribute(Oid relationId, AttrNumber attNum,
 	SPI_ARG_VALUE(2, OIDOID, relationId, false);
 	SPI_ARG_VALUE(3, INT2OID, attNum, false);
 
-	SPI_START();
+	/* switch to schema owner */
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
@@ -603,8 +579,6 @@ UpdateRegisteredFieldWriteDefaultForAttribute(Oid relationId, AttrNumber attNum,
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 /*
@@ -614,13 +588,6 @@ int
 GetLargestRegisteredFieldId(Oid relationId)
 {
 	int			fieldId = INVALID_FIELD_ID;
-
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
 
 	/*
 	 * Now, with SPI select from field_id_mappings (relation_id, pg_attnum)
@@ -634,7 +601,8 @@ GetLargestRegisteredFieldId(Oid relationId)
 
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 
-	SPI_START();
+	/* switch to schema owner */
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	/*
 	 * Although this is a read-only query, we need the execution to use the
@@ -659,8 +627,6 @@ GetLargestRegisteredFieldId(Oid relationId)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return fieldId;
 }
@@ -822,13 +788,6 @@ static void
 InsertFieldMapping(Oid relationId, int fieldId, AttrNumber attrNo, PGType pgType,
 				   const char *writeDefault, const char *initialDefault, int parentFieldId)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	/*
 	 * Now, with SPI select from field_id_mappings (relation_id, pg_attnum)
 	 */
@@ -852,15 +811,14 @@ InsertFieldMapping(Oid relationId, int fieldId, AttrNumber attrNo, PGType pgType
 	SPI_ARG_VALUE(7, TEXTOID, initialDefault, initialDefault == NULL);
 	SPI_ARG_VALUE(8, TEXTOID, writeDefault, writeDefault == NULL);
 
-	SPI_START();
+	/* switch to schema owner */
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
 	SPI_EXECUTE(query->data, readOnly);
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 
@@ -918,13 +876,6 @@ AssertAllNonDroppedColumnsHaveRegisteredFieldIds(Oid relationId)
 static List *
 GetAllRegisteredAttnumsForTopLevelColumns(Oid relationId)
 {
-	/* switch to schema owner */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeIceberg), SECURITY_LOCAL_USERID_CHANGE);
-
 	MemoryContext currentContext = CurrentMemoryContext;
 
 	/*
@@ -940,7 +891,8 @@ GetAllRegisteredAttnumsForTopLevelColumns(Oid relationId)
 
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 
-	SPI_START();
+	/* switch to schema owner */
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
 
 	bool		readOnly = false;
 
@@ -964,8 +916,6 @@ GetAllRegisteredAttnumsForTopLevelColumns(Oid relationId)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
 	return fieldIds;
 }

--- a/pg_lake_table/src/recovery/recover.c
+++ b/pg_lake_table/src/recovery/recover.c
@@ -82,14 +82,7 @@ RunAttachedCommand(char *command, char *databaseName)
 					 quote_literal_cstr(command), quote_literal_cstr(databaseName));
 
 	/* switch to schema owner, we assume callers checked permissions */
-	Oid			savedUserId = InvalidOid;
-	int			savedSecurityContext = 0;
-
-	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
-	SetUserIdAndSecContext(ExtensionOwnerId(PgLakeTable),
-						   SECURITY_LOCAL_USERID_CHANGE);
-
-	SPI_START();
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
 
 	bool		readOnly = false;
 
@@ -101,8 +94,6 @@ RunAttachedCommand(char *command, char *databaseName)
 	}
 
 	SPI_END();
-
-	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 }
 
 


### PR DESCRIPTION
Every site that called `SetUserIdAndSecContext(ExtensionOwnerId(...))` switched user identity for SPI queries or DDL helpers but only used `SECURITY_LOCAL_USERID_CHANGE`. Two gaps:

  1. `search_path` remained whatever the caller had configured. Any unqualified function/operator reference in our SPI queries (e.g. `jsonb_array_elements`, `::jsonb`, the `->` operator that `pg_lake_iceberg.list_object_store_tables` relies on) could be hijacked by a non-superuser who pre-pended a writable schema containing an overload onto `search_path`.
  2. Without `SECURITY_RESTRICTED_OPERATION`, SPI invocations could accept `SET LOCAL`, role changes, or other side-effecting commands.

We were pretty good/consistent with writing quoted queries for 1) (and should continue to do so), but we can lock down further with code.

Fix both at the helper level so all call sites pick it up:

  - `SPI_START_EXTENSION_OWNER` (used by ~28 sites) now also adds `SECURITY_RESTRICTED_OPERATION` and pins `search_path = pg_catalog, pg_temp` via `set_config_option` with `GUC_ACTION_SAVE`. `AtEOXact_GUC` (called from `SPI_END` via `RESET_QUERY_TRACKING`) restores the prior `search_path` even on error.
  - Add `BEGIN/END_EXTENSION_OWNER_CONTEXT` for non-SPI sites (`DefineSequence`, `RemoveRelations`, `setval()`, etc.) that need the same protection without going through the SPI machinery.
  - Migrate every inline `GetUser`/`SetUser`/`SPI_START`/.../`SPI_END` boilerplate to use one of the two helpers. ~39 sites across deletion_queue.c, in_progress_files.c, catalog.c, drop_table.c, data_files_catalog.c, data_file_stats_catalog.c, row_ids.c, field_id_mapping_catalog.c, recover.c.

All extension-owner SPI queries already used schema-qualified table names and pg_catalog.= operators, so the locked-down search_path does not require any query rewrites.
