### PR TITLE
Reject hour partition transform on time columns

### DIFF
--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -308,7 +308,7 @@ FDW options: (partition_by 'day(event_time), bucket(32, user_id)', location 's3:
 | **`year(col)`** | Extracts the year part of a date or timestamp. Good for coarse time partitioning. | **`date`**, **`timestamp(tz)`** |
 | **`month(col)`** | Extracts the year and month. Typically used for monthly aggregates or logs. | **`date`**, **`timestamp(tz)`** |
 | **`day(col)`** | Extracts the full date (year-month-day). Ideal for time-series or log data. | **`date`**, **`timestamp(tz)`** |
-| **`hour(col)`** | Extracts the hour of day. Useful for high-volume hourly events. | **`time`**, **`timestamp(tz)`** |
+| **`hour(col)`** | Extracts the hour of day. Useful for high-volume hourly events. | **`timestamp(tz)`** |
 | **`bucket(N, col)`** | Hashes the column and assigns it to one of **`N`** evenly distributed buckets. | **`int2`**, **`int4`**, **`int8`**, **`numeric`**, **`text`**, **`varchar`**, **`char(C)`**, **`bytea`**, **`uuid`**, **`date`**, **`timestamp(tz)`**, **`time`** |
 | **`truncate(N, col)`** | Truncates the value to a multiple of **`N`** (for integers) or to a prefix of length **`N`** (for string and binary). | **`int2`**, **`int4`**, **`int8`**, **`text`**, **`varchar`**, **`char(C)`**, **`bytea`** |
 

--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -304,12 +304,12 @@ FDW options: (partition_by 'day(event_time), bucket(32, user_id)', location 's3:
 ### Supported partition transforms
 | **Transform** | **Description** | **Supported types** |
 | --- | --- | --- |
-| **`col`** | Identity partitioning, stores the column’s value as-is. Useful for low-cardinality columns like **`region`** or **`status`**. | **`date`**, **`timestamp(tz)`**, **`time`**, **`int2`**, **`int4`**, **`int8`**, **`bool`**, **`float4`**, **`float8`**, **`numeric`**, **`text`**, **`varchar`**, **`bpchar`**, **`bytea`**, **`uuid`** |
+| **`col`** | Identity partitioning, stores the column’s value as-is. Useful for low-cardinality columns like **`region`** or **`status`**. | **`date`**, **`timestamp(tz)`**, **`time(tz)`**, **`int2`**, **`int4`**, **`int8`**, **`bool`**, **`float4`**, **`float8`**, **`numeric`**, **`text`**, **`varchar`**, **`bpchar`**, **`bytea`**, **`uuid`** |
 | **`year(col)`** | Extracts the year part of a date or timestamp. Good for coarse time partitioning. | **`date`**, **`timestamp(tz)`** |
 | **`month(col)`** | Extracts the year and month. Typically used for monthly aggregates or logs. | **`date`**, **`timestamp(tz)`** |
 | **`day(col)`** | Extracts the full date (year-month-day). Ideal for time-series or log data. | **`date`**, **`timestamp(tz)`** |
 | **`hour(col)`** | Extracts the hour of day. Useful for high-volume hourly events. | **`timestamp(tz)`** |
-| **`bucket(N, col)`** | Hashes the column and assigns it to one of **`N`** evenly distributed buckets. | **`int2`**, **`int4`**, **`int8`**, **`numeric`**, **`text`**, **`varchar`**, **`char(C)`**, **`bytea`**, **`uuid`**, **`date`**, **`timestamp(tz)`**, **`time`** |
+| **`bucket(N, col)`** | Hashes the column and assigns it to one of **`N`** evenly distributed buckets. | **`int2`**, **`int4`**, **`int8`**, **`numeric`**, **`text`**, **`varchar`**, **`char(C)`**, **`bytea`**, **`uuid`**, **`date`**, **`timestamp(tz)`**, **`time(tz)`** |
 | **`truncate(N, col)`** | Truncates the value to a multiple of **`N`** (for integers) or to a prefix of length **`N`** (for string and binary). | **`int2`**, **`int4`**, **`int8`**, **`text`**, **`varchar`**, **`char(C)`**, **`bytea`** |
 
 ### Iceberg hidden partitioning best practices

--- a/pg_lake_table/src/fdw/partitioning/partition_by_parser.c
+++ b/pg_lake_table/src/fdw/partitioning/partition_by_parser.c
@@ -960,7 +960,7 @@ EnsureValidTypeForBucketTransform(Oid typeOid)
 		typeOid != BPCHAROID && typeOid != BYTEAOID && typeOid != UUIDOID)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("bucket transform requires a int2, int4, int8, numeric, text, varchar, bytea or"
-						"uuid column, but type is %s",
+				 errmsg("bucket transform requires a int2, int4, int8, numeric, text, varchar, bytea, uuid, "
+						"date, time(tz) or timestamp(tz) column, but type is %s",
 						format_type_be(typeOid))));
 }

