### PR TITLE
pg_extension_base: add dependency_escalation_role GUC

### DIFF
--- a/pg_extension_base/include/pg_extension_base/extension_dependencies.h
+++ b/pg_extension_base/include/pg_extension_base/extension_dependencies.h
@@ -19,5 +19,6 @@
 
 extern bool EnableExtensionDependencyCreate;
 extern bool EnableExtensionDependencyUpdate;
+extern char *DependencyEscalationRoleName;
 
 void		InitializeExtensionDependencyInstaller(void);

--- a/pg_extension_base/src/extension_dependencies.c
+++ b/pg_extension_base/src/extension_dependencies.c
@@ -27,6 +27,9 @@
 #include "nodes/parsenodes.h"
 #include "nodes/plannodes.h"
 #include "tcop/utility.h"
+#include "catalog/pg_authid.h"
+#include "utils/acl.h"
+#include "utils/guc.h"
 
 
 static void ExtensionDependencyInstallerHook(PlannedStmt *plannedStmt,
@@ -42,6 +45,7 @@ static void HandleCreateExtensionStmt(CreateExtensionStmt *createExtension);
 static void EnsureExtensionExists(char *extensionName);
 static void EnsureExtensionIsUpdated(char *extensionName);
 static bool HasOption(List *options, char *optionName);
+static bool ShouldEscalateForDependency(void);
 
 
 /* whether to auto-install new dependencies */
@@ -49,6 +53,16 @@ bool		EnableExtensionDependencyCreate = true;
 
 /* whether to auto-update existing dependencies */
 bool		EnableExtensionDependencyUpdate = true;
+
+/*
+ * Optional role name; if the current user is a member of this role, the
+ * synthesized CREATE/ALTER EXTENSION calls used to install or update
+ * dependencies will run as the bootstrap superuser. This lets pg_extension_base
+ * escalate dependency work even when the surrounding session is not running
+ * under a privileged escalator (e.g. snowflake_user). Empty disables the
+ * behavior.
+ */
+char	   *DependencyEscalationRoleName = "";
 
 /* previous hooks */
 static ProcessUtility_hook_type PrevProcessUtility = NULL;
@@ -198,8 +212,29 @@ EnsureExtensionExists(char *extensionName)
 	createExtensionStmt->extname = extensionName;
 	createExtensionStmt->if_not_exists = true;
 	createExtensionStmt->options = list_make1(cascadeOption);
-	CreateExtension(NULL, createExtensionStmt);
-	CommandCounterIncrement();
+
+	Oid			savedUserId = InvalidOid;
+	int			savedSecContext = 0;
+	bool		escalated = ShouldEscalateForDependency();
+
+	if (escalated)
+	{
+		GetUserIdAndSecContext(&savedUserId, &savedSecContext);
+		SetUserIdAndSecContext(BOOTSTRAP_SUPERUSERID,
+							   savedSecContext | SECURITY_LOCAL_USERID_CHANGE);
+	}
+
+	PG_TRY();
+	{
+		CreateExtension(NULL, createExtensionStmt);
+		CommandCounterIncrement();
+	}
+	PG_FINALLY();
+	{
+		if (escalated)
+			SetUserIdAndSecContext(savedUserId, savedSecContext);
+	}
+	PG_END_TRY();
 }
 
 
@@ -236,10 +271,58 @@ EnsureExtensionIsUpdated(char *extensionName)
 	check_stack_depth();
 	HandleAlterExtensionStmt(alterExtensionStmt);
 
-	ExecAlterExtensionStmt(NULL, alterExtensionStmt);
-	CommandCounterIncrement();
+	Oid			savedUserId = InvalidOid;
+	int			savedSecContext = 0;
+	bool		escalated = ShouldEscalateForDependency();
+
+	if (escalated)
+	{
+		GetUserIdAndSecContext(&savedUserId, &savedSecContext);
+		SetUserIdAndSecContext(BOOTSTRAP_SUPERUSERID,
+							   savedSecContext | SECURITY_LOCAL_USERID_CHANGE);
+	}
+
+	PG_TRY();
+	{
+		ExecAlterExtensionStmt(NULL, alterExtensionStmt);
+		CommandCounterIncrement();
+	}
+	PG_FINALLY();
+	{
+		if (escalated)
+			SetUserIdAndSecContext(savedUserId, savedSecContext);
+	}
+	PG_END_TRY();
 
 	AtEOXact_GUC(true, gucNestLevel);
