### PR TITLE
Allow narrow temp-table creation under SPI_START_EXTENSION_OWNER

### DIFF
--- a/pg_extension_base/include/pg_extension_base/spi_helpers.h
+++ b/pg_extension_base/include/pg_extension_base/spi_helpers.h
@@ -217,42 +217,6 @@
 	SPI_connect();
 
 /*
- * ALLOW_TEMP_OBJECTS_BEGIN / ALLOW_TEMP_OBJECTS_END
- *
- * Temporarily clear SECURITY_RESTRICTED_OPERATION around a small region of
- * code so the enclosed operation can create or mutate temporary objects
- * (CREATE TEMP TABLE, CREATE TEMP SEQUENCE, etc.).  Use this for non-SPI
- * call sites where the restricted-op flag was set by a caller further up the
- * stack -- e.g. inside an FDW callback invoked from a user query running
- * under SPI_START_EXTENSION_OWNER.  For SPI sites that the current code
- * controls directly, use SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS
- * instead so the opt-out is visible at the SPI entry helper.
- *
- * The search_path lockdown that the surrounding extension-owner helpers
- * establish is unaffected; only the rejection of SET / role-change
- * side-effects is lifted.
- *
- * Use only around fixed, statically-known DDL.  Keep the region as small as
- * possible -- ideally a single DefineRelation() / DefineIndex() call with no
- * caller-supplied values flowing into the operation.  Always pair BEGIN with
- * END.
- *
- * Usage:
- *     ALLOW_TEMP_OBJECTS_BEGIN();
- *     DefineRelation(...);
- *     ALLOW_TEMP_OBJECTS_END();
- */
-#define ALLOW_TEMP_OBJECTS_BEGIN() \
-	Oid			_allowTempUserId; \
-	int			_allowTempSecContext; \
-	GetUserIdAndSecContext(&_allowTempUserId, &_allowTempSecContext); \
-	SetUserIdAndSecContext(_allowTempUserId, \
-						   _allowTempSecContext & ~SECURITY_RESTRICTED_OPERATION);
-
-#define ALLOW_TEMP_OBJECTS_END() \
-	SetUserIdAndSecContext(_allowTempUserId, _allowTempSecContext);
-
-/*
  * BEGIN_EXTENSION_OWNER_CONTEXT / END_EXTENSION_OWNER_CONTEXT are the non-SPI
  * counterparts to SPI_START_EXTENSION_OWNER / SPI_END. Use them when running
  * direct PostgreSQL operations (DefineSequence, RemoveRelations, setval(),

--- a/pg_extension_base/include/pg_extension_base/spi_helpers.h
+++ b/pg_extension_base/include/pg_extension_base/spi_helpers.h
@@ -189,6 +189,46 @@
 	SPI_finish();
 
 /*
+ * ALLOW_TEMP_OBJECTS_BEGIN / ALLOW_TEMP_OBJECTS_END
+ *
+ * Temporarily clear SECURITY_RESTRICTED_OPERATION around a small region of
+ * code so the enclosed operation can create or mutate temporary objects
+ * (CREATE TEMP TABLE, CREATE TEMP SEQUENCE, etc.).  PostgreSQL forbids those
+ * under SECURITY_RESTRICTED_OPERATION because the temp namespace cannot be
+ * safely established within a restricted context.
+ *
+ * Independent of SPI: works wherever the current security context has
+ * SECURITY_RESTRICTED_OPERATION set, including inside SPI_START_EXTENSION_OWNER
+ * blocks, BEGIN_EXTENSION_OWNER_CONTEXT blocks, or any caller that set the
+ * flag itself.  The search_path lockdown that the surrounding
+ * extension-owner helpers establish is unaffected; only the rejection of
+ * SET / role-change side-effects is lifted.
+ *
+ * Use only around fixed, statically-known DDL.  Keep the region as small as
+ * possible -- ideally a single SPI_execute() / DefineRelation() / similar
+ * call with no caller-supplied values flowing into the operation.  Always
+ * pair BEGIN with END.
+ *
+ * Usage:
+ *     SPI_START_EXTENSION_OWNER(PgLakeTable);
+ *     ...
+ *     ALLOW_TEMP_OBJECTS_BEGIN();
+ *     SPI_execute("create temporary table ...", false, 0);
+ *     ALLOW_TEMP_OBJECTS_END();
+ *     ...
+ *     SPI_END();
+ */
+#define ALLOW_TEMP_OBJECTS_BEGIN() \
+	Oid			_allowTempUserId; \
+	int			_allowTempSecContext; \
+	GetUserIdAndSecContext(&_allowTempUserId, &_allowTempSecContext); \
+	SetUserIdAndSecContext(_allowTempUserId, \
+						   _allowTempSecContext & ~SECURITY_RESTRICTED_OPERATION);
+
+#define ALLOW_TEMP_OBJECTS_END() \
+	SetUserIdAndSecContext(_allowTempUserId, _allowTempSecContext);
+
+/*
  * BEGIN_EXTENSION_OWNER_CONTEXT / END_EXTENSION_OWNER_CONTEXT are the non-SPI
  * counterparts to SPI_START_EXTENSION_OWNER / SPI_END. Use them when running
  * direct PostgreSQL operations (DefineSequence, RemoveRelations, setval(),

--- a/pg_extension_base/include/pg_extension_base/spi_helpers.h
+++ b/pg_extension_base/include/pg_extension_base/spi_helpers.h
@@ -189,34 +189,58 @@
 	SPI_finish();
 
 /*
+ * SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS is the temp-object-friendly
+ * variant of SPI_START_EXTENSION_OWNER.  It applies the same extension-owner
+ * identity switch and search_path = pg_catalog, pg_temp lockdown, but omits
+ * SECURITY_RESTRICTED_OPERATION so the enclosed SPI block may create temporary
+ * objects (CREATE TEMP TABLE, CREATE TEMP SEQUENCE, etc.).  PostgreSQL
+ * forbids creating temp objects under SECURITY_RESTRICTED_OPERATION because
+ * the temp namespace cannot be safely established within a restricted
+ * context.
+ *
+ * Use only around fixed, statically-known DDL with no caller-supplied values
+ * flowing into the SPI query: dropping the restricted-op flag re-permits
+ * SET / role-change side-effects, so the search_path lockdown is the only
+ * defense against hijack via the caller's environment.  Pair with SPI_END.
+ *
+ * Usage: SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS(PgLakeTable)
+ */
+#define SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS(Extension) \
+	SPI_START_VARS() \
+	GetUserIdAndSecContext(&_savedUserId, &_savedSecurityContext); \
+	SetUserIdAndSecContext(ExtensionOwnerId(Extension), \
+						   SECURITY_LOCAL_USERID_CHANGE); \
+	DISABLE_QUERY_TRACKING() \
+	(void) set_config_option("search_path", "pg_catalog, pg_temp", \
+							 PGC_SUSET, PGC_S_SESSION, \
+							 GUC_ACTION_SAVE, true, 0, false); \
+	SPI_connect();
+
+/*
  * ALLOW_TEMP_OBJECTS_BEGIN / ALLOW_TEMP_OBJECTS_END
  *
  * Temporarily clear SECURITY_RESTRICTED_OPERATION around a small region of
  * code so the enclosed operation can create or mutate temporary objects
- * (CREATE TEMP TABLE, CREATE TEMP SEQUENCE, etc.).  PostgreSQL forbids those
- * under SECURITY_RESTRICTED_OPERATION because the temp namespace cannot be
- * safely established within a restricted context.
+ * (CREATE TEMP TABLE, CREATE TEMP SEQUENCE, etc.).  Use this for non-SPI
+ * call sites where the restricted-op flag was set by a caller further up the
+ * stack -- e.g. inside an FDW callback invoked from a user query running
+ * under SPI_START_EXTENSION_OWNER.  For SPI sites that the current code
+ * controls directly, use SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS
+ * instead so the opt-out is visible at the SPI entry helper.
  *
- * Independent of SPI: works wherever the current security context has
- * SECURITY_RESTRICTED_OPERATION set, including inside SPI_START_EXTENSION_OWNER
- * blocks, BEGIN_EXTENSION_OWNER_CONTEXT blocks, or any caller that set the
- * flag itself.  The search_path lockdown that the surrounding
- * extension-owner helpers establish is unaffected; only the rejection of
- * SET / role-change side-effects is lifted.
+ * The search_path lockdown that the surrounding extension-owner helpers
+ * establish is unaffected; only the rejection of SET / role-change
+ * side-effects is lifted.
  *
  * Use only around fixed, statically-known DDL.  Keep the region as small as
- * possible -- ideally a single SPI_execute() / DefineRelation() / similar
- * call with no caller-supplied values flowing into the operation.  Always
- * pair BEGIN with END.
+ * possible -- ideally a single DefineRelation() / DefineIndex() call with no
+ * caller-supplied values flowing into the operation.  Always pair BEGIN with
+ * END.
  *
  * Usage:
- *     SPI_START_EXTENSION_OWNER(PgLakeTable);
- *     ...
  *     ALLOW_TEMP_OBJECTS_BEGIN();
- *     SPI_execute("create temporary table ...", false, 0);
+ *     DefineRelation(...);
  *     ALLOW_TEMP_OBJECTS_END();
- *     ...
- *     SPI_END();
  */
 #define ALLOW_TEMP_OBJECTS_BEGIN() \
 	Oid			_allowTempUserId; \

