### PR TITLE
Fix CI for #327: Fix column type OIDs in pgduck_server row description metadata 

### DIFF
--- a/pg_lake_table/tests/pytests/test_date_partitioned_writes.py
+++ b/pg_lake_table/tests/pytests/test_date_partitioned_writes.py
@@ -164,7 +164,7 @@ def test_calendar_partition_write(
             f"SELECT count(DISTINCT {part_expr}), count(*) FROM '{path}'",
             pgduck_conn,
         )
-        assert res[0][0] == "1"
+        assert res[0][0] == 1
         assert int(res[0][1]) == row_count
 
         res = run_query(
@@ -177,7 +177,9 @@ def test_calendar_partition_write(
             pg_conn,
         )
 
-        assert res_partition[0][0] == res[0][0]
+        # res_partition[0][0] is text; res[0][0] is now native (int for
+        # year/month/day partitions).
+        assert res_partition[0][0] == str(res[0][0])
 
     # register the same table to spark
     # and make sure it can understand our partitioning

--- a/pg_lake_table/tests/pytests/test_iceberg_remove_unreferenced_files.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_remove_unreferenced_files.py
@@ -900,7 +900,7 @@ def test_remove_unreferenced_files_13(
     res = run_query(
         f"SELECT count(*) FROM read_parquet('{file_paths_q[0][0]}/*')", pgduck_conn
     )
-    assert res[0][0] == "0"
+    assert res[0][0] == 0
 
     # no files inserted
     file_paths = run_query(

--- a/pg_lake_table/tests/pytests/test_identity_partitioned_writes.py
+++ b/pg_lake_table/tests/pytests/test_identity_partitioned_writes.py
@@ -260,21 +260,30 @@ def test_identity_partition_write(
             pg_conn,
         )
 
-        if col_type == "BOOLEAN":
-            assert bool(res_partition[0][0]) == bool(res[0][0])
-        elif col_type in ("TIMESTAMP", "TIMESTAMPTZ"):
-            expected = datetime.datetime.fromisoformat(res_partition[0][0])
-            actual = datetime.datetime.fromisoformat(res[0][0])
+        # res_partition is the partition-value text from
+        # lake_table.data_file_partition_values; res[0][0] now comes back as a
+        # native Python type from pgduck_server (the type depends on col_type).
+        partition_text = res_partition[0][0]
+        actual_value = res[0][0]
 
-            if actual.tzinfo is not None:
+        if col_type == "BOOLEAN":
+            # partition value is PG bool short form ("t" / "f")
+            expected_bool = partition_text == "t"
+            assert expected_bool == actual_value
+        elif col_type in ("TIMESTAMP", "TIMESTAMPTZ"):
+            expected = datetime.datetime.fromisoformat(partition_text)
+            if actual_value.tzinfo is not None and expected.tzinfo is None:
                 expected = expected.replace(tzinfo=datetime.timezone.utc)
-            assert expected == actual
+            assert expected == actual_value
         elif col_type == "DATE":
-            expected = datetime.date.fromisoformat(res_partition[0][0])
-            actual = datetime.date.fromisoformat(res[0][0])
-            assert expected == actual
+            expected = datetime.date.fromisoformat(partition_text)
+            assert expected == actual_value
+        elif col_type == "BYTEA":
+            # partition value is "\\x..." text; cursor returns memoryview
+            assert partition_text == "\\x" + bytes(actual_value).hex()
         else:
-            assert res_partition[0][0] == res[0][0]
+            # All other types compare cleanly via stringification.
+            assert partition_text == str(actual_value)
 
         res = run_query(f"SELECT count(*) FROM '{file_path}'", pgduck_conn)
         # each file should have a distinct value

--- a/pg_lake_table/tests/pytests/test_multi_expr_partition_writes.py
+++ b/pg_lake_table/tests/pytests/test_multi_expr_partition_writes.py
@@ -105,7 +105,7 @@ def test_multi_expression_partition_write(
             """,
             pgduck_conn,
         )[0][0]
-        assert part_key_cnt == "1"
+        assert part_key_cnt == 1
 
     # 5) tidy up session GUC
     run_command("RESET pg_lake_table.enable_insert_select_pushdown;", pg_conn)

--- a/pg_lake_table/tests/pytests/test_partition_evolution.py
+++ b/pg_lake_table/tests/pytests/test_partition_evolution.py
@@ -104,7 +104,7 @@ def test_partition_evolution(
 
     for p in files_stage1:
         rows = run_query(f"SELECT count(*) FROM '{p}'", pgduck_conn)[0][0]
-        assert rows == "2"
+        assert rows == 2
         _file_holds_single_key(p, KEY_STAGE1, pgduck_conn)
 
     # ─── stage 2  ── ALTER SET … + second insert (8 new partitions) ────────
@@ -135,7 +135,7 @@ def test_partition_evolution(
     assert len(files_stage2) == 8
 
     for p in files_stage2:
-        assert run_query(f"SELECT count(*) FROM '{p}'", pgduck_conn)[0][0] == "2"
+        assert run_query(f"SELECT count(*) FROM '{p}'", pgduck_conn)[0][0] == 2
         _file_holds_single_key(p, KEY_STAGE2, pgduck_conn)
 
     # ─── stage 3  ── ALTER DROP partition_by + final insert (un-partitioned) ─
@@ -153,7 +153,7 @@ def test_partition_evolution(
     assert len(files_stage3) == 1
 
     path = next(iter(files_stage3))
-    assert run_query(f"SELECT count(*) FROM '{path}'", pgduck_conn)[0][0] == "4"
+    assert run_query(f"SELECT count(*) FROM '{path}'", pgduck_conn)[0][0] == 4
 
     # ─── cleanup session GUC ────────────────────────────────────────────────
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_truncate_partitioned_writes.py
+++ b/pg_lake_table/tests/pytests/test_truncate_partitioned_writes.py
@@ -154,7 +154,7 @@ def test_truncate_partition_write(
         res = run_query(
             f"SELECT count(DISTINCT {part_expr}), count(*) FROM '{path}'", pgduck_conn
         )
-        assert res[0][0] == "1"
+        assert res[0][0] == 1
         assert int(res[0][1]) == row_count
 
         res = run_query(f"SELECT DISTINCT {part_expr} FROM '{path}'", pgduck_conn)
@@ -163,7 +163,9 @@ def test_truncate_partition_write(
             f"SELECT value FROM lake_table.data_file_partition_values WHERE id='{id}'",
             pg_conn,
         )
-        assert res_partition[0][0].strip() == res[0][0].strip()
+        # res_partition[0][0] is text; res[0][0] is now native (int for
+        # numeric truncations, string for varchar/char/text).
+        assert res_partition[0][0].strip() == str(res[0][0]).strip()
 
     # register the same table to spark
     # and make sure it can understand our partitioning

--- a/pgduck_server/include/duckdb/type_conversion.h
+++ b/pgduck_server/include/duckdb/type_conversion.h
@@ -59,4 +59,6 @@ typedef struct DuckDBTypeInfo
 
 extern DuckDBTypeInfo * find_duck_type_info(duckdb_type duckType);
 
+extern Oid duckdb_type_to_pg_oid(duckdb_type duckType);
+
 #endif

--- a/pgduck_server/include/duckdb/type_conversion.h
+++ b/pgduck_server/include/duckdb/type_conversion.h
@@ -59,6 +59,6 @@ typedef struct DuckDBTypeInfo
 
 extern DuckDBTypeInfo * find_duck_type_info(duckdb_type duckType);
 
-extern Oid duckdb_type_to_pg_oid(duckdb_type duckType);
+extern Oid	duckdb_type_to_pg_oid(duckdb_type duckType);
 
 #endif

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -1148,10 +1148,11 @@ duckdb_query_result_send_column_metadata(DuckDBQueryResult * duckdb_query_result
 			pq_writeint16(buf, originalColumnNumber);
 
 			/*
-			 * We always send columnTypeId=InvalidOid, columnLength=-1,
-			 * columnTypeMod=-1 see TypeInfo struct comment for the reasoning.
+			 * We convert each DuckDB type to the closest PostgreSQL OID equivalent.
+			 * columnLength and columnTypeMod are left as -1, see TypeInfo struct
+			 * comment for the reasoning.
 			 */
-			pq_writeint32(buf, InvalidOid);
+			pq_writeint32(buf, duckdb_type_to_pg_oid(duckType));
 			pq_writeint16(buf, -1);
 			pq_writeint32(buf, -1);
 		}

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -1148,9 +1148,9 @@ duckdb_query_result_send_column_metadata(DuckDBQueryResult * duckdb_query_result
 			pq_writeint16(buf, originalColumnNumber);
 
 			/*
-			 * We convert each DuckDB type to the closest PostgreSQL OID equivalent.
-			 * columnLength and columnTypeMod are left as -1, see TypeInfo struct
-			 * comment for the reasoning.
+			 * We convert each DuckDB type to the closest PostgreSQL OID
+			 * equivalent. columnLength and columnTypeMod are left as -1, see
+			 * TypeInfo struct comment for the reasoning.
 			 */
 			pq_writeint32(buf, duckdb_type_to_pg_oid(duckType));
 			pq_writeint16(buf, -1);

--- a/pgduck_server/src/duckdb/type_conversion.c
+++ b/pgduck_server/src/duckdb/type_conversion.c
@@ -348,103 +348,105 @@ find_duck_type_info(duckdb_type duckType)
  * For types with no direct PG equivalent (e.g. UBIGINT, HUGEINT, UHUGEINT,
  * complex logical types), we fall back to TEXTOID so the client can still
  * consume the text-serialised value we always send.
- * 
+ *
  * Note: consider falling back to InvalidOid (0).
  *
  * For DECIMAL we always return NUMERICOID regardless of width/scale;
  * callers that need the typmod should handle that separately.
  */
-Oid duckdb_type_to_pg_oid(duckdb_type duckType)
+Oid
+duckdb_type_to_pg_oid(duckdb_type duckType)
 {
 	switch (duckType)
 	{
-	/* ---- booleans ---- */
-	case DUCKDB_TYPE_BOOLEAN:
-		return BOOLOID;
+			/* ---- booleans ---- */
+		case DUCKDB_TYPE_BOOLEAN:
+			return BOOLOID;
 
-	/* ---- integers ---- */
-	case DUCKDB_TYPE_TINYINT:
-		return INT2OID; /* no INT1 in PG */
-	case DUCKDB_TYPE_SMALLINT:
-		return INT2OID;
-	case DUCKDB_TYPE_INTEGER:
-		return INT4OID;
-	case DUCKDB_TYPE_BIGINT:
-		return INT8OID;
+			/* ---- integers ---- */
+		case DUCKDB_TYPE_TINYINT:
+			return INT2OID;		/* no INT1 in PG */
+		case DUCKDB_TYPE_SMALLINT:
+			return INT2OID;
+		case DUCKDB_TYPE_INTEGER:
+			return INT4OID;
+		case DUCKDB_TYPE_BIGINT:
+			return INT8OID;
 
-	/* unsigned — promote to next signed size that fits */
-	case DUCKDB_TYPE_UTINYINT:
-		return INT2OID;
-	case DUCKDB_TYPE_USMALLINT:
-		return INT4OID;
-	case DUCKDB_TYPE_UINTEGER:
-		return INT8OID;
-	case DUCKDB_TYPE_UBIGINT:
-		return INT8OID; /* no u64 in PG, but this is the closest consistent choice */
-	case DUCKDB_TYPE_HUGEINT:
-		return NUMERICOID;
-	case DUCKDB_TYPE_UHUGEINT:
-		return NUMERICOID;
+			/* unsigned — promote to next signed size that fits */
+		case DUCKDB_TYPE_UTINYINT:
+			return INT2OID;
+		case DUCKDB_TYPE_USMALLINT:
+			return INT4OID;
+		case DUCKDB_TYPE_UINTEGER:
+			return INT8OID;
+		case DUCKDB_TYPE_UBIGINT:
+			return INT8OID;		/* no u64 in PG, but this is the closest
+								 * consistent choice */
+		case DUCKDB_TYPE_HUGEINT:
+			return NUMERICOID;
+		case DUCKDB_TYPE_UHUGEINT:
+			return NUMERICOID;
 
-	/* ---- floats ---- */
-	case DUCKDB_TYPE_FLOAT:
-		return FLOAT4OID;
-	case DUCKDB_TYPE_DOUBLE:
-		return FLOAT8OID;
+			/* ---- floats ---- */
+		case DUCKDB_TYPE_FLOAT:
+			return FLOAT4OID;
+		case DUCKDB_TYPE_DOUBLE:
+			return FLOAT8OID;
 
-	/* ---- arbitrary precision ---- */
-	case DUCKDB_TYPE_DECIMAL:
-		return NUMERICOID;
+			/* ---- arbitrary precision ---- */
+		case DUCKDB_TYPE_DECIMAL:
+			return NUMERICOID;
 
-	/* ---- text / bytes ---- */
-	case DUCKDB_TYPE_VARCHAR:
-		return TEXTOID;
-	case DUCKDB_TYPE_BLOB:
-		return BYTEAOID;
-	case DUCKDB_TYPE_BIT:
-		return BITOID;
-	case DUCKDB_TYPE_ENUM:
-		return TEXTOID; /* sent as label text */
+			/* ---- text / bytes ---- */
+		case DUCKDB_TYPE_VARCHAR:
+			return TEXTOID;
+		case DUCKDB_TYPE_BLOB:
+			return BYTEAOID;
+		case DUCKDB_TYPE_BIT:
+			return BITOID;
+		case DUCKDB_TYPE_ENUM:
+			return TEXTOID;		/* sent as label text */
 
-	/* ---- date / time ---- */
-	case DUCKDB_TYPE_DATE:
-		return DATEOID;
-	case DUCKDB_TYPE_TIME:
-		return TIMEOID;
-	case DUCKDB_TYPE_TIME_TZ:
-		return TIMETZOID;
-	case DUCKDB_TYPE_TIMESTAMP:
-		return TIMESTAMPOID;
-	case DUCKDB_TYPE_TIMESTAMP_S:
-		return TIMESTAMPOID;
-	case DUCKDB_TYPE_TIMESTAMP_MS:
-		return TIMESTAMPOID;
-	case DUCKDB_TYPE_TIMESTAMP_NS:
-		return TIMESTAMPOID;
-	case DUCKDB_TYPE_TIMESTAMP_TZ:
-		return TIMESTAMPTZOID;
-	case DUCKDB_TYPE_INTERVAL:
-		return INTERVALOID;
+			/* ---- date / time ---- */
+		case DUCKDB_TYPE_DATE:
+			return DATEOID;
+		case DUCKDB_TYPE_TIME:
+			return TIMEOID;
+		case DUCKDB_TYPE_TIME_TZ:
+			return TIMETZOID;
+		case DUCKDB_TYPE_TIMESTAMP:
+			return TIMESTAMPOID;
+		case DUCKDB_TYPE_TIMESTAMP_S:
+			return TIMESTAMPOID;
+		case DUCKDB_TYPE_TIMESTAMP_MS:
+			return TIMESTAMPOID;
+		case DUCKDB_TYPE_TIMESTAMP_NS:
+			return TIMESTAMPOID;
+		case DUCKDB_TYPE_TIMESTAMP_TZ:
+			return TIMESTAMPTZOID;
+		case DUCKDB_TYPE_INTERVAL:
+			return INTERVALOID;
 
-	/* ---- uuid ---- */
-	case DUCKDB_TYPE_UUID:
-		return UUIDOID;
+			/* ---- uuid ---- */
+		case DUCKDB_TYPE_UUID:
+			return UUIDOID;
 
-	/* ---- complex / nested — serialised as text ---- */
-	/* TODO: Handle this case */
-	case DUCKDB_TYPE_LIST:
-		return TEXTOID;
-	case DUCKDB_TYPE_ARRAY:
-		return TEXTOID;
-	case DUCKDB_TYPE_STRUCT:
-		return TEXTOID;
-	case DUCKDB_TYPE_MAP:
-		return TEXTOID;
-	case DUCKDB_TYPE_UNION:
-		return TEXTOID;
+			/* ---- complex / nested — serialised as text ---- */
+			/* TODO: Handle this case */
+		case DUCKDB_TYPE_LIST:
+			return TEXTOID;
+		case DUCKDB_TYPE_ARRAY:
+			return TEXTOID;
+		case DUCKDB_TYPE_STRUCT:
+			return TEXTOID;
+		case DUCKDB_TYPE_MAP:
+			return TEXTOID;
+		case DUCKDB_TYPE_UNION:
+			return TEXTOID;
 
-	default:
-		return InvalidOid;
+		default:
+			return InvalidOid;
 	}
 }
 

--- a/pgduck_server/src/duckdb/type_conversion.c
+++ b/pgduck_server/src/duckdb/type_conversion.c
@@ -349,8 +349,6 @@ find_duck_type_info(duckdb_type duckType)
  * complex logical types), we fall back to TEXTOID so the client can still
  * consume the text-serialised value we always send.
  *
- * Note: consider falling back to InvalidOid (0).
- *
  * For DECIMAL we always return NUMERICOID regardless of width/scale;
  * callers that need the typmod should handle that separately.
  */

--- a/pgduck_server/src/duckdb/type_conversion.c
+++ b/pgduck_server/src/duckdb/type_conversion.c
@@ -343,6 +343,112 @@ find_duck_type_info(duckdb_type duckType)
 }
 
 /*
+ * duckdb_type_to_pg_oid: maps a DuckDB type to its closest PostgreSQL OID.
+ *
+ * For types with no direct PG equivalent (e.g. UBIGINT, HUGEINT, UHUGEINT,
+ * complex logical types), we fall back to TEXTOID so the client can still
+ * consume the text-serialised value we always send.
+ * 
+ * Note: consider falling back to InvalidOid (0).
+ *
+ * For DECIMAL we always return NUMERICOID regardless of width/scale;
+ * callers that need the typmod should handle that separately.
+ */
+Oid duckdb_type_to_pg_oid(duckdb_type duckType)
+{
+	switch (duckType)
+	{
+	/* ---- booleans ---- */
+	case DUCKDB_TYPE_BOOLEAN:
+		return BOOLOID;
+
+	/* ---- integers ---- */
+	case DUCKDB_TYPE_TINYINT:
+		return INT2OID; /* no INT1 in PG */
+	case DUCKDB_TYPE_SMALLINT:
+		return INT2OID;
+	case DUCKDB_TYPE_INTEGER:
+		return INT4OID;
+	case DUCKDB_TYPE_BIGINT:
+		return INT8OID;
+
+	/* unsigned — promote to next signed size that fits */
+	case DUCKDB_TYPE_UTINYINT:
+		return INT2OID;
+	case DUCKDB_TYPE_USMALLINT:
+		return INT4OID;
+	case DUCKDB_TYPE_UINTEGER:
+		return INT8OID;
+	case DUCKDB_TYPE_UBIGINT:
+		return INT8OID; /* no u64 in PG, but this is the closest consistent choice */
+	case DUCKDB_TYPE_HUGEINT:
+		return NUMERICOID;
+	case DUCKDB_TYPE_UHUGEINT:
+		return NUMERICOID;
+
+	/* ---- floats ---- */
+	case DUCKDB_TYPE_FLOAT:
+		return FLOAT4OID;
+	case DUCKDB_TYPE_DOUBLE:
+		return FLOAT8OID;
+
+	/* ---- arbitrary precision ---- */
+	case DUCKDB_TYPE_DECIMAL:
+		return NUMERICOID;
+
+	/* ---- text / bytes ---- */
+	case DUCKDB_TYPE_VARCHAR:
+		return TEXTOID;
+	case DUCKDB_TYPE_BLOB:
+		return BYTEAOID;
+	case DUCKDB_TYPE_BIT:
+		return BITOID;
+	case DUCKDB_TYPE_ENUM:
+		return TEXTOID; /* sent as label text */
+
+	/* ---- date / time ---- */
+	case DUCKDB_TYPE_DATE:
+		return DATEOID;
+	case DUCKDB_TYPE_TIME:
+		return TIMEOID;
+	case DUCKDB_TYPE_TIME_TZ:
+		return TIMETZOID;
+	case DUCKDB_TYPE_TIMESTAMP:
+		return TIMESTAMPOID;
+	case DUCKDB_TYPE_TIMESTAMP_S:
+		return TIMESTAMPOID;
+	case DUCKDB_TYPE_TIMESTAMP_MS:
+		return TIMESTAMPOID;
+	case DUCKDB_TYPE_TIMESTAMP_NS:
+		return TIMESTAMPOID;
+	case DUCKDB_TYPE_TIMESTAMP_TZ:
+		return TIMESTAMPTZOID;
+	case DUCKDB_TYPE_INTERVAL:
+		return INTERVALOID;
+
+	/* ---- uuid ---- */
+	case DUCKDB_TYPE_UUID:
+		return UUIDOID;
+
+	/* ---- complex / nested — serialised as text ---- */
+	/* TODO: Handle this case */
+	case DUCKDB_TYPE_LIST:
+		return TEXTOID;
+	case DUCKDB_TYPE_ARRAY:
+		return TEXTOID;
+	case DUCKDB_TYPE_STRUCT:
+		return TEXTOID;
+	case DUCKDB_TYPE_MAP:
+		return TEXTOID;
+	case DUCKDB_TYPE_UNION:
+		return TEXTOID;
+
+	default:
+		return InvalidOid;
+	}
+}
+
+/*
  * This function performs necessary cleanup of a TextOutputBuffer for handling
  * error conditions.
  */

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import time
+from decimal import Decimal
 from utils_pytest import *
 
 CACHE_FILE_PREFIX = "pgl-cache."
@@ -63,11 +64,11 @@ def run_pg_lake_cache_file_test_for_protocol(protocol, prefix, pgduck_conn, clie
         f"SELECT file_size FROM pg_lake_list_cache() WHERE url = '{url}'", pgduck_conn
     )
     assert len(results) == 1
-    assert results[0][0] == str(cached_path.stat().st_size)
+    assert results[0][0] == cached_path.stat().st_size
 
     # Verify that we go the result from S3
     results = run_query(f"SELECT count(*) FROM '{url}'", pgduck_conn)
-    assert results[0][0] == "100"
+    assert results[0][0] == 100
 
     # Sneakily write something else to the cached file
     run_command(
@@ -79,11 +80,11 @@ def run_pg_lake_cache_file_test_for_protocol(protocol, prefix, pgduck_conn, clie
 
     # Verify that we are indeed reading from cache when using the URL
     results = run_query(f"SELECT count(*) FROM '{url}'", pgduck_conn)
-    assert results[0][0] == "50"
+    assert results[0][0] == 50
 
     # Can bypass cache using nocache prefix
     results = run_query(f"SELECT count(*) FROM 'nocache{url}'", pgduck_conn)
-    assert results[0][0] == "100"
+    assert results[0][0] == 100
 
     # Calling pg_lake_cache_file without force does not change that
     run_command(
@@ -95,7 +96,7 @@ def run_pg_lake_cache_file_test_for_protocol(protocol, prefix, pgduck_conn, clie
 
     # Verify that we are still from cache when using the URL
     results = run_query(f"SELECT count(*) FROM '{url}'", pgduck_conn)
-    assert results[0][0] == "50"
+    assert results[0][0] == 50
 
     # Calling pg_lake_cache_file with force will restore the real file
     run_command(
@@ -107,11 +108,11 @@ def run_pg_lake_cache_file_test_for_protocol(protocol, prefix, pgduck_conn, clie
 
     # Verify that we go the result from S3
     results = run_query(f"SELECT count(*) FROM '{url}'", pgduck_conn)
-    assert results[0][0] == "100"
+    assert results[0][0] == 100
 
     # Remove the cached file
     results = run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
-    assert results[0][0] == "t"
+    assert results[0][0] is True
 
     # Verify the file is gone
     assert not cached_path.exists()
@@ -143,7 +144,7 @@ def test_invalid_url(s3, pgduck_conn):
 
     # Trying to remove a non-existent URL just returns false
     results = run_query(f"CALL pg_lake_uncache_file('{url_notexists}');", pgduck_conn)
-    assert results[0][0] == "f"
+    assert results[0][0] is False
 
     pgduck_conn.rollback()
 
@@ -575,7 +576,7 @@ def test_concurrent_cache_same_file_no_force(s3, pgduck_conn):
 
     # ensure that this waited until the other pg_lake_cache_file
     # finished, then returned 0 bytes
-    assert results[0][0] == "0"
+    assert results[0][0] == 0
 
     t1.join()
 
@@ -746,7 +747,7 @@ def test_copy_concurrently(s3, pgduck_conn):
 
     # Verify that we always have the final results by the second COPY
     results = run_query(f"SELECT count(*) FROM '{url_1}'", pgduck_conn)
-    assert results[0][0] == "2000"
+    assert results[0][0] == 2000
 
 
 def test_pg_lake_remove_file(s3, pgduck_conn):
@@ -773,7 +774,7 @@ def run_test_pg_lake_remove_file(query_arg, s3, pgduck_conn):
 
     # Verify that we can read from the file
     results = run_query(f"SELECT sum(s) FROM '{url}'", pgduck_conn)
-    assert results[0][0] == "5050"
+    assert results[0][0] == Decimal("5050")
 
     # Remove the file
     run_command(

--- a/pgduck_server/tests/pytests/test_cancellations.py
+++ b/pgduck_server/tests/pytests/test_cancellations.py
@@ -117,7 +117,7 @@ def test_query_cancellation_for_multiple_clients(pgduck_server, num_clients=20):
         # make sure we can still run queries successfully
         cur = conn.cursor()
         cur.execute("SELECT 1")
-        assert cur.fetchall() == [("1",)]
+        assert cur.fetchall() == [(1,)]
 
     # Wait for all threads to finish
     for _, thread in threads:

--- a/pgduck_server/tests/pytests/test_functions.py
+++ b/pgduck_server/tests/pytests/test_functions.py
@@ -1,4 +1,6 @@
 import os
+from decimal import Decimal
+
 import pytest
 from utils_pytest import *
 
@@ -21,19 +23,19 @@ def test_list_files_s3(pgduck_conn, s3):
     assert len(result) == 2
     assert result[0] == [
         prefix + "/large.csv",
-        "707",
+        707,
         '"81d51ab47a013964a866395b6921e30d"',
     ]
     assert result[1] == [
         prefix + "/small.csv",
-        "14",
+        14,
         '"18a74ddc08d592acc32079bdedf76b99"',
     ]
 
     result = run_query(
         f"select sum(file_size) from pg_lake_list_files('{prefix}/*')", pgduck_conn
     )
-    assert result[0][0] == "721"
+    assert result[0][0] == Decimal("721")
 
 
 def test_list_files_azure(pgduck_conn, azure):
@@ -53,13 +55,13 @@ def test_list_files_azure(pgduck_conn, azure):
         pgduck_conn,
     )
     assert len(result) == 2
-    assert result[0] == [prefix + "/large.csv", "707"]
-    assert result[1] == [prefix + "/small.csv", "14"]
+    assert result[0] == [prefix + "/large.csv", 707]
+    assert result[1] == [prefix + "/small.csv", 14]
 
     result = run_query(
         f"select sum(file_size) from pg_lake_list_files('{prefix}/*')", pgduck_conn
     )
-    assert result[0][0] == "721"
+    assert result[0][0] == Decimal("721")
 
 
 def test_list_files_paginate(pgduck_conn, s3, azure):

--- a/pgduck_server/tests/pytests/test_postgres_scanner.py
+++ b/pgduck_server/tests/pytests/test_postgres_scanner.py
@@ -11,6 +11,8 @@ Scenarios covered:
 - Multidimensional array values in int[] column clamped to NULL
 """
 
+from decimal import Decimal
+
 import pytest
 from utils_pytest import *
 
@@ -231,7 +233,7 @@ def test_composite_type(pg_tables, pgduck_conn):
         f"FROM {scan} ORDER BY struct_extract(c, 'id') NULLS LAST",
         pgduck_conn,
     )
-    assert rows == [("42", "hello"), ("99", "world"), (None, None)]
+    assert rows == [(42, "hello"), (99, "world"), (None, None)]
 
 
 def test_composite_same_name_different_schemas(pg_tables, pgduck_conn):
@@ -241,7 +243,7 @@ def test_composite_same_name_different_schemas(pg_tables, pgduck_conn):
         f"SELECT struct_extract(c, 'id'), struct_extract(c, 'name') " f"FROM {scan_a}",
         pgduck_conn,
     )
-    assert rows_a == [("1", "alpha")]
+    assert rows_a == [(1, "alpha")]
 
     scan_b = _scan("comp_tbl", schema="scanner_schema_b")
     rows_b = perform_query_on_cursor(
@@ -250,7 +252,7 @@ def test_composite_same_name_different_schemas(pg_tables, pgduck_conn):
         f"FROM {scan_b}",
         pgduck_conn,
     )
-    assert rows_b == [("2", "beta", "42")]
+    assert rows_b == [(2, "beta", 42)]
 
 
 def test_composite_special_characters(pg_tables, pgduck_conn):
@@ -263,7 +265,7 @@ def test_composite_special_characters(pg_tables, pgduck_conn):
         f"FROM {scan}",
         pgduck_conn,
     )
-    assert rows == [("7", 'hi "there', "99")]
+    assert rows == [(7, 'hi "there', 99)]
 
 
 def test_composite_with_array_field(pg_tables, pgduck_conn):
@@ -274,7 +276,7 @@ def test_composite_with_array_field(pg_tables, pgduck_conn):
         f"FROM {scan} ORDER BY struct_extract(c, 'id') NULLS LAST",
         pgduck_conn,
     )
