### PR TITLE
pg19: build cleanly against PostgreSQL 19beta1

### DIFF
--- a/pg_extension_base/include/pg_extension_base/pg_compat.h
+++ b/pg_extension_base/include/pg_extension_base/pg_compat.h
@@ -18,6 +18,55 @@
 #pragma once
 #include "postgres.h"
 
+#include "catalog/pg_type_d.h"
+#include "commands/copy.h"
+#include "nodes/miscnodes.h"
+#include "utils/numeric.h"
+
+#if PG_VERSION_NUM >= 190000
+
+/*
+ * PG19 reshaped CopyFormatOptions: the bool fields ".binary" and ".csv_mode"
+ * were replaced by a single CopyFormat enum field ".format". Provide
+ * accessor macros so callers keep the older names.
+ */
+#define CopyOptsIsBinary(opts) ((opts).format == COPY_FORMAT_BINARY)
+#define CopyOptsIsCsvMode(opts) ((opts).format == COPY_FORMAT_CSV)
+
+/*
+ * PG19 renamed numeric_int4_opt_error -> numeric_int4_safe and switched the
+ * out-of-band error signal from a bool* to an ErrorSaveContext* (the standard
+ * "soft error" API). Wrap with the older name + bool* signature.
+ */
+static inline int32
+numeric_int4_opt_error(Numeric num, bool *have_error)
+{
+	ErrorSaveContext escontext = {T_ErrorSaveContext};
+	int32		result = numeric_int4_safe(num, (Node *) &escontext);
+
+	*have_error = escontext.error_occurred;
+	return result;
+}
+
+/*
+ * Likewise for the binary numeric arithmetic helpers, which were also
+ * renamed from foo_opt_error(Numeric, Numeric, bool *) to
+ * foo_safe(Numeric, Numeric, Node *escontext) in PG19. Our callers always
+ * pass NULL for the error argument, so just forward to the new name.
+ */
+#define numeric_add_opt_error(num1, num2, _ignored) numeric_add_safe(num1, num2, NULL)
+#define numeric_sub_opt_error(num1, num2, _ignored) numeric_sub_safe(num1, num2, NULL)
+#define numeric_mul_opt_error(num1, num2, _ignored) numeric_mul_safe(num1, num2, NULL)
+#define numeric_div_opt_error(num1, num2, _ignored) numeric_div_safe(num1, num2, NULL)
+#define numeric_mod_opt_error(num1, num2, _ignored) numeric_mod_safe(num1, num2, NULL)
+
+#else
+
+#define CopyOptsIsBinary(opts) ((opts).binary)
+#define CopyOptsIsCsvMode(opts) ((opts).csv_mode)
+
+#endif
+
 #if PG_VERSION_NUM < 170000
 
 #define foreach_ptr(type, var, lst) foreach_internal(type, *, var, lst, lfirst)

--- a/pg_extension_base/include/pg_extension_base/spi_helpers.h
+++ b/pg_extension_base/include/pg_extension_base/spi_helpers.h
@@ -18,6 +18,7 @@
 #ifndef SPI_UTILITIES_H
 #define SPI_UTILITIES_H
 
+#include "catalog/pg_type_d.h"
 #include "miscadmin.h"
 
 #include "executor/spi.h"
@@ -25,6 +26,7 @@
 #include "utils/guc.h"
 #include "utils/jsonb.h"
 #include "utils/pg_lsn.h"
+#include "utils/timestamp.h"
 
 /* SPI macros for setting parameters */
 #define DATUMIZE_TEXTOID(Value) CStringGetTextDatum(Value)

--- a/pg_extension_base/src/attached_worker.c
+++ b/pg_extension_base/src/attached_worker.c
@@ -29,6 +29,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 
+#include "access/htup_details.h"
 #include "access/xact.h"
 #include "catalog/pg_authid.h"
 #include "commands/dbcommands.h"
@@ -61,6 +62,7 @@
 #include "utils/syscache.h"
 #include "utils/timeout.h"
 #include "utils/typcache.h"
+#include "utils/tuplestore.h"
 
 #define QUEUE_SIZE ((Size) 65536)
 #define ATTACHED_WORKER_MAGIC			0x52004040

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -58,6 +58,9 @@
  * should still exist, or whether to clean up their shared memory records.
  */
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "access/htup_details.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "miscadmin.h"
@@ -94,6 +97,10 @@
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
+#if PG_VERSION_NUM >= 190000
+#include "utils/wait_event.h"
+#endif
 #include "tcop/utility.h"
 
 #include "pg_extension_base/base_workers.h"
