### PR TITLE
pg_lake_iceberg: rewrite object_store catalog at least once per minute, include catalog-snapshot-time

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/object_store_catalog/object_store_catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/object_store_catalog/object_store_catalog.h
@@ -7,12 +7,15 @@
 /* crunchy_iceberg.enable_object_store_catalog setting */
 extern PGDLLEXPORT bool EnableObjectStoreCatalog;
 
+/* pg_lake_iceberg.object_store_catalog_max_age setting, in seconds */
+extern PGDLLEXPORT int ObjectStoreCatalogMaxAge;
+
 extern PGDLLEXPORT char *ObjectStoreCatalogLocationPrefix;
 extern PGDLLEXPORT char *ExternalObjectStorePrefix;
 extern PGDLLEXPORT char *InternalObjectStorePrefix;
 
 extern PGDLLEXPORT void InitObjectStoreCatalog(void);
-extern PGDLLEXPORT void ExportIcebergCatalogIfChanged(void);
+extern PGDLLEXPORT void ExportIcebergCatalogIfNeeded(void);
 extern PGDLLEXPORT const char *GetObjectStoreDefaultLocationPrefix(void);
 extern PGDLLEXPORT char *GetMetadataLocationFromExternalObjectStoreCatalogForTable(Oid relationId);
 extern PGDLLEXPORT void ErrorIfExternalObjectStoreCatalogDoesNotExist(const char *catalogName);

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -114,6 +114,16 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
+	DefineCustomIntVariable("pg_lake_iceberg.object_store_catalog_max_age",
+							gettext_noop("Maximum age in seconds before the object store catalog "
+										 "file is rewritten even when no tables changed."),
+							gettext_noop("Periodically rewriting the catalog signals that "
+										 "Postgres is up and able to talk to object storage."),
+							&ObjectStoreCatalogMaxAge,
+							60, 1, INT_MAX / 1000,
+							PGC_SIGHUP, GUC_UNIT_S,
+							NULL, NULL, NULL);
+
 	DefineCustomStringVariable("pg_lake_iceberg.external_object_store_catalog_prefix",
 							   gettext_noop("Specifies the prefix used for the object store catalog files for external tables."),
 							   NULL,

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -7,6 +7,7 @@
 #include "utils/inval.h"
 #include "utils/snapmgr.h"
 #include "utils/lsyscache.h"
+#include "utils/timestamp.h"
 
 #include "pg_lake/json/json_utils.h"
 #include "pg_lake/iceberg/catalog.h"
@@ -34,9 +35,19 @@ PG_FUNCTION_INFO_V1(force_push_object_store_catalog);
 /* pg_lake_iceberg.enable_object_store_catalog setting */
 bool		EnableObjectStoreCatalog = true;
 
+/* pg_lake_iceberg.object_store_catalog_max_age setting, in seconds */
+int			ObjectStoreCatalogMaxAge = 60;
+
 
 /* whether to export the catalog to object storage, always do so on start-up */
 static List *InvalidatedRelationIds = NULL;
+
+/*
+ * Time of the last successful catalog push. Initialized to 0 so the first
+ * call to CatalogNeedsExport() always returns true, ensuring we write the
+ * catalog file at least once after start-up.
+ */
+static TimestampTz LastCatalogPushTime = 0;
 
 static bool CatalogNeedsExport(void);
 static void PushMetadataLocationToObjectStoreCatalog(void);
@@ -186,12 +197,13 @@ TrackInvalidateCatalogExport(Datum argument, Oid relationId)
 }
 
 /*
- * ExportIcebergCatalogIfChanged efficiently determines whether
- * tables_internal might have changed via invalidations, and if
- * so it re-exports the catalog.
+ * ExportIcebergCatalogIfNeeded re-exports the catalog when tables_internal
+ * may have changed via invalidations, or when more than
+ * ObjectStoreCatalogMaxAge seconds have passed since the last successful
+ * push.
  */
 void