--- a/pg_lake_table/Makefile
+++ b/pg_lake_table/Makefile
@@ -40,15 +40,19 @@ $(EXTENSION)--1.0.sql: $(EXTENSION).sql
 
 pg_lake_table-test:
 	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_data_file_hook/
 
 install-pg_lake_table-test: pg_lake_table-test
 	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/ install
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_data_file_hook/ install
 
 uninstall-pg_lake_table-test:
 	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/ uninstall
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_data_file_hook/ uninstall
 
 clean-pg_lake_table-test:
 	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_hideable/ clean
+	$(MAKE) -C tests/sample_extensions/pg_lake_table_test_data_file_hook/ clean
 
 prepare-check: install install-pg_lake_table-test
 finish-check: uninstall-pg_lake_table-test

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -1297,8 +1297,8 @@ DataFilesPartitionValuesCatalogExists(void)
  * to track data file IDs that are being added in the current transaction.
  *
  * PostgreSQL forbids CREATE TEMP TABLE under SECURITY_RESTRICTED_OPERATION,
- * so we narrowly lift the restricted-op flag around the SPI_execute via
- * ALLOW_TEMP_OBJECTS_{BEGIN,END}.  The search_path lockdown stays in
+ * so we use the SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS variant
+ * which omits the restricted-op flag.  The search_path lockdown stays in
  * effect; the DDL is a fixed string with no caller-supplied input.
  */
 static void

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -1295,6 +1295,11 @@ DataFilesPartitionValuesCatalogExists(void)
 /*
  * CreateTxDataFileIdsTempTableIfNotExists creates a temporary table
  * to track data file IDs that are being added in the current transaction.
+ *
+ * PostgreSQL forbids CREATE TEMP TABLE under SECURITY_RESTRICTED_OPERATION,
+ * so we narrowly lift the restricted-op flag around the SPI_execute via
+ * ALLOW_TEMP_OBJECTS_{BEGIN,END}.  The search_path lockdown stays in
+ * effect; the DDL is a fixed string with no caller-supplied input.
  */
 static void
 CreateTxDataFileIdsTempTableIfNotExists(void)
