### PR TITLE
pg_extension_base: install ProcessUtility hook before preloading libraries

### DIFF
--- a/pg_extension_base/src/pg_extension_base.c
+++ b/pg_extension_base/src/pg_extension_base.c
@@ -121,13 +121,33 @@ _PG_init(void)
 							NULL,
 							NULL);
 
+	/*
+	 * Install our ProcessUtility hook for ALTER EXTENSION ... UPDATE
+	 * dependency walking BEFORE preloading other extensions.  Postgres
+	 * ProcessUtility hooks chain LIFO, so when a preloaded extension installs
+	 * its own ProcessUtility hook later in PgExtensionBasePreloadLibraries
+	 * below, that extension's hook ends up at the head of the chain and runs
+	 * first.  That lets a preloaded extension intervene on CREATE / ALTER
+	 * EXTENSION (e.g. enforce a permission check or rewrite the statement)
+	 * before our hook dispatches to nested CreateExtension /
+	 * ExecAlterExtensionStmt calls that would otherwise bypass ProcessUtility
+	 * entirely.
+	 *
+	 * Skipped during pg_upgrade -- the dump-restore script issues the right
+	 * ALTER EXTENSION statements itself, and auto-walking dependencies in
+	 * that mode would fight with what pg_upgrade is doing.
+	 */
+	if (!IsBinaryUpgrade)
+		InitializeExtensionDependencyInstaller();
 
-
-	if (EnableBaseWorkerLauncher)
-	{
-		InitializeBaseWorkerLauncher();
-	}
-
+	/*
+	 * Library preloading runs even during pg_upgrade: pg_upgrade's "checking
+	 * for presence of required libraries" phase issues LOAD on every shared
+	 * library referenced by the catalog.  Several pg_lake libraries import
+	 * symbols from each other (e.g. pg_lake_table from pg_lake_engine), so
+	 * the chain-preload has to put pg_lake_engine in memory first or
+	 * pg_lake_table's LOAD fails on unresolved symbols.
+	 */
 	if (EnablePreloadLibraries)
 		PgExtensionBasePreloadLibraries();
 
@@ -135,5 +155,8 @@ _PG_init(void)
 	if (IsBinaryUpgrade)
 		return;
 
-	InitializeExtensionDependencyInstaller();
+	if (EnableBaseWorkerLauncher)
+	{
+		InitializeBaseWorkerLauncher();
+	}
 }


### PR DESCRIPTION
## Problem

Today \`_PG_init\` runs in this order:

\`\`\`c
InitializeBaseWorkerLauncher();          // installs a ProcessUtility hook
PgExtensionBasePreloadLibraries();       // loads preloaded extensions' .so;
                                         // their _PG_init may install hooks
if (IsBinaryUpgrade) return;
InitializeExtensionDependencyInstaller();// installs a ProcessUtility hook LAST
\`\`\`

Postgres ProcessUtility hooks chain LIFO, so the last hook installed runs
first.  The dependency-installer hook ends up at the head of the chain --
ahead of any hook a preloaded extension installed in its own \`_PG_init\`.

That makes it hard for a preloaded extension to intervene on
\`CREATE / ALTER EXTENSION\` (for example to enforce a permission check or
rewrite the statement): the dependency-installer hook fires first, and on
the dependency side it dispatches to nested \`CreateExtension\` /
\`ExecAlterExtensionStmt\` calls that bypass \`ProcessUtility\` entirely, so
the preloaded extension's hook never sees them.

The \`IsBinaryUpgrade\` short-circuit is also too late -- by the time we
hit it we have already started workers and preloaded other extensions,
neither of which is appropriate during pg_upgrade.

## Fix

Reorder \`_PG_init\` to install the dependency-installer hook **before**
the library preload:

\`\`\`c
DefineCustomBoolVariable(...);  // GUCs first, safe during binary upgrade

if (IsBinaryUpgrade) return;    // skip every hook / worker / preload

InitializeExtensionDependencyInstaller();  // installed first => runs LAST
if (EnableBaseWorkerLauncher) InitializeBaseWorkerLauncher();
if (EnablePreloadLibraries)   PgExtensionBasePreloadLibraries();
\`\`\`

Now any ProcessUtility hook a preloaded extension installs in its own
\`_PG_init\` wraps around the dependency-installer hook and can intervene
on \`CREATE / ALTER EXTENSION\` before it dispatches to the nested calls.

The redundant \`IsBinaryUpgrade\` check inside
\`InitializeBaseWorkerLauncher\` stays in place as defense in depth.

## Test plan

- [x] \`make install\` clean.
- [x] \`make prepare-check && pytest tests/pytests/test_extension_dependencies.py tests/pytests/test_library_preloader.py\` -- 6 passed.