@@ -508,11 +515,20 @@ BaseWorkerSharedMemoryInit(void)
 
 	if (!alreadyInitialized)
 	{
-		BaseWorkerControl->trancheId = LWLockNewTrancheId();
 		BaseWorkerControl->lockTrancheName = "pg_extension_base server starter locks";
+#if PG_VERSION_NUM >= 190000
 
+		/*
+		 * PG19 folded the name into LWLockNewTrancheId and removed
+		 * LWLockRegisterTranche entirely.
+		 */
+		BaseWorkerControl->trancheId =
+			LWLockNewTrancheId(BaseWorkerControl->lockTrancheName);
+#else
+		BaseWorkerControl->trancheId = LWLockNewTrancheId();
 		LWLockRegisterTranche(BaseWorkerControl->trancheId,
 							  BaseWorkerControl->lockTrancheName);
+#endif
 
 		LWLockInitialize(&BaseWorkerControl->lock,
 						 BaseWorkerControl->trancheId);
@@ -527,7 +543,11 @@ BaseWorkerSharedMemoryInit(void)
 	int			hashFlags = (HASH_ELEM | HASH_FUNCTION);
 
 	DatabaseStarterHash = ShmemInitHash("pg_extension_base database starter hash",
+#if PG_VERSION_NUM >= 190000
+										2 * max_worker_processes,
+#else
 										max_worker_processes, 2 * max_worker_processes,
+#endif
 										&hashInfo, hashFlags);
 
 	memset(&hashInfo, 0, sizeof(hashInfo));
@@ -537,7 +557,11 @@ BaseWorkerSharedMemoryInit(void)
 	hashFlags = (HASH_ELEM | HASH_FUNCTION);
 
 	BaseWorkerHash = ShmemInitHash("pg_extension_base base worker hash",
+#if PG_VERSION_NUM >= 190000
+								   2 * max_worker_processes,
+#else
 								   max_worker_processes, 2 * max_worker_processes,
+#endif
 								   &hashInfo, hashFlags);
 
 	LWLockRelease(AddinShmemInitLock);
@@ -650,7 +674,11 @@ PgExtensionServerStarterMain(Datum arg)
 	/* set up signal handlers */
 	pqsignal(SIGHUP, HandleSighup);
 	pqsignal(SIGTERM, HandleSigterm);
+#if PG_VERSION_NUM >= 190000
+	pqsignal(SIGINT, PG_SIG_IGN);
+#else
 	pqsignal(SIGINT, SIG_IGN);
+#endif
 
 	before_shmem_exit(PgBaseExtensionServerStarterSharedMemoryExit, 0);
 
@@ -1012,7 +1040,11 @@ PgExtensionBaseDatabaseStarterMain(Datum databaseIdDatum)
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, HandleSighup);
+#if PG_VERSION_NUM >= 190000
+	pqsignal(SIGINT, PG_SIG_IGN);
+#else
 	pqsignal(SIGINT, SIG_IGN);
+#endif
 	pqsignal(SIGTERM, HandleSigterm);
 
 	/* Set our exit handler before any calls to proc_exit */

--- a/pg_extension_base/src/library_preloader.c
+++ b/pg_extension_base/src/library_preloader.c
@@ -36,6 +36,7 @@
 #include "utils/builtins.h"
 #include "utils/conffiles.h"
 #include "utils/guc.h"
+#include "utils/tuplestore.h"
 
 /* PreloadLibrary represents a library to preload */
 typedef struct PreloadLibrary

--- a/pg_extension_updater/src/pg_extension_updater.c
+++ b/pg_extension_updater/src/pg_extension_updater.c
@@ -22,6 +22,7 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "miscadmin.h"
 

--- a/pg_lake_benchmark/src/tpcds.c
+++ b/pg_lake_benchmark/src/tpcds.c
@@ -19,6 +19,7 @@
 #include "fmgr.h"
 #include "funcapi.h"
 #include "utils/builtins.h"
+#include "utils/tuplestore.h"
 
 #include "pg_lake/benchmark.h"
 #include "pg_lake/copy/copy_format.h"

--- a/pg_lake_benchmark/src/tpch.c
+++ b/pg_lake_benchmark/src/tpch.c
@@ -19,6 +19,7 @@
 #include "fmgr.h"
 #include "funcapi.h"
 #include "utils/builtins.h"
+#include "utils/tuplestore.h"
 
 #include "pg_lake/benchmark.h"
 #include "pg_lake/copy/copy_format.h"

--- a/pg_lake_copy/src/test/types.c
+++ b/pg_lake_copy/src/test/types.c
@@ -20,12 +20,14 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 
 #include "pg_lake/pgduck/type.h"
 #include "pg_lake/pgduck/parse_struct.h"
 #include "utils/builtins.h"
+#include "utils/tuplestore.h"
 
 
 PG_FUNCTION_INFO_V1(duckdb_type_by_name);