-    assert rows == [("1", "{a,b}"), ("2", "{x}"), (None, None)]
+    assert rows == [(1, "{a,b}"), (2, "{x}"), (None, None)]
 
 
 def test_array_of_composite(pg_tables, pgduck_conn):
@@ -324,7 +326,7 @@ def test_bounded_numeric_nan_to_null(pg_tables, pgduck_conn, use_text_protocol):
         )
         # Source: 123.45, NaN, NULL, 0.00
         # After:  0.00, 123.45, NULL (NaN→NULL), NULL (original)
-        assert rows == [("0.00",), ("123.45",), (None,), (None,)]
+        assert rows == [(Decimal("0.00"),), (Decimal("123.45"),), (None,), (None,)]
     finally:
         if use_text_protocol:
             perform_query_on_cursor("SET pg_use_text_protocol = false", pgduck_conn)
@@ -429,9 +431,9 @@ def test_special_values_across_types(pg_tables, pgduck_conn, use_text_protocol):
         )
 
         assert rows == [
-            ("1", "nan", "nan", "nan", "nan", "null"),  # NaN (bounded → NULL)
+            (1, "nan", "nan", "nan", "nan", "null"),  # NaN (bounded → NULL)
             (
-                "2",
+                2,
                 "+inf",
                 "+inf",
                 "+inf",
@@ -439,15 +441,15 @@ def test_special_values_across_types(pg_tables, pgduck_conn, use_text_protocol):
                 "null",
             ),  # +Inf (large/bounded NULL in PG)
             (
-                "3",
+                3,
                 "-inf",
                 "-inf",
                 "-inf",
                 "null",
                 "null",
             ),  # -Inf (large/bounded NULL in PG)
-            ("4", "null", "null", "null", "null", "null"),  # NULL
-            ("5", "value", "value", "value", "value", "value"),  # 1.5
+            (4, "null", "null", "null", "null", "null"),  # NULL
+            (5, "value", "value", "value", "value", "value"),  # 1.5
         ]
     finally:
         if use_text_protocol:

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -30,7 +30,7 @@ def test_copy_to_parquet_s3(s3, pgduck_conn):
 
     results = perform_query_on_cursor("SELECT count(*) FROM mytable", pgduck_conn)
     assert len(results) == 1
