### PR TITLE
Allow r2:// URL scheme (CI) and make supported-URL errors generic

### DIFF
--- a/duckdb_pglake/src/fs/file_cache_manager.cpp
+++ b/duckdb_pglake/src/fs/file_cache_manager.cpp
@@ -227,7 +227,8 @@ FileCacheManager::IsCacheableURL(string cacheDir, string url)
 		   StringUtil::StartsWith(url, "abfss://") ||
 		   StringUtil::StartsWith(url, "https://") ||
 		   StringUtil::StartsWith(url, "http://") ||
-		   StringUtil::StartsWith(url, "hf://");
+		   StringUtil::StartsWith(url, "hf://") ||
+		   StringUtil::StartsWith(url, "r2://");
 }
 
 

--- a/pg_lake_benchmark/src/tpcds.c
+++ b/pg_lake_benchmark/src/tpcds.c
@@ -73,7 +73,7 @@ pg_lake_tpcds_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);

--- a/pg_lake_benchmark/src/tpcds.c
+++ b/pg_lake_benchmark/src/tpcds.c
@@ -73,8 +73,7 @@ pg_lake_tpcds_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-							   "currently supported")));
+						errmsg("unsupported URL: \"%s\"", location)));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);
 	BenchmarkTableType tableType = GetBenchTableType(tableTypeId);

--- a/pg_lake_benchmark/src/tpch.c
+++ b/pg_lake_benchmark/src/tpch.c
@@ -70,7 +70,7 @@ pg_lake_tpch_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);
@@ -104,7 +104,7 @@ pg_lake_tpch_gen_partitioned(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);

--- a/pg_lake_benchmark/src/tpch.c
+++ b/pg_lake_benchmark/src/tpch.c
@@ -70,8 +70,7 @@ pg_lake_tpch_gen(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-							   "currently supported")));
+						errmsg("unsupported URL: \"%s\"", location)));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);
 	BenchmarkTableType tableType = GetBenchTableType(tableTypeId);
@@ -104,8 +103,7 @@ pg_lake_tpch_gen_partitioned(PG_FUNCTION_ARGS)
 
 	if (!IsSupportedURL(location))
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-							   "currently supported")));
+						errmsg("unsupported URL: \"%s\"", location)));
 
 	Oid			tableTypeId = (BenchmarkTableType) PG_GETARG_OID(1);
 	BenchmarkTableType tableType = GetBenchTableType(tableTypeId);

--- a/pg_lake_copy/src/ddl/create_table.c
+++ b/pg_lake_copy/src/ddl/create_table.c
@@ -173,7 +173,7 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(definitionFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 								   "currently supported")));
 		}
 
@@ -194,7 +194,7 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(loadFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 								   "currently supported")));
 		}
 

--- a/pg_lake_copy/src/ddl/create_table.c
+++ b/pg_lake_copy/src/ddl/create_table.c
@@ -173,8 +173,8 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(definitionFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-								   "currently supported")));
+							errmsg("pg_lake_copy: unsupported URL: \"%s\"",
+								   definitionFromURL)));
 		}
 
 		/* determine format & compression to make DESCRIBE more precise */
@@ -194,8 +194,8 @@ ProcessCreateFromFile(CreateStmt *createStmt,
 		if (!IsSupportedURL(loadFromURL))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-								   "currently supported")));
+							errmsg("pg_lake_copy: unsupported URL: \"%s\"",
+								   loadFromURL)));
 		}
 
 		/* determine format & compression to make DESCRIBE more precise */

--- a/pg_lake_copy/tests/pytests/test_create_table.py
+++ b/pg_lake_copy/tests/pytests/test_create_table.py
@@ -301,9 +301,7 @@ def test_create_table_load_from_invalid_url(pg_conn, duckdb_conn, s3):
         pg_conn,
         raise_error=False,
     )
-    assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
-    )
+    assert error.startswith("ERROR:  pg_lake_copy: unsupported URL")
 
     pg_conn.rollback()
 
@@ -314,9 +312,7 @@ def test_create_table_load_from_invalid_url(pg_conn, duckdb_conn, s3):
         pg_conn,
         raise_error=False,
     )
