### PR TITLE
Expose query progress and connection id as SQL functions

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -32,6 +32,7 @@ UPDATEs = "UPDATEs"
 INSERTs = "INSERTs"
 DELETEs = "DELETEs"
 WARNINGs = "WARNINGs"
+GetRowsProcesseed = "GetRowsProcesseed"
 
 [default.extend-words]
 inh = "inh"

--- a/.typos.toml
+++ b/.typos.toml
@@ -32,6 +32,8 @@ UPDATEs = "UPDATEs"
 INSERTs = "INSERTs"
 DELETEs = "DELETEs"
 WARNINGs = "WARNINGs"
+# QueryProgress::GetRowsProcesseed is misspelled in DuckDB itself
+# (duckdb/common/progress_bar/progress_bar.hpp); we cannot rename it here.
 GetRowsProcesseed = "GetRowsProcesseed"
 
 [default.extend-words]

--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -927,12 +927,12 @@ DUCKDB_EXTENSION_API void duckdb_pglake_init_connection(duckdb_connection connec
 	 * progress aggregator only writes to ClientContext::query_progress
 	 * when the bar is on, so without this default pg_lake_query_progress
 	 * silently returns -1 / 0 / 0 even though everything else is wired
-	 * up.  Clients that do not want the bar can still issue
-	 * `SET enable_progress_bar = false` per session; the wait_time
-	 * setting (default 2000ms) keeps short queries from paying for an
-	 * aggregator they will never read from.  print_progress_bar stays
-	 * off because pgduck does not have a controlling terminal to render
-	 * to anyway.
+	 * up.  The cost is one walk over the executor's pipelines per task
+	 * iteration; wait_time does not avoid it, it only decides when a
+	 * bar would start printing.  Clients that would rather not pay it can
+	 * issue `SET enable_progress_bar = false` per session.
+	 * print_progress_bar stays off because pgduck does not have a
+	 * controlling terminal to render to anyway.
 	 */
 	duckdb::ClientConfig::GetConfig(*conn->context).enable_progress_bar = true;
 	duckdb::ClientConfig::GetConfig(*conn->context).print_progress_bar = false;

--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -921,6 +921,21 @@ DUCKDB_EXTENSION_API void duckdb_pglake_init_connection(duckdb_connection connec
 		conn->context->registered_state->GetOrCreate<duckdb::PgLakeQueryListener>("pg_lake_query_listener");
 
 	queryListener->connectionId = connectionId;
+
+	/*
+	 * Enable the progress bar by default for every pgduck session.  The
+	 * progress aggregator only writes to ClientContext::query_progress
+	 * when the bar is on, so without this default pg_lake_query_progress
+	 * silently returns -1 / 0 / 0 even though everything else is wired
+	 * up.  Clients that do not want the bar can still issue
+	 * `SET enable_progress_bar = false` per session; the wait_time
+	 * setting (default 2000ms) keeps short queries from paying for an
+	 * aggregator they will never read from.  print_progress_bar stays
+	 * off because pgduck does not have a controlling terminal to render
+	 * to anyway.
+	 */
+	duckdb::ClientConfig::GetConfig(*conn->context).enable_progress_bar = true;
+	duckdb::ClientConfig::GetConfig(*conn->context).print_progress_bar = false;
 }
 
 }