-    assert results[0][0] == "100"
+    assert results[0][0] == 100
 
     pgduck_conn.rollback()
 
@@ -59,7 +59,7 @@ def test_copy_to_parquet_gcs(gcs, pgduck_conn):
 
     results = perform_query_on_cursor("SELECT count(*) FROM mytable", pgduck_conn)
     assert len(results) == 1
-    assert results[0][0] == "100"
+    assert results[0][0] == 100
 
     pgduck_conn.rollback()
 
@@ -88,7 +88,7 @@ def test_copy_to_parquet_azure(azure, pgduck_conn):
 
     results = perform_query_on_cursor("SELECT count(*) FROM mytable", pgduck_conn)
     assert len(results) == 1
-    assert results[0][0] == "100"
+    assert results[0][0] == 100
 
     pgduck_conn.rollback()
 
@@ -120,7 +120,7 @@ def test_copy_to_parquet_azure_long_prefix(azure, pgduck_conn):
 
     results = perform_query_on_cursor("SELECT count(*) FROM mytable", pgduck_conn)
     assert len(results) == 1
-    assert results[0][0] == "100"
+    assert results[0][0] == 100
 
     pgduck_conn.rollback()
 

--- a/pgduck_server/tests/pytests/test_simple_server.py
+++ b/pgduck_server/tests/pytests/test_simple_server.py
@@ -119,9 +119,9 @@ def test_basic_parquet_copy_and_query(pgduck_server):
 
     assert len(results) == 1
     assert len(results[0]) == 4
