### PR TITLE
Fix base64 newline wrapping that corrupts the GHCR auth header

### DIFF
--- a/.github/actions/build-and-push-image/action.yml
+++ b/.github/actions/build-and-push-image/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       working-directory: ./docker
       run: |
-        GHCR_TOKEN=$(echo ${{ inputs.github_token }} | base64)
+        GHCR_TOKEN=$(echo -n "${{ inputs.github_token }}" | base64 -w 0)
         
         TAG=${{ hashFiles('docker/Dockerfile') }}-${{ inputs.base_image_name }}
         HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://ghcr.io/v2/${{ inputs.org_name }}/${{ inputs.final_image_name }}/manifests/$TAG)


### PR DESCRIPTION
`-w 0` disables base64 line wrapping, producing a single unbroken string
`-n` prevents echo from appending a trailing newline that would also be encoded


(not sure what changed in CI that produced this error, maybe curl version?)