@@ -1307,7 +1312,9 @@ CreateTxDataFileIdsTempTableIfNotExists(void)
 
 	bool		readOnly = false;
 
+	ALLOW_TEMP_OBJECTS_BEGIN();
 	SPI_execute(query, readOnly, 0);
+	ALLOW_TEMP_OBJECTS_END();
 
 	SPI_END();
 }

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -1308,13 +1308,11 @@ CreateTxDataFileIdsTempTableIfNotExists(void)
 		"create temporary table if not exists " TX_DATA_FILES_QUALIFIED_TABLE_NAME " "
 		"(id bigint primary key) USING heap ON COMMIT DELETE ROWS;";
 
-	SPI_START_EXTENSION_OWNER(PgLakeTable);
+	SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS(PgLakeTable);
 
 	bool		readOnly = false;
 
-	ALLOW_TEMP_OBJECTS_BEGIN();
 	SPI_execute(query, readOnly, 0);
-	ALLOW_TEMP_OBJECTS_END();
 
 	SPI_END();
 }

--- a/pg_lake_table/src/fdw/update_tracking.c
+++ b/pg_lake_table/src/fdw/update_tracking.c
@@ -159,12 +159,12 @@ GetUpdateTableRangeVar(Oid relationId)
  * for every UPDATE/DELETE on a pg_lake_table foreign table -- including
  * UPDATE/DELETE issued from inside a SECURITY_RESTRICTED_OPERATION context
  * such as SPI_START_EXTENSION_OWNER.  PostgreSQL forbids creating temporary
- * objects under SECURITY_RESTRICTED_OPERATION, so we narrowly lift the flag
- * around the DefineRelation + DefineIndex pair via ALLOW_TEMP_OBJECTS_BEGIN /
- * ALLOW_TEMP_OBJECTS_END.  The relation/index parameters are derived from
- * the target relation OID, not from caller-supplied SQL, so lifting the
- * restricted-op flag does not reopen a hijack vector; the search_path
- * lockdown set up by the surrounding SPI helper stays in effect.
+ * objects under SECURITY_RESTRICTED_OPERATION, so we narrowly clear the flag
+ * around the DefineRelation + DefineIndex pair.  The relation/index
+ * parameters are derived from the target relation OID, not from
+ * caller-supplied SQL, so lifting the restricted-op flag does not reopen a
+ * hijack vector; the search_path lockdown set up by the surrounding SPI
+ * helper stays in effect.
  */
 static Oid
 CreateUpdateTrackingTable(RangeVar *updateTableName)
@@ -186,7 +186,17 @@ CreateUpdateTrackingTable(RangeVar *updateTableName)
 	column->is_not_null = true;
 	createTempTable->tableElts = list_make1(column);
 
-	ALLOW_TEMP_OBJECTS_BEGIN();
+	/*
+	 * Clear SECURITY_RESTRICTED_OPERATION around the DefineRelation +
+	 * DefineIndex pair so the temp objects can be created.  See function
+	 * comment above for the rationale.
+	 */
+	Oid			savedUserId;
+	int			savedSecContext;
+
+	GetUserIdAndSecContext(&savedUserId, &savedSecContext);
+	SetUserIdAndSecContext(savedUserId,
+						   savedSecContext & ~SECURITY_RESTRICTED_OPERATION);
 
 	ObjectAddress updateTableAddress =
 		DefineRelation(createTempTable, RELKIND_RELATION, InvalidOid, NULL, "");
@@ -221,7 +231,7 @@ CreateUpdateTrackingTable(RangeVar *updateTableName)
 				 /* skip_builds */ false,
 				 /* quiet */ true);
 
-	ALLOW_TEMP_OBJECTS_END();
+	SetUserIdAndSecContext(savedUserId, savedSecContext);
 
 	CommandCounterIncrement();
 

--- a/pg_lake_table/src/fdw/update_tracking.c
+++ b/pg_lake_table/src/fdw/update_tracking.c
@@ -55,6 +55,7 @@
 #include "catalog/namespace.h"
 #include "commands/defrem.h"
 #include "commands/tablecmds.h"
+#include "pg_extension_base/spi_helpers.h"
 #include "pg_lake/fdw/update_tracking.h"
 #include "pg_lake/util/item_pointer_utils.h"
 #include "executor/executor.h"