-    assert results[0][0] == "1001"
-    assert results[0][1] == "500500"
-    assert results[0][2] == "1001000"
+    assert results[0][0] == 1001
+    assert results[0][1] == 500500
+    assert results[0][2] == 1001000
     assert results[0][3] == None
 
     conn.close()

--- a/pgduck_server/tests/pytests/test_types.py
+++ b/pgduck_server/tests/pytests/test_types.py
@@ -412,12 +412,12 @@ def test_boolean(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     pg_results = perform_query_on_cursor(query, pgduck_conn)
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
 
-    # Convert each element in pg_results to a boolean
-    pg_results_bool = [(strtobool(item[0]),) for item in pg_results]
+    # pg_results already contains native bool values. Transmit goes through CSV
+    # so we still need to parse the "t"/"f" text into bool.
     transmit_results_bool = [(strtobool(item[0]),) for item in transmit_results]
 
     assert (
-        pg_results_bool == duckdb_results == transmit_results_bool == expected
+        pg_results == duckdb_results == transmit_results_bool == expected
     ), "BOOLEAN results do not match expected values!"
 
 
@@ -437,12 +437,16 @@ def test_blob(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     pg_results = perform_query_on_cursor(query, pgduck_conn)
     print(pg_results)
 
+    # psycopg2 returns bytea as memoryview; convert back to the "\x..." text form
+    # the rest of the test compares against.
+    pg_results_str = [("\\x" + bytes(item[0]).hex(),) for item in pg_results]
+
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        pg_results == transmit_results == expected
+        pg_results_str == transmit_results == expected
     ), "BLOB results do not match expected values!"
 
 
@@ -452,15 +456,16 @@ def test_tinyint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
+    # Convert duckdb (int) and pg (int) results to strings for comparison.
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "TINYINT results do not match expected values!"
 
 
@@ -470,15 +475,15 @@ def test_smallint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "SMALLINT results do not match expected values!"
 
 
@@ -488,15 +493,15 @@ def test_int(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "INT results do not match expected values!"
 
 
@@ -506,15 +511,15 @@ def test_bigint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "BIGINT results do not match expected values!"
 
 
@@ -524,15 +529,15 @@ def test_utinyint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "UTINYINT results do not match expected values!"
 
 
@@ -542,15 +547,15 @@ def test_usmallint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "USMALLINT results do not match expected values!"
 
 
@@ -560,15 +565,15 @@ def test_uinteger(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "UINTEGER results do not match expected values!"
 
 
@@ -578,15 +583,15 @@ def test_uint64(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert each element in duckdb_results to a string
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "UINT64 results do not match expected values!"
 
 
@@ -719,19 +724,17 @@ def test_decimal(setup_table, duckdb_conn, pgduck_conn, tmp_path):
         ("99999999999999.999",),
     ]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
-    # Assuming pg_results is correctly fetched and formatted
-    pg_results = perform_query_on_cursor(
-        query, pgduck_conn
-    )  # This should be adjusted to your actual comparison
+    pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "Decimal results do not match expected values!"
 
 
@@ -780,18 +783,17 @@ def test_hugeint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
         ("17014118346046923173168730371588410572",),
     ]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
-    pg_results = perform_query_on_cursor(
-        query, pgduck_conn
-    )  # Adjust accordingly if comparing with PostgreSQL
+    pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "HUGEINT results do not match expected values!"
 
 
@@ -806,18 +808,17 @@ def test_uhugeint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
         ("340282366920938463463374607431768211455",),
     ]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
-    pg_results = perform_query_on_cursor(
-        query, pgduck_conn
-    )  # Adjust accordingly if comparing with PostgreSQL
+    pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
+    pg_results_str = [(str(item[0]),) for item in pg_results]
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "UHUGEINT results do not match expected values!"
 
 
@@ -827,18 +828,14 @@ import re
 
 def normalize_interval_to_timedelta(interval):
     """Normalize interval strings or timedelta objects to timedelta for comparison."""
+    if isinstance(interval, tuple):
+        # Cursor rows arrive as 1-tuples; unwrap and recurse.
+        return normalize_interval_to_timedelta(interval[0])
     if isinstance(interval, timedelta):
-        # Directly return timedelta objects from DuckDB
         return interval
-    elif isinstance(interval, tuple):
-        # Convert PostgreSQL interval string to timedelta
-        interval_str = interval[0]
-        return parse_interval_str_to_timedelta(interval_str)
-    elif isinstance(interval, str):
-        # Convert expected interval string to timedelta
+    if isinstance(interval, str):
         return parse_interval_str_to_timedelta(interval)
-    else:
-        raise ValueError("Unsupported interval format")
+    raise ValueError("Unsupported interval format")
 
 
 def parse_interval_str_to_timedelta(interval_str):
@@ -877,13 +874,24 @@ def test_interval_types(duckdb_conn, pgduck_conn, tmp_path):
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Normalize all intervals to timedelta for comparison
+    # Normalize duckdb and transmit (CSV string) results to timedelta using a
+    # simple averaging calendar (360-day year, 30-day month).
     duckdb_intervals_td = [
         normalize_interval_to_timedelta(item[0]) for item in duckdb_results
     ]
-    pg_intervals_td = [normalize_interval_to_timedelta(item) for item in pg_results]
     expected_intervals_td = [
         normalize_interval_to_timedelta(interval) for interval in expected_intervals
+    ]
+
+    # psycopg2 converts PG `interval` directly to timedelta with its own
+    # calendar (365-day year, 30-day month, with month/year normalization).
+    # PG normalizes "16 MONTHS 15 DAYS" -> "1 year 4 mons 15 days".
+    pg_intervals_td = [item[0] for item in pg_results]
+    expected_pg_intervals_td = [
+        timedelta(days=10),
+        timedelta(days=60),
+        timedelta(days=365),
+        timedelta(days=365 + 4 * 30 + 15),
     ]
 
     print(duckdb_intervals_td)
@@ -901,7 +909,7 @@ def test_interval_types(duckdb_conn, pgduck_conn, tmp_path):
         duckdb_intervals_td == expected_intervals_td
     ), "DuckDB interval results do not match expected values!"
     assert (
-        pg_intervals_td == expected_intervals_td
+        pg_intervals_td == expected_pg_intervals_td
     ), "PostgreSQL interval results do not match expected values!"
     assert (
         transmit_results == expected_intervals_td
@@ -981,12 +989,13 @@ def test_timestamp(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = convert_datetime_to_str(duckdb_results)
+    pg_results_str = convert_datetime_to_str(pg_results)
     print(duckdb_results_str)
-    print(pg_results)
+    print(pg_results_str)
     print(expected)
 
     assert (
-        duckdb_results_str == pg_results == expected
+        duckdb_results_str == pg_results_str == expected
     ), "Timestamp results do not match expected values!"
 
 
@@ -997,13 +1006,14 @@ def test_timestamp_ms(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = convert_datetime_to_str(duckdb_results)
+    pg_results_str = convert_datetime_to_str(pg_results)
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "Timestamp_ms results do not match expected values!"
 
 
@@ -1014,13 +1024,14 @@ def test_timestamp_ns(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = convert_datetime_to_str(duckdb_results)
+    pg_results_str = convert_datetime_to_str(pg_results)
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "Timestamp_ns results do not match expected values!"
 
 
@@ -1031,19 +1042,21 @@ def test_timestamp_sec(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = convert_datetime_to_str(duckdb_results)
+    pg_results_str = convert_datetime_to_str(pg_results)
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "Timestamp_sec results do not match expected values!"
 
 
 def test_timestamp_tz(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT timestamp_tz_col FROM duckdb_supported_types_table WHERE timestamp_tz_col IS NOT NULL ORDER BY timestamp_tz_col"
-    expected = [("2024-02-08 09:00:00+00",)]
+    expected_text = [("2024-02-08 09:00:00+00",)]
+    expected_dt = [(datetime(2024, 2, 8, 9, 0, 0, tzinfo=timezone.utc),)]
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     # We skip getting duckdb_results, because the output
@@ -1053,9 +1066,12 @@ def test_timestamp_tz(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
+    # pg cursor returns timezone-aware datetime; transmit (CSV) is the original
+    # text format ("...+00").
+    assert pg_results == expected_dt, "Timestamp_tz pg cursor results mismatch!"
     assert (
-        pg_results == transmit_results == expected
-    ), "Timestamp_tz results do not match expected values!"
+        transmit_results == expected_text
+    ), "Timestamp_tz transmit results do not match expected values!"
 
 
 def test_time(setup_table, duckdb_conn, pgduck_conn, tmp_path):
@@ -1065,19 +1081,21 @@ def test_time(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
     duckdb_results_str = convert_time_to_str(duckdb_results)
+    pg_results_str = convert_time_to_str(pg_results)
 
     # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results == transmit_results == expected
+        duckdb_results_str == pg_results_str == transmit_results == expected
     ), "Time results do not match expected values!"
 
 
 def test_tz_time(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT time_tz_col FROM duckdb_supported_types_table WHERE time_tz_col IS NOT NULL ORDER BY time_tz_col"
-    expected = [("12:00:00+03",)]
+    expected_text = [("12:00:00+03",)]
+    expected_t = [(time(12, 0, 0, tzinfo=timezone(timedelta(hours=3))),)]
 
     # We skip getting duckdb_results, because time_tz handling is not currently
     # implemented in the Python DuckDB module (to be revisited)
@@ -1088,9 +1106,12 @@ def test_tz_time(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
     transmit_results = [(item[0],) for item in transmit_results]
 
+    # pg cursor returns timezone-aware time; transmit (CSV) is the original
+    # text format ("...+03").
+    assert pg_results == expected_t, "Time_tz pg cursor results mismatch!"
     assert (
-        pg_results == transmit_results == expected
-    ), "Time_tz results do not match expected values!"
+        transmit_results == expected_text
+    ), "Time_tz transmit results do not match expected values!"
 
 
 def test_struct(setup_table, duckdb_conn, pgduck_conn, tmp_path):

--- a/pgduck_server/tests/pytests/test_types.py
+++ b/pgduck_server/tests/pytests/test_types.py
@@ -452,146 +452,114 @@ def test_blob(setup_table, duckdb_conn, pgduck_conn, tmp_path):
 
 def test_tinyint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT tiny_int_col FROM duckdb_supported_types_table WHERE tiny_int_col IS NOT NULL ORDER BY tiny_int_col"
-    expected = [("-128",), ("0",), ("127",)]
+    expected = [(-128,), (0,), (127,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    # Convert duckdb (int) and pg (int) results to strings for comparison.
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
+    # Transmit goes through CSV so values come back as text; parse to int.
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "TINYINT results do not match expected values!"
 
 
 def test_smallint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT smallint_col FROM duckdb_supported_types_table WHERE smallint_col IS NOT NULL ORDER BY smallint_col"
-    expected = [("-32768",), ("0",), ("32767",)]
+    expected = [(-32768,), (0,), (32767,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "SMALLINT results do not match expected values!"
 
 
 def test_int(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT int_col FROM duckdb_supported_types_table WHERE int_col IS NOT NULL ORDER BY int_col"
-    expected = [("-2147483648",), ("0",), ("2147483647",)]
+    expected = [(-2147483648,), (0,), (2147483647,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "INT results do not match expected values!"
 
 
 def test_bigint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT bigint_col FROM duckdb_supported_types_table WHERE bigint_col IS NOT NULL ORDER BY bigint_col"
-    expected = [("-9223372036854775808",), ("0",), ("9223372036854775807",)]
+    expected = [(-9223372036854775808,), (0,), (9223372036854775807,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "BIGINT results do not match expected values!"
 
 
 def test_utinyint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT utinyint_col FROM duckdb_supported_types_table WHERE utinyint_col IS NOT NULL ORDER BY utinyint_col"
-    expected = [("0",), ("255",)]
+    expected = [(0,), (255,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "UTINYINT results do not match expected values!"
 
 
 def test_usmallint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT usmallint_col FROM duckdb_supported_types_table WHERE usmallint_col IS NOT NULL ORDER BY usmallint_col"
-    expected = [("0",), ("65535",)]
+    expected = [(0,), (65535,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "USMALLINT results do not match expected values!"
 
 
 def test_uinteger(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT uinteger_col FROM duckdb_supported_types_table WHERE uinteger_col IS NOT NULL ORDER BY uinteger_col"
-    expected = [("0",), ("4294967295",)]
+    expected = [(0,), (4294967295,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "UINTEGER results do not match expected values!"
 
 
 def test_uint64(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT uint64_col FROM duckdb_supported_types_table WHERE uint64_col IS NOT NULL ORDER BY uint64_col"
-    expected = [("0",), ("9223372036854775807",), ("18446744073709551615",)]
+    expected = [(0,), (9223372036854775807,), (18446744073709551615,)]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "UINT64 results do not match expected values!"
 
 
@@ -770,55 +738,48 @@ def test_uuid(setup_table, duckdb_conn, pgduck_conn, tmp_path):
 def test_hugeint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT hugeint_col FROM duckdb_supported_types_table WHERE hugeint_col IS NOT NULL ORDER BY hugeint_col"
     expected = [
-        ("-17014118346046923173168730371588410572",),
-        ("-9223372036854775808",),
-        ("-2147483648",),
-        ("-32768",),
-        ("-1",),
-        ("0",),
-        ("1",),
-        ("32767",),
-        ("2147483647",),
-        ("9223372036854775807",),
-        ("17014118346046923173168730371588410572",),
+        (-17014118346046923173168730371588410572,),
+        (-9223372036854775808,),
+        (-2147483648,),
+        (-32768,),
+        (-1,),
+        (0,),
+        (1,),
+        (32767,),
+        (2147483647,),
+        (9223372036854775807,),
+        (17014118346046923173168730371588410572,),
     ]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
+    # pg_results arrive as Decimal (NUMERIC OID); Decimal == int compares equal.
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "HUGEINT results do not match expected values!"
 
 
 def test_uhugeint(setup_table, duckdb_conn, pgduck_conn, tmp_path):
     query = "SELECT uhugeint_col FROM duckdb_supported_types_table WHERE uhugeint_col IS NOT NULL ORDER BY uhugeint_col"
     expected = [
-        ("0",),
-        ("1",),
-        ("65535",),
-        ("4294967295",),
-        ("18446744073709551615",),
-        ("340282366920938463463374607431768211455",),
+        (0,),
+        (1,),
+        (65535,),
+        (4294967295,),
+        (18446744073709551615,),
+        (340282366920938463463374607431768211455,),
     ]
     duckdb_results = perform_query_on_cursor(query, duckdb_conn)
     pg_results = perform_query_on_cursor(query, pgduck_conn)
 
-    duckdb_results_str = [(str(item[0]),) for item in duckdb_results]
-    pg_results_str = [(str(item[0]),) for item in pg_results]
-
-    # Get normalized transmit results
     transmit_results = perform_transmit_query(query, pgduck_conn, tmp_path)
-    transmit_results = [(item[0],) for item in transmit_results]
+    transmit_results = [(int(item[0]),) for item in transmit_results]
 
     assert (
-        duckdb_results_str == pg_results_str == transmit_results == expected
+        duckdb_results == pg_results == transmit_results == expected
     ), "UHUGEINT results do not match expected values!"
 
 

--- a/test_common/helpers/db.py
+++ b/test_common/helpers/db.py
@@ -90,7 +90,7 @@ def run_simple_command(hostname, serverport):
     cur.execute("SELECT 1")
     r = cur.fetchall()
     print(r)
-    assert r == [("1",)]
+    assert r == [(1,)]
 
 
 def run_pgbench_command(commands):


### PR DESCRIPTION
The pgduck_server change in #327 resolved a long-standing quirk in our python tests that we had to do text comparisons.

Closes #327