+}
+
+
+/*
+ * ShouldEscalateForDependency returns true when the configured escalation role
+ * is non-empty and the current user is a member of it. The role is resolved
+ * each call so that SET ROLE / RESET ROLE inside the session is honored. If the
+ * configured role does not exist we silently treat it as "no escalation"; an
+ * unresolvable role is a configuration issue and we don't want to break
+ * unrelated DDL on the chance it happens to escalate dependencies.
+ */
+static bool
+ShouldEscalateForDependency(void)
+{
+	if (DependencyEscalationRoleName == NULL ||
+		DependencyEscalationRoleName[0] == '\0')
+		return false;
+
+	/* already running with full privileges; nothing to do */
+	if (superuser())
+		return false;
+
+	Oid			roleOid = get_role_oid(DependencyEscalationRoleName, true);
+
+	if (!OidIsValid(roleOid))
+		return false;
+
+	return is_member_of_role(GetUserId(), roleOid);
 }
 
 

--- a/pg_extension_base/src/pg_extension_base.c
+++ b/pg_extension_base/src/pg_extension_base.c
@@ -96,6 +96,19 @@ _PG_init(void)
 							 GUC_STANDARD,
 							 NULL, NULL, NULL);
 
+	DefineCustomStringVariable(
+							   "pg_extension_base.dependency_escalation_role",
+							   gettext_noop("If non-empty, automatic CREATE/ALTER EXTENSION calls "
+											"that install or update dependencies run as the "
+											"bootstrap superuser when the current user is a member "
+											"of this role"),
+							   NULL,
+							   &DependencyEscalationRoleName,
+							   "",
+							   PGC_SIGHUP,
+							   GUC_SUPERUSER_ONLY,
+							   NULL, NULL, NULL);
+
 	DefineCustomBoolVariable(
 							 "pg_extension_base.enable_base_worker_launcher",
 							 gettext_noop("Enables the bae worker launcher, which simplifies "

--- a/pg_extension_base/tests/pytests/test_extension_dependencies.py
+++ b/pg_extension_base/tests/pytests/test_extension_dependencies.py
@@ -91,11 +91,36 @@ def test_extension_dependency_role_escalation(superuser_conn):
     role_name = "ext_dep_escalator"
     user_name = "ext_dep_user"
 
+    def set_escalation_role(value):
+        # ALTER SYSTEM cannot run inside a transaction block; flip the
+        # connection into autocommit for the duration of the GUC update.
+        superuser_conn.commit()
+        superuser_conn.autocommit = True
+        try:
+            run_command(
+                f"alter system set pg_extension_base.dependency_escalation_role to '{value}';",
+                superuser_conn,
+            )
+            run_command("select pg_reload_conf();", superuser_conn)
+        finally:
+            superuser_conn.autocommit = False
+
+    def reset_escalation_role():
+        superuser_conn.commit()
+        superuser_conn.autocommit = True
+        try:
+            run_command(
+                "alter system reset pg_extension_base.dependency_escalation_role;",
+                superuser_conn,
+            )
+            run_command("select pg_reload_conf();", superuser_conn)
+        finally:
+            superuser_conn.autocommit = False
+
     # Set up: install old versions as superuser; create the role and a member
-    # user; reassign ownership of ext3 (and its schema) to the test user so
-    # they can run ALTER EXTENSION on it; configure the GUC to recognize the
-    # role. PG has no ALTER EXTENSION ... OWNER TO syntax, so we update the
-    # catalog directly.
+    # user; reassign ownership of ext3 to the test user so they can run
+    # ALTER EXTENSION on it. PG has no ALTER EXTENSION ... OWNER TO syntax,
+    # so we update the catalog directly.
     run_command(
         f"""
         drop extension if exists pg_extension_base cascade;
@@ -107,23 +132,15 @@ def test_extension_dependency_role_escalation(superuser_conn):
         create user {user_name} in role {role_name};
         update pg_extension set extowner = (select oid from pg_roles where rolname = '{user_name}')
             where extname = 'pg_extension_base_test_ext3';
-        alter system set pg_extension_base.dependency_escalation_role to '{role_name}';
-        select pg_reload_conf();
         """,
         superuser_conn,
     )
     superuser_conn.commit()
 
     try:
-        # Verify the precondition: without escalation, a non-superuser
-        # owner of ext3 can't update its dependency ext2 (which they don't
-        # own). We check this by temporarily blanking the role GUC.
-        run_command(
-            "alter system set pg_extension_base.dependency_escalation_role to '';"
-            "select pg_reload_conf();",
-            superuser_conn,
-        )
-        superuser_conn.commit()
+        # Precondition: without escalation, the non-superuser owner of ext3
+        # cannot cascade-update its dependency ext2 (which they don't own).
+        set_escalation_role("")
 
         user_conn = open_pg_conn(user=user_name)
         error = run_command(
@@ -137,14 +154,9 @@ def test_extension_dependency_role_escalation(superuser_conn):
         user_conn.rollback()
         user_conn.close()
 
-        # Now restore the escalation role; the same ALTER should succeed
-        # and cascade the dependency update under the bootstrap superuser.
-        run_command(
-            f"alter system set pg_extension_base.dependency_escalation_role to '{role_name}';"
-            "select pg_reload_conf();",
-            superuser_conn,
-        )
-        superuser_conn.commit()
+        # With the escalation role set, the same ALTER should succeed and
+        # cascade the dependency update under the bootstrap superuser.
+        set_escalation_role(role_name)
 
         user_conn = open_pg_conn(user=user_name)
         run_command(
@@ -160,10 +172,9 @@ def test_extension_dependency_role_escalation(superuser_conn):
         )
         assert result[0]["extversion"] == "1.1"
     finally:
+        reset_escalation_role()
         run_command(
             f"""
-            alter system reset pg_extension_base.dependency_escalation_role;
-            select pg_reload_conf();
             update pg_extension set extowner = (select oid from pg_roles where rolname = current_user)
                 where extname = 'pg_extension_base_test_ext3';
             drop owned by {user_name};

--- a/pg_extension_base/tests/pytests/test_extension_dependencies.py
+++ b/pg_extension_base/tests/pytests/test_extension_dependencies.py
@@ -82,6 +82,96 @@ def test_extension_dependency_update(superuser_conn):
     superuser_conn.rollback()
 
 
+# When pg_extension_base.dependency_escalation_role names a role that the
+# current user is a member of, the synthesized ALTER EXTENSION calls used to
+# update dependencies should run as the bootstrap superuser. Without the
+# escalation, a non-superuser cannot ALTER an extension they don't own, so
+# the cascading dependency update would fail.
+def test_extension_dependency_role_escalation(superuser_conn):
+    role_name = "ext_dep_escalator"
+    user_name = "ext_dep_user"
+
+    # Set up: install old versions as superuser; create the role and a member
+    # user; configure the GUC to recognize the role.
+    run_command(
+        f"""
+        drop extension if exists pg_extension_base cascade;
+        create extension pg_extension_base_test_ext2 version '1.0' cascade;
+        create extension pg_extension_base_test_ext3 version '1.0' cascade;
+        drop role if exists {user_name};
+        drop role if exists {role_name};
+        create role {role_name};
+        create user {user_name} in role {role_name};
+        alter extension pg_extension_base_test_ext3 owner to {user_name};
+        alter system set pg_extension_base.dependency_escalation_role to '{role_name}';
+        select pg_reload_conf();
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        # Verify the precondition: without escalation, a non-superuser
+        # owner of ext3 can't update its dependency ext2 (which they don't
+        # own). We check this by temporarily blanking the role GUC.
+        run_command(
+            "alter system set pg_extension_base.dependency_escalation_role to '';"
+            "select pg_reload_conf();",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        user_conn = open_pg_conn(user=user_name)
+        error = run_command(
+            "alter extension pg_extension_base_test_ext3 update;",
+            user_conn,
+            raise_error=False,
+        )
+        assert (
+            error is not None
+        ), "expected non-superuser update to fail without escalation"
+        user_conn.rollback()
+        user_conn.close()
+
+        # Now restore the escalation role; the same ALTER should succeed
+        # and cascade the dependency update under the bootstrap superuser.
+        run_command(
+            f"alter system set pg_extension_base.dependency_escalation_role to '{role_name}';"
+            "select pg_reload_conf();",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        user_conn = open_pg_conn(user=user_name)
+        run_command(
+            "alter extension pg_extension_base_test_ext3 update;",
+            user_conn,
+        )
+        user_conn.commit()
+        user_conn.close()
+
+        result = run_query(
+            "select extversion from pg_extension where extname = 'pg_extension_base_test_ext2'",
+            superuser_conn,
+        )
+        assert result[0]["extversion"] == "1.1"
+    finally:
+        run_command(
+            f"""
+            alter system reset pg_extension_base.dependency_escalation_role;
+            select pg_reload_conf();
+            alter extension pg_extension_base_test_ext3 owner to current_user;
+            drop owned by {user_name};
+            drop user if exists {user_name};
+            drop role if exists {role_name};
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+    superuser_conn.rollback()
+
+
 # We first create an older version of pg_extension_base, and then the
 # up-to-date version of pg_extension_base_test_ext1, which triggers
 # an update of pg_extension_base.

--- a/pg_extension_base/tests/pytests/test_extension_dependencies.py
+++ b/pg_extension_base/tests/pytests/test_extension_dependencies.py
@@ -92,7 +92,10 @@ def test_extension_dependency_role_escalation(superuser_conn):
     user_name = "ext_dep_user"
 
     # Set up: install old versions as superuser; create the role and a member
-    # user; configure the GUC to recognize the role.
+    # user; reassign ownership of ext3 (and its schema) to the test user so
+    # they can run ALTER EXTENSION on it; configure the GUC to recognize the
+    # role. PG has no ALTER EXTENSION ... OWNER TO syntax, so we update the
+    # catalog directly.
     run_command(
         f"""
         drop extension if exists pg_extension_base cascade;
@@ -102,7 +105,8 @@ def test_extension_dependency_role_escalation(superuser_conn):
         drop role if exists {role_name};
         create role {role_name};
         create user {user_name} in role {role_name};
-        alter extension pg_extension_base_test_ext3 owner to {user_name};
+        update pg_extension set extowner = (select oid from pg_roles where rolname = '{user_name}')
+            where extname = 'pg_extension_base_test_ext3';
         alter system set pg_extension_base.dependency_escalation_role to '{role_name}';
         select pg_reload_conf();
         """,
@@ -160,7 +164,8 @@ def test_extension_dependency_role_escalation(superuser_conn):
             f"""
             alter system reset pg_extension_base.dependency_escalation_role;
             select pg_reload_conf();
-            alter extension pg_extension_base_test_ext3 owner to current_user;
+            update pg_extension set extowner = (select oid from pg_roles where rolname = current_user)
+                where extname = 'pg_extension_base_test_ext3';
             drop owned by {user_name};
             drop user if exists {user_name};
             drop role if exists {role_name};


### PR DESCRIPTION
  ## Summary

  - Add `pg_extension_base.dependency_escalation_role` GUC: when set, the synthesized CREATE/ALTER EXTENSION calls used by the dependency installer ProcessUtility hook
  run as the bootstrap superuser if the current user is a member of the named role.
  - Default empty (no behavior change). `GUC_SUPERUSER_ONLY`, `PGC_SIGHUP`.
  - `EnsureExtensionExists` / `EnsureExtensionIsUpdated` wrap their direct `CreateExtension` / `ExecAlterExtensionStmt` calls with `SetUserIdAndSecContext` + `PG_TRY` /
  `PG_FINALLY` so userid is restored on error.
  - Short-circuits when already superuser, so deployments running under snowflake_user are unaffected.

  ## Why

  Dependency escalation in `extension_dependencies.c` calls `CreateExtension`/`ExecAlterExtensionStmt` directly, bypassing the ProcessUtility hook chain. An outer hook
  that escalates only on specific top-level CREATE EXTENSION statements does not see the cascaded calls, so a non-superuser member of `snowflake_manage_extensions`
  running CREATE/ALTER on the pg_lake graph fails when the cascade tries to ALTER a dependency it doesn't own. Production is fine (snowflake_user escalates the whole
  statement); testing without snowflake_user is the gap. This change lets pg_extension_base elevate its own synthesized DDL based on role membership, independent of which
   extension was named at the top level and independent of `shared_preload_libraries` ordering.

  ## Test plan

  - [ ] New `test_extension_dependency_role_escalation` runs in CI
  - [ ] Manual: production-like setup with snowflake_user still works (escalation short-circuits via `superuser()` check)