### PR TITLE
Fix Oid signed overflow in format strings producing negative values

### DIFF
--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -210,7 +210,7 @@ FinishStageRestCatalogIcebergTableCreateRestRequest(Oid relationId, DataFileSche
 	const char *namespaceName = GetRestCatalogNamespace(relationId);
 	const char *relationName = GetRestCatalogTableName(relationId);
 
-	appendStringInfo(location, "%s/%s/%s/%s/%d", IcebergDefaultLocationPrefix, catalogName, namespaceName, relationName, relationId);
+	appendStringInfo(location, "%s/%s/%s/%s/%u", IcebergDefaultLocationPrefix, catalogName, namespaceName, relationName, relationId);
 	appendJsonString(body, "location", location->data);
 	appendStringInfoChar(body, '}');	/* end set-location */
 

--- a/pg_lake_table/src/fdw/row_ids.c
+++ b/pg_lake_table/src/fdw/row_ids.c
@@ -89,7 +89,7 @@ EnableRowIdsOnTable(Oid relationId)
 RangeVar *
 RowIdSequenceGetRangeVar(Oid relationId)
 {
-	char	   *sequenceName = psprintf("rowid_%d_seq", relationId);
+	char	   *sequenceName = psprintf("rowid_%u_seq", relationId);
 
 	return makeRangeVar(REPLICATION_WRITES_SCHEMA, sequenceName, -1);
 }
@@ -113,7 +113,7 @@ CreateRelationRowIdSequence(Oid relationId)
 
 	if (OidIsValid(sequenceId))
 		ereport(ERROR, (errmsg("rowid sequence already exists "
-							   "for relation %d", relationId),
+							   "for relation %u", relationId),
 						errcode(ERRCODE_DUPLICATE_TABLE)));
 
 	/* generate our create sequence statement */

--- a/pg_lake_table/src/fdw/update_tracking.c
+++ b/pg_lake_table/src/fdw/update_tracking.c
@@ -142,7 +142,7 @@ static RangeVar *
 GetUpdateTableRangeVar(Oid relationId)
 {
 	char	   *schemaName = NULL;
-	char	   *tableName = psprintf("lake_update_%d", relationId);
+	char	   *tableName = psprintf("lake_update_%u", relationId);
 	RangeVar   *relation = makeRangeVar(schemaName, tableName, -1);
 
 	relation->relpersistence = RELPERSISTENCE_TEMP;


### PR DESCRIPTION
Oid is unsigned int, but several format strings used %d (signed) instead of %u, causing OIDs above INT_MAX to appear negative in S3 paths, sequence names, and temp table names.