### PR TITLE
test_common: honor PGLAKE_EXTRA_INITDB_ARGS in initdb

### DIFF
--- a/test_common/helpers/server.py
+++ b/test_common/helpers/server.py
@@ -6,6 +6,7 @@ import grp
 import os
 import platform
 import queue
+import shlex
 import shutil
 import signal
 import socket
@@ -553,6 +554,13 @@ def initdb(initdb_bindir, db_path, db_user):
         # Linux
         locale_setting = "C.UTF-8"
 
+    # Caller-supplied extra args (e.g. additional --set GUC=VALUE pairs)
+    # are appended after the harness defaults, so a duplicate key wins —
+    # this lets a downstream test suite override SPL or any GUC without
+    # patching the harness.  shlex.split lets the caller pass a single
+    # space-separated string with quoted values where needed.
+    extra_args = shlex.split(os.environ.get("PGLAKE_EXTRA_INITDB_ARGS", ""))
+
     subprocess.run(
         [
             f"{initdb_bindir}/initdb",
@@ -598,6 +606,7 @@ def initdb(initdb_bindir, db_path, db_user):
             f"pg_lake_engine.host=host={server_params.PGDUCK_UNIX_DOMAIN_PATH} port={server_params.PGDUCK_PORT}",
             "--set",
             "pg_lake_engine.enable_heavy_asserts=on",
+            *extra_args,
             db_path,
         ]
     )


### PR DESCRIPTION
Lets a downstream test suite contribute extra initdb arguments (typically additional --set GUC=value pairs) without patching the harness.  Args are shlex-split, appended after the existing defaults so a duplicate key wins, and the env var is empty by default — no behavior change for existing callers.

Motivating use case: an out-of-tree extension that registers a ProcessUtility hook needs to be in shared_preload_libraries before pg_extension_base's hook walks dependencies, so the dependent extension's hook can wrap (and escalate) the synthesized ALTER EXTENSION calls pg_extension_base emits.  Today the SPL list is hard-coded; with this hook the caller can extend it.