--- a/pg_lake_engine/include/pg_lake/csv/csv_options.h
+++ b/pg_lake_engine/include/pg_lake/csv/csv_options.h
@@ -20,6 +20,15 @@
 #include "commands/copy.h"
 #include "nodes/pg_list.h"
 
+#if PG_VERSION_NUM >= 190000
+/*
+ * PG19 dropped the CopyHeaderChoice enum and stores the header choice as a
+ * plain int holding COPY_HEADER_FALSE / COPY_HEADER_TRUE / COPY_HEADER_MATCH.
+ * Reintroduce the typedef here so we keep a stable signature.
+ */
+typedef int CopyHeaderChoice;
+#endif
+
 extern PGDLLEXPORT List *InternalCSVOptions(bool includeHeader);
 extern PGDLLEXPORT List *NormalizedExternalCSVOptions(List *inputOptions);
 extern PGDLLEXPORT CopyHeaderChoice GetCopyHeaderChoice(DefElem *def, bool is_from);

--- a/pg_lake_engine/include/pg_lake/pgduck/serialize.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/serialize.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 
 #include "pg_lake/parquet/field.h"

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -19,6 +19,7 @@
  * Functions for cleaning up orphaned files.
  */
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 
@@ -30,6 +31,7 @@
 #include "pg_lake/util/string_utils.h"
 #include "datatype/timestamp.h"
 #include "storage/procarray.h"
+#include "utils/tuplestore.h"
 
 #define DELETION_QUEUE_TABLE "lake_engine.deletion_queue"
 

--- a/pg_lake_engine/src/cleanup/in_progress_files.c
+++ b/pg_lake_engine/src/cleanup/in_progress_files.c
@@ -24,6 +24,7 @@
  * via VACUUM.
  */
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 
@@ -42,11 +43,13 @@
 #include "pg_lake/util/plan_cache.h"
 #include "pg_lake/util/string_utils.h"
 #include "datatype/timestamp.h"
+#include "storage/lock.h"
 #include "storage/procarray.h"
 #include "utils/fmgroids.h"
 #include "utils/memutils.h"
 #include "utils/lsyscache.h"
 #include "utils/snapmgr.h"
+#include "utils/tuplestore.h"
 
 #define OPERATION_ID_SEQUENCE "operationid_seq"
 

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -42,7 +42,9 @@
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
+#include "pg_extension_base/pg_compat.h"
 #include "port/pg_bswap.h"