--- a/duckdb_pglake/src/utility_functions.cpp
+++ b/duckdb_pglake/src/utility_functions.cpp
@@ -130,6 +130,143 @@ static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p,
 
 
 /*
+ * QueryProgressFunctionData defines the custom state for pg_lake_query_progress.
+ */
+struct QueryProgressFunctionData : public TableFunctionData
+{
+	int64_t targetConnectionId;
+	bool finished = false;
+};
+
+
+/*
+ * QueryProgressBind implements the bind phase for pg_lake_query_progress.
+ *
+ * Takes a connection identifier and returns at most one row, with the
+ * cumulative progress that DuckDB's executor publishes on
+ * ClientContext::query_progress for the matching session. This is the
+ * same value DuckDB's progress bar would display, exposed so that a
+ * monitor connection can read it for any session by id.
+ *
+ * What the percentage measures.  The aggregator walks the executor's
+ * pipelines and reads progress from each scan operator that registered
+ * a table_scan_progress callback (postgres_scan, parquet_scan, csv read,
+ * range, and so on).  It does not look at sinks (COPY TO, parquet
+ * writer, S3 multipart upload finalize) or post-scan operators
+ * (sort, join, aggregate beyond their input scans).  The number is
+ * therefore "how much of the source has been read", not "how much of
+ * the wall-clock work is left".  In particular for COPY (SELECT FROM
+ * postgres_scan(...)) TO ... the bar can sit pinned near 100% while
+ * the destination side is still flushing.
+ *
+ * The fields are populated by the executor only for sessions where
+ * enable_progress_bar is on.  pgduck enables it by default in
+ * duckdb_pglake_init_connection, but the executor still waits
+ * client_config.wait_time milliseconds (default 2000) before turning
+ * the aggregator on, so very short queries return -1 / 0 / 0 even on
+ * a session with the bar enabled.  If a session has disabled the bar
+ * (`SET enable_progress_bar = false`) the row carries percentage = -1
+ * with rows_processed and total_rows_to_process both 0.  We surface
+ * those raw values without filtering.  If no session has the
+ * requested connection_id, or the matching session has no active
+ * query, the result is empty.
+ */
+static unique_ptr<FunctionData> QueryProgressBind(ClientContext &context,
+												  TableFunctionBindInput &input,
+												  vector<LogicalType> &return_types,
+												  vector<string> &names) {
+	auto functionData = make_uniq<QueryProgressFunctionData>();
+	functionData->targetConnectionId = input.inputs[0].GetValue<int64_t>();
+
+	return_types.emplace_back(LogicalType::DOUBLE);
+	return_types.emplace_back(LogicalType::BIGINT);
+	return_types.emplace_back(LogicalType::BIGINT);
+	names.emplace_back("percentage");
+	names.emplace_back("rows_processed");
+	names.emplace_back("total_rows_to_process");
+
+	return std::move(functionData);
+}
+
+
+/*
+ * QueryProgressExec implements the execution for pg_lake_query_progress.
+ *
+ * Like pg_lake_stat_activity, this iterates the connection list from a
+ * thread other than the one running the inspected sessions, so it must
+ * not touch per-session state that the owning thread mutates.  We match
+ * on connectionId (set once at init, safe to read directly) and gate on
+ * the listener's thread-safe IsQueryActive() rather than the raw
+ * isQueryActive field, and we do not call ClientContext::
+ * ExecutionIsFinished() -- that reads the active_query unique_ptr the
+ * owning session resets in QueryEnd and is the cross-thread deref behind
+ * issue #148.
+ *
+ * GetQueryProgress itself returns a copy of the QueryProgress struct,
+ * whose fields are atomic, so it is safe to call from another thread.
+ * The same pattern is used by DuckDB's own C API entry point
+ * duckdb_query_progress.
+ */
+static void QueryProgressExec(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &functionData = (QueryProgressFunctionData &)*data_p.bind_data;
+	if (functionData.finished)
+		return;
+	functionData.finished = true;
+
+	ConnectionManager &connectionManager = context.db->GetConnectionManager();
+	vector<shared_ptr<ClientContext>> connections = connectionManager.GetConnectionList();
+
+	for (auto &connection : connections)
+	{
+		if (!connection)
+			continue;
+
+		shared_ptr<PgLakeQueryListener> queryListener =
+			connection->registered_state->Get<PgLakeQueryListener>("pg_lake_query_listener");
+
+		if (!queryListener || queryListener->connectionId != functionData.targetConnectionId)
+			continue;
+
+		if (!queryListener->IsQueryActive())
+			continue;
+
+		QueryProgress progress = connection->GetQueryProgress();
+
+		output.SetValue(0, 0, Value::DOUBLE(progress.GetPercentage()));
+		output.SetValue(1, 0, Value::BIGINT(progress.GetRowsProcesseed()));
+		output.SetValue(2, 0, Value::BIGINT(progress.GetTotalRowsToProcess()));
+		output.SetCardinality(1);
+		return;
+	}
+
+	output.SetCardinality(0);
+}
+
+
+/*
+ * Implementation of the pg_lake_connection_id scalar function.
+ *
+ * Returns the connection identifier assigned by pgduck_server to the
+ * current session. This is the same value libpq's PQbackendPID returns
+ * to a client connected to pgduck, and the same value reported in the
+ * connection_id column of pg_lake_stat_activity. Pass it to
+ * pg_lake_query_progress(connection_id) to read the executor's progress
+ * for this session from another connection.
+ */
+static void
+ConnectionIdScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	ClientContext &context = state.GetContext();
+	shared_ptr<PgLakeQueryListener> queryListener =
+		context.registered_state->Get<PgLakeQueryListener>("pg_lake_query_listener");
+
+	int64_t connectionId = queryListener ? queryListener->connectionId : 0;
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::GetData<int64_t>(result)[0] = connectionId;
+}
+
+
+/*
  * Implementation of the pg_lake_sleep scalar function.
  */
 static void
@@ -191,6 +328,28 @@ PgLakeUtilityFunctions::RegisterFunctions(ExtensionLoader &loader)
 						   SleepScalarFun);
 
 		loader.RegisterFunction(pg_lake_sleep);
+	}
+
+	/* pg_lake_query_progress function definition */
+	{
+		TableFunctionSet pg_lake_query_progress("pg_lake_query_progress");
+
+		pg_lake_query_progress.AddFunction(
+			TableFunction({LogicalType::BIGINT},
+						  QueryProgressExec, QueryProgressBind));
+
+		loader.RegisterFunction(pg_lake_query_progress);
+	}
+
+	/* pg_lake_connection_id function definition */
+	{
+		ScalarFunction pg_lake_connection_id=
+			ScalarFunction("pg_lake_connection_id",
+						   {},
+						   LogicalType::BIGINT,
+						   ConnectionIdScalarFun);
+
+		loader.RegisterFunction(pg_lake_connection_id);
 	}
 }
 

