### PR TITLE
Fix data race on PgLakeQueryListener active query state

### DIFF
--- a/duckdb_pglake/src/include/pg_lake/query_listener.hpp
+++ b/duckdb_pglake/src/include/pg_lake/query_listener.hpp
@@ -17,30 +17,68 @@
 
 #pragma once
 
+#include <mutex>
+
 namespace duckdb {
 
 /*
- * PgLakeQueryListener can be used to safely get the query
- * string from a ClientContext. GetCurrentQuery is only safe to call
- * while a query is active.
+ * PgLakeQueryListener tracks the active query for one DuckDB ClientContext
+ * so that pg_lake_stat_activity (and similar inspection functions) can
+ * report it from a different connection.
+ *
+ * QueryBegin / QueryEnd run on the session's own thread.  GetActiveQuery
+ * runs on whatever thread the caller is on -- typically a different
+ * session iterating ConnectionManager::GetConnectionList().  The query
+ * string and start timestamp are mutated on every QueryBegin / QueryEnd,
+ * so a concurrent direct read is a data race; std::string in particular
+ * is undefined behaviour to read while another thread writes to it.
+ *
+ * The mutex protects the (is_active, active_query, active_start) triple.
+ * connectionId is set once during duckdb_pglake_init_connection and
+ * never modified afterwards, so it is safe to read directly.
  */
 struct PgLakeQueryListener : public ClientContextState {
-	int64_t connectionId;
-
-	bool isQueryActive;
-	string queryString;
-	timestamp_t queryStart;
+	int64_t connectionId = 0;
 
 	void QueryBegin(ClientContext &context) override {
-		isQueryActive = true;
-		queryString = context.GetCurrentQuery();
-		queryStart = Timestamp::GetCurrentTimestamp();
+		std::lock_guard<std::mutex> lock(active_mutex);
+		is_active = true;
+		active_query = context.GetCurrentQuery();
+		active_start = Timestamp::GetCurrentTimestamp();
 	}
 
 	void QueryEnd(ClientContext &context) override {
-		isQueryActive = false;
-		queryString = "";
+		std::lock_guard<std::mutex> lock(active_mutex);
+		is_active = false;
+		active_query.clear();
 	}
+
+	//! Snapshot the active query state under the listener's mutex.
+	//! Returns true and fills out_query / out_start when a query is
+	//! currently running; returns false otherwise.  Safe to call from
+	//! any thread.
+	bool GetActiveQuery(string &out_query, timestamp_t &out_start) const {
+		std::lock_guard<std::mutex> lock(active_mutex);
+		if (!is_active) {
+			return false;
+		}
+		out_query = active_query;
+		out_start = active_start;
+		return true;
+	}
+
+	//! Cheap probe of the active flag without copying the query string.
+	//! Held briefly under the same mutex as GetActiveQuery.
+	bool IsQueryActive() const {
+		std::lock_guard<std::mutex> lock(active_mutex);
+		return is_active;
+	}
+
+private:
+	mutable std::mutex active_mutex;
+	bool is_active = false;
+	string active_query;
+	timestamp_t active_start = timestamp_t(0);
 };
 
 

--- a/duckdb_pglake/src/utility_functions.cpp
+++ b/duckdb_pglake/src/utility_functions.cpp
@@ -33,8 +33,8 @@ struct StatActivityFunctionData : public TableFunctionData
 {
 	/* Function state */
 	vector<shared_ptr<ClientContext>> connections;
-	int offset;
-	bool finished = false;
+	idx_t		offset = 0;
+	bool		finished = false;
 };
 
 
@@ -63,6 +63,26 @@ static unique_ptr<FunctionData> StatActivityBind(ClientContext &context,
 
 /*
  * StatActivityExecute implements the execution for pg_lake_stat_activity.
+ *
+ * We are iterating connections from a thread that is not the one running
+ * any of the inspected sessions.  Two pieces of inspected state need
+ * care:
+ *
+ * 1. The PgLakeQueryListener's query string and start timestamp are
+ *    mutated on every QueryBegin / QueryEnd on the session's own thread.
+ *    GetActiveQuery reads them under the listener's mutex and returns
+ *    false when no query is active, so sessions that start or end a
+ *    query mid-iteration are simply skipped.
+ *
+ * 2. ClientContext::ExecutionIsFinished is not safe to call from another
+ *    thread: it reads the ClientContext's active_query unique_ptr, which
+ *    the owning session resets in QueryEnd.  We previously used it as a
+ *    cheap "is a query running" probe; the listener's GetActiveQuery
+ *    already answers that question safely, so the ExecutionIsFinished
+ *    call is removed.
+ *
+ * connectionId is set once at session initialization and never modified
+ * afterwards, so it is safe to read directly.
  */
 static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &functionData = (StatActivityFunctionData &)*data_p.bind_data;
@@ -81,16 +101,19 @@ static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p,
 	while (functionData.offset< functionData.connections.size() && rowsInChunk < STANDARD_VECTOR_SIZE) {
 		shared_ptr<ClientContext> connection = functionData.connections[functionData.offset];
 
-		if (connection && !connection->ExecutionIsFinished())
+		if (connection)
 		{
 			shared_ptr<PgLakeQueryListener> queryListener =
 				connection->registered_state->Get<PgLakeQueryListener>("pg_lake_query_listener");
 
-			if (queryListener && queryListener->isQueryActive)
+			string activeQuery;
+			timestamp_t activeStart;
+
+			if (queryListener && queryListener->GetActiveQuery(activeQuery, activeStart))
 			{
 				output.SetValue(0, rowsInChunk, Value::BIGINT(queryListener->connectionId));
-				output.SetValue(1, rowsInChunk, Value(queryListener->queryString));
-				output.SetValue(2, rowsInChunk, Value::TIMESTAMP(queryListener->queryStart));
+				output.SetValue(1, rowsInChunk, Value(activeQuery));
+				output.SetValue(2, rowsInChunk, Value::TIMESTAMP(activeStart));
 
 				rowsInChunk++;
 			}

--- a/pgduck_server/tests/pytests/test_stat_activity.py
+++ b/pgduck_server/tests/pytests/test_stat_activity.py
@@ -59,3 +59,116 @@ def wait_for_connection(conn):
             select.select([conn.fileno()], [], [])
         else:
             raise psycopg2.OperationalError("poll() returned %s" % state)
+
+
+# Regression test for https://github.com/Snowflake-Labs/pg_lake/issues/148:
+# running pg_lake_stat_activity() concurrently from several pgbench clients
+# used to crash pgduck_server because StatActivityExec read another
+# session's PgLakeQueryListener fields and called ClientContext::
+# ExecutionIsFinished() across threads. Both reads now go through
+# thread-safe paths, and the test fails if pgduck_server crashes (pgbench
+# starts reporting connection errors and exits non-zero).
+def test_stat_activity_concurrent_pgbench(s3, pgduck_server):
+    file_path = "/tmp/stat_activity_concurrent.sql"
+    with open(file_path, "w") as f:
+        f.write("SELECT count(*) FROM pg_lake_stat_activity();\n")
+
+    returncode, stdout, stderr = run_pgbench_command(
+        [
+            "-n",
+            "-c",
+            "4",
+            "-j",
+            "2",
+            "-T",
+            "5",
+            "-f",
+            file_path,
+            "-h",
+            server_params.PGDUCK_UNIX_DOMAIN_PATH,
+            "-p",
+            str(server_params.PGDUCK_PORT),
+        ]
+    )
+
+    assert returncode == 0, (
+        f"pgbench against pg_lake_stat_activity() failed; "
+        f"stdout=\n{stdout}\nstderr=\n{stderr}"
+    )
+    assert "number of transactions actually processed" in stdout, stdout
+    # All transactions must succeed; a crashed pgduck_server shows up as
+    # "number of failed transactions" > 0 or a non-zero return code.
+    assert "number of failed transactions: 0" in stdout, stdout
+
+    # The server must still be reachable after the stress run.
+    run_simple_command(server_params.PGDUCK_UNIX_DOMAIN_PATH, server_params.PGDUCK_PORT)
+
+
+# Companion repro for the second scenario described in issue #148: a
+# single client looping over pg_lake_stat_activity() while a wider fleet
+# of pgbench clients hammers pgduck_server with cheap queries. The
+# stat_activity caller iterates ConnectionManager::GetConnectionList()
+# while many sessions are racing through QueryBegin / QueryEnd, which
+# was the original trigger okalaci observed.
+def test_stat_activity_under_background_load(s3, pgduck_server):
+    import subprocess
+
+    background_sql = "/tmp/stat_activity_background.sql"
+    foreground_sql = "/tmp/stat_activity_foreground.sql"
+    with open(background_sql, "w") as f:
+        f.write("SELECT 1;\n")
+    with open(foreground_sql, "w") as f:
+        f.write("SELECT count(*) FROM pg_lake_stat_activity();\n")
+
+    background = subprocess.Popen(
+        [
+            "pgbench",
+            "-n",
+            "-c",
+            "16",
+            "-j",
+            "4",
+            "-T",
+            "5",
+            "-f",
+            background_sql,
+            "-h",
+            server_params.PGDUCK_UNIX_DOMAIN_PATH,
+            "-p",
+            str(server_params.PGDUCK_PORT),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    returncode, stdout, stderr = run_pgbench_command(
+        [
+            "-n",
+            "-c",
+            "1",
+            "-j",
+            "1",
+            "-T",
+            "5",
+            "-f",
+            foreground_sql,
+            "-h",
+            server_params.PGDUCK_UNIX_DOMAIN_PATH,
+            "-p",
+            str(server_params.PGDUCK_PORT),
+        ]
+    )
+
+    bg_stdout, bg_stderr = background.communicate()
+    bg_returncode = background.returncode
+
+    assert (
+        returncode == 0
+    ), f"foreground pgbench failed; stdout=\n{stdout}\nstderr=\n{stderr}"
+    assert "number of failed transactions: 0" in stdout, stdout
+    assert bg_returncode == 0, (
+        f"background pgbench failed; stdout=\n{bg_stdout.decode()}\n"
+        f"stderr=\n{bg_stderr.decode()}"
+    )
+
+    run_simple_command(server_params.PGDUCK_UNIX_DOMAIN_PATH, server_params.PGDUCK_PORT)


### PR DESCRIPTION
## Problem

`pg_lake_stat_activity` iterates DuckDB's `ConnectionManager::GetConnectionList()` from a thread that is not the one running any of the inspected sessions. Two reads in that loop are unsafe:

1. `PgLakeQueryListener::queryString` and `queryStart` are mutated by the listener's `QueryBegin` and `QueryEnd` hooks on every query boundary, on the session's own thread. Reading those fields from another thread is a data race; for `std::string` it is undefined behaviour because the small-string-optimised buffer can be read mid-write.

2. `connection->ExecutionIsFinished()` calls `ClientContext::ExecutionIsFinished`, which reads the `active_query` unique_ptr. The owning session resets that unique_ptr in `QueryEnd`. That deref is what the [issue #148](https://github.com/Snowflake-Labs/pg_lake/issues/148) stack trace points at:

```
2  duckdb::unique_ptr<duckdb::Expression, ...>::operator->() const + 92
3  duckdb::ClientContext::ExecutionIsFinished() + 56
4  duckdb::StatActivityExec(...) + 160
```

`StatActivityFunctionData::offset` was also declared `int offset;` with no initializer. The first iteration relies on `offset == 0` to populate the connection list; relying on heap zero-initialisation of `make_uniq` is fragile.

## Solution

- Move `(is_active, active_query, active_start)` on `PgLakeQueryListener` behind a `std::mutex` and expose a `GetActiveQuery(out_query, out_start)` getter that returns a consistent snapshot under the lock. `connectionId` stays a public field because it is set exactly once during `duckdb_pglake_init_connection` and never modified afterwards.
- Drop the `connection->ExecutionIsFinished()` check entirely. The listener's `is_active` flag (set in `QueryBegin`, cleared in `QueryEnd`) already filters to sessions with an active query, so the cross-thread `ExecutionIsFinished` call was a redundant probe that happened to be unsafe.
- Initialise `StatActivityFunctionData::offset` to `0`.

Sessions that start or end a query mid-iteration are simply skipped, which is the same observable behaviour as the racy version on the lucky path.

## Test plan

- [x] Build clean against the existing `test_stat_activity.py` workload.
- [x] Adds `test_stat_activity_concurrent_pgbench`: pgbench `-c 4 -j 2 -T 5` running `SELECT count(*) FROM pg_lake_stat_activity();` against pgduck_server. This is a scaled-down version of the issue's repro (`-c 2 -j 2 -P 1 -T 30`). The test fails if pgduck_server crashes or any pgbench transaction fails.
- [x] Adds `test_stat_activity_under_background_load`: one client running `pg_lake_stat_activity()` alongside 16 clients running `SELECT 1`. This is the follow-up scenario [sfc-gh-okalaci](https://github.com/Snowflake-Labs/pg_lake/issues/148#issuecomment-3742368222) described, where the stat_activity caller races against many sessions transitioning through `QueryBegin` / `QueryEnd`.

Fixes #148