### PR TITLE
pg_lake_table: tune autovacuum on commit-time diff catalogs

### DIFF
--- a/pg_lake_table/pg_lake_table--3.3--3.4.sql
+++ b/pg_lake_table/pg_lake_table--3.3--3.4.sql
@@ -1,1 +1,17 @@
 -- Upgrade script for pg_lake_table from 3.3 to 3.4
+
+-- Tighten autovacuum_analyze on the commit-time diff catalogs so the planner's
+-- reltuples stays close enough to reality to keep the diff query off the
+-- nested-loop cliff. Complements pg_lake_table.commit_time_analyze_threshold.
+ALTER TABLE lake_table.files SET (
+    autovacuum_analyze_scale_factor = 0.05,
+    autovacuum_analyze_threshold    = 500
+);
+ALTER TABLE lake_table.data_file_partition_values SET (
+    autovacuum_analyze_scale_factor = 0.05,
+    autovacuum_analyze_threshold    = 500
+);
+ALTER TABLE lake_table.data_file_column_stats SET (
+    autovacuum_analyze_scale_factor = 0.05,
+    autovacuum_analyze_threshold    = 500
+);


### PR DESCRIPTION
The diff query in GetDataFileMetadataOperations joins lake_table.files, data_file_partition_values, and data_file_column_stats; plan choice is dominated by pg_class.reltuples. PG's defaults (scale_factor=0.10, threshold=50) let reltuples drift enough on these high-churn catalogs that the planner flips from hash join to nested loop.

Set scale_factor=0.05, threshold=500 on all three. Half PG's default scale factor caps reltuples drift at ~5%, well inside planner tolerance; lowering further is mostly ANALYZE thrash without a planner benefit (diminishing returns). threshold=500 sits strictly below the pg_lake_table.commit_time_analyze_threshold GUC (default 1000) from #352, so autovacuum backstops the small-tx workload where the GUC opts out.

Complements #352: the in-tx GUC handles large txs autovacuum cannot reach; these storage params keep reltuples fresh between txs.
