### PR TITLE
Invalidate Parquet metadata on explicit uncache (CI)

### DIFF
--- a/duckdb_pglake/src/fs/file_cache_manager.cpp
+++ b/duckdb_pglake/src/fs/file_cache_manager.cpp
@@ -415,7 +415,7 @@ FileCacheManager::RemoveCacheFile(ClientContext &context, string url, bool waitF
 	/* remove the file from the cache */
 	CacheRemoveStatus status =
 		RemoveCacheFileInternal(file_system, finalCacheFilePath, finalCacheFilePath, waitForLock);
-	if (status == CacheRemoveStatus::FILE_EXISTS)
+	if (status != CacheRemoveStatus::LOCK_NOT_ACQUIRED)
 	{
 		/*
 		* Also remove Parquet metadata from in-memory cache to not leak
@@ -423,7 +423,9 @@ FileCacheManager::RemoveCacheFile(ClientContext &context, string url, bool waitF
 		* the file changed. We do this after removing the file, to ensure
 		* future readers do not see metadata. We also do it if there was
 		* no file, to not leave any cache remnants when explicitly uncaching
-		* a file.
+		* a file. If we could not acquire the lock, then a concurrent cache
+		* mutation is still in progress and we must not invalidate its
+		* metadata view underneath it.
 		*/
 		parquetMetadataCache.Delete(url);
 	}

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -388,6 +388,56 @@ def test_parquet_metadata_cache_invalidation(s3, pgduck_conn):
     assert len(results[0]) == 4
 
 
+def test_parquet_metadata_cache_invalidation_if_uncache_finds_no_local_file(
+    s3, pgduck_conn
+):
+    url = (
+        f"s3://{TEST_BUCKET}/"
+        "test_parquet_metadata_cache_invalidation_if_uncache_finds_no_local_file/"
+        "data1.parquet"
+    )
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/s3/{TEST_BUCKET}/"
+        "test_parquet_metadata_cache_invalidation_if_uncache_finds_no_local_file/"
+        f"{CACHE_FILE_PREFIX}data1.parquet"
+    )
+
+    run_command(
+        f"""
+        COPY (SELECT 1 AS a, 2 AS b) TO '{url}'
+    """,
+        pgduck_conn,
+    )
+
+    results = run_query(f"SELECT * FROM '{url}'", pgduck_conn)
+    assert len(results[0]) == 2
+
+    run_command(
+        f"""
+        SELECT * FROM pg_lake_cache_file('{url}')
+    """,
+        pgduck_conn,
+    )
+
+    results = run_query(f"SELECT * FROM '{url}'", pgduck_conn)
+    assert len(results[0]) == 2
+
+    run_command(
+        f"""
+        COPY (SELECT 1 AS a, 2 AS b, 3 AS c) TO '{url}'
+    """,
+        pgduck_conn,
+    )
+
+    cached_path.unlink()
+
+    results = run_query(f"SELECT * FROM pg_lake_uncache_file('{url}')", pgduck_conn)
+    assert results[0][0] is False
+
+    results = run_query(f"SELECT * FROM '{url}'", pgduck_conn)
+    assert len(results[0]) == 3
+
+
 # we can cache two different files concurrently
 def test_concurrent_cache_uncache_different_files(s3, pgduck_conn):
     url_1 = f"s3://{TEST_BUCKET}/test_concurrent_cache_file/file_1.csv"


### PR DESCRIPTION
This is the change from #367 by @fallintoplace. Pushed to a `marcoslot/*` branch in this repo to run CI (forked contributor PRs don't get the full workflow). Original commit and Signed-off-by preserved.

Closes #367
Closes #366