### PR TITLE
pgduck client: include conninfo in start-failure error

### DIFF
--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -143,15 +143,22 @@ GetPGDuckConnection(void)
 
 		PQfinish(connection);
 
-#ifdef USE_ASSERT_CHECKING
-		ereport(ERROR,
-				(errmsg("could not start query engine: %s", errorMessage),
-				 errdetail("connection string: %s", PgduckServerConninfo)));
-#else
-		/* hide internals from users */
-		ereport(ERROR,
+		/*
+		 * Log the conninfo to the server log so an administrator can debug
+		 * misconfigured servers (issue #293) without exposing the connection
+		 * string -- which may include credentials -- to the client.  We
+		 * intentionally do not include the libpq error message here; it is
+		 * surfaced only in the assertion-enabled ERROR below.
+		 */
+		ereport(LOG_SERVER_ONLY,
 				(errmsg("could not start query engine"),
 				 errdetail("connection string: %s", PgduckServerConninfo)));
+
+#ifdef USE_ASSERT_CHECKING
+		ereport(ERROR, (errmsg("could not start query engine: %s", errorMessage)));
+#else
+		/* hide internals from users */
+		ereport(ERROR, (errmsg("could not start query engine")));
 #endif
 	}
 

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -39,6 +39,7 @@
 
 static void InitializePGDuckClient(void);
 static void SetupPgDuckConnectionHash(void);
+static char *ResolvePgduckConninfo(void);
 
 static void PGDuckClientTransactionCallback(XactEvent event, void *arg);
 static void PGDuckClientSubtransactionCallback(SubXactEvent event,
@@ -128,6 +129,77 @@ SetupPgDuckConnectionHash(void)
 
 
 /*
+ * ResolvePgduckConninfo returns a palloc'd connection string showing the
+ * options libpq would actually use to reach pgduck_server, including values
+ * supplied via environment variables (e.g. PGHOSTADDR, PGPORT) and libpq's
+ * compiled-in defaults.  This is what an administrator needs to debug a
+ * misconfigured server -- PgduckServerConninfo alone hides any env-supplied
+ * overrides.
+ *
+ * We resolve options without opening a socket: PQconndefaults() returns the
+ * options with environment variables and compiled-in defaults applied, and
+ * PQconninfoParse() returns the values from the configured conninfo string.
+ * Configured values override defaults.  Options whose dispchar starts with
+ * '*' (passwords) or 'D' (debug-only) are omitted, as are empty values.
+ */
+static char *
+ResolvePgduckConninfo(void)
+{
+	StringInfoData buf;
+
+	initStringInfo(&buf);
+
+	PQconninfoOption *defaults = PQconndefaults();
+	PQconninfoOption *configured = PQconninfoParse(PgduckServerConninfo, NULL);
+
+	if (defaults == NULL)
+	{
+		/* OOM inside libpq; fall back to the raw configured string */
+		if (configured != NULL)
+			PQconninfoFree(configured);
+		appendStringInfoString(&buf, PgduckServerConninfo);
+		return buf.data;
+	}
+
+	bool		first = true;
+
+	for (PQconninfoOption *opt = defaults; opt->keyword != NULL; opt++)
+	{
+		const char *val = opt->val;
+
+		if (configured != NULL)
+		{
+			for (PQconninfoOption *c = configured; c->keyword != NULL; c++)
+			{
+				if (strcmp(c->keyword, opt->keyword) == 0)
+				{
+					if (c->val != NULL)
+						val = c->val;
+					break;
+				}
+			}
+		}
+
+		if (val == NULL || val[0] == '\0')
+			continue;
+		if (opt->dispchar != NULL &&
+			(opt->dispchar[0] == '*' || opt->dispchar[0] == 'D'))
+			continue;
+
+		appendStringInfo(&buf, "%s%s='%s'",
+						 first ? "" : " ", opt->keyword, val);
+		first = false;
+	}
+
+	PQconninfoFree(defaults);
+	if (configured != NULL)
+		PQconninfoFree(configured);
+
+	return buf.data;
+}
+
+
+/*
  * GetPGDuckConnection returns the main PGDuck connection.
  */
 PGDuckConnection *
@@ -150,9 +222,12 @@ GetPGDuckConnection(void)
 		 * intentionally do not include the libpq error message here; it is
 		 * surfaced only in the assertion-enabled ERROR below.
 		 */
+		char	   *resolved = ResolvePgduckConninfo();
+
 		ereport(LOG_SERVER_ONLY,
 				(errmsg("could not start query engine"),
-				 errdetail("connection string: %s", PgduckServerConninfo)));
+				 errdetail("connection string: %s", resolved)));
+		pfree(resolved);
 
 #ifdef USE_ASSERT_CHECKING
 		ereport(ERROR, (errmsg("could not start query engine: %s", errorMessage)));

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -144,10 +144,14 @@ GetPGDuckConnection(void)
 		PQfinish(connection);
 
 #ifdef USE_ASSERT_CHECKING