-    assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
-    )
+    assert error.startswith("ERROR:  pg_lake_copy: unsupported URL")
 
     pg_conn.rollback()
 

--- a/pg_lake_copy/tests/pytests/test_create_table.py
+++ b/pg_lake_copy/tests/pytests/test_create_table.py
@@ -302,7 +302,7 @@ def test_create_table_load_from_invalid_url(pg_conn, duckdb_conn, s3):
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()
@@ -315,7 +315,7 @@ def test_create_table_load_from_invalid_url(pg_conn, duckdb_conn, s3):
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()

--- a/pg_lake_copy/tests/pytests/test_r2_copy.py
+++ b/pg_lake_copy/tests/pytests/test_r2_copy.py
@@ -79,6 +79,7 @@ def test_r2_copy_from_parquet_invalid(pg_conn, r2):
     assert (
         error.startswith("ERROR:  HTTP Error: HTTP GET error")
         or "Unable to connect to URL" in error
+        or "Could not establish connection" in error
     )
 
     pg_conn.rollback()

--- a/pg_lake_copy/tests/pytests/test_r2_copy.py
+++ b/pg_lake_copy/tests/pytests/test_r2_copy.py
@@ -1,0 +1,84 @@
+import pytest
+import psycopg2
+import time
+import duckdb
+import math
+from utils_pytest import *
+
+
+def test_r2_copy_to_parquet(pg_conn, duckdb_conn, r2):
+    url = f"r2://{TEST_BUCKET_R2}/test_r2_copy_to/data.parquet"
+
+    # Create a Parquet file in mock R2
+    run_command(
+        f"""
+        COPY (SELECT s AS id, 'hello-'||s AS desc FROM generate_series(1,5) s) TO '{url}';
+    """,
+        pg_conn,
+    )
+
+    assert list_objects(r2, TEST_BUCKET_R2, "test_r2_copy_to/") == [
+        "test_r2_copy_to/data.parquet"
+    ]
+
+    # Make sure it's actually Parquet
+    duckdb_conn.execute("SELECT count(*) AS count FROM read_parquet($1)", [str(url)])
+    duckdb_result = duckdb_conn.fetchall()
+    assert duckdb_result[0][0] == 5
+
+    pg_conn.rollback()
+
+    # Read the Parquet file from prior tests
+    run_command(
+        f"""
+        CREATE TABLE test_r2_copy_from_parquet (id int, description text);
+        COPY test_r2_copy_from_parquet FROM '{url}';
+    """,
+        pg_conn,
+    )
+
+    result = run_query(
+        "SELECT id, description FROM test_r2_copy_from_parquet ORDER BY 1", pg_conn
+    )
+    assert len(result) == 5
+    assert result[0]["id"] == 1
+    assert result[0]["description"] == "hello-1"
+
+    pg_conn.rollback()
+
+
+def test_r2_copy_from_parquet_notexists(pg_conn, r2):
+    url = f"r2://{TEST_BUCKET_R2}/test_r2_copy_to/notexists.parquet"
+
+    # Read a Parquet file that does not exist
+    error = run_command(
+        f"""
+        CREATE TABLE test_r2_copy_from_parquet_notexists (id int, description text);
+        COPY test_r2_copy_from_parquet_notexists FROM '{url}';
+    """,
+        pg_conn,
+        raise_error=False,
+    )
+    assert error.startswith("ERROR:  HTTP Error: Unable to connect to URL ")
+
+    pg_conn.rollback()
+
+
+def test_r2_copy_from_parquet_invalid(pg_conn, r2):
+    url = f"r2://foo/invalid.parquet"
+
+    # Read a Parquet file we cannot have access to
+    error = run_command(
+        f"""
+        CREATE TABLE test_r2_copy_from_parquet_invalid (id int, description text);
+        COPY test_r2_copy_from_parquet_invalid FROM '{url}';
+    """,
+        pg_conn,
+        raise_error=False,
+    )
+    assert (
+        error.startswith("ERROR:  HTTP Error: HTTP GET error")
+        or "Unable to connect to URL" in error
+    )
+
+    pg_conn.rollback()