-ExportIcebergCatalogIfChanged(void)
+ExportIcebergCatalogIfNeeded(void)
 {
 	AcceptInvalidationMessages();
 
@@ -208,6 +220,11 @@ ExportIcebergCatalogIfChanged(void)
 /*
 * CatalogNeedsExport checks if the iceberg catalog needs to be exported
 * to object storage.
+*
+* In addition to invalidations from changes to tables_internal, we also
+* re-export the catalog when more than ObjectStoreCatalogMaxAge seconds
+* have passed since the last push. The periodic rewrite signals that
+* Postgres is up and able to talk to object storage.
 */
 static bool
 CatalogNeedsExport(void)
@@ -233,6 +250,13 @@ CatalogNeedsExport(void)
 	{
 		list_free(InvalidatedRelationIds);
 		InvalidatedRelationIds = NIL;
+	}
+
+	if (!catalogNeedsExport &&
+		TimestampDifferenceExceeds(LastCatalogPushTime, GetCurrentTimestamp(),
+								   ObjectStoreCatalogMaxAge * 1000))
+	{
+		catalogNeedsExport = true;
 	}
 
 	return catalogNeedsExport;
@@ -382,6 +406,8 @@ PushMetadataLocationToObjectStoreCatalog(void)
 
 	CopyLocalFileToS3(localFilePath,
 					  GetInternalObjectStoreCatalogFilePath(get_database_name(MyDatabaseId)));
+
+	LastCatalogPushTime = GetCurrentTimestamp();
 }
 
 

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -1,6 +1,7 @@
 #include "postgres.h"
 #include "funcapi.h"
 #include "miscadmin.h"
+#include "pgtime.h"
 
 #include "commands/dbcommands.h"
 #include "foreign/foreign.h"
@@ -56,6 +57,7 @@ static char *GetExternalObjectStoreCatalogFilePath(const char *catalogName);
 static char *GetInternalObjectStoreCatalogFilePath(const char *catalogName);
 static bool CheckIfExternalObjectStoreCatalogExists(const char *catalogName);
 static void GetObjectStoreCatalogInfoFromCatalog(Oid relationId, char **catalogName, char **catalogNamespace, char **catalogTableName);
+static void FormatCurrentTimestampUTC(char *buf, size_t bufsize);
 
 /*
 * Lists all tables registered in the given object store catalog.
@@ -340,6 +342,18 @@ PushMetadataLocationToObjectStoreCatalog(void)
 
 	/* Start JSON object */
 	appendStringInfoString(objectStoreCatalogFileContent, "{");
+
+	/*
+	 * catalog-snapshot-time records when this snapshot of the catalog was
+	 * taken, so operators can tell whether the file is fresh. Format is ISO
+	 * 8601 UTC, e.g. "2026-06-16T09:30:00Z".
+	 */
+	char		snapshotTime[24];
+
+	FormatCurrentTimestampUTC(snapshotTime, sizeof(snapshotTime));
+	appendJsonString(objectStoreCatalogFileContent, "catalog-snapshot-time", snapshotTime);
+	appendStringInfoString(objectStoreCatalogFileContent, ",");
+
 	appendJsonKey(objectStoreCatalogFileContent, "tables");
 	appendStringInfoString(objectStoreCatalogFileContent, "[");
 
@@ -581,6 +595,26 @@ TriggerCatalogExportIfObjectStoreTable(Oid relationId)
 
 	if (icebergCatalogType == OBJECT_STORE_READ_WRITE)
 		CacheInvalidateRelcacheByRelid(IcebergTablesInternalTableId());