-		ereport(ERROR, (errmsg("could not start query engine: %s", errorMessage)));
+		ereport(ERROR,
+				(errmsg("could not start query engine: %s", errorMessage),
+				 errdetail("connection string: %s", PgduckServerConninfo)));
 #else
 		/* hide internals from users */
-		ereport(ERROR, (errmsg("could not start query engine")));
+		ereport(ERROR,
+				(errmsg("could not start query engine"),
+				 errdetail("connection string: %s", PgduckServerConninfo)));
 #endif
 	}
 

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -206,18 +206,19 @@ ResolvePgduckConninfo(void)
 PGDuckConnection *
 GetPGDuckConnection(void)
 {
-  InitializePGDuckClient();
+	InitializePGDuckClient();
 
-  /*
-   * PGHOSTADDR, if set in the server environment, overrides host= in the
-   * conninfo — including unix-socket paths — and silently redirects libpq
-   * to connect via TCP to a numeric IP instead.  Clear it before connecting
-   * so PgduckServerConninfo is always honoured.  Unlike PGHOST/PGPORT, which
-   * lose to explicit conninfo values, PGHOSTADDR unconditionally wins.
-   */
-  unsetenv("PGHOSTADDR");
+	/*
+	 * PGHOSTADDR, if set in the server environment, overrides host= in the
+	 * conninfo — including unix-socket paths — and silently redirects
+	 * libpq to connect via TCP to a numeric IP instead.  Clear it before
+	 * connecting so PgduckServerConninfo is always honoured.  Unlike
+	 * PGHOST/PGPORT, which lose to explicit conninfo values, PGHOSTADDR
+	 * unconditionally wins.
+	 */
+	unsetenv("PGHOSTADDR");
 
-  PGconn     *connection = PQconnectdb(PgduckServerConninfo);
+	PGconn	   *connection = PQconnectdb(PgduckServerConninfo);
 
 	if (PQstatus(connection) != CONNECTION_OK)
 	{

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -131,10 +131,11 @@ SetupPgDuckConnectionHash(void)
 /*
  * ResolvePgduckConninfo returns a palloc'd connection string showing the
  * options libpq would actually use to reach pgduck_server, including values
- * supplied via environment variables (e.g. PGHOSTADDR, PGPORT) and libpq's
+ * supplied via environment variables (e.g. PGPORT, PGUSER) and libpq's
  * compiled-in defaults.  This is what an administrator needs to debug a
  * misconfigured server -- PgduckServerConninfo alone hides any env-supplied
- * overrides.
+ * overrides.  Note: PGHOSTADDR is cleared before connecting (see caller),
+ * so it will not appear in the resolved output.
  *
  * We resolve options without opening a socket: PQconndefaults() returns the
  * options with environment variables and compiled-in defaults applied, and
@@ -205,9 +206,18 @@ ResolvePgduckConninfo(void)
 PGDuckConnection *
 GetPGDuckConnection(void)
 {
-	InitializePGDuckClient();
+  InitializePGDuckClient();
 
-	PGconn	   *connection = PQconnectdb(PgduckServerConninfo);
+  /*
+   * PGHOSTADDR, if set in the server environment, overrides host= in the
+   * conninfo — including unix-socket paths — and silently redirects libpq
+   * to connect via TCP to a numeric IP instead.  Clear it before connecting
+   * so PgduckServerConninfo is always honoured.  Unlike PGHOST/PGPORT, which
+   * lose to explicit conninfo values, PGHOSTADDR unconditionally wins.
+   */
+  unsetenv("PGHOSTADDR");
+
+  PGconn     *connection = PQconnectdb(PgduckServerConninfo);
 
 	if (PQstatus(connection) != CONNECTION_OK)
 	{


### PR DESCRIPTION
  When the connection to pgduck_server fails, the user-facing ERROR only says "could not start query engine", which leaves administrators with nothing to
  debug a misconfigured server (e.g. environment variables overriding the configured conninfo).

  This PR adds a LOG_SERVER_ONLY ereport before the user-facing ERROR with the connection string in errdetail. The conninfo lands in the PostgreSQL server
  log where the administrator can see it, but is never sent to the client (which may be a less-trusted role and the conninfo can include credentials).

  The user-facing ERROR is unchanged — the libpq error message is still only included in assertion-enabled builds, and the conninfo is never included.

  It may still be worth a follow-up to look at the underlying behavior of environment variables superseding the configured connection string; that seems
  undesirable.