--- a/duckdb_pglake/src/utility_functions.cpp
+++ b/duckdb_pglake/src/utility_functions.cpp
@@ -27,15 +27,34 @@
 namespace duckdb {
 
 /*
- * StatActivityFunctionData defines the custom state for pg_lake_stat_activity
+ * StatActivityFunctionData defines the bind data for pg_lake_stat_activity.
+ *
+ * Bind data is shared by every execution of a plan, so there is nothing to
+ * keep here; the scan's own state lives in StatActivityGlobalState.
  */
 struct StatActivityFunctionData : public TableFunctionData
 {
-	/* Function state */
+};
+
+
+/*
+ * StatActivityGlobalState holds the per-execution state: the snapshot of
+ * connections this scan is walking, how far it has got, and whether it is
+ * done.  DuckDB creates it once per execution, which is exactly the lifetime
+ * this state wants.
+ */
+struct StatActivityGlobalState : public GlobalTableFunctionState
+{
 	vector<shared_ptr<ClientContext>> connections;
 	idx_t		offset = 0;
 	bool		finished = false;
 };
+
+
+static unique_ptr<GlobalTableFunctionState> StatActivityInitGlobal(ClientContext &context,
+																   TableFunctionInitInput &input) {
+	return make_uniq<StatActivityGlobalState>();
+}
 
 
 /*
@@ -85,21 +104,21 @@ static unique_ptr<FunctionData> StatActivityBind(ClientContext &context,
  * afterwards, so it is safe to read directly.
  */
 static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &functionData = (StatActivityFunctionData &)*data_p.bind_data;
-	if (functionData.finished)
+	auto &globalState = data_p.global_state->Cast<StatActivityGlobalState>();
+	if (globalState.finished)
 		return;
 
 	/* Do the work */
-	if (functionData.offset == 0)
+	if (globalState.offset == 0)
 	{
 		ConnectionManager &connectionManager = context.db->GetConnectionManager();
-		functionData.connections = connectionManager.GetConnectionList();
+		globalState.connections = connectionManager.GetConnectionList();
 	}
 
 	/* Set return values */
 	idx_t rowsInChunk = 0;
-	while (functionData.offset< functionData.connections.size() && rowsInChunk < STANDARD_VECTOR_SIZE) {
-		shared_ptr<ClientContext> connection = functionData.connections[functionData.offset];
+	while (globalState.offset < globalState.connections.size() && rowsInChunk < STANDARD_VECTOR_SIZE) {
+		shared_ptr<ClientContext> connection = globalState.connections[globalState.offset];
 
 		if (connection)
 		{
@@ -119,25 +138,45 @@ static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p,
 			}
 		}
 
-		functionData.offset++;
+		globalState.offset++;
 	}
 
 	output.SetCardinality(rowsInChunk);
 
-	if (functionData.offset == functionData.connections.size())
-		functionData.finished = true;
+	if (globalState.offset == globalState.connections.size())
+		globalState.finished = true;
 }
 
 
 /*
- * QueryProgressFunctionData defines the custom state for pg_lake_query_progress.
+ * QueryProgressFunctionData defines the bind data for pg_lake_query_progress.
+ *
+ * Bind data is shared by every execution of a plan -- a prepared statement
+ * binds once and executes many times -- so it only holds what the argument
+ * determined, and nothing the scan mutates.
  */
 struct QueryProgressFunctionData : public TableFunctionData
 {
 	int64_t targetConnectionId = 0;
 	bool haveTargetConnectionId = false;
+};
+
+
+/*
+ * QueryProgressGlobalState holds the per-execution state: whether this scan
+ * has already produced its single row.  This belongs in the global state
+ * rather than in bind data, because DuckDB creates it once per execution.
+ */
+struct QueryProgressGlobalState : public GlobalTableFunctionState
+{
 	bool finished = false;
 };
+
+
+static unique_ptr<GlobalTableFunctionState> QueryProgressInitGlobal(ClientContext &context,
+																	TableFunctionInitInput &input) {
+	return make_uniq<QueryProgressGlobalState>();
+}
 
 
 /*
@@ -221,10 +260,12 @@ static unique_ptr<FunctionData> QueryProgressBind(ClientContext &context,
  * duckdb_query_progress.
  */
 static void QueryProgressExec(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &functionData = (QueryProgressFunctionData &)*data_p.bind_data;
-	if (functionData.finished)
+	auto &functionData = data_p.bind_data->Cast<QueryProgressFunctionData>();
+	auto &globalState = data_p.global_state->Cast<QueryProgressGlobalState>();
+
+	if (globalState.finished)
 		return;
-	functionData.finished = true;
+	globalState.finished = true;
 
 	if (!functionData.haveTargetConnectionId)
 	{
@@ -333,7 +374,7 @@ PgLakeUtilityFunctions::RegisterFunctions(ExtensionLoader &loader)
 		/* pg_lake_stat_activity() */
 		pg_lake_stat_activity.AddFunction(
 			TableFunction({},
-						  StatActivityExec, StatActivityBind));
+						  StatActivityExec, StatActivityBind, StatActivityInitGlobal));
 
 	    loader.RegisterFunction(pg_lake_stat_activity);
 	}