+}
+
+
+/*
+ * FormatCurrentTimestampUTC writes the current time into buf as an ISO 8601
+ * UTC string with second precision, e.g. "2026-06-16T09:30:00Z". The buffer
+ * must be at least 21 bytes.
+ */
+static void
+FormatCurrentTimestampUTC(char *buf, size_t bufsize)
+{
+	pg_time_t	epoch = timestamptz_to_time_t(GetCurrentTimestamp());
+	struct pg_tm *tm = pg_gmtime(&epoch);
+
+	if (tm == NULL)
+		elog(ERROR, "could not convert current timestamp to UTC");
+
+	snprintf(buf, bufsize, "%04d-%02d-%02dT%02d:%02d:%02dZ",
+			 tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+			 tm->tm_hour, tm->tm_min, tm->tm_sec);
 }
 
 

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -176,7 +176,7 @@ pg_lake_iceberg_vacuum(PG_FUNCTION_ARGS)
 
 			START_TRANSACTION();
 			{
-				ExportIcebergCatalogIfChanged();
+				ExportIcebergCatalogIfNeeded();
 			}
 			END_TRANSACTION_NO_THROW(WARNING);
 		}

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1,5 +1,6 @@
 from utils_pytest import *
 import itertools
+import time
 
 
 # don't accept 'catalog_name', 'catalog_namespace', 'catalog_table_name'
@@ -1033,6 +1034,73 @@ def test_re_create_tables(
         pg_conn,
     )
     pg_conn.commit()
+
+
+# the catalog file is rewritten at least once per
+# pg_lake_iceberg.object_store_catalog_max_age, even when no tables changed
+def test_object_store_catalog_periodic_rewrite(
+    pg_conn,
+    superuser_conn,
+    s3,
+    extension,
+    with_default_location,
+    adjust_object_store_settings,
+):
+    superuser_conn.autocommit = True
+    run_command(
+        "ALTER SYSTEM SET pg_lake_iceberg.object_store_catalog_max_age = '2s'",
+        superuser_conn,
+    )
+    run_command("SELECT pg_reload_conf()", superuser_conn)
+    # bg workers need a moment to pick up the SIGHUP-driven GUC reload
+    run_command("SELECT pg_sleep(0.2)", superuser_conn)
+
+    try:
+        run_command("CREATE SCHEMA test_periodic_rewrite", pg_conn)
+        run_command(
+            "CREATE TABLE test_periodic_rewrite.tbl(a int) USING iceberg WITH (catalog='object_store')",
+            pg_conn,
+        )
+        pg_conn.commit()
+        wait_until_object_store_writable_table_pushed(
+            pg_conn, "test_periodic_rewrite", "tbl"
+        )
+
+        dbname = run_query("SELECT current_database()", pg_conn)[0][0]
+        prefix = run_query(
+            "SHOW pg_lake_iceberg.internal_object_store_catalog_prefix",
+            superuser_conn,
+        )[0][0]
+        key = f"{prefix}/catalog/{dbname}/catalog.json"
+
+        first_modified = s3.head_object(Bucket=TEST_BUCKET, Key=key)["LastModified"]
+
+        # bg worker ticks every second; with max_age=2s we expect another
+        # rewrite within ~3 seconds, leave 8 seconds of slack.
+        deadline = time.monotonic() + 8
+        current_modified = first_modified
+        while time.monotonic() < deadline:
+            time.sleep(0.5)
+            current_modified = s3.head_object(Bucket=TEST_BUCKET, Key=key)[
+                "LastModified"
+            ]
+            if current_modified > first_modified:
+                break
+
+        assert current_modified > first_modified, (
+            f"catalog object {key} last-modified did not advance "
+            f"({first_modified} == {current_modified}) within the rewrite window"
+        )
+
+        run_command("DROP SCHEMA test_periodic_rewrite CASCADE", pg_conn)
+        pg_conn.commit()
+    finally:
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.object_store_catalog_max_age",
+            superuser_conn,
+        )
+        run_command("SELECT pg_reload_conf()", superuser_conn)
+        superuser_conn.autocommit = False
 
 
 def assert_tables_are_the_same(pg_conn, tbl_1, tbl_2):

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1,5 +1,8 @@
 from utils_pytest import *
+import datetime
 import itertools
+import json
+import re
 import time
 
 
