### PR TITLE
Allow r2:// URL scheme

### DIFF
--- a/pg_lake_benchmark/src/tpcds.c
+++ b/pg_lake_benchmark/src/tpcds.c
@@ -73,7 +73,7 @@ pg_lake_tpcds_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);

--- a/pg_lake_benchmark/src/tpch.c
+++ b/pg_lake_benchmark/src/tpch.c
@@ -70,7 +70,7 @@ pg_lake_tpch_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);
@@ -104,7 +104,7 @@ pg_lake_tpch_gen_partitioned(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);

--- a/pg_lake_copy/src/ddl/create_table.c
+++ b/pg_lake_copy/src/ddl/create_table.c
@@ -173,7 +173,7 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(definitionFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 								   "currently supported")));
 		}
 
@@ -194,7 +194,7 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(loadFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 								   "currently supported")));
 		}
 

--- a/pg_lake_copy/tests/pytests/test_create_table.py
+++ b/pg_lake_copy/tests/pytests/test_create_table.py
@@ -302,7 +302,7 @@ def test_create_table_load_from_invalid_url(pg_conn, duckdb_conn, s3):
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()
@@ -315,7 +315,7 @@ def test_create_table_load_from_invalid_url(pg_conn, duckdb_conn, s3):
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()

--- a/pg_lake_engine/include/pg_lake/copy/copy_format.h
+++ b/pg_lake_engine/include/pg_lake/copy/copy_format.h
@@ -30,6 +30,7 @@
 #define HTTP_URL_PREFIX "http://"
 #define HTTPS_URL_PREFIX "https://"
 #define HUGGING_FACE_URL_PREFIX "hf://"
+#define R2_URL_PREFIX "r2://"
 #define STAGE_URL_PREFIX "@STAGE/"
 
 

--- a/pg_lake_engine/src/copy/copy_format.c
+++ b/pg_lake_engine/src/copy/copy_format.c
@@ -437,7 +437,8 @@ IsSupportedURL(const char *path)
 		strncmp(path, AZURE_DLS_URL_PREFIX, strlen(AZURE_DLS_URL_PREFIX)) == 0 ||
 		strncmp(path, HTTP_URL_PREFIX, strlen(HTTP_URL_PREFIX)) == 0 ||
 		strncmp(path, HTTPS_URL_PREFIX, strlen(HTTPS_URL_PREFIX)) == 0 ||
-		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0;
+		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0 ||
+		strncmp(path, R2_URL_PREFIX, strlen(R2_URL_PREFIX)) == 0;
 }
 
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_functions.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_functions.c
@@ -49,7 +49,7 @@ iceberg_metadata(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
 	}
 
 	CheckURLReadAccess();
@@ -71,7 +71,7 @@ iceberg_files(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
 	}
 
 	CheckURLReadAccess();
@@ -144,7 +144,7 @@ iceberg_snapshots(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
 	}
 
 	CheckURLReadAccess();

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -345,7 +345,7 @@ IcebergDefaultLocationCheckHook(char **newvalue, void **extra, GucSource source)
 
 	if (!IsSupportedURL(newLocationPrefix))
 	{
-		GUC_check_errdetail("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+		GUC_check_errdetail("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							"supported as the default location prefix");
 		return false;
 	}

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
@@ -49,7 +49,7 @@ def test_pg_lake_iceberg_table_metadata(
     )
 
     assert (
-        "pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported"
+        "pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported"
         in error
     )
 
@@ -111,7 +111,7 @@ def test_unsupported_url(installcheck, superuser_conn, iceberg_extension, s3):
     error = run_query(query, superuser_conn, raise_error=False)
 
     assert (
-        "pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported"
+        "pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported"
         in error
     )
 

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -380,14 +380,14 @@ ErrorIfUnsupportedLakeTable(CreateForeignTableStmt *createStmt)
 	if (!isWritable && !IsSupportedURL(path))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 	}
 	else if (isWritable && !IsSupportedURL(location))
 	{
 
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 	}
 

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -204,7 +204,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(path))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// "
+								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
 									   "URLs are currently supported for the \"path\" "
 									   "option.")));
 