--- a/pg_lake_engine/include/pg_lake/copy/copy_format.h
+++ b/pg_lake_engine/include/pg_lake/copy/copy_format.h
@@ -30,6 +30,7 @@
 #define HTTP_URL_PREFIX "http://"
 #define HTTPS_URL_PREFIX "https://"
 #define HUGGING_FACE_URL_PREFIX "hf://"
+#define R2_URL_PREFIX "r2://"
 #define STAGE_URL_PREFIX "@STAGE/"
 
 

--- a/pg_lake_engine/src/copy/copy_format.c
+++ b/pg_lake_engine/src/copy/copy_format.c
@@ -437,7 +437,8 @@ IsSupportedURL(const char *path)
 		strncmp(path, AZURE_DLS_URL_PREFIX, strlen(AZURE_DLS_URL_PREFIX)) == 0 ||
 		strncmp(path, HTTP_URL_PREFIX, strlen(HTTP_URL_PREFIX)) == 0 ||
 		strncmp(path, HTTPS_URL_PREFIX, strlen(HTTPS_URL_PREFIX)) == 0 ||
-		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0;
+		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0 ||
+		strncmp(path, R2_URL_PREFIX, strlen(R2_URL_PREFIX)) == 0;
 }
 
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_functions.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_functions.c
@@ -49,7 +49,7 @@ iceberg_metadata(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
+						errmsg("pg_lake_iceberg: unsupported URL: \"%s\"", metadataUri)));
 	}
 
 	CheckURLReadAccess();
@@ -71,7 +71,7 @@ iceberg_files(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
+						errmsg("pg_lake_iceberg: unsupported URL: \"%s\"", metadataUri)));
 	}
 
 	CheckURLReadAccess();
@@ -144,7 +144,7 @@ iceberg_snapshots(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
+						errmsg("pg_lake_iceberg: unsupported URL: \"%s\"", metadataUri)));
 	}
 
 	CheckURLReadAccess();

--- a/pg_lake_iceberg/src/iceberg/iceberg_functions.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_functions.c
@@ -49,7 +49,7 @@ iceberg_metadata(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
 	}
 
 	CheckURLReadAccess();
@@ -71,7 +71,7 @@ iceberg_files(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
 	}
 
 	CheckURLReadAccess();
@@ -144,7 +144,7 @@ iceberg_snapshots(PG_FUNCTION_ARGS)
 	if (!IsSupportedURL(metadataUri))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported")));
+						errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported")));
 	}
 
 	CheckURLReadAccess();

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -351,7 +351,7 @@ IcebergDefaultLocationCheckHook(char **newvalue, void **extra, GucSource source)
 
 	if (!IsSupportedURL(newLocationPrefix))
 	{
-		GUC_check_errdetail("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+		GUC_check_errdetail("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							"supported as the default location prefix");
 		return false;
 	}

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -351,8 +351,8 @@ IcebergDefaultLocationCheckHook(char **newvalue, void **extra, GucSource source)
 
 	if (!IsSupportedURL(newLocationPrefix))
 	{
-		GUC_check_errdetail("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-							"supported as the default location prefix");
+		GUC_check_errdetail("pg_lake_iceberg: unsupported URL for default location prefix: \"%s\"",
+							newLocationPrefix);
 		return false;
 	}
 

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
@@ -48,10 +48,7 @@ def test_pg_lake_iceberg_table_metadata(
         raise_error=False,
     )
 
-    assert (
-        "pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported"
-        in error
-    )
+    assert "pg_lake_iceberg: unsupported URL" in error
 
     pg_conn.rollback()
 
@@ -110,10 +107,7 @@ def test_unsupported_url(installcheck, superuser_conn, iceberg_extension, s3):
 
     error = run_query(query, superuser_conn, raise_error=False)
 
-    assert (
-        "pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported"
-        in error
-    )
+    assert "pg_lake_iceberg: unsupported URL" in error
 
 
 @pytest.fixture(scope="module")

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_functions.py
@@ -49,7 +49,7 @@ def test_pg_lake_iceberg_table_metadata(
     )
 
     assert (
-        "pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported"
+        "pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported"
         in error
     )
 
@@ -111,7 +111,7 @@ def test_unsupported_url(installcheck, superuser_conn, iceberg_extension, s3):
     error = run_query(query, superuser_conn, raise_error=False)
 
     assert (
-        "pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// are supported"
+        "pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// are supported"
         in error
     )
 

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -455,15 +455,13 @@ ErrorIfUnsupportedLakeTable(CreateForeignTableStmt *createStmt)
 	if (!isWritable && !IsSupportedURL(path))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-							   "currently supported")));