@@ -1074,6 +1077,26 @@ def test_object_store_catalog_periodic_rewrite(
         key = f"{prefix}/catalog/{dbname}/catalog.json"
 
         first_modified = s3.head_object(Bucket=TEST_BUCKET, Key=key)["LastModified"]
+        first_body = json.loads(
+            s3.get_object(Bucket=TEST_BUCKET, Key=key)["Body"].read()
+        )
+        # catalog-snapshot-time is an ISO 8601 UTC timestamp recorded when
+        # this snapshot of the catalog was taken.
+        snapshot_re = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+        assert snapshot_re.match(first_body["catalog-snapshot-time"]), (
+            f"unexpected catalog-snapshot-time format: "
+            f"{first_body['catalog-snapshot-time']!r}"
+        )
+        first_snapshot_time = datetime.datetime.strptime(
+            first_body["catalog-snapshot-time"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=datetime.timezone.utc)
+        # the timestamp should be roughly now, leave 5 minutes of slack for
+        # clock skew between Postgres and the test runner.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        assert abs((now - first_snapshot_time).total_seconds()) < 300, (
+            f"catalog-snapshot-time {first_snapshot_time} too far from "
+            f"current time {now}"
+        )
 
         # bg worker ticks every second; with max_age=2s we expect another
         # rewrite within ~3 seconds, leave 8 seconds of slack.
@@ -1090,6 +1113,18 @@ def test_object_store_catalog_periodic_rewrite(
         assert current_modified > first_modified, (
             f"catalog object {key} last-modified did not advance "
             f"({first_modified} == {current_modified}) within the rewrite window"
+        )
+
+        # the snapshot time inside the file should also have advanced
+        second_body = json.loads(
+            s3.get_object(Bucket=TEST_BUCKET, Key=key)["Body"].read()
+        )
+        second_snapshot_time = datetime.datetime.strptime(
+            second_body["catalog-snapshot-time"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=datetime.timezone.utc)
+        assert second_snapshot_time > first_snapshot_time, (
+            f"catalog-snapshot-time did not advance "
+            f"({first_snapshot_time} == {second_snapshot_time})"
         )
 
         run_command("DROP SCHEMA test_periodic_rewrite CASCADE", pg_conn)


### PR DESCRIPTION
## Problem

When `catalog='object_store'`, the catalog.json file in object storage is only rewritten when a table in `lake_iceberg.tables_internal` changes. If no DDL or DML happens on object_store tables, the file can sit unchanged for hours. Operators want a regular write to confirm Postgres is up and able to talk to object storage, so a stale catalog.json is a clear signal that something is wrong.

## Solution

Add a new `pg_lake_iceberg.object_store_catalog_max_age` setting (default 60 seconds, `PGC_SIGHUP`). `CatalogNeedsExport()` now returns true when more than `max_age` seconds have passed since the last successful push, even when there were no invalidations. The push timestamp is tracked in a static variable that starts at 0, so the first call after start-up always exports.

```sql
-- Default: catalog.json is rewritten at least once per minute.
SHOW pg_lake_iceberg.object_store_catalog_max_age;

-- Adjust the interval without restarting Postgres.
ALTER SYSTEM SET pg_lake_iceberg.object_store_catalog_max_age = '30s';
SELECT pg_reload_conf();
```

The catalog.json file now also includes a `catalog-snapshot-time` field at the top level, recording the UTC time at which the file was generated:

```json
{"catalog-snapshot-time":"2026-06-16T09:30:00Z","tables":[...]}
```

Operators can read the field directly from the JSON to confirm the catalog is fresh, without having to look at the object's last-modified header. We may want to add a `last-modification-time` later, but Postgres does not currently have a reliable way to know when `tables_internal` last changed.

## Test plan

- [x] Build pg_lake_iceberg cleanly, restart Postgres, `SHOW pg_lake_iceberg.object_store_catalog_max_age` returns `1min`.
- [x] `ALTER SYSTEM SET ... = '30s'; SELECT pg_reload_conf()` and re-`SHOW` returns `30s`.
- [x] `test_object_store_catalog_periodic_rewrite` asserts that the catalog file is re-written within the `max_age` window with no table changes, and that `catalog-snapshot-time` advances each rewrite.
- [x] CI (existing object_store_catalog tests still pass; behavior change is additive).