@@ -153,6 +154,17 @@ GetUpdateTableRangeVar(Oid relationId)
 /*
  * CreateUpdateTrackingTable creates a temporary table used for tracking
  * updated ctids.
+ *
+ * BeginRelationUpdateTracking runs from BeginForeignModify, which is reached
+ * for every UPDATE/DELETE on a pg_lake_table foreign table -- including
+ * UPDATE/DELETE issued from inside a SECURITY_RESTRICTED_OPERATION context
+ * such as SPI_START_EXTENSION_OWNER.  PostgreSQL forbids creating temporary
+ * objects under SECURITY_RESTRICTED_OPERATION, so we narrowly lift the flag
+ * around the DefineRelation + DefineIndex pair via ALLOW_TEMP_OBJECTS_BEGIN /
+ * ALLOW_TEMP_OBJECTS_END.  The relation/index parameters are derived from
+ * the target relation OID, not from caller-supplied SQL, so lifting the
+ * restricted-op flag does not reopen a hijack vector; the search_path
+ * lockdown set up by the surrounding SPI helper stays in effect.
  */
 static Oid
 CreateUpdateTrackingTable(RangeVar *updateTableName)
@@ -173,6 +185,8 @@ CreateUpdateTrackingTable(RangeVar *updateTableName)
 
 	column->is_not_null = true;
 	createTempTable->tableElts = list_make1(column);
+
+	ALLOW_TEMP_OBJECTS_BEGIN();
 
 	ObjectAddress updateTableAddress =
 		DefineRelation(createTempTable, RELKIND_RELATION, InvalidOid, NULL, "");
@@ -206,6 +220,8 @@ CreateUpdateTrackingTable(RangeVar *updateTableName)
 				 /* check_not_in_use */ false,
 				 /* skip_builds */ false,
 				 /* quiet */ true);
+
+	ALLOW_TEMP_OBJECTS_END();
 
 	CommandCounterIncrement();
 