@@ -355,7 +396,7 @@ PgLakeUtilityFunctions::RegisterFunctions(ExtensionLoader &loader)
 
 		pg_lake_query_progress.AddFunction(
 			TableFunction({LogicalType::BIGINT},
-						  QueryProgressExec, QueryProgressBind));
+						  QueryProgressExec, QueryProgressBind, QueryProgressInitGlobal));
 
 		loader.RegisterFunction(pg_lake_query_progress);
 	}

--- a/duckdb_pglake/src/utility_functions.cpp
+++ b/duckdb_pglake/src/utility_functions.cpp
@@ -343,7 +343,7 @@ PgLakeUtilityFunctions::RegisterFunctions(ExtensionLoader &loader)
 
 	/* pg_lake_connection_id function definition */
 	{
-		ScalarFunction pg_lake_connection_id=
+		ScalarFunction pg_lake_connection_id =
 			ScalarFunction("pg_lake_connection_id",
 						   {},
 						   LogicalType::BIGINT,

--- a/duckdb_pglake/src/utility_functions.cpp
+++ b/duckdb_pglake/src/utility_functions.cpp
@@ -134,7 +134,8 @@ static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p,
  */
 struct QueryProgressFunctionData : public TableFunctionData
 {
-	int64_t targetConnectionId;
+	int64_t targetConnectionId = 0;
+	bool haveTargetConnectionId = false;
 	bool finished = false;
 };
 
@@ -151,7 +152,7 @@ struct QueryProgressFunctionData : public TableFunctionData
  * What the percentage measures.  The aggregator walks the executor's
  * pipelines and reads progress from each scan operator that registered
  * a table_scan_progress callback (postgres_scan, parquet_scan, csv read,
- * range, and so on).  It does not look at sinks (COPY TO, parquet
+ * and so on).  It does not look at sinks (COPY TO, parquet
  * writer, S3 multipart upload finalize) or post-scan operators
  * (sort, join, aggregate beyond their input scans).  The number is
  * therefore "how much of the source has been read", not "how much of
@@ -160,23 +161,35 @@ struct QueryProgressFunctionData : public TableFunctionData
  * the destination side is still flushing.
  *
  * The fields are populated by the executor only for sessions where
- * enable_progress_bar is on.  pgduck enables it by default in
- * duckdb_pglake_init_connection, but the executor still waits
- * client_config.wait_time milliseconds (default 2000) before turning
- * the aggregator on, so very short queries return -1 / 0 / 0 even on
- * a session with the bar enabled.  If a session has disabled the bar
- * (`SET enable_progress_bar = false`) the row carries percentage = -1
- * with rows_processed and total_rows_to_process both 0.  We surface
- * those raw values without filtering.  If no session has the
- * requested connection_id, or the matching session has no active
- * query, the result is empty.
+ * enable_progress_bar is on, which pgduck turns on by default in
+ * duckdb_pglake_init_connection.  wait_time decides when the bar starts
+ * printing, not when the aggregator runs, so the numbers are live from
+ * the first executor task onwards.  A session that has disabled the bar
+ * (`SET enable_progress_bar = false`) reports percentage = -1 with
+ * rows_processed and total_rows_to_process both 0, and a plan whose
+ * sources register no progress callback (range is one) leaves the
+ * numbers frozen at the executor's first estimate.  We surface those raw
+ * values without filtering.  If the requested connection_id is NULL, or
+ * no session has it, or the matching session has no active query, the
+ * result is empty.
  */
 static unique_ptr<FunctionData> QueryProgressBind(ClientContext &context,
 												  TableFunctionBindInput &input,
 												  vector<LogicalType> &return_types,
 												  vector<string> &names) {
 	auto functionData = make_uniq<QueryProgressFunctionData>();
-	functionData->targetConnectionId = input.inputs[0].GetValue<int64_t>();
+
+	/*
+	 * A NULL argument reaches bind as a NULL constant, and GetValue on it
+	 * throws InternalException, which pgduck_server treats as unrecoverable
+	 * and answers by terminating the server.  Treat NULL the way SQL would:
+	 * it matches no session, so the function returns no rows.
+	 */
+	if (!input.inputs[0].IsNull())
+	{
+		functionData->targetConnectionId = input.inputs[0].GetValue<int64_t>();
+		functionData->haveTargetConnectionId = true;
+	}
 
 	return_types.emplace_back(LogicalType::DOUBLE);
 	return_types.emplace_back(LogicalType::BIGINT);
@@ -212,6 +225,12 @@ static void QueryProgressExec(ClientContext &context, TableFunctionInput &data_p
 	if (functionData.finished)
 		return;
 	functionData.finished = true;
+
+	if (!functionData.haveTargetConnectionId)
+	{
+		output.SetCardinality(0);
+		return;
+	}
 
 	ConnectionManager &connectionManager = context.db->GetConnectionManager();
 	vector<shared_ptr<ClientContext>> connections = connectionManager.GetConnectionList();

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -736,8 +736,18 @@ duckdb_session_init(DuckDBSession * duckSession, PGSession * clientSession)
 		return DUCKDB_SESSION_INITIALIZATION_ERROR;
 	}
 
+	/*
+	 * Use the cancellation proc id (a 32-bit random generated when the
+	 * session reserved its threadpool slot) as the DuckDB-side connection
+	 * identifier.  This is the same value pgduck_server sends in the
+	 * BackendKeyData message and that the client therefore observes via
+	 * libpq's PQbackendPID, so pg_lake_stat_activity, pg_lake_connection_id,
+	 * and pg_lake_query_progress all key on a value the client already has
+	 * without an extra round trip.  Using the random cancellation id also
+	 * avoids the rapid recycling that the raw client socket fd is subject to.
+	 */
 	duckdb_pglake_init_connection(duckSession->connection,
-								  clientSession->pgClient->clientSocket);
+								  clientSession->pgClient->cancellationProcId);
 
 	duckSession->clientSession = clientSession;
 

--- a/pgduck_server/tests/pytests/test_query_progress.py
+++ b/pgduck_server/tests/pytests/test_query_progress.py
@@ -1,0 +1,141 @@
+import pytest
+import time
+import psycopg2
+import select
+from utils_pytest import *
+
+
+def test_connection_id_matches_stat_activity(s3, pgduck_conn):
+    """
+    pg_lake_connection_id returns the current session's connection
+    identifier. The same identifier shows up in the connection_id column of
+    pg_lake_stat_activity when the session has an active query.
+    """
+    sleep_conn = psycopg2.connect(
+        host=server_params.PGDUCK_UNIX_DOMAIN_PATH,
+        port=server_params.PGDUCK_PORT,
+        async_=1,
+    )
+    wait_for_connection(sleep_conn)
+
+    sleep_query = "SELECT pg_lake_connection_id() AS my_id, pg_lake_sleep(10) AS slept"
+    sleep_cur = sleep_conn.cursor()
+    sleep_cur.execute(sleep_query)
+
+    try:
+        observed_id = None
+        while True:
+            state = sleep_conn.poll()
+
+            result = run_query(
+                "SELECT connection_id FROM pg_lake_stat_activity() "
+                "WHERE query LIKE '%pg_lake_sleep%' "
+                "  AND query NOT LIKE '%stat_activity%'",
+                pgduck_conn,
+            )
+
+            if len(result) == 1:
+                observed_id = result[0][0]
+                break
+
+            if state == psycopg2.extensions.POLL_OK:
+                pytest.fail("sleep query finished before stat_activity reported it")
+
+            time.sleep(0.05)
+
+        sleep_conn.cancel()
+    finally:
+        try:
+            sleep_conn.close()
+        finally:
+            pgduck_conn.rollback()
+
+    assert observed_id is not None
+
+
+def test_query_progress_returns_active_query(s3, pgduck_conn):
+    """
+    pg_lake_query_progress(connection_id) returns one row carrying the
+    executor's progress for the matching session. The numeric columns
+    reflect whatever the executor has populated; for queries without a
+    measurable scan they are -1 / 0 but the row still appears.
+    """
+    sleep_conn = psycopg2.connect(
+        host=server_params.PGDUCK_UNIX_DOMAIN_PATH,
+        port=server_params.PGDUCK_PORT,
+        async_=1,
+    )
+    wait_for_connection(sleep_conn)
+
+    sleep_query = "SELECT pg_lake_sleep(10)"
+    sleep_cur = sleep_conn.cursor()
+    sleep_cur.execute(sleep_query)
+
+    try:
+        sleep_connection_id = None
+        progress_row = None
+        while True:
+            state = sleep_conn.poll()
+
+            stat = run_query(
+                "SELECT connection_id FROM pg_lake_stat_activity() "
+                "WHERE query LIKE '%pg_lake_sleep%' "
+                "  AND query NOT LIKE '%query_progress%'",
+                pgduck_conn,
+            )
+            if len(stat) == 1:
+                sleep_connection_id = stat[0][0]
+
+                progress = run_query(
+                    f"SELECT percentage, rows_processed, total_rows_to_process "
+                    f"FROM pg_lake_query_progress({sleep_connection_id})",
+                    pgduck_conn,
+                )
+                if len(progress) == 1:
+                    progress_row = progress[0]
+                    break
+
+            if state == psycopg2.extensions.POLL_OK:
+                pytest.fail("sleep query finished before progress was observed")
+
+            time.sleep(0.05)
+
+        sleep_conn.cancel()
+    finally:
+        try:
+            sleep_conn.close()
+        finally:
+            pgduck_conn.rollback()
+
+    assert progress_row is not None
+    percentage, rows_processed, total_rows = progress_row
+    assert isinstance(percentage, float)
+    assert rows_processed >= 0
+    assert total_rows >= 0
+
+
+def test_query_progress_unknown_id_returns_no_rows(s3, pgduck_conn):
+    """
+    pg_lake_query_progress(connection_id) returns no rows when no session
+    matches the requested id. Connection ids are positive socket fds, so
+    -1 is guaranteed never to match any active session.
+    """
+    result = run_query(
+        "SELECT percentage, rows_processed, total_rows_to_process "
+        "FROM pg_lake_query_progress(-1)",
+        pgduck_conn,
+    )
+    assert result == []
+
+
+def wait_for_connection(conn):
+    while True:
+        state = conn.poll()
+        if state == psycopg2.extensions.POLL_OK:
+            break
+        elif state == psycopg2.extensions.POLL_WRITE:
+            select.select([], [conn.fileno()], [])
+        elif state == psycopg2.extensions.POLL_READ:
+            select.select([conn.fileno()], [], [])
+        else:
+            raise psycopg2.OperationalError("poll() returned %s" % state)

--- a/pgduck_server/tests/pytests/test_query_progress.py
+++ b/pgduck_server/tests/pytests/test_query_progress.py
@@ -153,6 +153,27 @@ def test_query_progress_unknown_id_returns_no_rows(s3, pgduck_conn):
     assert result == []
 
 
+def test_query_progress_null_id_returns_no_rows(s3, pgduck_conn):
+    """
+    A NULL connection_id matches no session, so the function returns no rows.
+
+    This is a regression test for a server crash rather than a nicety: the
+    NULL constant reaches the bind phase, and reading it with GetValue throws
+    an InternalException, which pgduck_server classifies as unrecoverable and
+    answers by terminating the whole process. Any client could take the server
+    down with a single statement. The follow-up query is what actually proves
+    the server survived.
+    """
+    result = run_query(
+        "SELECT percentage, rows_processed, total_rows_to_process "
+        "FROM pg_lake_query_progress(NULL)",
+        pgduck_conn,
+    )
+    assert result == []
+
+    assert run_query("SELECT 1", pgduck_conn) == [(1,)]
+
+
 def cancel_and_wait(sleep_conn, pgduck_conn):
     """
     Cancel the sleeping session and wait until the server stops reporting it.

--- a/pgduck_server/tests/pytests/test_query_progress.py
+++ b/pgduck_server/tests/pytests/test_query_progress.py
@@ -8,8 +8,9 @@ from utils_pytest import *
 def test_connection_id_matches_stat_activity(s3, pgduck_conn):
     """
     pg_lake_connection_id returns the current session's connection
-    identifier. The same identifier shows up in the connection_id column of
-    pg_lake_stat_activity when the session has an active query.
+    identifier. That is the same value libpq reports as PQbackendPID, and the
+    same value that shows up in the connection_id column of
+    pg_lake_stat_activity while the session has an active query.
     """
     sleep_conn = psycopg2.connect(
         host=server_params.PGDUCK_UNIX_DOMAIN_PATH,
@@ -18,9 +19,19 @@ def test_connection_id_matches_stat_activity(s3, pgduck_conn):
     )
     wait_for_connection(sleep_conn)
 
-    sleep_query = "SELECT pg_lake_connection_id() AS my_id, pg_lake_sleep(10) AS slept"
+    # Read the id from the session itself first, so we have something to
+    # compare the stat_activity row against. The sleep query below never
+    # returns, so we cannot read it from there.
     sleep_cur = sleep_conn.cursor()
-    sleep_cur.execute(sleep_query)
+    sleep_cur.execute("SELECT pg_lake_connection_id()")
+    wait_for_connection(sleep_conn)
+    my_id = sleep_cur.fetchone()[0]
+
+    # pgduck seeds the DuckDB-side connection id from the cancellation proc
+    # id it sends in BackendKeyData, which is what libpq exposes here.
+    assert my_id == sleep_conn.get_backend_pid()
+
+    sleep_cur.execute("SELECT pg_lake_sleep(10)")
 
     try:
         observed_id = None
@@ -43,14 +54,14 @@ def test_connection_id_matches_stat_activity(s3, pgduck_conn):
 
             time.sleep(0.05)
 
-        sleep_conn.cancel()
+        cancel_and_wait(sleep_conn, pgduck_conn)
     finally:
         try:
             sleep_conn.close()
         finally:
             pgduck_conn.rollback()
 
-    assert observed_id is not None
+    assert observed_id == my_id
 
 
 def test_query_progress_returns_active_query(s3, pgduck_conn):
@@ -100,7 +111,7 @@ def test_query_progress_returns_active_query(s3, pgduck_conn):
 
             time.sleep(0.05)
 
-        sleep_conn.cancel()
+        cancel_and_wait(sleep_conn, pgduck_conn)
     finally:
         try:
             sleep_conn.close()
@@ -117,15 +128,55 @@ def test_query_progress_returns_active_query(s3, pgduck_conn):
 def test_query_progress_unknown_id_returns_no_rows(s3, pgduck_conn):
     """
     pg_lake_query_progress(connection_id) returns no rows when no session
-    matches the requested id. Connection ids are positive socket fds, so
-    -1 is guaranteed never to match any active session.
+    matches the requested id. Connection ids come from the random int32 the
+    server generates for the cancellation key, so rather than assuming a
+    particular value is unused we pick one that is not currently reported by
+    pg_lake_stat_activity. Both functions only consider sessions with an
+    active query, so an id missing there cannot match here either.
     """
+    active_ids = {
+        row[0]
+        for row in run_query(
+            "SELECT connection_id FROM pg_lake_stat_activity()", pgduck_conn
+        )
+    }
+
+    unused_id = -1
+    while unused_id in active_ids:
+        unused_id -= 1
+
     result = run_query(
         "SELECT percentage, rows_processed, total_rows_to_process "
-        "FROM pg_lake_query_progress(-1)",
+        f"FROM pg_lake_query_progress({unused_id})",
         pgduck_conn,
     )
     assert result == []
+
+
+def cancel_and_wait(sleep_conn, pgduck_conn):
+    """
+    Cancel the sleeping session and wait until the server stops reporting it.
+
+    Closing the connection right after cancel() is not enough: the session can
+    still be running its sleep when the next test starts, and a test that
+    expects a single row in pg_lake_stat_activity then sees two. pg_lake_sleep
+    checks for interrupts every 10ms, so the wait is short.
+    """
+    sleep_conn.cancel()
+
+    for _ in range(600):
+        remaining = run_query(
+            "SELECT 1 FROM pg_lake_stat_activity() "
+            "WHERE query LIKE '%pg_lake_sleep%' "
+            "  AND query NOT LIKE '%stat_activity%'",
+            pgduck_conn,
+        )
+        if not remaining:
+            return
+
+        time.sleep(0.05)
+
+    pytest.fail("cancelled sleep session is still reported by pg_lake_stat_activity")
 
 
 def wait_for_connection(conn):

--- a/pgduck_server/tests/pytests/test_query_progress.py
+++ b/pgduck_server/tests/pytests/test_query_progress.py
@@ -174,6 +174,85 @@ def test_query_progress_null_id_returns_no_rows(s3, pgduck_conn):
     assert run_query("SELECT 1", pgduck_conn)[0][0] == 1
 
 
+def test_prepared_statement_can_be_executed_more_than_once(s3, pgduck_conn):
+    """
+    Prepared statements over pg_lake_query_progress and pg_lake_stat_activity
+    return rows on every execution, not only the first.
+
+    Both functions used to keep their scan state in bind data: the "already
+    produced my rows" flag, and stat_activity's snapshot of the connection
+    list. DuckDB binds once per plan and reuses that bind data for every
+    execution, so the second EXECUTE found the flag already set and returned
+    nothing. The state belongs in a GlobalTableFunctionState, which is created
+    per execution.
+    """
+    sleep_conn = psycopg2.connect(
+        host=server_params.PGDUCK_UNIX_DOMAIN_PATH,
+        port=server_params.PGDUCK_PORT,
+        async_=1,
+    )
+    wait_for_connection(sleep_conn)
+
+    sleep_cur = sleep_conn.cursor()
+    sleep_cur.execute("SELECT pg_lake_sleep(10)")
+
+    try:
+        sleep_connection_id = wait_for_sleep_session(sleep_conn, pgduck_conn)
+
+        cur = pgduck_conn.cursor()
+        cur.execute(
+            "PREPARE reused_progress AS "
+            "SELECT percentage, rows_processed, total_rows_to_process "
+            f"FROM pg_lake_query_progress({sleep_connection_id})"
+        )
+        cur.execute(
+            "PREPARE reused_activity AS "
+            "SELECT connection_id FROM pg_lake_stat_activity()"
+        )
+        cur.close()
+
+        for execution in range(1, 4):
+            progress = run_query("EXECUTE reused_progress", pgduck_conn)
+            assert (
+                len(progress) == 1
+            ), f"execution {execution} of reused_progress returned {len(progress)} rows"
+
+            activity = run_query("EXECUTE reused_activity", pgduck_conn)
+            assert sleep_connection_id in [
+                row[0] for row in activity
+            ], f"execution {execution} of reused_activity lost the sleeping session"
+
+        cancel_and_wait(sleep_conn, pgduck_conn)
+    finally:
+        try:
+            sleep_conn.close()
+        finally:
+            pgduck_conn.rollback()
+
+
+def wait_for_sleep_session(sleep_conn, pgduck_conn):
+    """
+    Wait until pg_lake_stat_activity reports the sleeping session and return
+    its connection id.
+    """
+    while True:
+        state = sleep_conn.poll()
+
+        stat = run_query(
+            "SELECT connection_id FROM pg_lake_stat_activity() "
+            "WHERE query LIKE '%pg_lake_sleep%' "
+            "  AND query NOT LIKE '%stat_activity%'",
+            pgduck_conn,
+        )
+        if len(stat) == 1:
+            return stat[0][0]
+
+        if state == psycopg2.extensions.POLL_OK:
+            pytest.fail("sleep query finished before stat_activity reported it")
+
+        time.sleep(0.05)
+
+
 def cancel_and_wait(sleep_conn, pgduck_conn):
     """
     Cancel the sleeping session and wait until the server stops reporting it.

--- a/pgduck_server/tests/pytests/test_query_progress.py
+++ b/pgduck_server/tests/pytests/test_query_progress.py
@@ -171,7 +171,7 @@ def test_query_progress_null_id_returns_no_rows(s3, pgduck_conn):
     )
     assert result == []
 
-    assert run_query("SELECT 1", pgduck_conn) == [(1,)]
+    assert run_query("SELECT 1", pgduck_conn)[0][0] == 1
 
 
 def cancel_and_wait(sleep_conn, pgduck_conn):


### PR DESCRIPTION
## Problem

DuckDB's executor already tracks per-query progress (`ClientContext::query_progress`, populated when `enable_progress_bar` is on), but the only way to read it from outside the running query was to call `duckdb_query_progress` against the *same* `duckdb_connection`. There is no SQL surface for asking another session's progress, which makes it impossible for a sidecar / monitor connection to report on a running query.

## Solution

Two new SQL functions registered by the `duckdb_pglake` extension:

```sql
-- the connection_id pgduck_server assigned to this session
-- (the same value libpq's PQbackendPID returns to the client)
SELECT pg_lake_connection_id();

-- progress for one specific session, identified by connection_id
SELECT percentage, rows_processed, total_rows_to_process
FROM pg_lake_query_progress(42);
```

`pg_lake_query_progress(connection_id)` iterates the `ConnectionManager`'s connection list (the same pattern `pg_lake_stat_activity` uses), finds the session whose `PgLakeQueryListener.connectionId` matches the argument, and returns one row with the values from `ClientContext::GetQueryProgress()`. The result is empty when no session has the requested id or the matching session has no active query. Returning by id rather than as a global list keeps this function orthogonal to whatever shape `pg_lake_stat_activity` evolves into; if we later want progress alongside the activity columns we can extend `pg_lake_stat_activity` itself.

The aggregator only measures source-side scans — postgres_scan, parquet, csv, and so on (a source with no `table_scan_progress` callback, such as `range`, reports nothing and leaves the numbers at the executor's first estimate). Sinks (CSV serialization, S3 multipart upload, parquet writer flush, COPY TO) and post-scan operators (sort, join, aggregate beyond their input) are not measured. The percentage therefore tracks "how much of the source has been read", not wall-clock progress; for `COPY (SELECT FROM postgres_scan(...)) TO ...` the bar can sit pinned near 100% while the destination side is still flushing.

`pg_lake_connection_id()` reads the current `ClientContext`'s `PgLakeQueryListener.connectionId`. Behind the scenes, pgduck_server now seeds that identifier from the cancellation proc id (the random int32 it already sends in `BackendKeyData`) instead of the raw client socket fd. That unifies the value with libpq's `PQbackendPID`, makes `pg_lake_stat_activity` look more like real postgres `pg_stat_activity`, and avoids the rapid fd recycling that would otherwise let a stat snapshot taken across a couple of disconnect/reconnect cycles show the same "id" for two different sessions.

`duckdb_pglake_init_connection` also enables `enable_progress_bar` by default for every new pgduck session and disables `print_progress_bar` (no terminal to render to). Without this default the new function would silently return `-1 / 0 / 0` even though everything else is wired up; turning the bar on lets the executor populate `ClientContext::query_progress` from the first executor task onwards. `wait_time` does not delay that — it only decides when a bar would start *printing* — so the cost of the default is one walk over the executor's pipelines per task iteration, paid by every session. Clients can still issue `SET enable_progress_bar = false` per session to opt back out.

The progress struct's fields are atomic and DuckDB documents `GetQueryProgress` as safe to call from another thread, which is the same access pattern used by the C-API `duckdb_query_progress`.

## Test plan

- [x] CI: `pgduck_server/tests/pytests/test_query_progress.py` covers both functions. It asserts `pg_lake_connection_id()` equals what libpq reports as `PQbackendPID` for the same session, that the id shows up in `pg_lake_stat_activity`, that an id no session is using returns no rows, and that a NULL id returns no rows without taking the server down.
- [x] Manual smoke test: with two psql sessions, A running `COPY (SELECT FROM postgres_scan(...)) TO ...` (no manual SET) and B querying `pg_lake_query_progress(<id-from-stat-activity>)`, the percentage advances.
- [x] Manual smoke test on a 40-file, 120M-row parquet glob: `percentage` and `rows_processed` track the scan (99.99 / 120000000 / 120000002 mid-query), and the row disappears once the query ends.
- [x] Full `pgduck_server` pytest suite passes locally (173 tests).

