### PR TITLE
Fix domain types in Iceberg always mapping to string

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/map.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/map.h
@@ -24,5 +24,6 @@ char	   *GetDuckDBMapDefinitionForPGType(Oid postgresTypeId,
 											CopyDataFormat format);
 
 extern PGDLLEXPORT bool IsMapTypeOid(Oid typeId);
+extern PGDLLEXPORT Oid ResolveDomainBaseType(Oid typeId);
 extern PGDLLEXPORT PGType GetMapKeyType(Oid mapOid);
 extern PGDLLEXPORT PGType GetMapValueType(Oid mapOid);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -35,6 +35,7 @@
 #include "pg_lake/csv/csv_writer.h"
 #include "pg_lake/extensions/postgis.h"
 #include "pg_lake/pgduck/numeric.h"
+#include "pg_lake/pgduck/map.h"
 #include "pg_lake/pgduck/serialize.h"
 #include "pg_lake/util/numeric.h"
 #include "executor/executor.h"
@@ -1222,6 +1223,11 @@ GetCSVDestReceiverFileSize(DestReceiver *dest)
 bool
 ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType)
 {
+	/* unwrap domain to base type so per-type checks below see the real type */
+	if (!IsMapTypeOid(postgresType.postgresTypeOid) &&
+		get_typtype(postgresType.postgresTypeOid) == TYPTYPE_DOMAIN)
+		postgresType.postgresTypeOid = getBaseType(postgresType.postgresTypeOid);
+
 	Oid			typeId = postgresType.postgresTypeOid;
 
 	if (IsGeometryType(postgresType))

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -1224,9 +1224,7 @@ bool
 ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType)
 {
 	/* unwrap domain to base type so per-type checks below see the real type */
-	if (!IsMapTypeOid(postgresType.postgresTypeOid) &&
-		get_typtype(postgresType.postgresTypeOid) == TYPTYPE_DOMAIN)
-		postgresType.postgresTypeOid = getBaseType(postgresType.postgresTypeOid);
+	postgresType.postgresTypeOid = ResolveDomainBaseType(postgresType.postgresTypeOid);
 
 	Oid			typeId = postgresType.postgresTypeOid;
 

--- a/pg_lake_engine/src/pgduck/map.c
+++ b/pg_lake_engine/src/pgduck/map.c
@@ -222,6 +222,21 @@ GetMapCreateFunctionOid()
 
 
 /*
+ * ResolveDomainBaseType returns the base type OID for a domain, or the OID
+ * unchanged if it is not a domain.  Map types are domains with special
+ * semantics and are left as-is.
+ */
+Oid
+ResolveDomainBaseType(Oid typeId)
+{
+	if (!IsMapTypeOid(typeId) && get_typtype(typeId) == TYPTYPE_DOMAIN)
+		return getBaseType(typeId);
+
+	return typeId;
+}
+
+
+/*
  * GetDuckDBMapDefinitionForPGType returns a type definition string for a DuckDB map type.
  */
 char *

--- a/pg_lake_engine/src/pgduck/serialize.c
+++ b/pg_lake_engine/src/pgduck/serialize.c
@@ -129,11 +129,9 @@ PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 {
 	/*
 	 * Unwrap domain types so that e.g. a domain-over-bytea is serialized with
-	 * the bytea-specific path rather than the generic text output path. Map
-	 * types are domains with special semantics and must not be unwrapped.
+	 * the bytea-specific path rather than the generic text output path.
 	 */
-	if (!IsMapTypeOid(columnType) && get_typtype(columnType) == TYPTYPE_DOMAIN)
-		columnType = getBaseType(columnType);
+	columnType = ResolveDomainBaseType(columnType);
 
 	if (flinfo->fn_oid == ARRAY_OUT_OID)
 	{

--- a/pg_lake_engine/src/pgduck/serialize.c
+++ b/pg_lake_engine/src/pgduck/serialize.c
@@ -127,6 +127,14 @@ char *
 PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 				CopyDataFormat format)
 {
+	/*
+	 * Unwrap domain types so that e.g. a domain-over-bytea is serialized with
+	 * the bytea-specific path rather than the generic text output path. Map
+	 * types are domains with special semantics and must not be unwrapped.
+	 */
+	if (!IsMapTypeOid(columnType) && get_typtype(columnType) == TYPTYPE_DOMAIN)
+		columnType = getBaseType(columnType);
+
 	if (flinfo->fn_oid == ARRAY_OUT_OID)
 	{
 		/* maps are a type of array */

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -414,6 +414,14 @@ GetDuckDBTypeForPGType(PGType postgresType)
 		return DUCKDB_TYPE_STRUCT;
 	}
 
+	if (typtype == TYPTYPE_DOMAIN)
+	{
+		Oid			baseTypeId = getBaseType(pgTypeId);
+
+		postgresType.postgresTypeOid = baseTypeId;
+		return GetDuckDBTypeForPGType(postgresType);
+	}
+
 	switch (pgTypeId)
 	{
 

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -414,14 +414,6 @@ GetDuckDBTypeForPGType(PGType postgresType)
 		return DUCKDB_TYPE_STRUCT;
 	}
 
-	if (typtype == TYPTYPE_DOMAIN)
-	{
-		Oid			baseTypeId = getBaseType(pgTypeId);
-
-		postgresType.postgresTypeOid = baseTypeId;
-		return GetDuckDBTypeForPGType(postgresType);
-	}
-
 	switch (pgTypeId)
 	{
 

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -629,12 +629,9 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 
 	/*
 	 * Unwrap domain types so that e.g. a domain over bytea is written as BLOB
-	 * rather than falling through to VARCHAR.  Map types are domains with
-	 * special semantics and must not be unwrapped.
+	 * rather than falling through to VARCHAR.
 	 */
-	if (!IsMapTypeOid(postgresType.postgresTypeOid) &&
-		get_typtype(postgresType.postgresTypeOid) == TYPTYPE_DOMAIN)
-		postgresType.postgresTypeOid = getBaseType(postgresType.postgresTypeOid);
+	postgresType.postgresTypeOid = ResolveDomainBaseType(postgresType.postgresTypeOid);
 
 	DuckDBType	duckTypeId = GetDuckDBTypeForPGType(postgresType);
 

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -32,6 +32,7 @@
 #include "pg_lake/pgduck/keywords.h"
 #include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/pgduck/read_data.h"
+#include "pg_lake/pgduck/map.h"
 #include "pg_lake/pgduck/type.h"
 #include "pg_lake/pgduck/iceberg_query_validation.h"
 #include "pg_lake/pgduck/write_data.h"
@@ -625,6 +626,15 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 	 */
 	if (isArrayType)
 		postgresType.postgresTypeOid = elementTypeId;
+
+	/*
+	 * Unwrap domain types so that e.g. a domain over bytea is written as BLOB
+	 * rather than falling through to VARCHAR.  Map types are domains with
+	 * special semantics and must not be unwrapped.
+	 */
+	if (!IsMapTypeOid(postgresType.postgresTypeOid) &&
+		get_typtype(postgresType.postgresTypeOid) == TYPTYPE_DOMAIN)
+		postgresType.postgresTypeOid = getBaseType(postgresType.postgresTypeOid);
 
 	DuckDBType	duckTypeId = GetDuckDBTypeForPGType(postgresType);
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -183,11 +183,10 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 	 * Unwrap domain types to their base type so that e.g. a domain over
 	 * integer maps to Iceberg "int" rather than falling through to the
 	 * default "string" case.  Map types are domains too but carry special
-	 * semantics, so check for them first.
+	 * semantics; ResolveDomainBaseType leaves those unchanged.
 	 */
-	if (!IsMapTypeOid(typeId))
 	{
-		Oid			baseTypeId = getBaseType(typeId);
+		Oid			baseTypeId = ResolveDomainBaseType(typeId);
 
 		if (baseTypeId != typeId)
 		{

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -179,6 +179,23 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 
 	Field	   *field = palloc0(sizeof(Field));
 
+	/*
+	 * Unwrap domain types to their base type so that e.g. a domain over
+	 * integer maps to Iceberg "int" rather than falling through to the
+	 * default "string" case.  Map types are domains too but carry special
+	 * semantics, so check for them first.
+	 */
+	if (!IsMapTypeOid(typeId))
+	{
+		Oid			baseTypeId = getBaseType(typeId);
+
+		if (baseTypeId != typeId)
+		{
+			typeId = baseTypeId;
+			pgType.postgresTypeOid = baseTypeId;
+		}
+	}
+
 	if (type_is_array(typeId))
 	{
 		field->type = FIELD_TYPE_LIST;

--- a/pg_lake_table/tests/pytests/test_data_file_pruning.py
+++ b/pg_lake_table/tests/pytests/test_data_file_pruning.py
@@ -1488,16 +1488,16 @@ def test_pruning_for_domains(
         pg_conn,
     )
 
-    # we cannot apply pruning on domain types
-    assert int(fetch_data_files_used(results)) == 2
+    # domain-over-int maps to Iceberg "int" so min/max pruning works
+    assert int(fetch_data_files_used(results)) == 1
 
-    # with explicit cast, do not apply pruning
+    # explicit cast to int also prunes
     results = run_query(
         f"{explain_prefix}  SELECT * FROM users WHERE age = 25::int",
         pg_conn,
     )
 
-    assert int(fetch_data_files_used(results)) == 2
+    assert int(fetch_data_files_used(results)) == 1
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -55,6 +55,8 @@ def test_domain_iceberg_field_type(extension, pg_conn, s3, with_default_location
     """Domain over a scalar type must produce the base type in Iceberg metadata, not string."""
     run_command(
         """
+        create schema test_domain_field_type;
+        set search_path to test_domain_field_type;
         create domain year_int as integer check (value >= 1 and value <= 9999);
         create domain small_float as double precision check (value > 0);
         create table domain_types (
@@ -66,9 +68,11 @@ def test_domain_iceberg_field_type(extension, pg_conn, s3, with_default_location
     """,
         pg_conn,
     )
+    pg_conn.commit()
 
     results = run_query(
-        "SELECT metadata_location FROM iceberg_tables WHERE table_name = 'domain_types'",
+        "SELECT metadata_location FROM lake_iceberg.tables"
+        " WHERE table_name = 'domain_types' AND table_namespace = 'test_domain_field_type'",
         pg_conn,
     )
     assert len(results) == 1
@@ -88,3 +92,5 @@ def test_domain_iceberg_field_type(extension, pg_conn, s3, with_default_location
     assert result[0]["t"] == "hello"
 
     pg_conn.rollback()
+    run_command("drop schema if exists test_domain_field_type cascade;", pg_conn)
+    pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from utils_pytest import *
 
@@ -46,5 +47,44 @@ def test_copy_from_domain(extension, pg_conn, s3, with_default_location):
         raise_error=False,
     )
     assert "value for domain positive violates check constraint" in error
+
+    pg_conn.rollback()
+
+
+def test_domain_iceberg_field_type(extension, pg_conn, s3, with_default_location):
+    """Domain over a scalar type must produce the base type in Iceberg metadata, not string."""
+    run_command(
+        """
+        create domain year_int as integer check (value >= 1 and value <= 9999);
+        create domain small_float as double precision check (value > 0);
+        create table domain_types (
+            y year_int,
+            d small_float,
+            t text
+        ) using iceberg;
+        insert into domain_types values (2024, 3.14, 'hello');
+    """,
+        pg_conn,
+    )
+
+    results = run_query(
+        "SELECT metadata_location FROM iceberg_tables WHERE table_name = 'domain_types'",
+        pg_conn,
+    )
+    assert len(results) == 1
+    metadata_path = results[0][0]
+
+    data = read_s3_operations(s3, metadata_path)
+    parsed = json.loads(data)
+    fields = {f["name"]: f["type"] for f in parsed["schemas"][0]["fields"]}
+
+    assert fields["y"] == "int", f"domain over integer should be 'int', got {fields['y']!r}"
+    assert fields["d"] == "double", f"domain over double precision should be 'double', got {fields['d']!r}"
+    assert fields["t"] == "string"
+
+    result = run_query("SELECT y, d, t FROM domain_types", pg_conn)
+    assert result[0]["y"] == 2024
+    assert abs(result[0]["d"] - 3.14) < 0.001
+    assert result[0]["t"] == "hello"
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -82,8 +82,12 @@ def test_domain_iceberg_field_type(extension, pg_conn, s3, with_default_location
     parsed = json.loads(data)
     fields = {f["name"]: f["type"] for f in parsed["schemas"][0]["fields"]}
 
-    assert fields["y"] == "int", f"domain over integer should be 'int', got {fields['y']!r}"
-    assert fields["d"] == "double", f"domain over double precision should be 'double', got {fields['d']!r}"
+    assert (
+        fields["y"] == "int"
+    ), f"domain over integer should be 'int', got {fields['y']!r}"
+    assert (
+        fields["d"] == "double"
+    ), f"domain over double precision should be 'double', got {fields['d']!r}"
     assert fields["t"] == "string"
 
     result = run_query("SELECT y, d, t FROM domain_types", pg_conn)


### PR DESCRIPTION
Currently domain types on int get correctly stored as int in Parquet, but are defined as string in Iceberg metadata.