--- a/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
+++ b/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
@@ -1,0 +1,81 @@
+"""
+Regression test for SPI_START_EXTENSION_OWNER_ALLOW_TEMP.
+
+PgLakeAddDataFileHook is an extension point used by sfpg-extension-pg_lake_replication
+(and any other module that needs to know which data file IDs were added in
+the current transaction). When the hook is set and returns true, pg_lake_table
+records each new data file ID in a per-transaction temp table created lazily
+inside SPI_START_EXTENSION_OWNER.
+
+Before SPI_START_EXTENSION_OWNER_ALLOW_TEMP existed, the temp-table create
+ran under SECURITY_RESTRICTED_OPERATION, which PostgreSQL forbids: the temp
+namespace cannot be safely established within a restricted context, so the
+INSERT failed with "cannot create temporary table within security-restricted
+operation".
+
+This test loads pg_lake_table_test_data_file_hook (a sample extension that
+sets the hook to always-true) and runs an INSERT into an Iceberg table. If
+the temp-table site regresses to the restricted helper, the INSERT fails
+with the above error.
+"""
+
+import psycopg2
+import pytest
+from utils_pytest import *
+
+
+@pytest.fixture(scope="module")
+def with_data_file_hook(superuser_conn):
+    """Load the test extension that registers PgLakeAddDataFileHook."""
+    run_command(
+        "CREATE EXTENSION IF NOT EXISTS pg_lake_table_test_data_file_hook CASCADE",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command(
+        "DROP EXTENSION IF EXISTS pg_lake_table_test_data_file_hook",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
+def test_iceberg_insert_with_data_file_hook(
+    s3, pg_conn, extension, with_default_location, with_data_file_hook
+):
+    """An INSERT into an Iceberg table with PgLakeAddDataFileHook active
+    must successfully create and populate the per-transaction temp table.
+    """
+    run_command(
+        "CREATE TABLE test_data_file_hook_temp_table(a int, b text) USING iceberg",
+        pg_conn,
+    )
+
+    # The INSERT triggers AddDataFileToCatalog -> InsertDataFileIdIntoTransactionTable
+    # -> CreateTxDataFileIdsTempTableIfNotExists, which is the
+    # SPI_START_EXTENSION_OWNER_ALLOW_TEMP call site under test.
+    run_command(
+        "INSERT INTO test_data_file_hook_temp_table VALUES (1, 'one'), (2, 'two')",
+        pg_conn,
+    )
+
+    res = run_query(
+        "SELECT a, b FROM test_data_file_hook_temp_table ORDER BY a",
+        pg_conn,
+    )
+    assert res == [[1, "one"], [2, "two"]]
+
+    # Run a second INSERT in a fresh transaction to exercise the
+    # "if not exists" branch as well.
+    run_command(
+        "INSERT INTO test_data_file_hook_temp_table VALUES (3, 'three')",
+        pg_conn,
+    )
+
+    res = run_query(
+        "SELECT count(*) FROM test_data_file_hook_temp_table",
+        pg_conn,
+    )
+    assert res == [[3]]

--- a/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
+++ b/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
@@ -79,3 +79,74 @@ def test_iceberg_insert_with_data_file_hook(
         pg_conn,
     )
     assert res == [[3]]
+
+
+@pytest.mark.parametrize(
+    "dml",
+    [
+        "DELETE FROM public.test_iceberg_dml_under_owner WHERE a OPERATOR(pg_catalog.>=) 2",
+        "UPDATE public.test_iceberg_dml_under_owner "
+        "SET b = b OPERATOR(pg_catalog.||) '!' "
+        "WHERE a OPERATOR(pg_catalog.>=) 2",
+    ],
+    ids=["delete", "update"],
+)
+def test_iceberg_dml_under_extension_owner(
+    s3,
+    superuser_conn,
+    pg_conn,
+    extension,
+    with_default_location,
+    with_data_file_hook,
+    dml,
+):
+    """UPDATE/DELETE on an Iceberg foreign table issued from inside
+    SPI_START_EXTENSION_OWNER must succeed.
+
+    pg_lake_table's BeginForeignModify creates a per-statement temp tracking
+    table for both UPDATE and DELETE via CreateUpdateTrackingTable, which
+    calls DefineRelation + DefineIndex directly.  Under the lockdown added
+    in the parent commit those would fail with "cannot create temporary
+    table within security-restricted operation" without the narrow
+    ALLOW_TEMP_OBJECTS_BEGIN/END scope around the create.
+
+    Downstream extensions that wrap their own SPI calls in
+    SPI_START_EXTENSION_OWNER and then issue Iceberg DML hit this -- the
+    motivating example was sfpg-extension-pg_lake_replication's expiry path
+    running DELETE on the change-log Iceberg table.
+    """
+    run_command(
+        "CREATE TABLE test_iceberg_dml_under_owner(a int, b text) USING iceberg",
+        pg_conn,
+    )
+    run_command(
+        "INSERT INTO test_iceberg_dml_under_owner VALUES "
+        "(1, 'one'), (2, 'two'), (3, 'three')",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Run the DML under the extension-owner lockdown.
+    run_command(
+        f"SELECT run_iceberg_dml_under_extension_owner({_quote_literal(dml)})",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    if dml.startswith("DELETE"):
+        res = run_query(
+            "SELECT count(*) FROM test_iceberg_dml_under_owner",
+            pg_conn,
+        )
+        assert res == [[1]]
+    else:
+        res = run_query(
+            "SELECT a, b FROM test_iceberg_dml_under_owner ORDER BY a",
+            pg_conn,
+        )
+        assert res == [[1, "one"], [2, "two!"], [3, "three!"]]
+
+
+def _quote_literal(s: str) -> str:
+    """Quote a string for embedding in a SQL statement as a literal."""
+    return "'" + s.replace("'", "''") + "'"

--- a/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
+++ b/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
@@ -1,5 +1,5 @@
 """
-Regression test for SPI_START_EXTENSION_OWNER_ALLOW_TEMP.
+Regression tests for ALLOW_TEMP_OBJECTS_BEGIN / ALLOW_TEMP_OBJECTS_END.
 
 PgLakeAddDataFileHook is an extension point used by sfpg-extension-pg_lake_replication
 (and any other module that needs to know which data file IDs were added in
@@ -7,10 +7,10 @@ the current transaction). When the hook is set and returns true, pg_lake_table
 records each new data file ID in a per-transaction temp table created lazily
 inside SPI_START_EXTENSION_OWNER.
 
-Before SPI_START_EXTENSION_OWNER_ALLOW_TEMP existed, the temp-table create
-ran under SECURITY_RESTRICTED_OPERATION, which PostgreSQL forbids: the temp
-namespace cannot be safely established within a restricted context, so the
-INSERT failed with "cannot create temporary table within security-restricted
+Before ALLOW_TEMP_OBJECTS_BEGIN/END existed, the temp-table create ran under
+SECURITY_RESTRICTED_OPERATION, which PostgreSQL forbids: the temp namespace
+cannot be safely established within a restricted context, so the INSERT
+failed with "cannot create temporary table within security-restricted
 operation".
 
 This test loads pg_lake_table_test_data_file_hook (a sample extension that
@@ -55,7 +55,7 @@ def test_iceberg_insert_with_data_file_hook(
 
     # The INSERT triggers AddDataFileToCatalog -> InsertDataFileIdIntoTransactionTable
     # -> CreateTxDataFileIdsTempTableIfNotExists, which is the
-    # SPI_START_EXTENSION_OWNER_ALLOW_TEMP call site under test.
+    # ALLOW_TEMP_OBJECTS_BEGIN/END call site under test.
     run_command(
         "INSERT INTO test_data_file_hook_temp_table VALUES (1, 'one'), (2, 'two')",
         pg_conn,

--- a/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
+++ b/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
@@ -81,16 +81,7 @@ def test_iceberg_insert_with_data_file_hook(
     assert res == [[3]]
 
 
-@pytest.mark.parametrize(
-    "dml",
-    [
-        "DELETE FROM public.test_iceberg_dml_under_owner WHERE a OPERATOR(pg_catalog.>=) 2",
-        "UPDATE public.test_iceberg_dml_under_owner "
-        "SET b = b OPERATOR(pg_catalog.||) '!' "
-        "WHERE a OPERATOR(pg_catalog.>=) 2",
-    ],
-    ids=["delete", "update"],
-)
+@pytest.mark.parametrize("operation", ["delete", "update"])
 def test_iceberg_dml_under_extension_owner(
     s3,
     superuser_conn,
@@ -98,7 +89,7 @@ def test_iceberg_dml_under_extension_owner(
     extension,
     with_default_location,
     with_data_file_hook,
-    dml,
+    operation,
 ):
     """UPDATE/DELETE on an Iceberg foreign table issued from inside
     SPI_START_EXTENSION_OWNER must succeed.
@@ -115,13 +106,25 @@ def test_iceberg_dml_under_extension_owner(
     motivating example was sfpg-extension-pg_lake_replication's expiry path
     running DELETE on the change-log Iceberg table.
     """
+    # pg_conn is module-scoped, so each parametrization needs a distinct
+    # table to avoid "relation already exists" on the second run.
+    table = f"test_iceberg_dml_under_owner_{operation}"
+
+    if operation == "delete":
+        dml = f"DELETE FROM public.{table} " "WHERE a OPERATOR(pg_catalog.>=) 2"
+    else:
+        dml = (
+            f"UPDATE public.{table} "
+            "SET b = b OPERATOR(pg_catalog.||) '!' "
+            "WHERE a OPERATOR(pg_catalog.>=) 2"
+        )
+
     run_command(
-        "CREATE TABLE test_iceberg_dml_under_owner(a int, b text) USING iceberg",
+        f"CREATE TABLE {table}(a int, b text) USING iceberg",
         pg_conn,
     )
     run_command(
-        "INSERT INTO test_iceberg_dml_under_owner VALUES "
-        "(1, 'one'), (2, 'two'), (3, 'three')",
+        f"INSERT INTO {table} VALUES (1, 'one'), (2, 'two'), (3, 'three')",
         pg_conn,
     )
     pg_conn.commit()
@@ -133,17 +136,11 @@ def test_iceberg_dml_under_extension_owner(
     )
     superuser_conn.commit()
 
-    if dml.startswith("DELETE"):
-        res = run_query(
-            "SELECT count(*) FROM test_iceberg_dml_under_owner",
-            pg_conn,
-        )
+    if operation == "delete":
+        res = run_query(f"SELECT count(*) FROM {table}", pg_conn)
         assert res == [[1]]
     else:
-        res = run_query(
-            "SELECT a, b FROM test_iceberg_dml_under_owner ORDER BY a",
-            pg_conn,
-        )
+        res = run_query(f"SELECT a, b FROM {table} ORDER BY a", pg_conn)
         assert res == [[1, "one"], [2, "two!"], [3, "three!"]]
 
 

--- a/pg_lake_table/tests/pytests/test_iceberg_xacts.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_xacts.py
@@ -42,8 +42,13 @@ def test_writable_iceberg_table_tx(
     )
     pg_conn.commit()
 
+    # Drop any leftover schema from a previous attempt before recreating it.
+    # The test is marked flaky(reruns=2); if the first attempt fails mid-test
+    # (e.g. moto S3 transient 404) the cleanup at the bottom never runs, and
+    # the rerun would then fail on CREATE SCHEMA without this guard.
     run_command(
         """
+                DROP SCHEMA IF EXISTS test_writable_iceberg_table_tx CASCADE;
                 CREATE SCHEMA test_writable_iceberg_table_tx;
                 """,
         pg_conn,

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/Makefile
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/Makefile
@@ -1,0 +1,15 @@
+EXTENSION = pg_lake_table_test_data_file_hook
+
+MODULE_big = $(EXTENSION)
+
+DATA = $(EXTENSION)--1.0.sql
+SOURCES := $(wildcard src/*.c)
+OBJS := $(patsubst %.c,%.o,$(sort $(SOURCES)))
+
+PG_CPPFLAGS = -Iinclude -I../../../include -I../../../../pg_extension_base/include -I../../../../pg_lake_engine/include -I../../../../pg_lake_iceberg/include -I$(shell $(PG_CONFIG) --includedir) -std=gnu99
+override CFLAGS := $(filter-out -Wdeclaration-after-statement,$(CFLAGS))
+
+PG_CONFIG ?= pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+USE_PGXS=1
+include $(PGXS)

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/pg_lake_table_test_data_file_hook--1.0.sql
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/pg_lake_table_test_data_file_hook--1.0.sql
@@ -1,0 +1,9 @@
+-- pg_lake_table_test_data_file_hook
+--
+-- Loading the .so via LOAD or `requires`-cascade installs an _PG_init that
+-- registers PgLakeAddDataFileHook to always return true.  That causes
+-- pg_lake_table to insert added file IDs into the per-transaction temp
+-- table inside SPI_START_EXTENSION_OWNER, which is the codepath this
+-- extension exists to exercise.
+--
+-- No SQL objects are needed; the .so does the work in _PG_init.

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/pg_lake_table_test_data_file_hook--1.0.sql
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/pg_lake_table_test_data_file_hook--1.0.sql
@@ -6,4 +6,12 @@
 -- table inside SPI_START_EXTENSION_OWNER, which is the codepath this
 -- extension exists to exercise.
 --
--- No SQL objects are needed; the .so does the work in _PG_init.
+-- The extension also exposes run_iceberg_dml_under_extension_owner so
+-- tests can drive an UPDATE/DELETE on an Iceberg foreign table from
+-- inside SPI_START_EXTENSION_OWNER, exercising the temp-table create in
+-- CreateUpdateTrackingTable.
+
+CREATE FUNCTION run_iceberg_dml_under_extension_owner(query text)
+RETURNS void
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'run_iceberg_dml_under_extension_owner';

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/pg_lake_table_test_data_file_hook.control
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/pg_lake_table_test_data_file_hook.control
@@ -1,0 +1,6 @@
+comment = 'Test extension that registers PgLakeAddDataFileHook to exercise the in-transaction temp table'
+default_version = '1.0'
+module_pathname = '$libdir/pg_lake_table_test_data_file_hook'
+relocatable = false
+requires = 'pg_lake_table'
+schema = pg_catalog

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
@@ -16,23 +16,38 @@
  */
 
 /*
- * Test extension that registers a PgLakeAddDataFileHook returning true.
+ * Test extension that exposes hooks/helpers used to exercise narrow
+ * temp-object-creation sites under SPI_START_EXTENSION_OWNER.
  *
- * pg_lake_table calls this hook on each newly-added data file; when the
- * hook is set and returns true, pg_lake_table records the file ID in a
- * per-transaction temp table.  That temp-table creation path is the only
- * SPI_START_EXTENSION_OWNER caller that needs to allow CREATE TEMP, so
- * having this extension loaded during DML on an Iceberg table guarantees
- * we exercise SPI_START_EXTENSION_OWNER_ALLOW_TEMP end-to-end.
+ * 1. Registers a PgLakeAddDataFileHook returning true.  pg_lake_table
+ *    calls this hook on each newly-added data file; when the hook is set
+ *    and returns true, pg_lake_table records the file ID in a
+ *    per-transaction temp table.  That site exercises the
+ *    ALLOW_TEMP_OBJECTS scope around SPI in
+ *    CreateTxDataFileIdsTempTableIfNotExists.
+ *
+ * 2. Exposes run_iceberg_dml_under_extension_owner(query text), a SQL
+ *    helper that runs an UPDATE/DELETE on an Iceberg foreign table from
+ *    inside SPI_START_EXTENSION_OWNER.  pg_lake_table's BeginForeignModify
+ *    creates a per-statement temp tracking table for both UPDATE and
+ *    DELETE; the temp create must succeed under
+ *    SECURITY_RESTRICTED_OPERATION.  Without ALLOW_TEMP_OBJECTS_BEGIN/END
+ *    in CreateUpdateTrackingTable this fails with "cannot create temporary
+ *    table within security-restricted operation".
  *
  * Used by tests/pytests/test_data_file_hook_temp_table.py.
  */
 #include "postgres.h"
 #include "fmgr.h"
 
+#include "pg_extension_base/extension_ids.h"
+#include "pg_extension_base/spi_helpers.h"
 #include "pg_lake/fdw/data_files_catalog.h"
+#include "utils/builtins.h"
 
 PG_MODULE_MAGIC;
+
+extern PGDLLIMPORT CachedExtensionIds * PgLakeTable;
 
 void		_PG_init(void);
 
@@ -50,4 +65,36 @@ void
 _PG_init(void)
 {
 	PgLakeAddDataFileHook = AlwaysAddDataFile;
+}
+
+
+PG_FUNCTION_INFO_V1(run_iceberg_dml_under_extension_owner);
+
+/*
+ * run_iceberg_dml_under_extension_owner(query text) RETURNS void
+ *
+ * Runs an arbitrary SQL string from inside SPI_START_EXTENSION_OWNER, i.e.
+ * with SECURITY_RESTRICTED_OPERATION set and search_path pinned to
+ * pg_catalog,pg_temp.  Tests pass an UPDATE/DELETE on an Iceberg foreign
+ * table to exercise CreateUpdateTrackingTable's narrow ALLOW_TEMP_OBJECTS
+ * scope.
+ *
+ * Test-only.  Not safe to expose to untrusted callers since it executes
+ * caller-supplied SQL as the extension owner.
+ */
+Datum
+run_iceberg_dml_under_extension_owner(PG_FUNCTION_ARGS)
+{
+	char	   *query = text_to_cstring(PG_GETARG_TEXT_PP(0));
+
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+
+	int			spiStatus = SPI_execute(query, false /* readOnly */ , 0);
+
+	if (spiStatus < 0)
+		ereport(ERROR, (errmsg("SPI_execute returned %d", spiStatus)));
+
+	SPI_END();
+
+	PG_RETURN_VOID();
 }

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
@@ -23,7 +23,7 @@
  *    calls this hook on each newly-added data file; when the hook is set
  *    and returns true, pg_lake_table records the file ID in a
  *    per-transaction temp table.  That site exercises the
- *    ALLOW_TEMP_OBJECTS scope around SPI in
+ *    SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS variant in
  *    CreateTxDataFileIdsTempTableIfNotExists.
  *
  * 2. Exposes run_iceberg_dml_under_extension_owner(query text), a SQL

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
@@ -31,7 +31,7 @@
  *    inside SPI_START_EXTENSION_OWNER.  pg_lake_table's BeginForeignModify
  *    creates a per-statement temp tracking table for both UPDATE and
  *    DELETE; the temp create must succeed under
- *    SECURITY_RESTRICTED_OPERATION.  Without ALLOW_TEMP_OBJECTS_BEGIN/END
+ *    SECURITY_RESTRICTED_OPERATION.  Without the narrow restricted-op clear
  *    in CreateUpdateTrackingTable this fails with "cannot create temporary
  *    table within security-restricted operation".
  *
@@ -76,8 +76,8 @@ PG_FUNCTION_INFO_V1(run_iceberg_dml_under_extension_owner);
  * Runs an arbitrary SQL string from inside SPI_START_EXTENSION_OWNER, i.e.
  * with SECURITY_RESTRICTED_OPERATION set and search_path pinned to
  * pg_catalog,pg_temp.  Tests pass an UPDATE/DELETE on an Iceberg foreign
- * table to exercise CreateUpdateTrackingTable's narrow ALLOW_TEMP_OBJECTS
- * scope.
+ * table to exercise CreateUpdateTrackingTable's narrow restricted-op clear
+ * around DefineRelation/DefineIndex.
  *
  * Test-only.  Not safe to expose to untrusted callers since it executes
  * caller-supplied SQL as the extension owner.

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_data_file_hook/src/pg_lake_table_test_data_file_hook.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test extension that registers a PgLakeAddDataFileHook returning true.
+ *
+ * pg_lake_table calls this hook on each newly-added data file; when the
+ * hook is set and returns true, pg_lake_table records the file ID in a
+ * per-transaction temp table.  That temp-table creation path is the only
+ * SPI_START_EXTENSION_OWNER caller that needs to allow CREATE TEMP, so
+ * having this extension loaded during DML on an Iceberg table guarantees
+ * we exercise SPI_START_EXTENSION_OWNER_ALLOW_TEMP end-to-end.
+ *
+ * Used by tests/pytests/test_data_file_hook_temp_table.py.
+ */
+#include "postgres.h"
+#include "fmgr.h"
+
+#include "pg_lake/fdw/data_files_catalog.h"
+
+PG_MODULE_MAGIC;
+
+void		_PG_init(void);
+
+static bool AlwaysAddDataFile(void);
+
+
+static bool
+AlwaysAddDataFile(void)
+{
+	return true;
+}
+
+
+void
+_PG_init(void)
+{
+	PgLakeAddDataFileHook = AlwaysAddDataFile;
+}


### PR DESCRIPTION
 ## Summary

  #359 ("Lock down extension-owner SPI / direct-call sites") added `SECURITY_RESTRICTED_OPERATION` to `SPI_START_EXTENSION_OWNER`. PostgreSQL forbids
  creating temporary objects under that flag — the temp namespace cannot be safely established within a restricted context — which broke two sites in
  `pg_lake_table` that create temp tables under the extension owner's identity:

  1. `CreateTxDataFileIdsTempTableIfNotExists` in `data_files_catalog.c` — a per-transaction temp table populated only when an external module registers a
   non-NULL `PgLakeAddDataFileHook`. pg_lake's own pytest suite never exercised it; downstream consumers hit it as soon as they bumped to a pg_lake commit
   that includes #359.
  2. `CreateUpdateTrackingTable` in `update_tracking.c` — a per-statement temp tracking table created from `BeginForeignModify`, reached by every
  UPDATE/DELETE on a pg_lake_table foreign table. Triggered when DML runs from inside another extension's `SPI_START_EXTENSION_OWNER` block.

  Both error with `cannot create temporary table within security-restricted operation`.

  ## Approach

  1. Add `SPI_START_EXTENSION_OWNER_ALLOWING_TEMP_OBJECTS` to `pg_extension_base/include/pg_extension_base/spi_helpers.h`. Same identity switch and pinned
   `search_path = pg_catalog, pg_temp` as `SPI_START_EXTENSION_OWNER`, just without `SECURITY_RESTRICTED_OPERATION`. The opt-out is visible at the SPI
  entry helper. Pair with `SPI_END`.

  2. Switch `CreateTxDataFileIdsTempTableIfNotExists` to the new SPI helper. The DDL is a fixed string with no caller-supplied input, so lifting the
  restricted-op flag does not reopen the hijack vector that motivated #359; the search_path lockdown stays in effect.

  3. For `CreateUpdateTrackingTable`, the restricted-op flag is set further up the stack (by a caller's `SPI_START_EXTENSION_OWNER`), not by code we
  control at the entry. Inline a narrow `GetUserIdAndSecContext` / `SetUserIdAndSecContext` pair around the `DefineRelation` + `DefineIndex` calls to
  clear and restore the flag. The relation/index parameters are derived from the target relation OID, not caller-supplied SQL.

  4. Add a regression test that would have caught both paths:
     - `pg_lake_table_test_data_file_hook` — new sample extension that registers a `PgLakeAddDataFileHook` always returning true, and exposes
  `run_iceberg_dml_under_extension_owner(query text)` that runs SQL from inside `SPI_START_EXTENSION_OWNER`.
     - `tests/pytests/test_data_file_hook_temp_table.py` — loads the extension and exercises both the INSERT path (hits
  `CreateTxDataFileIdsTempTableIfNotExists`) and an UPDATE/DELETE on an Iceberg table run under `SPI_START_EXTENSION_OWNER` (hits
  `CreateUpdateTrackingTable`). Without the fix, both fail with the error above.

     The new sample extension is wired into `pg_lake_table/Makefile` alongside `pg_lake_table_test_hideable`, installed on `prepare-check` and uninstalled
   on `finish-check`.

  5. Drive-by fix: `test_writable_iceberg_table_tx` in `test_iceberg_xacts.py` is marked `@pytest.mark.flaky(reruns=2)` for moto S3 transient errors, but
  its `DROP SCHEMA` cleanup runs at the end of the test. A mid-test failure leaves the schema behind, and the rerun then fails immediately on `CREATE
  SCHEMA` with `DuplicateSchema` — defeating the rerun. Drop the schema with `IF EXISTS CASCADE` before recreating.