@@ -216,7 +216,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(value))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// "
+								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
 									   "URLs are currently supported for the \"location\" "
 									   "option.")));
 
@@ -726,7 +726,7 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(location))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// "
+								errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
 									   "URLs are currently supported for the \"location\" "
 									   "option.")));
 

--- a/pg_lake_table/src/util/s3_file_utils.c
+++ b/pg_lake_table/src/util/s3_file_utils.c
@@ -62,7 +62,7 @@ pg_lake_file_size(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_size: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("file_size: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -94,7 +94,7 @@ pg_lake_list_files(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(globURL) || !IsFileListSupportedUrl(globURL))
-		ereport(ERROR, (errmsg("list_files: only s3://, gs://, az://, azure://, abfss://, and hf:// urls are supported"),
+		ereport(ERROR, (errmsg("list_files: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -143,7 +143,8 @@ IsFileListSupportedUrl(char *path)
 		strncmp(path, AZURE_URL_PREFIX, strlen(AZURE_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_BLOB_URL_PREFIX, strlen(AZURE_BLOB_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_DLS_URL_PREFIX, strlen(AZURE_DLS_URL_PREFIX)) == 0 ||
-		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0;
+		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0 ||
+		strncmp(path, R2_URL_PREFIX, strlen(R2_URL_PREFIX)) == 0;
 }
 
 
@@ -160,7 +161,7 @@ pg_lake_file_exists(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_exists: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("file_exists: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -218,7 +219,7 @@ pg_lake_file_preview(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(url))
-		ereport(ERROR, (errmsg("file_preview: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("file_preview: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -269,7 +270,7 @@ pg_lake_delete_file(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("delete_file: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("delete_file: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLWriteAccess();

--- a/pg_lake_table/tests/pytests/test_create_as_select.py
+++ b/pg_lake_table/tests/pytests/test_create_as_select.py
@@ -57,7 +57,7 @@ def test_unsupported_url(s3, pg_conn, extension):
         pg_conn,
         raise_error=False,
     )
-    assert "only s3://, gs://, az://, azure://, and abfss:// URLs" in error
+    assert "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs" in error
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
+++ b/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
@@ -274,7 +274,7 @@ def test_create_table_load_from_invalid_url(
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()
@@ -287,7 +287,7 @@ def test_create_table_load_from_invalid_url(
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_file_preview.py
+++ b/pg_lake_table/tests/pytests/test_file_preview.py
@@ -56,7 +56,7 @@ def test_file_preview_non_s3_url(pg_conn, extension):
         raise_error=False,
     )
     assert (
-        "only s3://, gs://, az://, azure://, and abfss:// urls are supported" in error
+        "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported" in error
     )
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_list_file.py
+++ b/pg_lake_table/tests/pytests/test_list_file.py
@@ -31,7 +31,7 @@ def test_list_files_non_s3_url(pg_conn, generate_data_on_s3):
         raise_error=False,
     )
     assert (
-        "only s3://, gs://, az://, azure://, abfss://, and hf:// urls are supported"
+        "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"
         in error
     )
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_queries.py
+++ b/pg_lake_table/tests/pytests/test_queries.py
@@ -1331,7 +1331,7 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
 
     except psycopg2.errors.FeatureNotSupported as e:
         assert (
-            "pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+            "pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
             in str(e)
         )
         cur.close()
@@ -1356,7 +1356,7 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
     except psycopg2.errors.FeatureNotSupported as e:
         assert (
             str(e)
-            == 'pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported for the "path" option.\n'
+            == 'pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported for the "path" option.\n'
         )
         cur.close()
         pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_writable_iceberg.py
+++ b/pg_lake_table/tests/pytests/test_writable_iceberg.py
@@ -111,7 +111,7 @@ def test_writable_iceberg_create_wrong_option(pg_conn, extension):
         raise_error=False,
     )
     assert (
-        'pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported for the "location" option.'
+        'pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported for the "location" option.'
         in str(error)
     )
     pg_conn.rollback()


### PR DESCRIPTION
## Description

Allow Cloudflare R2 (\`r2://\`) URLs through pg_lake's PG-side URL allowlists.

### Why this works

The DuckDB \`S3FileSystem\` natively recognizes \`r2://\` alongside \`s3://\`, \`s3a://\`, \`s3n://\`, \`gcs://\`, and \`gs://\` — see [\`duckdb-httpfs/src/s3fs.cpp\` \`S3FileSystem::CanHandleFile\`](https://github.com/duckdb/duckdb-httpfs/blob/main/src/s3fs.cpp). \`duckdb_pglake\`'s \`RegionAwareS3FileSystem\` already short-circuits all non-\`s3://\` URLs straight to the underlying \`S3FileSystem\` (region auto-detection is intentionally \`s3://\` only — R2 always uses \`auto\`), so no \`duckdb_pglake\` change is needed. The only thing gating \`r2://\` today is pg_lake's PG-side URL allowlist.

### What this PR changes

1. Add \`r2://\` to both URL allowlists:

   - **\`pg_lake_engine/src/copy/copy_format.c\` \`IsSupportedURL\`** — the project-wide check consulted by:
     - \`pg_lake_copy\` (\`CREATE TABLE ... load_from\`/\`definition_from\`)
     - \`pg_lake_iceberg\` (\`lake_iceberg.metadata\`/\`files\`/\`snapshots\`, the \`pg_lake_iceberg.default_location_prefix\` GUC)
     - \`pg_lake_table\` (\`file_size\`/\`file_exists\`/\`file_preview\`/\`delete_file\`, foreign-table \`path\`/\`location\` options, \`CREATE TABLE\` for iceberg / pg_lake_table)
     - \`pg_lake_benchmark\`
   - **\`pg_lake_table/src/util/s3_file_utils.c\` \`IsFileListSupportedUrl\`** — the tighter list-only check used by \`lake_file.list\` (excludes \`http(s)://\` since those can't enumerate directories).

2. Refresh the now-stale \`"only s3://, gs://, az://, azure://, and abfss://"\` error strings across the codebase so they accurately reflect what \`IsSupportedURL\` accepts. This also picks up the previously-missing \`hf://\` — HuggingFace URLs have been accepted by \`IsSupportedURL\` for a while but the error strings were never updated. Updated the four pytest assertions that match those strings exactly.

### Repro of the original failure

\`\`\`sql
SELECT * FROM lake_file.list('r2://my-bucket/prefix/*');
-- ERROR:  list_files: only s3://, gs://, az://, azure://, abfss://, and hf:// urls are supported
\`\`\`

After this PR the same call falls through to \`pgduck_server\` / DuckDB which handles \`r2://\` via the standard R2 secret mechanism.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## Notes for reviewers

- I considered narrowing the patch to only \`IsFileListSupportedUrl\` + the \`list_files\` error string, but every other call site that gates on \`IsSupportedURL\` (CREATE FOREIGN TABLE, iceberg metadata functions, the location-prefix GUC, etc.) would have inconsistent behavior — \`r2://\` would work in some paths and not others. Adding \`r2://\` centrally in \`IsSupportedURL\` keeps the surface consistent.
- The error-message refresh is mechanical: every occurrence of the stale prefix list now lists what \`IsSupportedURL\` actually accepts. Happy to split that out of this PR if you'd prefer two smaller commits.
- Did not add an e2e test that hits a real R2 bucket — that would require account credentials in CI. The pytest assertions in \`test_list_file.py\`, \`test_file_preview.py\`, \`test_create_table.py\`, \`test_create_as_select.py\`, \`test_create_iceberg_table_load_from.py\`, \`test_iceberg_functions.py\`, \`test_queries.py\`, and \`test_writable_iceberg.py\` exercise the allowlist gate against invalid URLs and now verify the updated error string. Happy to add an R2-specific positive test if you have a preferred pattern.