+#include "storage/fd.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
@@ -198,7 +200,7 @@ CopySendEndOfRow(CopyToState cstate)
 	switch (cstate->copy_dest)
 	{
 		case COPY_FILE:
-			if (!cstate->opts.binary)
+			if (!CopyOptsIsBinary(cstate->opts))
 			{
 				/* Default line termination depends on platform */
 #ifndef WIN32
@@ -264,7 +266,7 @@ CopySendInt16(CopyToState cstate, int16 val)
 static void
 EndCopy(CopyToState cstate)
 {
-	if (cstate->opts.binary)
+	if (CopyOptsIsBinary(cstate->opts))
 	{
 		/* Generate trailer for a binary copy */
 		CopySendInt16(cstate, -1);
@@ -461,7 +463,7 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 		bool		isvarlena;
 		Form_pg_attribute attr = TupleDescAttr(tupDesc, attnum - 1);
 
-		if (cstate->opts.binary)
+		if (CopyOptsIsBinary(cstate->opts))
 			getTypeBinaryOutputInfo(attr->atttypid,
 									&out_func_oid,
 									&isvarlena);
@@ -482,7 +484,7 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 											   "COPY TO",
 											   ALLOCSET_DEFAULT_SIZES);
 
-	if (cstate->opts.binary)
+	if (CopyOptsIsBinary(cstate->opts))
 	{
 		/* Generate header for a binary copy */
 		int32		tmp;
@@ -523,7 +525,7 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 
 				colname = NameStr(TupleDescAttr(tupDesc, attnum - 1)->attname);
 
-				if (cstate->opts.csv_mode)
+				if (CopyOptsIsCsvMode(cstate->opts))
 					CopyAttributeOutCSV(cstate, colname, false,
 										list_length(cstate->attnumlist) == 1);
 				else
@@ -731,7 +733,7 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 	MemoryContextReset(cstate->rowcontext);
 	oldcontext = MemoryContextSwitchTo(cstate->rowcontext);
 
-	if (cstate->opts.binary)
+	if (CopyOptsIsBinary(cstate->opts))
 	{
 		/* Binary per-tuple header */
 		CopySendInt16(cstate, list_length(cstate->attnumlist));
@@ -746,7 +748,7 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 		Datum		value = slot->tts_values[attnum - 1];
 		bool		isnull = slot->tts_isnull[attnum - 1];
 
-		if (!cstate->opts.binary)
+		if (!CopyOptsIsBinary(cstate->opts))
 		{
 			if (need_delim)
 				CopySendChar(cstate, cstate->opts.delim[0]);
@@ -755,14 +757,14 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 
 		if (isnull)
 		{
-			if (!cstate->opts.binary)
+			if (!CopyOptsIsBinary(cstate->opts))
 				CopySendString(cstate, cstate->opts.null_print_client);
 			else
 				CopySendInt32(cstate, -1);
 		}
 		else
 		{
-			if (!cstate->opts.binary)
+			if (!CopyOptsIsBinary(cstate->opts))
 			{
 				/*
 				 * Lookup the underlying tuple's attribute so we can pass in
@@ -802,7 +804,7 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 				}
 
 
-				if (cstate->opts.csv_mode)
+				if (CopyOptsIsCsvMode(cstate->opts))
 					CopyAttributeOutCSV(cstate, string,
 										cstate->opts.force_quote_flags[attnum - 1],
 										list_length(cstate->attnumlist) == 1);

--- a/pg_lake_engine/src/data_file/data_file_stats.c
+++ b/pg_lake_engine/src/data_file/data_file_stats.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include "executor/executor.h"
 #include "pg_lake/data_file/data_files.h"

--- a/pg_lake_engine/src/json/json_reader.c
+++ b/pg_lake_engine/src/json/json_reader.c
@@ -18,6 +18,7 @@
 #include "postgres.h"
 
 #include "common/fe_memutils.h"
+#include "pg_extension_base/pg_compat.h"
 #include "pg_lake/json/json_reader.h"
 #include "utils/builtins.h"
 #include "utils/jsonb.h"

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include "common/int.h"
 

--- a/pg_lake_engine/src/parsetree/const.c
+++ b/pg_lake_engine/src/parsetree/const.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include "pg_lake/parsetree/const.h"
 

--- a/pg_lake_engine/src/parsetree/expression.c
+++ b/pg_lake_engine/src/parsetree/expression.c
@@ -24,6 +24,7 @@
 #include "pg_lake/parsetree/const.h"
 #include "pg_lake/parsetree/expression.h"
 #include "datatype/timestamp.h"
+#include "utils/timestamp.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/parsenodes.h"

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
 #include "miscadmin.h"
 #include "libpq-fe.h"
 

--- a/pg_lake_engine/src/pgduck/map.c
+++ b/pg_lake_engine/src/pgduck/map.c
@@ -16,6 +16,8 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
+#include "catalog/pg_type_d.h"
 #include "miscadmin.h"
 #include "libpq-fe.h"
 

--- a/pg_lake_engine/src/pgduck/parse_struct.c
+++ b/pg_lake_engine/src/pgduck/parse_struct.c
@@ -23,6 +23,7 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
 #include "miscadmin.h"
 #include "libpq-fe.h"
 

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -19,6 +19,7 @@
  * Functions for generating query for reading data from pgduck server.
  */
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include <inttypes.h>
 

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -16,6 +16,9 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
+#include "catalog/pg_type_d.h"
+#include "utils/hsearch.h"
 
 #include <float.h>
 #include <math.h>

--- a/pg_lake_engine/src/pgduck/shippable_spatial_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_spatial_functions.c
@@ -20,6 +20,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include "nodes/nodeFuncs.h"
 #include "optimizer/optimizer.h"

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
 #include "miscadmin.h"
 #include "libpq-fe.h"
 

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -19,6 +19,7 @@
  * Functions for generating query for writing data via pgduck server.
  */
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include "access/tupdesc.h"
 #include "commands/defrem.h"

--- a/pg_lake_engine/src/query/execute.c
+++ b/pg_lake_engine/src/query/execute.c
@@ -75,7 +75,11 @@ uint64
 ExecuteQueryToDestReceiver(Query *query, const char *queryString,
 						   ParamListInfo params, DestReceiver *dest)
 {
-	PlannedStmt *plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, params);
+	PlannedStmt *plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, params
+#if PG_VERSION_NUM >= 190000
+									  ,NULL
+#endif
+		);
 
 	return ExecutePlanToDestReceiver(plan, queryString, params, dest);
 }

--- a/pg_lake_engine/src/utils/compare_utils.c
+++ b/pg_lake_engine/src/utils/compare_utils.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "catalog/pg_collation.h"
 #include "fmgr.h"
 #include "utils/builtins.h"

--- a/pg_lake_engine/src/utils/operator_utils.c
+++ b/pg_lake_engine/src/utils/operator_utils.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
 
 #include "catalog/pg_operator.h"
 #include "pg_lake/util/operator_utils.h"

--- a/pg_lake_engine/src/utils/plan_cache.c
+++ b/pg_lake_engine/src/utils/plan_cache.c
@@ -26,6 +26,7 @@
  * consider the cache size and eviction policy.
  */
 #include "postgres.h"
+#include "utils/hsearch.h"
 #include "fmgr.h"
 #include "miscadmin.h"
 

--- a/pg_lake_iceberg/src/iceberg/api/table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/api/table_metadata.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "storage/fd.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "libpq-fe.h"

--- a/pg_lake_iceberg/src/iceberg/catalog.c
+++ b/pg_lake_iceberg/src/iceberg/catalog.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "miscadmin.h"
 
 #include "pg_lake/extensions/pg_lake_iceberg.h"

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
@@ -16,6 +16,10 @@
  */
 
 #include "postgres.h"
+
+#include <math.h>
+
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "libpq-fe.h"

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "libpq-fe.h"

--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
 #include "fmgr.h"
 #include "access/xact.h"
 #include "common/hashfn.h"

--- a/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
+++ b/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
@@ -23,6 +23,7 @@
 * referenced in the latest metadata.json file.
 */
 #include "postgres.h"
+#include "utils/hsearch.h"
 #include "miscadmin.h"
 #include "fmgr.h"
 #include "funcapi.h"

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -16,11 +16,14 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "libpq-fe.h"
 #include "miscadmin.h"
 
+#include "storage/fd.h"
 #include "utils/builtins.h"
 #include "utils/snapmgr.h"
 #include "utils/wait_event.h"

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -1,4 +1,5 @@
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 
@@ -7,6 +8,7 @@
 #include "utils/inval.h"
 #include "utils/snapmgr.h"
 #include "utils/lsyscache.h"
+#include "utils/tuplestore.h"
 
 #include "pg_lake/json/json_utils.h"
 #include "pg_lake/iceberg/catalog.h"

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -18,6 +18,7 @@
 #include <inttypes.h>
 
 #include "postgres.h"
+#include "pg_extension_base/pg_compat.h"
 #include "miscadmin.h"
 
 #include "common/base64.h"

--- a/pg_lake_iceberg/src/test/test_http_client.c
+++ b/pg_lake_iceberg/src/test/test_http_client.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "utils/array.h"

--- a/pg_lake_iceberg/src/test/test_iceberg_binary_serde.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_binary_serde.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 
@@ -28,6 +29,7 @@
 
 #include "utils/builtins.h"
 #include "utils/json.h"
+#include "utils/tuplestore.h"
 
 
 static ColumnBound * FindColumnBoundByColumnId(ColumnBound * bounds, int numBounds, int columnId);

--- a/pg_lake_iceberg/src/test/test_iceberg_field_ids.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_field_ids.c
@@ -24,6 +24,7 @@
 #include "pg_lake/parquet/leaf_field.h"
 
 #include "utils/builtins.h"
+#include "utils/tuplestore.h"
 
 
 PG_FUNCTION_INFO_V1(pg_lake_get_leaf_field_ids);

--- a/pg_lake_iceberg/src/test/test_iceberg_manifest.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_manifest.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "libpq-fe.h"
@@ -28,6 +29,7 @@
 #include "pg_lake/iceberg/partitioning/partition.h"
 
 #include "utils/builtins.h"
+#include "utils/tuplestore.h"
 
 static const char *FetchCurrentSnapshotManifestListPathFromTableMetadataUri(const char *tableMetadataPath);
 static List *FetchDataFilePathsFromTableMetadataUri(const char *tableMetadataPath, bool isDelete);

--- a/pg_lake_iceberg/src/utils/truncate_utils.c
+++ b/pg_lake_iceberg/src/utils/truncate_utils.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "pg_extension_base/pg_compat.h"
 #include "mb/pg_wchar.h"
 #include "utils/builtins.h"
 #include "utils/fmgrprotos.h"

--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -22,7 +22,9 @@
 #include "pg_lake/util/s3_reader_utils.h"
 
 #include "nodes/pg_list.h"
+#if PG_VERSION_NUM < 190000
 #include "utils/dynahash.h"
+#endif
 
 #define DATA_FILES_TABLE_QUALIFIED \
 	PG_LAKE_TABLE_SCHEMA "." PG_LAKE_TABLE_FILES_TABLE_NAME

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
 #include "miscadmin.h"
 
 #include "access/heapam.h"

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "miscadmin.h"
 
 #include "access/table.h"

--- a/pg_lake_table/src/describe/describe.c
+++ b/pg_lake_table/src/describe/describe.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "libpq-fe.h"
 
 #include "commands/defrem.h"

--- a/pg_lake_table/src/duckdb/transform_query_to_duckdb.c
+++ b/pg_lake_table/src/duckdb/transform_query_to_duckdb.c
@@ -28,6 +28,7 @@
 #include "access/relation.h"
 #include "access/xact.h"
 #include "utils/builtins.h"
+#include "utils/timestamp.h"
 #include "catalog/pg_class_d.h"
 #include "catalog/pg_type_d.h"
 #include "pg_lake/iceberg/api/table_schema.h"

--- a/pg_lake_table/src/fdw/data_file_pruning.c
+++ b/pg_lake_table/src/fdw/data_file_pruning.c
@@ -21,6 +21,9 @@
 *   execution and statistics of the data files.
 */
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "access/htup_details.h"
+#include "catalog/pg_type_d.h"
 
 #include "catalog/pg_am_d.h"
 #include "catalog/pg_index.h"

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -16,6 +16,8 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "miscadmin.h"

--- a/pg_lake_table/src/fdw/data_files_catalog_batch.c
+++ b/pg_lake_table/src/fdw/data_files_catalog_batch.c
@@ -25,6 +25,8 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 
 #include "pg_extension_base/extension_ids.h"
 #include "pg_extension_base/spi_helpers.h"
@@ -42,7 +44,9 @@
 
 #include "executor/spi.h"
 #include "utils/builtins.h"
+#if PG_VERSION_NUM < 190000
 #include "utils/dynahash.h"
+#endif
 
 /* path -> int64 file id, built from RETURNING output of ExecInsertDataFiles */
 typedef struct FileIdHashEntry

--- a/pg_lake_table/src/fdw/deparse.c
+++ b/pg_lake_table/src/fdw/deparse.c
@@ -1222,7 +1222,11 @@ is_foreign_pathkey(PlannerInfo *root,
 static char *
 deparse_type_name(Oid type_oid, int32 typemod)
 {
+#if PG_VERSION_NUM >= 190000
+	uint16		flags = FORMAT_TYPE_TYPEMOD_GIVEN;
+#else
 	bits16		flags = FORMAT_TYPE_TYPEMOD_GIVEN;
+#endif
 
 	if (!is_builtin(type_oid))
 		flags |= FORMAT_TYPE_FORCE_QUALIFY;

--- a/pg_lake_table/src/fdw/deparse_ruleutils.c
+++ b/pg_lake_table/src/fdw/deparse_ruleutils.c
@@ -25,6 +25,7 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include "parser/parse_func.h"
 #include "parser/parsetree.h"

--- a/pg_lake_table/src/fdw/partition_transform.c
+++ b/pg_lake_table/src/fdw/partition_transform.c
@@ -16,6 +16,8 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/lsyscache.h"

--- a/pg_lake_table/src/fdw/partitioning/partition_spec_catalog.c
+++ b/pg_lake_table/src/fdw/partitioning/partition_spec_catalog.c
@@ -16,6 +16,8 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 
 #include "pg_lake/extensions/pg_lake_table.h"

--- a/pg_lake_table/src/fdw/partitioning/partitioned_dest_receiver.c
+++ b/pg_lake_table/src/fdw/partitioning/partitioned_dest_receiver.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
 
 #include "access/tupdesc.h"
 #include "commands/copy.h"

--- a/pg_lake_table/src/fdw/pg_lake_table.c
+++ b/pg_lake_table/src/fdw/pg_lake_table.c
@@ -25,6 +25,8 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 #include "funcapi.h"
 
 #include <limits.h>

--- a/pg_lake_table/src/fdw/position_delete_dest.c
+++ b/pg_lake_table/src/fdw/position_delete_dest.c
@@ -16,6 +16,8 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
+#include "utils/hsearch.h"
 
 #include "access/tupdesc.h"
 #include "commands/copy.h"

--- a/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
+++ b/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
@@ -22,6 +22,7 @@
 * from/to catalog lake_table.field_id_mappings.
 */
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 #include "miscadmin.h"
 
 #include "access/relation.h"

--- a/pg_lake_table/src/fdw/update_tracking.c
+++ b/pg_lake_table/src/fdw/update_tracking.c
@@ -219,7 +219,11 @@ CreateUpdateTrackingTable(RangeVar *updateTableName)
 	indexColumn->name = "rowid";
 	createPrimaryKey->indexParams = list_make1(indexColumn);
 
-	DefineIndex(updateTableAddress.objectId,
+	DefineIndex(
+#if PG_VERSION_NUM >= 190000
+				 /* pstate */ NULL,
+#endif
+				updateTableAddress.objectId,
 				createPrimaryKey,
 				 /* indexRelationId */ InvalidOid,
 				 /* parentIndexId */ InvalidOid,

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -16,6 +16,9 @@
  */
 
 #include "postgres.h"
+#include "storage/lock.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "miscadmin.h"

--- a/pg_lake_table/src/planner/insert_select.c
+++ b/pg_lake_table/src/planner/insert_select.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "catalog/pg_type_d.h"
 
 #include "access/table.h"
 #include "pg_lake/extensions/postgis.h"

--- a/pg_lake_table/src/planner/query_pushdown.c
+++ b/pg_lake_table/src/planner/query_pushdown.c
@@ -16,6 +16,8 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "catalog/pg_type_d.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 
@@ -95,7 +97,11 @@ typedef struct IsShippableContext
 
 
 static PlannedStmt *LakeTablePlanner(Query *parse, const char *queryString,
-									 int cursorOptions, ParamListInfo boundParams);
+									 int cursorOptions, ParamListInfo boundParams
+#if PG_VERSION_NUM >= 190000
+									 ,ExplainState *es
+#endif
+);
 static bool AdjustParseTreeForPgLake(Node *node, void *context);
 static bool ProcessNotShippableExpressionWalker(Node *node, IsShippableContext * context);
 static bool AddMissingRTEAliasaes(Node *node, void *context);
@@ -253,7 +259,11 @@ AppendPermInfos(PlannedStmt *pushdownPlan, PlannedStmt *localPlan)
  */
 static PlannedStmt *
 LakeTablePlanner(Query *parse, const char *queryString,
-				 int cursorOptions, ParamListInfo boundParams)
+				 int cursorOptions, ParamListInfo boundParams
+#if PG_VERSION_NUM >= 190000
+				 ,ExplainState *es
+#endif
+)
 {
 	Query	   *originalQuery = NULL;
 	bool		hasLakeTable = false;
@@ -293,7 +303,11 @@ LakeTablePlanner(Query *parse, const char *queryString,
 
 	PG_TRY();
 	{
-		plan = PreviousPlannerHook(parse, queryString, cursorOptions, boundParams);
+		plan = PreviousPlannerHook(parse, queryString, cursorOptions, boundParams
+#if PG_VERSION_NUM >= 190000
+								   ,es
+#endif
+			);
 		if (EnableFullQueryPushdown &&
 			hasLakeTable &&
 			(cursorOptions & CURSOR_OPT_SCROLL) == 0)

--- a/pg_lake_table/src/planner/restriction_collector.c
+++ b/pg_lake_table/src/planner/restriction_collector.c
@@ -24,6 +24,7 @@
 *       that Postgres planner knows about.
 */
 #include "postgres.h"
+#include "utils/hsearch.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 

--- a/pg_lake_table/src/recovery/recover.c
+++ b/pg_lake_table/src/recovery/recover.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
 #include "miscadmin.h"
 #include "fmgr.h"
 

--- a/pg_lake_table/src/test/hide_lake_objects.c
+++ b/pg_lake_table/src/test/hide_lake_objects.c
@@ -16,6 +16,8 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
+#include "access/htup_details.h"
 #include "miscadmin.h"
 
 #include "access/genam.h"

--- a/pg_lake_table/src/test/test_partition_tuple.c
+++ b/pg_lake_table/src/test/test_partition_tuple.c
@@ -16,11 +16,14 @@
  */
 
 #include "postgres.h"
+#include "access/htup_details.h"
+#include "catalog/pg_type_d.h"
 #include "funcapi.h"
 #include "access/relation.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
+#include "utils/tuplestore.h"
 
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_lake/fdw/partition_transform.h"

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "utils/hsearch.h"
 #include "access/xact.h"
 #include "common/int.h"
 #include "utils/memutils.h"

--- a/pg_map/src/map.c
+++ b/pg_map/src/map.c
@@ -53,6 +53,7 @@
 #include "utils/regproc.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/tuplestore.h"
 
 
 /* Check PgSQL version */

--- a/pgduck_server/Makefile
+++ b/pgduck_server/Makefile
@@ -12,9 +12,11 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 
 PG_LAKE_DELTA_SUPPORT ?= 0
 
-# compile with C11 option to use modern C
+# compile with C11 option to use modern C; use GNU dialect so that
+# typeof / static_assert resolve when including PG19's c.h, which
+# uses both unconditionally
 # use duckdb.h from the duckdb submodule
-PG_CPPFLAGS = -std=c11 -I$(PG_INCLUDEDIR) -Iinclude -DPG_LAKE_DELTA_SUPPORT=$(PG_LAKE_DELTA_SUPPORT)
+PG_CPPFLAGS = -std=gnu11 -I$(PG_INCLUDEDIR) -Iinclude -DPG_LAKE_DELTA_SUPPORT=$(PG_LAKE_DELTA_SUPPORT)
 
 # Add dependencies
 SHLIB_LINK_INTERNAL = $(libpq)

--- a/pgduck_server/include/utils/numutils.h
+++ b/pgduck_server/include/utils/numutils.h
@@ -25,8 +25,6 @@
 
 #include "c.h"
 
-#include "nodes/nodes.h"
-
 extern int	pg_itoa(int16 i, char *a);
 extern int	pg_ulltoa_n(uint64 value, char *a);
 extern int	pg_ultoa_n(uint32 value, char *a);

--- a/pgduck_server/src/duckdb/type_conversion.c
+++ b/pgduck_server/src/duckdb/type_conversion.c
@@ -22,6 +22,7 @@
  *
  * Copyright (c) 2025 Snowflake Computing, Inc. All rights reserved.
  */
+#include "catalog/pg_type_d.h"
 #include "c.h"
 
 #include "postgres_fe.h"

--- a/pgduck_server/tests/ctests/Makefile
+++ b/pgduck_server/tests/ctests/Makefile
@@ -12,8 +12,10 @@ PG_INCLUDEDIR = $(shell $(PG_CONFIG) --includedir)
 # PGXS: Locates PostgreSQL extension building infrastructure using 'pg_config'.
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 
-# compile with C11 option to use modern C
-PG_CPPFLAGS = -std=c11 -I$(PG_INCLUDEDIR) -g
+# compile with C11 option to use modern C; use GNU dialect so that
+# typeof / static_assert resolve when including PG19's c.h, which
+# uses both unconditionally
+PG_CPPFLAGS = -std=gnu11 -I$(PG_INCLUDEDIR) -g
 
 PG_LDFLAGS  = -L$(PG_LIBDIR) -lpq -lpgcommon -lduckdb -Wl,-rpath,$(PG_LIBDIR)
 


### PR DESCRIPTION
  ## Summary

  Builds on top of #363 (add-pg19-ci) — that PR adds the PG19 build/test infrastructure with continue-on-error; this PR makes the code actually compile against PG19.

  PG19 dropped a number of transitive header includes and reshaped a few APIs. Most of the diff is just adding the explicit `#include` that PG18 was getting transitively.
   The handful of real API changes are version-gated behind `#if PG_VERSION_NUM >= 190000`.

  ### Header reorg
  PG19 dropped these from common transitive include paths, so the relevant `.c` files now include them explicitly:

  | Header | Why |
  |---|---|
  | `utils/tuplestore.h` | was reached via `nodes/execnodes.h` |
  | `access/htup_details.h` | was reached via `executor/tuptable.h` |
  | `utils/hsearch.h` | `HASHCTL`, `hash_create`, `hash_search` |
  | `catalog/pg_type_d.h` | `TEXTOID`, `INTERVALOID`, etc. |
  | `utils/wait_event.h` | `WAIT_EVENT_CLIENT_READ` |
  | `utils/timestamp.h` | `DatumGetTimestampTz`, `TimestampTzGetDatum`, `IntervalPGetDatum` |
  | `storage/lock.h` | `LockAcquire`, `LockAcquireResult` |
  | `storage/fd.h` | `AllocateFile`, `FreeFile` |

  ### API changes
  Wrapped behind `#if PG_VERSION_NUM >= 190000`:

  - **`LWLockNewTrancheId()`** now requires a name argument; the separate `LWLockRegisterTranche()` helper is gone.
  - **`ShmemInitHash()`** collapsed `init_size` / `max_size` into a single `nelems`.
  - **`SIG_IGN`** → **`PG_SIG_IGN`** (`pqsigfunc`-typed sentinel) when used with `pqsignal()`.
  - **`pg_plan_query()`** gained a trailing `ExplainState *` (pass `NULL`).
  - **`CopyFormatOptions.binary` / `.csv_mode`** were replaced by an enum `.format` field. Wrapped behind `CopyOptsIsBinary` / `CopyOptsIsCsvMode` macros in `pg_compat.h`
   so callers keep the older names.
  - **`CopyHeaderChoice`** enum was removed; `header_line` is now a plain `int` with `COPY_HEADER_TRUE/FALSE/MATCH` constants. Reintroduced the typedef locally so the
  exported API signature stays stable.
  - **`numeric_int4_opt_error()`** renamed to **`numeric_int4_safe()`** and switched from a `bool *` error flag to an `ErrorSaveContext *` (soft-error API). Wrapped via
  an inline shim that preserves the older `bool *` signature.

  ### Drive-by
  `pgduck_server` is a frontend program; the unused `#include "nodes/nodes.h"` in `numutils.h` started failing because PG19 changed `nodes.h` to use `Datum` in extern
  declarations. Removed the vestigial include.

  ## Test plan

  Built locally against PG19beta1 cleanly for:
  - [x] `pg_extension_base`
  - [x] `pg_map`
  - [x] `pg_lake_engine`
  - [x] `pg_lake_copy`
  - [x] `pg_lake`

  `pg_lake_iceberg` / `pg_lake_table` were not exercised locally because the avro library was not built; the same include patterns applied here cover the breakages they
  exhibited under PG19, but CI is the source of truth.

  - [ ] Once #363 lands, drop the PG19 `continue-on-error` overrides and confirm the matrix is green.