--- a/pg_lake_table/src/fdw/partitioning/partition_by_parser.c
+++ b/pg_lake_table/src/fdw/partitioning/partition_by_parser.c
@@ -923,10 +923,10 @@ EnsureValidTypeForDayTransform(Oid typeOid)
 static void
 EnsureValidTypeForHourTransform(Oid typeOid)
 {
-	if (!IsTimeOrTimestampType(typeOid))
+	if (typeOid != TIMESTAMPOID && typeOid != TIMESTAMPTZOID)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("hour transform requires a time(tz) or timestamp(tz) column, but type is %s",
+				 errmsg("hour transform requires a timestamp(tz) column, but type is %s",
 						format_type_be(typeOid))));
 }
 

--- a/pg_lake_table/tests/pytests/test_partition_pruning.py
+++ b/pg_lake_table/tests/pytests/test_partition_pruning.py
@@ -246,8 +246,8 @@ def test_simple_data_pruning_for_data_types(
         if column_type not in ("date", "timestamp", "timestamptz"):
             return
 
-    if partition_type in ("hour"):
-        if column_type not in ("time", "timetz", "timestamp", "timestamptz"):
+    if partition_type == "hour":
+        if column_type not in ("timestamp", "timestamptz"):
             return
 
     if "bucket" in partition_type:

--- a/pg_lake_table/tests/pytests/test_partition_pruning.py
+++ b/pg_lake_table/tests/pytests/test_partition_pruning.py
@@ -822,65 +822,24 @@ def test_timestamptz_partition_pruning(
     assert results[0][0] == 3
 
 
-# it is hard to extend more generic functions
-# to have time column, so we have a separate test
-def test_pruning_hour_partition_on_time(
+# Iceberg does not define the hour transform for time columns.
+def test_hour_partition_on_time_rejected(
     s3,
-    disable_data_file_pruning,
     pg_conn,
     extension,
     with_default_location,
-    grant_access_to_data_file_partition,
 ):
-    explain_prefix = "EXPLAIN (analyze, verbose, format json) "
-
-    run_command(
+    error = run_command(
         """
                 CREATE SCHEMA hour_on_time;
                 CREATE TABLE hour_on_time.tbl (col time) USING iceberg WITH (partition_by = 'hour(col)', autovacuum_enabled='False');
-
-                -- fill in all hours
-                INSERT INTO hour_on_time.tbl SELECT generate_series('2000-01-01 00:00:00'::timestamp, '2000-01-31 23:00:00'::timestamp, '1 hour')::time;
-
         """,
         pg_conn,
+        raise_error=False,
     )
 
-    plan = run_query(
-        f"""{explain_prefix} SELECT * FROM hour_on_time.tbl
-            WHERE col >= '00:00:00'
-            AND col < '01:00:00'""",
-        pg_conn,
-    )
-    assert fetch_data_files_used(plan) == "1"
-
-    plan = run_query(
-        f"""{explain_prefix} SELECT * FROM hour_on_time.tbl
-            WHERE col >= '00:00:00'""",
-        pg_conn,
-    )
-    assert fetch_data_files_used(plan) == "24"
-
-    plan = run_query(
-        f"""{explain_prefix} SELECT * FROM hour_on_time.tbl
-            WHERE col >= '20:00:00'""",
-        pg_conn,
-    )
-    assert fetch_data_files_used(plan) == "4"
-
-    plan = run_query(
-        f"""{explain_prefix} SELECT * FROM hour_on_time.tbl
-            WHERE col IN ('20:00:00', '20:15:00') """,
-        pg_conn,
-    )
-    assert fetch_data_files_used(plan) == "1"
-
-    plan = run_query(
-        f"""{explain_prefix} SELECT * FROM hour_on_time.tbl
-            WHERE col IN ('20:00:00', '22:15:00') """,
-        pg_conn,
-    )
-    assert fetch_data_files_used(plan) == "2"
+    assert "hour transform requires a timestamp(tz) column" in error
+    pg_conn.rollback()
 
 
 # TODO: truncate fails due to overflow

--- a/pg_lake_table/tests/pytests/test_partition_pruning.py
+++ b/pg_lake_table/tests/pytests/test_partition_pruning.py
@@ -822,17 +822,19 @@ def test_timestamptz_partition_pruning(
     assert results[0][0] == 3
 
 
-# Iceberg does not define the hour transform for time columns.
-def test_hour_partition_on_time_rejected(
+# Iceberg does not define the hour transform for time, timetz, or date columns.
+@pytest.mark.parametrize("col_type", ["time", "timetz", "date"])
+def test_hour_partition_on_invalid_types_rejected(
     s3,
     pg_conn,
     extension,
     with_default_location,
+    col_type,
 ):
     error = run_command(
-        """
-                CREATE SCHEMA hour_on_time;
-                CREATE TABLE hour_on_time.tbl (col time) USING iceberg WITH (partition_by = 'hour(col)', autovacuum_enabled='False');
+        f"""
+                CREATE SCHEMA hour_on_{col_type};
+                CREATE TABLE hour_on_{col_type}.tbl (col {col_type}) USING iceberg WITH (partition_by = 'hour(col)', autovacuum_enabled='False');
         """,
         pg_conn,
         raise_error=False,

--- a/pg_lake_table/tests/pytests/test_pg_lake_iceberg_apply_partition_transform.py
+++ b/pg_lake_table/tests/pytests/test_pg_lake_iceberg_apply_partition_transform.py
@@ -488,7 +488,7 @@ def test_partition_transform_time(
     with_default_location,
 ):
     run_command(
-        "create table test_partition_transform_time(a time) using iceberg with (partition_by = 'a, bucket(100, a), hour(a)');",
+        "create table test_partition_transform_time(a time) using iceberg with (partition_by = 'a, bucket(100, a)');",
         pg_conn,
     )
     pg_conn.commit()
@@ -500,11 +500,11 @@ def test_partition_transform_time(
     pg_conn.commit()
 
     result = run_query(
-        "select transformed.* from test_partition_transform_time t, lateral lake_table.partition_tuple(t.*) as transformed(a time, a_bucket_100 int4, a_year int4) order by a, a_bucket_100, a_year;",
+        "select transformed.* from test_partition_transform_time t, lateral lake_table.partition_tuple(t.*) as transformed(a time, a_bucket_100 int4) order by a, a_bucket_100;",
         pg_conn,
     )
 
-    assert result == [[datetime.time(0, 0), 76, 0], [datetime.time(23, 59, 59), 78, 23]]
+    assert result == [[datetime.time(0, 0), 76], [datetime.time(23, 59, 59), 78]]
 
     run_command("DROP TABLE test_partition_transform_time", pg_conn)
     pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_pg_lake_iceberg_partition_by.py
+++ b/pg_lake_table/tests/pytests/test_pg_lake_iceberg_partition_by.py
@@ -118,7 +118,6 @@ COLUMN_TRANSFORMS = [
     ("day(col_ts)", [SpecTransform("day", "col_ts_day", 1000, 7, [7])]),
     # hour only
     ("hour(col_ts)", [SpecTransform("hour", "col_ts_hour", 1000, 7, [7])]),
-    ("hour(col_time)", [SpecTransform("hour", "col_time_hour", 1000, 8, [8])]),
     # combinations with different applicable transforms and whitespaces and quotes
     (
         "col_short, col_int",
@@ -128,10 +127,10 @@ COLUMN_TRANSFORMS = [
         ],
     ),
     (
-        "col_short, hour(col_time)",
+        "col_short, hour(col_ts)",
         [
             SpecTransform("identity", "col_short", 1000, 1, [1]),
-            SpecTransform("hour", "col_time_hour", 1001, 8, [8]),
+            SpecTransform("hour", "col_ts_hour", 1001, 7, [7]),
         ],
     ),
     (
@@ -142,10 +141,10 @@ COLUMN_TRANSFORMS = [
         ],
     ),
     (
-        'truncate(2,col_short), hour( "col_time"    )',
+        'truncate(2,col_short), hour( "col_ts"    )',
         [
             SpecTransform("truncate[2]", "col_short_trunc_2", 1000, 1, [1]),
-            SpecTransform("hour", "col_time_hour", 1001, 8, [8]),
+            SpecTransform("hour", "col_ts_hour", 1001, 7, [7]),
         ],
     ),
     (
@@ -459,6 +458,8 @@ def test_create_iceberg_table_partition_by_inapplicable_transform_types(
         "day(col_int)",
         "month(col_text)",
         "year(col_binary)",
+        "hour(col_time)",
+        "hour(col_timetz)",
         "bucket(4,col_bool)",
         "truncate(4,col_bool)",
         "truncate(1231232134234324324,col_short)",
@@ -469,7 +470,7 @@ def test_create_iceberg_table_partition_by_inapplicable_transform_types(
         error = run_command(
             f"""
             CREATE TABLE test_create_iceberg_table_partition_by (col_short int2, col_int int4, col_bigint int8, col_text text, col_numeric numeric,
-                                                                 col_binary bytea, col_date date, col_ts timestamp, col_time time, col_bool bool, col_json json
+                                                                 col_binary bytea, col_date date, col_ts timestamp, col_time time, col_timetz timetz, col_bool bool, col_json json
                                                                 ) USING iceberg WITH (partition_by = '{transform}');
             """,
             pg_conn,


### PR DESCRIPTION
## Description
Fixes #112.

This updates the partition_by parser so `hour(...)` only accepts `timestamp` and `timestamptz` columns. Iceberg does not define the hour transform for `time` columns, so `time` and `timetz` are now rejected at parse time.

Also updated the partition transform tests and docs so valid time partitions still cover identity and bucket behavior, while hour on time columns is covered as an invalid partition spec.

## Validation
- [x] `git diff --check`
- [x] `python3 -m py_compile pg_lake_table/tests/pytests/test_pg_lake_iceberg_partition_by.py pg_lake_table/tests/pytests/test_pg_lake_iceberg_apply_partition_transform.py pg_lake_table/tests/pytests/test_partition_pruning.py`
- [ ] `make -C pg_lake_table src/fdw/partitioning/partition_by_parser.o -j1` could not run locally because `pg_config` and PostgreSQL headers are not installed in this environment (`postgres.h` missing).

## Checklist
- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**