+						errmsg("pg_lake_table: unsupported URL: \"%s\"", path)));
 	}
 	else if (isWritable && !IsSupportedURL(location))
 	{
 
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
-							   "currently supported")));
+						errmsg("pg_lake_table: unsupported URL: \"%s\"", location)));
 	}
 
 	if (isWritable)

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -455,14 +455,14 @@ ErrorIfUnsupportedLakeTable(CreateForeignTableStmt *createStmt)
 	if (!isWritable && !IsSupportedURL(path))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 	}
 	else if (isWritable && !IsSupportedURL(location))
 	{
 
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are "
+						errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are "
 							   "currently supported")));
 	}
 

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -205,9 +205,8 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(path))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
-									   "URLs are currently supported for the \"path\" "
-									   "option.")));
+								errmsg("pg_lake_table: unsupported URL: \"%s\" for the \"path\" option",
+									   path)));
 
 			foundServerPath = true;
 		}
@@ -217,9 +216,8 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(value))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
-									   "URLs are currently supported for the \"location\" "
-									   "option.")));
+								errmsg("pg_lake_table: unsupported URL: \"%s\" for the \"location\" option",
+									   value)));
 
 			foundLocation = true;
 		}
@@ -727,9 +725,8 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(location))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
-									   "URLs are currently supported for the \"location\" "
-									   "option.")));
+								errmsg("pg_lake_iceberg: unsupported URL: \"%s\" for the \"location\" option",
+									   location)));
 
 			char	   *charPointer = strchr(location, '?');
 

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -205,7 +205,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(path))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// "
+								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
 									   "URLs are currently supported for the \"path\" "
 									   "option.")));
 
@@ -217,7 +217,7 @@ pg_lake_table_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(value))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// "
+								errmsg("pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
 									   "URLs are currently supported for the \"location\" "
 									   "option.")));
 
@@ -727,7 +727,7 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 
 			if (!IsSupportedURL(location))
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// "
+								errmsg("pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// "
 									   "URLs are currently supported for the \"location\" "
 									   "option.")));
 

