### PR TITLE
build: add Fedora support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -202,7 +202,7 @@ detect_os() {
         . /etc/os-release
         if [[ "$ID" == "debian" ]] || [[ "$ID" == "ubuntu" ]] || [[ "$ID_LIKE" == *"debian"* ]]; then
             OS="debian"
-        elif [[ "$ID" == "rhel" ]] || [[ "$ID" == "almalinux" ]] || [[ "$ID" == "rocky" ]] || [[ "$ID_LIKE" == *"rhel"* ]]; then
+        elif [[ "$ID" == "rhel" ]] || [[ "$ID" == "fedora" ]] || [[ "$ID" == "almalinux" ]] || [[ "$ID" == "rocky" ]] || [[ "$ID_LIKE" == *"rhel"* ]]; then
             OS="rhel"
         else
             print_error "Unsupported Linux distribution: $ID"


### PR DESCRIPTION
Fedora is part of the RHEL family but was missing from the list of supported distributions in the install script. Added it to the rhel-based distros list to enable successful builds.

I've tested it on my Fedora 43 machine and everything built correctly. 