--- a/pg_lake_table/src/util/s3_file_utils.c
+++ b/pg_lake_table/src/util/s3_file_utils.c
@@ -62,7 +62,7 @@ pg_lake_file_size(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_size: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
+		ereport(ERROR, (errmsg("file_size: unsupported URL: \"%s\"", path),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -94,7 +94,7 @@ pg_lake_list_files(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(globURL) || !IsFileListSupportedUrl(globURL))
-		ereport(ERROR, (errmsg("list_files: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
+		ereport(ERROR, (errmsg("list_files: unsupported URL: \"%s\"", globURL),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -161,7 +161,7 @@ pg_lake_file_exists(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_exists: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
+		ereport(ERROR, (errmsg("file_exists: unsupported URL: \"%s\"", path),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -219,7 +219,7 @@ pg_lake_file_preview(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(url))
-		ereport(ERROR, (errmsg("file_preview: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
+		ereport(ERROR, (errmsg("file_preview: unsupported URL: \"%s\"", url),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -270,7 +270,7 @@ pg_lake_delete_file(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("delete_file: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
+		ereport(ERROR, (errmsg("delete_file: unsupported URL: \"%s\"", path),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLWriteAccess();

--- a/pg_lake_table/src/util/s3_file_utils.c
+++ b/pg_lake_table/src/util/s3_file_utils.c
@@ -62,7 +62,7 @@ pg_lake_file_size(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_size: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("file_size: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -94,7 +94,7 @@ pg_lake_list_files(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(globURL) || !IsFileListSupportedUrl(globURL))
-		ereport(ERROR, (errmsg("list_files: only s3://, gs://, az://, azure://, abfss://, and hf:// urls are supported"),
+		ereport(ERROR, (errmsg("list_files: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -143,7 +143,8 @@ IsFileListSupportedUrl(char *path)
 		strncmp(path, AZURE_URL_PREFIX, strlen(AZURE_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_BLOB_URL_PREFIX, strlen(AZURE_BLOB_URL_PREFIX)) == 0 ||
 		strncmp(path, AZURE_DLS_URL_PREFIX, strlen(AZURE_DLS_URL_PREFIX)) == 0 ||
-		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0;
+		strncmp(path, HUGGING_FACE_URL_PREFIX, strlen(HUGGING_FACE_URL_PREFIX)) == 0 ||
+		strncmp(path, R2_URL_PREFIX, strlen(R2_URL_PREFIX)) == 0;
 }
 
 
@@ -160,7 +161,7 @@ pg_lake_file_exists(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("file_exists: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("file_exists: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -218,7 +219,7 @@ pg_lake_file_preview(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(url))
-		ereport(ERROR, (errmsg("file_preview: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("file_preview: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLReadAccess();
@@ -269,7 +270,7 @@ pg_lake_delete_file(PG_FUNCTION_ARGS)
 
 	/* sanity-check URL */
 	if (!IsSupportedURL(path))
-		ereport(ERROR, (errmsg("delete_file: only s3://, gs://, az://, azure://, and abfss:// urls are supported"),
+		ereport(ERROR, (errmsg("delete_file: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"),
 						errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 
 	CheckURLWriteAccess();

--- a/pg_lake_table/tests/pytests/test_create_as_select.py
+++ b/pg_lake_table/tests/pytests/test_create_as_select.py
@@ -57,7 +57,7 @@ def test_unsupported_url(s3, pg_conn, extension):
         pg_conn,
         raise_error=False,
     )
-    assert "only s3://, gs://, az://, azure://, and abfss:// URLs" in error
+    assert "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs" in error
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_create_as_select.py
+++ b/pg_lake_table/tests/pytests/test_create_as_select.py
@@ -57,7 +57,7 @@ def test_unsupported_url(s3, pg_conn, extension):
         pg_conn,
         raise_error=False,
     )
-    assert "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs" in error
+    assert "unsupported URL" in error
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
+++ b/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
@@ -273,9 +273,7 @@ def test_create_table_load_from_invalid_url(
         pg_conn,
         raise_error=False,
     )
-    assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
-    )
+    assert error.startswith("ERROR:  pg_lake_copy: unsupported URL")
 
     pg_conn.rollback()
 
@@ -286,9 +284,7 @@ def test_create_table_load_from_invalid_url(
         pg_conn,
         raise_error=False,
     )
-    assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
-    )
+    assert error.startswith("ERROR:  pg_lake_copy: unsupported URL")
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
+++ b/pg_lake_table/tests/pytests/test_create_iceberg_table_load_from.py
@@ -274,7 +274,7 @@ def test_create_table_load_from_invalid_url(
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()
@@ -287,7 +287,7 @@ def test_create_table_load_from_invalid_url(
         raise_error=False,
     )
     assert error.startswith(
-        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+        "ERROR:  pg_lake_copy: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
     )
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_file_preview.py
+++ b/pg_lake_table/tests/pytests/test_file_preview.py
@@ -55,9 +55,7 @@ def test_file_preview_non_s3_url(pg_conn, extension):
         pg_conn,
         raise_error=False,
     )
-    assert (
-        "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported" in error
-    )
+    assert "unsupported URL" in error
     pg_conn.rollback()
 
 

--- a/pg_lake_table/tests/pytests/test_file_preview.py
+++ b/pg_lake_table/tests/pytests/test_file_preview.py
@@ -56,7 +56,7 @@ def test_file_preview_non_s3_url(pg_conn, extension):
         raise_error=False,
     )
     assert (
-        "only s3://, gs://, az://, azure://, and abfss:// urls are supported" in error
+        "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported" in error
     )
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_list_file.py
+++ b/pg_lake_table/tests/pytests/test_list_file.py
@@ -31,7 +31,7 @@ def test_list_files_non_s3_url(pg_conn, generate_data_on_s3):
         raise_error=False,
     )
     assert (
-        "only s3://, gs://, az://, azure://, abfss://, and hf:// urls are supported"
+        "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"
         in error
     )
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_list_file.py
+++ b/pg_lake_table/tests/pytests/test_list_file.py
@@ -30,10 +30,7 @@ def test_list_files_non_s3_url(pg_conn, generate_data_on_s3):
         pg_conn,
         raise_error=False,
     )
-    assert (
-        "only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// urls are supported"
-        in error
-    )
+    assert "unsupported URL" in error
     pg_conn.rollback()
 
 

--- a/pg_lake_table/tests/pytests/test_queries.py
+++ b/pg_lake_table/tests/pytests/test_queries.py
@@ -1331,7 +1331,7 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
 
     except psycopg2.errors.FeatureNotSupported as e:
         assert (
-            "pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported"
+            "pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
             in str(e)
         )
         cur.close()
@@ -1356,7 +1356,7 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
     except psycopg2.errors.FeatureNotSupported as e:
         assert (
             str(e)
-            == 'pg_lake_table: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported for the "path" option.\n'
+            == 'pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported for the "path" option.\n'
         )
         cur.close()
         pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_queries.py
+++ b/pg_lake_table/tests/pytests/test_queries.py
@@ -1330,10 +1330,7 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
         pg_conn.commit()
 
     except psycopg2.errors.FeatureNotSupported as e:
-        assert (
-            "pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported"
-            in str(e)
-        )
+        assert "pg_lake_table: unsupported URL" in str(e)
         cur.close()
         pg_conn.commit()
 
@@ -1355,8 +1352,7 @@ def test_fdw_table_without_path(pg_conn, s3, extension):
 
     except psycopg2.errors.FeatureNotSupported as e:
         assert (
-            str(e)
-            == 'pg_lake_table: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported for the "path" option.\n'
+            str(e) == 'pg_lake_table: unsupported URL: "/tmp" for the "path" option\n'
         )
         cur.close()
         pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_stage_location_integration.py
+++ b/pg_lake_table/tests/pytests/test_stage_location_integration.py
@@ -259,7 +259,7 @@ def test_stage_without_leading_slash(superuser_conn, setup_stage_location, exten
         raise_error=False,
     )
     # Should fail with URL validation error, not @STAGE/ resolution error
-    assert "only s3://, gs://" in error or "is not supported" in error
+    assert "unsupported URL" in error or "is not supported" in error
     superuser_conn.rollback()
 
 

--- a/pg_lake_table/tests/pytests/test_writable_iceberg.py
+++ b/pg_lake_table/tests/pytests/test_writable_iceberg.py
@@ -38,6 +38,45 @@ def test_writable_iceberg_create_table(pg_conn, s3, extension):
     pg_conn.commit()
 
 
+def test_writable_iceberg_r2_insert_select_delete(pg_conn, r2, extension):
+    schema = "test_writable_iceberg_r2"
+    run_command(f"CREATE SCHEMA {schema}", pg_conn)
+    pg_conn.commit()
+
+    location = f"r2://{TEST_BUCKET_R2}/{schema}"
+    run_command(
+        f"""CREATE FOREIGN TABLE {schema}.ft1 (
+                    id int,
+                    value text
+                ) SERVER pg_lake_iceberg OPTIONS (location '{location}');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"INSERT INTO {schema}.ft1 SELECT i, 'r2-'||i FROM generate_series(1,10) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    results = run_query(f"SELECT count(*) FROM {schema}.ft1", pg_conn)
+    assert results[0][0] == 10
+
+    results = run_query(f"SELECT id, value FROM {schema}.ft1 ORDER BY id", pg_conn)
+    assert results[0]["id"] == 1
+    assert results[0]["value"] == "r2-1"
+
+    run_command(f"DELETE FROM {schema}.ft1 WHERE id <= 5", pg_conn)
+    pg_conn.commit()
+
+    results = run_query(f"SELECT count(*) FROM {schema}.ft1", pg_conn)
+    assert results[0][0] == 5
+
+    run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 def test_writable_iceberg_create_table_no_cols(pg_conn, s3, extension):
     run_command(
         """

--- a/pg_lake_table/tests/pytests/test_writable_iceberg.py
+++ b/pg_lake_table/tests/pytests/test_writable_iceberg.py
@@ -111,7 +111,7 @@ def test_writable_iceberg_create_wrong_option(pg_conn, extension):
         raise_error=False,
     )
     assert (
-        'pg_lake_iceberg: only s3://, gs://, az://, azure://, and abfss:// URLs are currently supported for the "location" option.'
+        'pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported for the "location" option.'
         in str(error)
     )
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_writable_iceberg.py
+++ b/pg_lake_table/tests/pytests/test_writable_iceberg.py
@@ -111,7 +111,7 @@ def test_writable_iceberg_create_wrong_option(pg_conn, extension):
         raise_error=False,
     )
     assert (
-        'pg_lake_iceberg: only s3://, gs://, az://, azure://, abfss://, hf://, and r2:// URLs are currently supported for the "location" option.'
+        'pg_lake_iceberg: unsupported URL: "file://somebucket" for the "location" option'
         in str(error)
     )
     pg_conn.rollback()

--- a/pgduck_server/tests/test_secrets.sql
+++ b/pgduck_server/tests/test_secrets.sql
@@ -18,6 +18,16 @@ CREATE SECRET gcstest (
     URL_STYLE 'path', USE_SSL false
 );
 
+-- Add a secret for testbucketr2
+CREATE SECRET r2test (
+    TYPE R2,
+    KEY_ID 'testing',
+    SECRET 'testing',
+    ENDPOINT 'localhost:5997',
+    SCOPE 'r2://testbucketr2',
+    URL_STYLE 'path', USE_SSL false
+);
+
 -- Add a secret for testcontainer
 CREATE SECRET aztest (
     TYPE AZURE,

--- a/test_common/helpers/cloud_storage.py
+++ b/test_common/helpers/cloud_storage.py
@@ -37,6 +37,10 @@ MOTO_PORT_GCS = 5998
 TEST_BUCKET_GCS = "testbucketgcs"
 TEST_GCS_REGION = "europe-west4"
 
+MOTO_PORT_R2 = 5997
+TEST_BUCKET_R2 = "testbucketr2"
+TEST_R2_REGION = "eu-west-1"
+
 AZURITE_CONNECTION_STRING = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1"
 
 
@@ -62,6 +66,15 @@ def create_duckdb_conn():
             TYPE GCS, KEY_ID 'testing', SECRET 'testing',
             ENDPOINT 'localhost:5998',
             SCOPE 'gs://testbucketgcs', URL_STYLE 'path', USE_SSL false
+        );
+    """
+    )
+    conn.execute(
+        """
+        CREATE SECRET r2test (
+            TYPE R2, KEY_ID 'testing', SECRET 'testing',
+            ENDPOINT 'localhost:5997',
+            SCOPE 'r2://testbucketr2', URL_STYLE 'path', USE_SSL false
         );
     """
     )
@@ -256,6 +269,28 @@ def create_mock_gcs():
     return client, server
 
 
+# Start a background server that pretends to be Cloudflare R2.
+#
+# R2 is S3-compatible and DuckDB's TYPE R2 secret accepts an ENDPOINT override,
+# so we mock it with Moto on a separate port — same shape as create_mock_gcs().
+def create_mock_r2():
+    server = ThreadedMotoServer(port=MOTO_PORT_R2)
+    server.start()
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=f"http://localhost:{MOTO_PORT_R2}",
+        region_name=TEST_R2_REGION,
+        aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+    )
+    client.create_bucket(
+        Bucket=TEST_BUCKET_R2,
+        CreateBucketConfiguration={"LocationConstraint": TEST_R2_REGION},
+    )
+    return client, server
+
+
 def create_kms_client():
     return boto3.client(
         "kms",
@@ -330,6 +365,7 @@ def stop_moto_server(server, timeout=5):
 # ---------------------------------------------------------------------------
 _mock_s3_cache = None
 _gcs_cache = None
+_r2_cache = None
 _azure_cache = None
 
 
@@ -369,6 +405,19 @@ def gcs():
         return
     client, server = create_mock_gcs()
     _gcs_cache = client
+    atexit.register(stop_moto_server, server)
+    yield client
+    stop_moto_server(server)
+
+
+@pytest.fixture(scope="session")
+def r2():
+    global _r2_cache
+    if _r2_cache is not None:
+        yield _r2_cache
+        return
+    client, server = create_mock_r2()
+    _r2_cache = client
     atexit.register(stop_moto_server, server)
     yield client
     stop_moto_server(server)

--- a/test_common/helpers/server.py
+++ b/test_common/helpers/server.py
@@ -26,10 +26,12 @@ from .cloud_storage import (
     MANAGED_STORAGE_BUCKET,
     MOTO_PORT,
     MOTO_PORT_GCS,
+    MOTO_PORT_R2,
     TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_SECRET_ACCESS_KEY,
     TEST_BUCKET,
     TEST_BUCKET_GCS,
+    TEST_BUCKET_R2,
 )
 from .db import (
     capture_output,
@@ -110,6 +112,16 @@ def setup_pgduck_server():
             SECRET '{TEST_AWS_SECRET_ACCESS_KEY}',
             ENDPOINT 'localhost:{MOTO_PORT_GCS}',
             SCOPE 'gs://{TEST_BUCKET_GCS}',
+            URL_STYLE 'path', USE_SSL false
+          );
+
+          -- Add a secret for testbucketr2
+          CREATE SECRET r2test (
+            TYPE R2,
+            KEY_ID '{TEST_AWS_ACCESS_KEY_ID}',
+            SECRET '{TEST_AWS_SECRET_ACCESS_KEY}',
+            ENDPOINT 'localhost:{MOTO_PORT_R2}',
+            SCOPE 'r2://{TEST_BUCKET_R2}',
             URL_STYLE 'path', USE_SSL false
           );
 


### PR DESCRIPTION
## Problem

DuckDB's `S3FileSystem` already handles `r2://` natively, and `RegionAwareS3FileSystem` short-circuits non-`s3://` URLs straight to it. The only thing blocking Cloudflare R2 today is the PG-side allowlist in `IsSupportedURL` and `IsFileListSupportedUrl`. As a side issue, the per-callsite error message hard-codes the supported-scheme list ("only s3://, gs://, az://, …"), which has been adjusted three times now whenever a scheme is added or renamed and which overstates what works in any given deployment (Azure / GCS / R2 still need a configured secret to actually succeed).

## Solution

First commit (the change from #365 by @timmclaughlin, preserved verbatim with DCO signoff): add `r2://` to `IsSupportedURL` and `IsFileListSupportedUrl`.

Second commit: replace every listed-scheme error message with a bare generic form that names the offending URL and gets out of the way of secret configuration. The module/function prefix is preserved for grep-ability, and the option-name / GUC-name context is kept inline:

```text
ERROR:  pg_lake_table: unsupported URL: "file://example/path"
ERROR:  pg_lake_iceberg: unsupported URL for default location prefix: "file://"
ERROR:  list_files: unsupported URL: "ftp://host/dir"
ERROR:  pg_lake_table: unsupported URL: "/tmp" for the "path" option
```

19 errmsg sites and 13 pytest assertions updated; net −31 lines. Tests now match on `unsupported URL` so the next scheme addition only touches the allowlist.

This is the change from #365 by @timmclaughlin plus a follow-up commit. Pushed to a `marcoslot/*` branch in this repo to run CI (forked contributor PRs don't get the full workflow). Original commit and Signed-off-by preserved.

Closes #365.

## Test plan

- [x] Full CI green on `marcoslot/r2-url-scheme` (run [26875414792](https://github.com/Snowflake-Labs/pg_lake/actions/runs/26875414792)).