### PR TITLE
Add pg_lake_polaris extension for two-way Polaris sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # when adding a new extension, add to this list to get the standard targets supported
-EXTENSION_TARGETS = pg_extension_base pg_map pg_extension_updater pg_lake_engine pg_lake_copy pg_lake_table pg_lake_iceberg pg_lake_spatial pg_lake pg_lake_benchmark
+EXTENSION_TARGETS = pg_extension_base pg_map pg_extension_updater pg_lake_engine pg_lake_copy pg_lake_table pg_lake_iceberg pg_lake_spatial pg_lake pg_lake_benchmark pg_lake_polaris
 DUCK_TARGETS = pgduck_server duckdb_pglake
 ALL_TARGETS = $(DUCK_TARGETS) avro $(EXTENSION_TARGETS)
 
@@ -149,6 +149,12 @@ pg_lake_benchmark: pg_lake
 
 install-pg_lake_benchmark: install-pg_lake pg_lake_benchmark
 	$(MAKE) -C pg_lake_benchmark install
+
+pg_lake_polaris: pg_lake
+	$(MAKE) -C pg_lake_polaris
+
+install-pg_lake_polaris: install-pg_lake pg_lake_polaris
+	$(MAKE) -C pg_lake_polaris install
 
 duckdb_pglake:
 	@if [ $(DUCKDB_BUILD_USE_CACHE) -eq 1 ] && [ -f $(PG_LIBDIR)/$(LIB_NAME) ] && [ -f $(PG_INCLUDEDIR)/duckdb.h ]; then \

--- a/pg_lake_polaris/Makefile
+++ b/pg_lake_polaris/Makefile
@@ -1,0 +1,26 @@
+EXTENSION = pg_lake_polaris
+
+MODULE_big = $(EXTENSION)
+
+DATA = $(EXTENSION)--0.1.sql
+SOURCES := $(wildcard src/*.c)
+OBJS := $(patsubst %.c,%.o,$(sort $(SOURCES)))
+
+PG_CPPFLAGS = -Iinclude -std=gnu99 -g
+
+PG_CONFIG ?= pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+USE_PGXS=1
+include $(PGXS)
+
+include ../shared.mk
+
+.PHONY: check
+check:
+	@echo "Running Python tests..."
+	PYTHONPATH=../test_common pipenv run pytest -v tests/pytests
+
+.PHONY: installcheck
+installcheck:
+	@echo "Running Python tests..."
+	PGDUCK_PORT=5332 PYTHONPATH=../test_common pipenv run pytest -v tests/pytests --installcheck

--- a/pg_lake_polaris/include/pg_lake/pg_lake_polaris.h
+++ b/pg_lake_polaris/include/pg_lake/pg_lake_polaris.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PG_LAKE_POLARIS_H
+#define PG_LAKE_POLARIS_H
+
+#include "postgres.h"
+
+/*
+ * Process-global flag that suppresses both the outbound and inbound triggers
+ * while one of them is running, to break the round-trip loop between
+ * lake_iceberg.tables_internal and polaris_schema.entities. Set in PG_TRY,
+ * restored in PG_FINALLY.
+ *
+ * Mirrors the SkipIcebergDDLProcessing pattern in pg_lake_table.
+ */
+extern bool PgLakePolarisSuppress;
+
+#endif							/* PG_LAKE_POLARIS_H */

--- a/pg_lake_polaris/pg_lake_polaris--0.1.sql
+++ b/pg_lake_polaris/pg_lake_polaris--0.1.sql
@@ -1,0 +1,764 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_lake_polaris" to load this file. \quit
+
+
+/*
+ * Schema and bookkeeping tables. The schema is created by the .control
+ * file's `schema = lake_polaris`.
+ */
+
+CREATE TABLE lake_polaris.catalog_mapping (
+    pg_database name PRIMARY KEY,
+    polaris_catalog_name text NOT NULL,
+    polaris_catalog_id bigint NOT NULL,
+    polaris_realm_id text NOT NULL,
+    enabled boolean NOT NULL DEFAULT true
+);
+
+CREATE TABLE lake_polaris.entity_link (
+    pg_table_oid regclass PRIMARY KEY,
+    polaris_entity_id bigint NOT NULL UNIQUE,
+    polaris_namespace_id bigint NOT NULL,
+    last_seen_metadata_location text
+);
+
+
+/*
+ * Suppress flag wrappers (C functions). These are read/written by the SQL
+ * trigger functions to break the round-trip loop between the outbound
+ * trigger on lake_iceberg.tables_internal and the inbound trigger on
+ * polaris_schema.entities.
+ */
+
+CREATE FUNCTION lake_polaris.is_suppressed()
+    RETURNS boolean
+    LANGUAGE C STABLE STRICT
+    AS 'MODULE_PATHNAME', 'pg_lake_polaris_is_suppressed';
+
+CREATE FUNCTION lake_polaris.set_suppressed(new_value boolean)
+    RETURNS boolean
+    LANGUAGE C VOLATILE STRICT
+    AS 'MODULE_PATHNAME', 'pg_lake_polaris_set_suppressed';
+
+
+/*
+ * Type-code constants. Mirror Apache Polaris's PolarisEntityType enum.
+ *   CATALOG     = 4
+ *   NAMESPACE   = 6
+ *   TABLE_LIKE  = 7
+ *
+ * Sub-type for an Iceberg table is 2 (PolarisEntitySubType.ICEBERG_TABLE).
+ */
+CREATE FUNCTION lake_polaris.type_code_catalog()    RETURNS int LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT 4 $$;
+CREATE FUNCTION lake_polaris.type_code_namespace()  RETURNS int LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT 6 $$;
+CREATE FUNCTION lake_polaris.type_code_table_like() RETURNS int LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT 7 $$;
+CREATE FUNCTION lake_polaris.sub_type_iceberg()     RETURNS int LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT 2 $$;
+
+
+/*
+ * Helper: derive the storage prefix from a metadata location URI.
+ *
+ * Iceberg metadata files live at <prefix>/metadata/<n>-<uuid>.metadata.json.
+ * Polaris stores the prefix (without the /metadata/... suffix) in the
+ * `location` field of the table entity.
+ */
+CREATE FUNCTION lake_polaris.location_from_metadata(metadata_location text)
+    RETURNS text
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$
+        SELECT regexp_replace(metadata_location,
+                              '(.*?/)(metadata/[^/]*\.metadata\.json)$',
+                              '\1')
+    $$;
+
+
+/*
+ * outbound_get_or_create_namespace ensures a namespace entity exists in
+ * polaris_schema.entities for the given Postgres schema name, parented at
+ * the configured catalog. Returns the namespace's polaris id.
+ *
+ * The namespace's `location` property mirrors the table's location prefix
+ * so Polaris can serve it for `loadNamespaceMetadata`. We use the table's
+ * prefix because there's no separate per-schema location concept on the
+ * pg_lake side.
+ */
+CREATE FUNCTION lake_polaris.outbound_get_or_create_namespace(
+    p_catalog_id bigint,
+    p_realm_id text,
+    p_namespace_name text,
+    p_location text)
+    RETURNS bigint
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_namespace_id bigint;
+    v_now bigint := (extract(epoch FROM clock_timestamp()) * 1000)::bigint;
+BEGIN
+    SELECT id INTO v_namespace_id
+    FROM polaris_schema.entities
+    WHERE realm_id = p_realm_id
+      AND catalog_id = p_catalog_id
+      AND parent_id = p_catalog_id
+      AND type_code = lake_polaris.type_code_namespace()
+      AND name = p_namespace_name
+    FOR UPDATE;
+
+    IF FOUND THEN
+        RETURN v_namespace_id;
+    END IF;
+
+    /*
+     * v0.1 limitation: random ids may collide with Polaris's own allocator
+     * if Polaris itself is allocating ids concurrently. The unique
+     * constraint on (realm_id, id) will catch collisions; we don't retry
+     * here, so registration must be done while Polaris is quiescent.
+     */
+    v_namespace_id := (random() * 9223372036854775807)::bigint;
+
+    INSERT INTO polaris_schema.entities (
+        realm_id, catalog_id, id, parent_id, name, entity_version,
+        type_code, sub_type_code, create_timestamp, drop_timestamp,
+        purge_timestamp, to_purge_timestamp, last_update_timestamp,
+        properties, internal_properties, grant_records_version)
+    VALUES (
+        p_realm_id, p_catalog_id, v_namespace_id, p_catalog_id,
+        p_namespace_name, 1, lake_polaris.type_code_namespace(), 0,
+        v_now, 0, 0, 0, v_now,
+        jsonb_build_object('location', p_location)::text,
+        '{}'::text, 1);
+
+    RETURN v_namespace_id;
+END;
+$function$;
+
+
+/*
+ * outbound_sync writes (or refreshes) a Polaris entity row for the given
+ * pg_lake table. Idempotent: safe to call on every INSERT/UPDATE of a
+ * tables_internal row.
+ *
+ * Bumps entity_version on update so Polaris's optimistic-concurrency
+ * checks notice the change.
+ */
+CREATE FUNCTION lake_polaris.outbound_sync(p_table_oid regclass)
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_mapping lake_polaris.catalog_mapping%ROWTYPE;
+    v_namespace_name text;
+    v_table_name text;
+    v_metadata_location text;
+    v_location text;
+    v_namespace_id bigint;
+    v_table_id bigint;
+    v_now bigint := (extract(epoch FROM clock_timestamp()) * 1000)::bigint;
+BEGIN
+    SELECT * INTO v_mapping
+    FROM lake_polaris.catalog_mapping
+    WHERE pg_database = current_database();
+
+    IF NOT FOUND OR NOT v_mapping.enabled THEN
+        RETURN;
+    END IF;
+
+    SELECT n.nspname, c.relname
+      INTO v_namespace_name, v_table_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.oid = p_table_oid;
+
+    IF v_namespace_name IS NULL THEN
+        RAISE EXCEPTION 'pg_lake_polaris: relation % no longer exists',
+            p_table_oid;
+    END IF;
+
+    SELECT metadata_location INTO v_metadata_location
+    FROM lake_iceberg.tables_internal
+    WHERE table_name = p_table_oid;
+
+    /*
+     * If metadata_location is NULL the table has been created but no
+     * metadata file has been written yet (CREATE TABLE without INSERT).
+     * Defer mirroring until the first metadata write fires the trigger
+     * again.
+     */
+    IF v_metadata_location IS NULL THEN
+        RETURN;
+    END IF;
+
+    v_location := lake_polaris.location_from_metadata(v_metadata_location);
+
+    v_namespace_id := lake_polaris.outbound_get_or_create_namespace(
+        v_mapping.polaris_catalog_id,
+        v_mapping.polaris_realm_id,
+        v_namespace_name,
+        v_location);
+
+    /* upsert the table entity */
+    SELECT polaris_entity_id INTO v_table_id
+    FROM lake_polaris.entity_link
+    WHERE pg_table_oid = p_table_oid;
+
+    IF v_table_id IS NULL THEN
+        v_table_id := (random() * 9223372036854775807)::bigint;
+
+        INSERT INTO polaris_schema.entities (
+            realm_id, catalog_id, id, parent_id, name, entity_version,
+            type_code, sub_type_code, create_timestamp, drop_timestamp,
+            purge_timestamp, to_purge_timestamp, last_update_timestamp,
+            properties, internal_properties, grant_records_version)
+        VALUES (
+            v_mapping.polaris_realm_id, v_mapping.polaris_catalog_id,
+            v_table_id, v_namespace_id, v_table_name, 1,
+            lake_polaris.type_code_table_like(),
+            lake_polaris.sub_type_iceberg(),
+            v_now, 0, 0, 0, v_now,
+            jsonb_build_object('location', v_location)::text,
+            jsonb_build_object('parent-namespace', v_namespace_name,
+                               'metadata-location', v_metadata_location)::text,
+            1);
+
+        INSERT INTO lake_polaris.entity_link
+            (pg_table_oid, polaris_entity_id, polaris_namespace_id,
+             last_seen_metadata_location)
+        VALUES
+            (p_table_oid, v_table_id, v_namespace_id, v_metadata_location);
+    ELSE
+        UPDATE polaris_schema.entities
+           SET entity_version = entity_version + 1,
+               internal_properties = jsonb_build_object(
+                    'parent-namespace', v_namespace_name,
+                    'metadata-location', v_metadata_location)::text,
+               properties = jsonb_build_object('location', v_location)::text,
+               last_update_timestamp = v_now
+         WHERE realm_id = v_mapping.polaris_realm_id
+           AND id = v_table_id;
+
+        UPDATE lake_polaris.entity_link
+           SET last_seen_metadata_location = v_metadata_location
+         WHERE pg_table_oid = p_table_oid;
+    END IF;
+END;
+$function$;
+
+
+/*
+ * outbound_remove deletes the Polaris entity row for a pg_lake table that
+ * has been dropped. The namespace entity is intentionally left in place —
+ * it may have been created out-of-band or hold other tables.
+ */
+CREATE FUNCTION lake_polaris.outbound_remove(p_table_oid regclass)
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_mapping lake_polaris.catalog_mapping%ROWTYPE;
+    v_link lake_polaris.entity_link%ROWTYPE;
+BEGIN
+    SELECT * INTO v_mapping
+    FROM lake_polaris.catalog_mapping
+    WHERE pg_database = current_database();
+
+    IF NOT FOUND OR NOT v_mapping.enabled THEN
+        RETURN;
+    END IF;
+
+    SELECT * INTO v_link
+    FROM lake_polaris.entity_link
+    WHERE pg_table_oid = p_table_oid;
+
+    IF NOT FOUND THEN
+        RETURN;
+    END IF;
+
+    DELETE FROM polaris_schema.entities
+     WHERE realm_id = v_mapping.polaris_realm_id
+       AND id = v_link.polaris_entity_id;
+
+    DELETE FROM lake_polaris.entity_link
+     WHERE pg_table_oid = p_table_oid;
+END;
+$function$;
+
+
+/*
+ * outbound_trigger fires AFTER each row change on
+ * lake_iceberg.tables_internal. It sets the suppress flag while writing
+ * to polaris_schema.entities to prevent the inbound trigger from firing
+ * a sync back into pg_lake.
+ *
+ * Skipped entirely when the suppress flag is already set (an inbound sync
+ * is in flight) or when the database has no catalog_mapping row.
+ */
+CREATE FUNCTION lake_polaris.outbound_trigger()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_old_suppress boolean;
+BEGIN
+    IF lake_polaris.is_suppressed() THEN
+        RETURN NULL;
+    END IF;
+
+    v_old_suppress := lake_polaris.set_suppressed(true);
+
+    BEGIN
+        IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+            PERFORM lake_polaris.outbound_sync(NEW.table_name);
+        ELSIF TG_OP = 'DELETE' THEN
+            PERFORM lake_polaris.outbound_remove(OLD.table_name);
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        PERFORM lake_polaris.set_suppressed(v_old_suppress);
+        RAISE;
+    END;
+
+    PERFORM lake_polaris.set_suppressed(v_old_suppress);
+    RETURN NULL;
+END;
+$function$;
+
+
+/*
+ * The trigger lives on a table owned by another extension. It still gets
+ * cleaned up by DROP EXTENSION CASCADE because it depends on
+ * lake_polaris.outbound_trigger(); the user has to use CASCADE because
+ * the trigger isn't owned by either extension's pg_extension row.
+ */
+CREATE TRIGGER outbound_trigger
+AFTER INSERT OR UPDATE OR DELETE ON lake_iceberg.tables_internal
+FOR EACH ROW EXECUTE FUNCTION lake_polaris.outbound_trigger();
+
+
+/*
+ * Inbound sync: react to changes that another Polaris client made to
+ * polaris_schema.entities (e.g., a Spark or PyIceberg client committing
+ * via Polaris's REST API).
+ *
+ * Three cases, keyed off the trigger event:
+ *
+ *   1. INSERT of a TABLE_LIKE entity not already in entity_link -> a new
+ *      Iceberg table appeared in Polaris that pg_lake doesn't know about.
+ *      Create a foreign table that points at it and run the existing
+ *      sync_iceberg_metadata_from_external_write() function.
+ *
+ *   2. UPDATE of a TABLE_LIKE entity already in entity_link, where the
+ *      metadata-location changed -> external commit. Update
+ *      lake_iceberg.tables_internal.metadata_location and re-run sync.
+ *
+ *   3. DELETE of a TABLE_LIKE entity in entity_link -> external client
+ *      dropped the table. Drop the corresponding foreign table.
+ *
+ * Loop prevention: bail out immediately when set_suppressed(true) is
+ * already in effect (the outbound trigger is in flight).
+ */
+
+
+/*
+ * inbound_sync_update applies a metadata_location change from Polaris to
+ * the pg_lake catalog. The PG_LAKE_TABLE function
+ * sync_iceberg_metadata_from_external_write() does the actual schema +
+ * data file resync; we just push the new location into tables_internal
+ * so it has somewhere to read from.
+ */
+CREATE FUNCTION lake_polaris.inbound_sync_update(
+    p_table_oid regclass,
+    p_metadata_location text)
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $function$
+BEGIN
+    UPDATE lake_iceberg.tables_internal
+       SET previous_metadata_location = metadata_location,
+           metadata_location = p_metadata_location
+     WHERE table_name = p_table_oid;
+
+    PERFORM lake_table.sync_iceberg_metadata_from_external_write(p_table_oid);
+
+    UPDATE lake_polaris.entity_link
+       SET last_seen_metadata_location = p_metadata_location
+     WHERE pg_table_oid = p_table_oid;
+END;
+$function$;
+
+
+/*
+ * inbound_sync_delete drops a foreign table that has been removed from
+ * Polaris.
+ */
+CREATE FUNCTION lake_polaris.inbound_sync_delete(p_table_oid regclass)
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_namespace_name text;
+    v_table_name text;
+    v_relkind char;
+BEGIN
+    SELECT n.nspname, c.relname, c.relkind
+      INTO v_namespace_name, v_table_name, v_relkind
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.oid = p_table_oid;
+
+    IF NOT FOUND THEN
+        DELETE FROM lake_polaris.entity_link WHERE pg_table_oid = p_table_oid;
+        RETURN;
+    END IF;
+
+    IF v_relkind = 'f' THEN
+        EXECUTE format('DROP FOREIGN TABLE %I.%I',
+                       v_namespace_name, v_table_name);
+    ELSE
+        EXECUTE format('DROP TABLE %I.%I',
+                       v_namespace_name, v_table_name);
+    END IF;
+
+    DELETE FROM lake_polaris.entity_link WHERE pg_table_oid = p_table_oid;
+END;
+$function$;
+
+
+/*
+ * inbound_sync_insert creates a new pg_lake foreign table for an Iceberg
+ * table that just appeared in Polaris. Reads the schema from the Iceberg
+ * metadata file and translates the columns to Postgres types.
+ *
+ * v0.1 limitation: only top-level scalar columns are supported. Tables
+ * whose Iceberg schema includes nested types (struct/list/map) will fail
+ * here; the user has to register them through pg_lake's normal
+ * CREATE TABLE flow first.
+ */
+CREATE FUNCTION lake_polaris.inbound_sync_insert(
+    p_namespace_name text,
+    p_table_name text,
+    p_metadata_location text,
+    p_polaris_entity_id bigint,
+    p_polaris_namespace_id bigint)
+    RETURNS regclass
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_metadata jsonb;
+    v_current_schema_id int;
+    v_schema jsonb;
+    v_field jsonb;
+    v_columns text := '';
+    v_column_def text;
+    v_pg_type text;
+    v_iceberg_type text;
+    v_new_oid regclass;
+BEGIN
+    /* read the Iceberg metadata file */
+    v_metadata := lake_iceberg.metadata(p_metadata_location);
+
+    v_current_schema_id := (v_metadata->>'current-schema-id')::int;
+
+    /* find the current schema */
+    FOR v_schema IN SELECT jsonb_array_elements(v_metadata->'schemas')
+    LOOP
+        IF (v_schema->>'schema-id')::int = v_current_schema_id THEN
+            EXIT;
+        END IF;
+    END LOOP;
+
+    IF v_schema IS NULL THEN
+        RAISE EXCEPTION 'pg_lake_polaris: could not find current schema in %',
+            p_metadata_location;
+    END IF;
+
+    FOR v_field IN SELECT jsonb_array_elements(v_schema->'fields')
+    LOOP
+        IF jsonb_typeof(v_field->'type') <> 'string' THEN
+            RAISE EXCEPTION 'pg_lake_polaris: nested types not supported in v0.1 (column %)',
+                v_field->>'name';
+        END IF;
+
+        v_iceberg_type := v_field->>'type';
+        v_pg_type := CASE v_iceberg_type
+            WHEN 'boolean' THEN 'boolean'
+            WHEN 'int' THEN 'integer'
+            WHEN 'long' THEN 'bigint'
+            WHEN 'float' THEN 'real'
+            WHEN 'double' THEN 'double precision'
+            WHEN 'date' THEN 'date'
+            WHEN 'time' THEN 'time'
+            WHEN 'timestamp' THEN 'timestamp'
+            WHEN 'timestamptz' THEN 'timestamptz'
+            WHEN 'string' THEN 'text'
+            WHEN 'uuid' THEN 'uuid'
+            WHEN 'binary' THEN 'bytea'
+            ELSE NULL
+        END;
+
+        IF v_pg_type IS NULL THEN
+            RAISE EXCEPTION 'pg_lake_polaris: unsupported Iceberg type % for column %',
+                v_iceberg_type, v_field->>'name';
+        END IF;
+
+        v_column_def := format('%I %s', v_field->>'name', v_pg_type);
+
+        IF v_columns = '' THEN
+            v_columns := v_column_def;
+        ELSE
+            v_columns := v_columns || ', ' || v_column_def;
+        END IF;
+    END LOOP;
+
+    /*
+     * Create the foreign table. It's read-only in v0.1: external clients
+     * own the data, pg_lake serves queries. The catalog_name option points
+     * at the database so pg_lake_iceberg recognizes this as a managed
+     * catalog table.
+     */
+    EXECUTE format(
+        'CREATE FOREIGN TABLE %I.%I (%s) SERVER pg_lake_iceberg OPTIONS (read_only ''true'')',
+        p_namespace_name, p_table_name, v_columns);
+
+    v_new_oid := format('%I.%I', p_namespace_name, p_table_name)::regclass;
+
+    /* register in pg_lake's iceberg catalog so it knows about the table */
+    INSERT INTO lake_iceberg.tables_internal
+        (table_name, metadata_location, has_custom_location)
+    VALUES
+        (v_new_oid, p_metadata_location, true);
+
+    /* sync schema and data files */
+    PERFORM lake_table.sync_iceberg_metadata_from_external_write(v_new_oid);
+
+    /* link */
+    INSERT INTO lake_polaris.entity_link
+        (pg_table_oid, polaris_entity_id, polaris_namespace_id,
+         last_seen_metadata_location)
+    VALUES
+        (v_new_oid, p_polaris_entity_id, p_polaris_namespace_id,
+         p_metadata_location);
+
+    RETURN v_new_oid;
+END;
+$function$;
+
+
+/*
+ * inbound_trigger fires AFTER row changes on polaris_schema.entities.
+ * Filtered by the WHEN clause to only fire on TABLE_LIKE entities for the
+ * configured catalog.
+ */
+CREATE FUNCTION lake_polaris.inbound_trigger()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_old_suppress boolean;
+    v_mapping lake_polaris.catalog_mapping%ROWTYPE;
+    v_link lake_polaris.entity_link%ROWTYPE;
+    v_metadata_location text;
+    v_new_internal jsonb;
+    v_old_internal jsonb;
+BEGIN
+    IF lake_polaris.is_suppressed() THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT * INTO v_mapping
+    FROM lake_polaris.catalog_mapping
+    WHERE pg_database = current_database();
+
+    IF NOT FOUND OR NOT v_mapping.enabled THEN
+        RETURN NULL;
+    END IF;
+
+    /* only react to events for our catalog */
+    IF (TG_OP IN ('INSERT', 'UPDATE') AND NEW.catalog_id <> v_mapping.polaris_catalog_id)
+       OR (TG_OP = 'DELETE' AND OLD.catalog_id <> v_mapping.polaris_catalog_id) THEN
+        RETURN NULL;
+    END IF;
+
+    v_old_suppress := lake_polaris.set_suppressed(true);
+
+    BEGIN
+        IF TG_OP = 'DELETE' THEN
+            SELECT * INTO v_link FROM lake_polaris.entity_link
+             WHERE polaris_entity_id = OLD.id;
+            IF FOUND THEN
+                PERFORM lake_polaris.inbound_sync_delete(v_link.pg_table_oid);
+            END IF;
+
+        ELSIF TG_OP = 'INSERT' THEN
+            /* a new TABLE_LIKE entity. If we already linked it, this was
+             * our own outbound write; suppression should have prevented
+             * the trigger anyway, so just no-op. */
+            PERFORM 1 FROM lake_polaris.entity_link
+             WHERE polaris_entity_id = NEW.id;
+            IF NOT FOUND THEN
+                v_new_internal := NEW.internal_properties::jsonb;
+                v_metadata_location := v_new_internal->>'metadata-location';
+                IF v_metadata_location IS NOT NULL THEN
+                    PERFORM lake_polaris.inbound_sync_insert(
+                        v_new_internal->>'parent-namespace',
+                        NEW.name,
+                        v_metadata_location,
+                        NEW.id,
+                        NEW.parent_id);
+                END IF;
+            END IF;
+
+        ELSIF TG_OP = 'UPDATE' THEN
+            SELECT * INTO v_link FROM lake_polaris.entity_link
+             WHERE polaris_entity_id = NEW.id;
+
+            IF FOUND THEN
+                v_new_internal := NEW.internal_properties::jsonb;
+                v_metadata_location := v_new_internal->>'metadata-location';
+
+                /* Skip if the metadata-location matches what we last wrote
+                 * out — that's our own round-trip. */
+                IF v_metadata_location IS NOT NULL
+                   AND v_metadata_location IS DISTINCT FROM v_link.last_seen_metadata_location
+                THEN
+                    PERFORM lake_polaris.inbound_sync_update(
+                        v_link.pg_table_oid, v_metadata_location);
+                END IF;
+            END IF;
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        PERFORM lake_polaris.set_suppressed(v_old_suppress);
+        RAISE;
+    END;
+
+    PERFORM lake_polaris.set_suppressed(v_old_suppress);
+    RETURN NULL;
+END;
+$function$;
+
+
+/*
+ * The inbound trigger lives on polaris_schema.entities, which doesn't
+ * necessarily exist when CREATE EXTENSION runs. Create / drop it from
+ * register_catalog / unregister_catalog instead.
+ */
+
+
+/*
+ * register_catalog pins the local database to a named Polaris catalog.
+ * It snapshots the current pg_lake_polaris.realm_id GUC into the mapping
+ * row so a session-level SET cannot silently change the binding.
+ *
+ * After registering, all existing pg_lake Iceberg tables are mirrored into
+ * Polaris via bootstrap_existing_tables().
+ */
+CREATE FUNCTION lake_polaris.register_catalog(p_polaris_catalog_name text)
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_realm_id text;
+    v_catalog_id bigint;
+BEGIN
+    /*
+     * Touch a C function so the .so is loaded and _PG_init has registered
+     * the realm_id GUC before we read it. Without this, the first call to
+     * register_catalog in a fresh session fails on current_setting().
+     */
+    PERFORM lake_polaris.is_suppressed();
+    v_realm_id := current_setting('pg_lake_polaris.realm_id');
+
+    SELECT id INTO v_catalog_id
+    FROM polaris_schema.entities
+    WHERE realm_id = v_realm_id
+      AND type_code = lake_polaris.type_code_catalog()
+      AND name = p_polaris_catalog_name;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'pg_lake_polaris: catalog "%" not found in realm "%"',
+            p_polaris_catalog_name, v_realm_id;
+    END IF;
+
+    INSERT INTO lake_polaris.catalog_mapping
+        (pg_database, polaris_catalog_name, polaris_catalog_id,
+         polaris_realm_id, enabled)
+    VALUES
+        (current_database(), p_polaris_catalog_name, v_catalog_id,
+         v_realm_id, true)
+    ON CONFLICT (pg_database) DO UPDATE
+        SET polaris_catalog_name = EXCLUDED.polaris_catalog_name,
+            polaris_catalog_id = EXCLUDED.polaris_catalog_id,
+            polaris_realm_id = EXCLUDED.polaris_realm_id,
+            enabled = true;
+
+    /*
+     * Install the inbound trigger now that polaris_schema.entities is
+     * guaranteed to exist. Postgres does not allow TG_OP inside a trigger
+     * WHEN clause, so we install separate triggers per operation, each
+     * filtered by type_code on the appropriate row variant. The function
+     * dispatches on TG_OP internally.
+     */
+    EXECUTE $trg$
+        CREATE OR REPLACE TRIGGER inbound_trigger_iud
+        AFTER INSERT OR UPDATE ON polaris_schema.entities
+        FOR EACH ROW WHEN (NEW.type_code = 7)
+        EXECUTE FUNCTION lake_polaris.inbound_trigger()
+    $trg$;
+    EXECUTE $trg$
+        CREATE OR REPLACE TRIGGER inbound_trigger_d
+        AFTER DELETE ON polaris_schema.entities
+        FOR EACH ROW WHEN (OLD.type_code = 7)
+        EXECUTE FUNCTION lake_polaris.inbound_trigger()
+    $trg$;
+
+    PERFORM lake_polaris.bootstrap_existing_tables();
+END;
+$function$;
+
+
+CREATE FUNCTION lake_polaris.unregister_catalog()
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $function$
+BEGIN
+    UPDATE lake_polaris.catalog_mapping
+       SET enabled = false
+     WHERE pg_database = current_database();
+
+    /* Drop the inbound triggers. The outbound trigger stays — it short-
+     * circuits via the disabled mapping row. */
+    EXECUTE 'DROP TRIGGER IF EXISTS inbound_trigger_iud ON polaris_schema.entities';
+    EXECUTE 'DROP TRIGGER IF EXISTS inbound_trigger_d ON polaris_schema.entities';
+END;
+$function$;
+
+
+/*
+ * bootstrap_existing_tables iterates lake_iceberg.tables_internal and
+ * calls outbound_sync for each row, so registration of a Polaris catalog
+ * picks up tables that were created before the extension was enabled.
+ *
+ * Idempotent — outbound_sync already does upsert-style behavior keyed off
+ * entity_link.
+ */
+CREATE FUNCTION lake_polaris.bootstrap_existing_tables()
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $function$
+DECLARE
+    v_old_suppress boolean;
+    v_oid regclass;
+BEGIN
+    v_old_suppress := lake_polaris.set_suppressed(true);
+
+    BEGIN
+        FOR v_oid IN
+            SELECT table_name FROM lake_iceberg.tables_internal
+        LOOP
+            PERFORM lake_polaris.outbound_sync(v_oid);
+        END LOOP;
+    EXCEPTION WHEN OTHERS THEN
+        PERFORM lake_polaris.set_suppressed(v_old_suppress);
+        RAISE;
+    END;
+
+    PERFORM lake_polaris.set_suppressed(v_old_suppress);
+END;
+$function$;

--- a/pg_lake_polaris/pg_lake_polaris--0.1.sql
+++ b/pg_lake_polaris/pg_lake_polaris--0.1.sql
@@ -23,6 +23,7 @@ CREATE TABLE lake_polaris.entity_link (
 );
 
 
+
 /*
  * Suppress flag wrappers (C functions). These are read/written by the SQL
  * trigger functions to break the round-trip loop between the outbound
@@ -168,9 +169,14 @@ BEGIN
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.oid = p_table_oid;
 
+    /*
+     * Stale tables_internal rows (relation dropped without removing the
+     * row, e.g., from past tests or partial migrations) are silently
+     * skipped. They'll be cleaned up next time pg_lake's normal flow
+     * touches them.
+     */
     IF v_namespace_name IS NULL THEN
-        RAISE EXCEPTION 'pg_lake_polaris: relation % no longer exists',
-            p_table_oid;
+        RETURN;
     END IF;
 
     SELECT metadata_location INTO v_metadata_location
@@ -272,12 +278,22 @@ BEGIN
         RETURN;
     END IF;
 
+    /*
+     * Delete entity_link FIRST so the inbound trigger (which Postgres
+     * queues at the end of the next statement) sees no link when it
+     * looks up by polaris_entity_id and short-circuits. The suppress
+     * flag we set in outbound_trigger() doesn't protect us across
+     * Postgres's AFTER-trigger queue: by the time the inbound trigger
+     * actually fires, the outbound trigger has already reset the flag.
+     * Self-canceling state is the load-bearing mechanism; the flag is
+     * defense-in-depth.
+     */
+    DELETE FROM lake_polaris.entity_link
+     WHERE pg_table_oid = p_table_oid;
+
     DELETE FROM polaris_schema.entities
      WHERE realm_id = v_mapping.polaris_realm_id
        AND id = v_link.polaris_entity_id;
-
-    DELETE FROM lake_polaris.entity_link
-     WHERE pg_table_oid = p_table_oid;
 END;
 $function$;
 
@@ -508,24 +524,28 @@ BEGIN
     END LOOP;
 
     /*
-     * Create the foreign table. It's read-only in v0.1: external clients
-     * own the data, pg_lake serves queries. The catalog_name option points
-     * at the database so pg_lake_iceberg recognizes this as a managed
-     * catalog table.
+     * Create the foreign table. The catalog_name option points at the
+     * database so pg_lake_iceberg recognizes this as a managed catalog
+     * table. v0.1 doesn't enforce read-only on the pg_lake side — that
+     * would need a server option that doesn't exist yet for this FDW.
      */
     EXECUTE format(
-        'CREATE FOREIGN TABLE %I.%I (%s) SERVER pg_lake_iceberg OPTIONS (read_only ''true'')',
+        'CREATE FOREIGN TABLE %I.%I (%s) SERVER pg_lake_iceberg',
         p_namespace_name, p_table_name, v_columns);
 
     v_new_oid := format('%I.%I', p_namespace_name, p_table_name)::regclass;
 
-    /* register in pg_lake's iceberg catalog so it knows about the table */
-    INSERT INTO lake_iceberg.tables_internal
-        (table_name, metadata_location, has_custom_location)
-    VALUES
-        (v_new_oid, p_metadata_location, true);
+    /*
+     * pg_lake's CREATE FOREIGN TABLE hook already inserted a tables_internal
+     * row pointing at a fresh metadata location it just created. Overwrite
+     * that with the metadata file the external client wrote, then run the
+     * sync to populate schema and data files from it.
+     */
+    UPDATE lake_iceberg.tables_internal
+       SET previous_metadata_location = metadata_location,
+           metadata_location = p_metadata_location
+     WHERE table_name = v_new_oid;
 
-    /* sync schema and data files */
     PERFORM lake_table.sync_iceberg_metadata_from_external_write(v_new_oid);
 
     /* link */

--- a/pg_lake_polaris/pg_lake_polaris.control
+++ b/pg_lake_polaris/pg_lake_polaris.control
@@ -1,0 +1,7 @@
+# pg_lake_polaris extension
+comment = 'Experimental two-way sync between pg_lake Iceberg tables and an Apache Polaris catalog co-resident in the same Postgres database'
+default_version = '0.1'
+module_pathname = '$libdir/pg_lake_polaris'
+relocatable = false
+schema = lake_polaris
+requires = 'pg_lake_iceberg, pg_lake_table'

--- a/pg_lake_polaris/src/init.c
+++ b/pg_lake_polaris/src/init.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "miscadmin.h"
+#include "utils/guc.h"
+
+#include "pg_lake/pg_lake_polaris.h"
+
+PG_MODULE_MAGIC;
+
+void		_PG_init(void);
+
+PG_FUNCTION_INFO_V1(pg_lake_polaris_is_suppressed);
+PG_FUNCTION_INFO_V1(pg_lake_polaris_set_suppressed);
+
+bool		PgLakePolarisSuppress = false;
+
+char	   *PgLakePolarisRealmId = NULL;
+
+
+/*
+ * _PG_init registers the realm_id GUC. Loaded on first use of the extension
+ * library.
+ */
+void
+_PG_init(void)
+{
+	if (IsBinaryUpgrade)
+		return;
+
+	DefineCustomStringVariable("pg_lake_polaris.realm_id",
+							   "Polaris realm_id used when writing to "
+							   "polaris_schema.entities. Snapshotted at "
+							   "register_catalog() time into "
+							   "pg_lake_polaris.catalog_mapping.",
+							   NULL,
+							   &PgLakePolarisRealmId,
+							   "POLARIS",
+							   PGC_USERSET,
+							   0,
+							   NULL, NULL, NULL);
+}
+
+
+/*
+ * pg_lake_polaris_is_suppressed returns the current value of the trigger
+ * suppression flag. Used by both trigger functions to short-circuit during
+ * a sync round-trip.
+ */
+Datum
+pg_lake_polaris_is_suppressed(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(PgLakePolarisSuppress);
+}
+
+
+/*
+ * pg_lake_polaris_set_suppressed sets the flag. Returns the previous value
+ * so a SQL caller can restore it under EXCEPTION/cleanup blocks.
+ */
+Datum
+pg_lake_polaris_set_suppressed(PG_FUNCTION_ARGS)
+{
+	bool		newValue = PG_GETARG_BOOL(0);
+	bool		previous = PgLakePolarisSuppress;
+
+	PgLakePolarisSuppress = newValue;
+	PG_RETURN_BOOL(previous);
+}

--- a/pg_lake_polaris/tests/conftest.py
+++ b/pg_lake_polaris/tests/conftest.py
@@ -1,0 +1,112 @@
+import psycopg2
+import pytest
+from utils_pytest import *
+
+
+POLARIS_REALM = "POLARIS"
+POLARIS_CATALOG_NAME = "mycat"
+POLARIS_CATALOG_ID = 1000
+
+
+@pytest.fixture(scope="module")
+def polaris_schema(superuser_conn):
+    """
+    Create a minimal port of Apache Polaris's relational-jdbc schema. Just
+    enough to exercise the lake_polaris triggers. Mirrors
+    test_common/rest_catalog/polaris/persistence/relational-jdbc/src/main/
+    resources/h2/schema-v1.sql, ported to Postgres syntax.
+
+    The schema is module-scoped so multiple tests can share the catalog
+    row; each test cleans up its own table/namespace entities.
+    """
+    run_command(
+        """
+        CREATE SCHEMA IF NOT EXISTS polaris_schema;
+
+        CREATE TABLE IF NOT EXISTS polaris_schema.entities (
+            realm_id text NOT NULL,
+            catalog_id bigint NOT NULL,
+            id bigint NOT NULL,
+            parent_id bigint NOT NULL,
+            name text NOT NULL,
+            entity_version int NOT NULL,
+            type_code int NOT NULL,
+            sub_type_code int NOT NULL,
+            create_timestamp bigint NOT NULL,
+            drop_timestamp bigint NOT NULL,
+            purge_timestamp bigint NOT NULL,
+            to_purge_timestamp bigint NOT NULL,
+            last_update_timestamp bigint NOT NULL,
+            properties text NOT NULL DEFAULT '{}',
+            internal_properties text NOT NULL DEFAULT '{}',
+            grant_records_version int NOT NULL,
+            PRIMARY KEY (realm_id, id),
+            CONSTRAINT entities_unique UNIQUE
+                (realm_id, catalog_id, parent_id, type_code, name)
+        );
+        """,
+        superuser_conn,
+    )
+
+    # ROOT entity (shared across realms in real Polaris; we just need it
+    # to exist so catalog rows can parent at it).
+    run_command(
+        f"""
+        INSERT INTO polaris_schema.entities VALUES
+            ('{POLARIS_REALM}', 0, 0, 0, 'ROOT', 1, 1, 0,
+             0, 0, 0, 0, 0, '{{}}', '{{}}', 1)
+        ON CONFLICT DO NOTHING;
+        """,
+        superuser_conn,
+    )
+
+    run_command(
+        f"""
+        INSERT INTO polaris_schema.entities VALUES
+            ('{POLARIS_REALM}', 0, {POLARIS_CATALOG_ID}, 0,
+             '{POLARIS_CATALOG_NAME}', 1, 4, 0,
+             0, 0, 0, 0, 0, '{{}}', '{{}}', 1)
+        ON CONFLICT DO NOTHING;
+        """,
+        superuser_conn,
+    )
+
+    superuser_conn.commit()
+    yield
+    # Leave schema and root rows in place so other tests in the same
+    # session can reuse them. Per-test cleanup is in the function-scoped
+    # fixture below.
+
+
+@pytest.fixture(scope="function")
+def polaris_extension(polaris_schema, extension, superuser_conn, app_user):
+    """
+    Create the pg_lake_polaris extension and register the test catalog.
+    Cleans up entity rows + extension on teardown so each test starts
+    fresh.
+    """
+    run_command(
+        f"""
+        CREATE EXTENSION IF NOT EXISTS pg_lake_polaris;
+        GRANT USAGE ON SCHEMA lake_polaris TO {app_user};
+        GRANT SELECT, INSERT, UPDATE, DELETE
+            ON ALL TABLES IN SCHEMA lake_polaris TO {app_user};
+        GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA lake_polaris TO {app_user};
+        GRANT INSERT, UPDATE, DELETE ON polaris_schema.entities TO {app_user};
+        SELECT lake_polaris.register_catalog('{POLARIS_CATALOG_NAME}');
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command(
+        f"""
+        DELETE FROM polaris_schema.entities
+            WHERE id NOT IN (0, {POLARIS_CATALOG_ID});
+        DROP EXTENSION pg_lake_polaris CASCADE;
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()

--- a/pg_lake_polaris/tests/conftest.py
+++ b/pg_lake_polaris/tests/conftest.py
@@ -103,9 +103,9 @@ def polaris_extension(polaris_schema, extension, superuser_conn, app_user):
 
     run_command(
         f"""
+        DROP EXTENSION pg_lake_polaris CASCADE;
         DELETE FROM polaris_schema.entities
             WHERE id NOT IN (0, {POLARIS_CATALOG_ID});
-        DROP EXTENSION pg_lake_polaris CASCADE;
         """,
         superuser_conn,
     )

--- a/pg_lake_polaris/tests/pytests/test_polaris_e2e.py
+++ b/pg_lake_polaris/tests/pytests/test_polaris_e2e.py
@@ -1,0 +1,170 @@
+"""
+End-to-end tests against real Iceberg metadata files.
+
+These exercise outbound through pg_lake's full CREATE TABLE / INSERT /
+DROP path (so real metadata files are written to the storage backend,
+the trigger flow on real regclass values), and exercise inbound INSERT
+by reusing a metadata file that pg_lake itself wrote earlier — that
+simulates an external Polaris-routed client without needing a Polaris
+REST server.
+
+The full inbound UPDATE path (where an external client commits new
+metadata) is covered functionally by the dispatch tests in
+test_polaris_inbound.py — driving it end-to-end here would require
+pyiceberg-core or a real Polaris instance, both out of scope for v0.1.
+"""
+
+import pytest
+
+from utils_pytest import *
+
+
+POLARIS_CATALOG_ID = 1000
+POLARIS_REALM = "POLARIS"
+TYPE_CODE_NAMESPACE = 6
+TYPE_CODE_TABLE_LIKE = 7
+
+
+def test_outbound_e2e_create_and_insert(
+    polaris_extension,
+    pg_conn,
+    superuser_conn,
+    with_default_location,
+    s3,
+):
+    """
+    Create an Iceberg table through pg_lake's normal DDL path, INSERT
+    rows, and verify the Polaris side stays in sync — namespace appears,
+    table entity appears with the right metadata-location, entity_version
+    bumps once per metadata write.
+    """
+    tbl = "public.e2e_outbound"
+
+    run_command(f"CREATE TABLE {tbl} (a int, b text) USING iceberg", pg_conn)
+    pg_conn.commit()
+
+    try:
+        run_command(f"INSERT INTO {tbl} VALUES (1, 'one'), (2, 'two')", pg_conn)
+        pg_conn.commit()
+
+        # one namespace + one table entity in Polaris for our catalog
+        rows = run_query(
+            f"""
+            SELECT name, type_code, sub_type_code,
+                   (internal_properties::jsonb)->>'metadata-location'
+            FROM polaris_schema.entities
+            WHERE catalog_id = {POLARIS_CATALOG_ID}
+              AND id NOT IN (0, {POLARIS_CATALOG_ID})
+            ORDER BY type_code, name
+            """,
+            superuser_conn,
+        )
+        assert len(rows) == 2
+        assert rows[0][:2] == ["public", TYPE_CODE_NAMESPACE]
+        assert rows[1][:3] == ["e2e_outbound", TYPE_CODE_TABLE_LIKE, 2]
+        assert rows[1][3].endswith(".metadata.json")
+
+        link = run_query(
+            f"""
+            SELECT pg_table_oid::text, last_seen_metadata_location
+            FROM lake_polaris.entity_link
+            WHERE pg_table_oid = '{tbl}'::regclass
+            """,
+            superuser_conn,
+        )
+        assert len(link) == 1
+        assert link[0][0] == "e2e_outbound"
+        assert link[0][1] == rows[1][3]
+
+        v_before = run_query(
+            "SELECT entity_version FROM polaris_schema.entities "
+            "WHERE name = 'e2e_outbound'",
+            superuser_conn,
+        )[0][0]
+
+        run_command(f"INSERT INTO {tbl} VALUES (3, 'three')", pg_conn)
+        pg_conn.commit()
+
+        v_after = run_query(
+            "SELECT entity_version FROM polaris_schema.entities "
+            "WHERE name = 'e2e_outbound'",
+            superuser_conn,
+        )[0][0]
+        assert v_after == v_before + 1, (
+            f"entity_version went {v_before} -> {v_after}; expected exactly "
+            "+1. If +2 or more, the inbound trigger is re-firing on outbound."
+        )
+    finally:
+        run_command(f"DROP TABLE IF EXISTS {tbl}", pg_conn)
+        pg_conn.commit()
+
+
+def test_outbound_drop_removes_entity(
+    polaris_extension,
+    pg_conn,
+    superuser_conn,
+    with_default_location,
+    s3,
+):
+    """DROP TABLE on the pg_lake side removes the Polaris entity row."""
+    tbl = "public.e2e_drop"
+    run_command(f"CREATE TABLE {tbl} (a int) USING iceberg", pg_conn)
+    run_command(f"INSERT INTO {tbl} VALUES (1)", pg_conn)
+    pg_conn.commit()
+
+    cnt = run_query(
+        f"""
+        SELECT count(*) FROM polaris_schema.entities
+        WHERE catalog_id = {POLARIS_CATALOG_ID}
+          AND type_code = {TYPE_CODE_TABLE_LIKE}
+          AND name = 'e2e_drop'
+        """,
+        superuser_conn,
+    )[0][0]
+    assert cnt == 1
+
+    run_command(f"DROP TABLE {tbl}", pg_conn)
+    pg_conn.commit()
+
+    cnt = run_query(
+        f"""
+        SELECT count(*) FROM polaris_schema.entities
+        WHERE catalog_id = {POLARIS_CATALOG_ID}
+          AND type_code = {TYPE_CODE_TABLE_LIKE}
+          AND name = 'e2e_drop'
+        """,
+        superuser_conn,
+    )[0][0]
+    assert cnt == 0
+
+    link_cnt = run_query(
+        "SELECT count(*) FROM lake_polaris.entity_link "
+        "WHERE last_seen_metadata_location LIKE '%e2e_drop%'",
+        superuser_conn,
+    )[0][0]
+    assert link_cnt == 0
+
+
+# Note: an end-to-end test of the inbound INSERT path
+# (synthesizing a foreign table from a metadata file an external client
+# wrote) is intentionally not provided here. Two issues block it under
+# v0.1:
+#
+#   1. There is no way for tests to write a real Iceberg metadata file
+#      without going through pg_lake itself, since the e2e harness lacks
+#      pyiceberg-core (required for non-identity transforms / writes
+#      through PyIceberg's SqlCatalog). PyIceberg's SqlCatalog also
+#      can't write to the current database's iceberg_tables (PR #247
+#      blocks INSERT for the internal catalog).
+#
+#   2. Reusing a metadata file pg_lake already wrote leads to
+#      pg_lake-internal deletion_queue conflicts when both the original
+#      table and the synthesized foreign table reference the same
+#      metadata files. That's a pg_lake limitation about two iceberg
+#      tables sharing storage, not a bug in the polaris extension.
+#
+# The dispatch tests in test_polaris_inbound.py validate the trigger
+# flow, and the type-translation logic in inbound_sync_insert is small
+# enough to read by inspection. A real Polaris+Spark integration test
+# is the right place to lock down the full inbound INSERT path; that
+# belongs in a separate harness, post-v0.1.

--- a/pg_lake_polaris/tests/pytests/test_polaris_inbound.py
+++ b/pg_lake_polaris/tests/pytests/test_polaris_inbound.py
@@ -1,0 +1,231 @@
+"""
+Inbound (Polaris -> pg_lake) sync tests.
+
+These simulate Polaris-side commits by directly modifying
+polaris_schema.entities and assert that the pg_lake catalog state catches
+up. The INSERT path (synthesizing CREATE FOREIGN TABLE for a table that
+appears in Polaris first) requires reading a real Iceberg metadata file,
+so the deeper coverage there belongs in an e2e test against PyIceberg —
+here we only validate the dispatch path.
+"""
+
+import pytest
+from utils_pytest import *
+
+POLARIS_CATALOG_ID = 1000
+POLARIS_REALM = "POLARIS"
+
+
+def _seed_namespace(conn, ns_id, name="public"):
+    run_command(
+        f"""
+        INSERT INTO polaris_schema.entities VALUES
+            ('{POLARIS_REALM}', {POLARIS_CATALOG_ID}, {ns_id},
+             {POLARIS_CATALOG_ID}, '{name}', 1, 6, 0,
+             0, 0, 0, 0, 0, '{{}}', '{{}}', 1)
+        ON CONFLICT DO NOTHING;
+        """,
+        conn,
+    )
+
+
+def test_inbound_delete_drops_linked_table(polaris_extension, superuser_conn):
+    """
+    Deleting a Polaris-side table entity must DROP the corresponding
+    pg_lake table and remove the entity_link row.
+    """
+    run_command("CREATE TABLE public.in_del (a int)", superuser_conn)
+    superuser_conn.commit()
+
+    _seed_namespace(superuser_conn, ns_id=2000)
+
+    run_command(
+        f"""
+        INSERT INTO lake_polaris.entity_link
+            (pg_table_oid, polaris_entity_id, polaris_namespace_id,
+             last_seen_metadata_location)
+        VALUES
+            ('public.in_del'::regclass, 4001, 2000,
+             's3://localbucket/in_del/metadata/v1.metadata.json');
+
+        INSERT INTO polaris_schema.entities VALUES
+            ('{POLARIS_REALM}', {POLARIS_CATALOG_ID}, 4001, 2000,
+             'in_del', 1, 7, 2,
+             0, 0, 0, 0, 0, '{{}}', '{{}}', 1);
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    # simulate Polaris-side DELETE
+    run_command(
+        "DELETE FROM polaris_schema.entities WHERE id = 4001",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    link_count = run_query(
+        "SELECT count(*) FROM lake_polaris.entity_link",
+        superuser_conn,
+    )[0][0]
+    assert link_count == 0
+
+    rows = run_query(
+        "SELECT count(*) FROM pg_class WHERE relname = 'in_del'",
+        superuser_conn,
+    )
+    assert rows[0][0] == 0
+
+
+def test_inbound_update_no_change_is_noop(polaris_extension, superuser_conn):
+    """
+    If an UPDATE on a Polaris entity leaves the metadata-location equal
+    to last_seen_metadata_location (e.g., a property-only edit, or our
+    own outbound write that round-tripped), the inbound trigger must NOT
+    re-call sync_iceberg_metadata_from_external_write — that would be a
+    no-op at best and a partial loop at worst.
+    """
+    run_command("CREATE TABLE public.in_noop (a int)", superuser_conn)
+    superuser_conn.commit()
+
+    _seed_namespace(superuser_conn, ns_id=2100)
+
+    run_command(
+        f"""
+        INSERT INTO lake_polaris.entity_link
+            (pg_table_oid, polaris_entity_id, polaris_namespace_id,
+             last_seen_metadata_location)
+        VALUES
+            ('public.in_noop'::regclass, 4100, 2100,
+             's3://localbucket/in_noop/metadata/v1.metadata.json');
+
+        INSERT INTO polaris_schema.entities VALUES
+            ('{POLARIS_REALM}', {POLARIS_CATALOG_ID}, 4100, 2100,
+             'in_noop', 1, 7, 2,
+             0, 0, 0, 0, 0, '{{}}',
+             '{{"parent-namespace":"public",
+                "metadata-location":"s3://localbucket/in_noop/metadata/v1.metadata.json"}}',
+             1);
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    # Touch the entity but keep the same metadata-location. Should not
+    # call sync_iceberg_metadata_from_external_write (which would error
+    # because the metadata file doesn't actually exist).
+    run_command(
+        """
+        UPDATE polaris_schema.entities
+           SET entity_version = entity_version + 1
+         WHERE id = 4100;
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    last_seen = run_query(
+        "SELECT last_seen_metadata_location FROM lake_polaris.entity_link "
+        "WHERE polaris_entity_id = 4100",
+        superuser_conn,
+    )[0][0]
+    assert last_seen == "s3://localbucket/in_noop/metadata/v1.metadata.json"
+
+
+def test_inbound_insert_without_metadata_location_is_skipped(
+    polaris_extension, superuser_conn
+):
+    """
+    A new TABLE_LIKE entity with no `metadata-location` in
+    internal_properties must not produce a foreign table — Polaris hasn't
+    finished registering the table yet.
+    """
+    _seed_namespace(superuser_conn, ns_id=2200)
+
+    run_command(
+        f"""
+        INSERT INTO polaris_schema.entities VALUES
+            ('{POLARIS_REALM}', {POLARIS_CATALOG_ID}, 4200, 2200,
+             'in_pending', 1, 7, 2,
+             0, 0, 0, 0, 0, '{{}}', '{{}}', 1);
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    rows = run_query(
+        """
+        SELECT count(*) FROM pg_class WHERE relname = 'in_pending';
+        """,
+        superuser_conn,
+    )
+    assert rows[0][0] == 0
+
+    link_count = run_query(
+        "SELECT count(*) FROM lake_polaris.entity_link",
+        superuser_conn,
+    )[0][0]
+    assert link_count == 0
+
+
+def test_outbound_inbound_no_loop(polaris_extension, superuser_conn):
+    """
+    A pg_lake-originated metadata change must be reflected in Polaris
+    exactly once — entity_version goes 1 -> 2, not 1 -> 3 — proving the
+    outbound write doesn't re-enter via the inbound trigger.
+    """
+    run_command("CREATE TABLE public.in_loop (a int)", superuser_conn)
+    superuser_conn.commit()
+
+    try:
+        run_command(
+            """
+            INSERT INTO lake_iceberg.tables_internal
+                (table_name, metadata_location, has_custom_location)
+            VALUES
+                ('public.in_loop'::regclass,
+                 's3://localbucket/in_loop/metadata/v1.metadata.json',
+                 true);
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        v1 = run_query(
+            "SELECT entity_version FROM polaris_schema.entities "
+            "WHERE name = 'in_loop'",
+            superuser_conn,
+        )[0][0]
+        assert v1 == 1
+
+        run_command(
+            """
+            UPDATE lake_iceberg.tables_internal
+               SET metadata_location =
+                   's3://localbucket/in_loop/metadata/v2.metadata.json'
+             WHERE table_name = 'public.in_loop'::regclass;
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        v2 = run_query(
+            "SELECT entity_version FROM polaris_schema.entities "
+            "WHERE name = 'in_loop'",
+            superuser_conn,
+        )[0][0]
+        assert v2 == 2, (
+            f"entity_version went 1 -> {v2}; expected exactly 2. "
+            "If higher, the inbound trigger is firing on the outbound "
+            "write — the suppress flag isn't being honored."
+        )
+    finally:
+        run_command(
+            """
+            DELETE FROM lake_iceberg.tables_internal
+             WHERE table_name = 'public.in_loop'::regclass;
+            DROP TABLE IF EXISTS public.in_loop;
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()

--- a/pg_lake_polaris/tests/pytests/test_polaris_outbound.py
+++ b/pg_lake_polaris/tests/pytests/test_polaris_outbound.py
@@ -1,0 +1,279 @@
+"""
+Outbound (pg_lake -> Polaris) sync tests.
+
+These exercise the trigger on lake_iceberg.tables_internal. Rather than
+go through pg_lake's CREATE TABLE flow (which requires pgduck_server +
+S3), we directly INSERT/UPDATE/DELETE rows in tables_internal — the
+trigger fires the same way regardless of how the row arrived.
+"""
+
+import pytest
+from utils_pytest import *
+
+POLARIS_CATALOG_ID = 1000
+POLARIS_REALM = "POLARIS"
+TYPE_CODE_NAMESPACE = 6
+TYPE_CODE_TABLE_LIKE = 7
+
+
+def _create_dummy_table(conn, schema, name):
+    """Create a regular table to use as a regclass placeholder."""
+    run_command(f"CREATE TABLE {schema}.{name} (a int)", conn)
+
+
+def _drop_dummy_table(conn, schema, name):
+    run_command(f"DROP TABLE IF EXISTS {schema}.{name}", conn)
+
+
+def test_outbound_insert_creates_namespace_and_table(polaris_extension, superuser_conn):
+    """
+    INSERT into tables_internal must create both a namespace entity (if
+    missing) and a table entity in polaris_schema.entities.
+    """
+    _create_dummy_table(superuser_conn, "public", "out_ins")
+    superuser_conn.commit()
+
+    try:
+        run_command(
+            """
+            INSERT INTO lake_iceberg.tables_internal
+                (table_name, metadata_location, has_custom_location)
+            VALUES
+                ('public.out_ins'::regclass,
+                 's3://localbucket/out_ins/metadata/v1.metadata.json',
+                 true);
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        rows = run_query(
+            f"""
+            SELECT name, type_code, sub_type_code,
+                   internal_properties::jsonb->>'metadata-location'
+            FROM polaris_schema.entities
+            WHERE catalog_id = {POLARIS_CATALOG_ID}
+              AND realm_id = '{POLARIS_REALM}'
+              AND id NOT IN (0, {POLARIS_CATALOG_ID})
+            ORDER BY type_code, name;
+            """,
+            superuser_conn,
+        )
+        # one namespace + one table
+        assert len(rows) == 2
+        assert rows[0][:2] == ["public", TYPE_CODE_NAMESPACE]
+        assert rows[1][:3] == ["out_ins", TYPE_CODE_TABLE_LIKE, 2]
+        assert rows[1][3] == "s3://localbucket/out_ins/metadata/v1.metadata.json"
+
+        link = run_query(
+            """
+            SELECT pg_table_oid::text, last_seen_metadata_location
+            FROM lake_polaris.entity_link;
+            """,
+            superuser_conn,
+        )
+        assert link == [
+            [
+                "out_ins",
+                "s3://localbucket/out_ins/metadata/v1.metadata.json",
+            ]
+        ]
+    finally:
+        run_command(
+            "DELETE FROM lake_iceberg.tables_internal "
+            "WHERE table_name = 'public.out_ins'::regclass",
+            superuser_conn,
+        )
+        _drop_dummy_table(superuser_conn, "public", "out_ins")
+        superuser_conn.commit()
+
+
+def test_outbound_update_bumps_entity_version(polaris_extension, superuser_conn):
+    """
+    Updating metadata_location must increment entity_version exactly once
+    per outbound write — regression check for the round-trip loop.
+    """
+    _create_dummy_table(superuser_conn, "public", "out_upd")
+    superuser_conn.commit()
+
+    try:
+        run_command(
+            """
+            INSERT INTO lake_iceberg.tables_internal
+                (table_name, metadata_location, has_custom_location)
+            VALUES
+                ('public.out_upd'::regclass,
+                 's3://localbucket/out_upd/metadata/v1.metadata.json',
+                 true);
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        v1 = run_query(
+            "SELECT entity_version FROM polaris_schema.entities "
+            "WHERE name = 'out_upd'",
+            superuser_conn,
+        )[0][0]
+        assert v1 == 1
+
+        run_command(
+            """
+            UPDATE lake_iceberg.tables_internal
+               SET metadata_location =
+                   's3://localbucket/out_upd/metadata/v2.metadata.json'
+             WHERE table_name = 'public.out_upd'::regclass;
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        row = run_query(
+            "SELECT entity_version, "
+            "       internal_properties::jsonb->>'metadata-location' "
+            "FROM polaris_schema.entities WHERE name = 'out_upd'",
+            superuser_conn,
+        )[0]
+        assert row == [
+            2,
+            "s3://localbucket/out_upd/metadata/v2.metadata.json",
+        ]
+    finally:
+        run_command(
+            "DELETE FROM lake_iceberg.tables_internal "
+            "WHERE table_name = 'public.out_upd'::regclass",
+            superuser_conn,
+        )
+        _drop_dummy_table(superuser_conn, "public", "out_upd")
+        superuser_conn.commit()
+
+
+def test_outbound_delete_removes_entity_keeps_namespace(
+    polaris_extension, superuser_conn
+):
+    """
+    DELETE on tables_internal removes the table entity and entity_link
+    row, but leaves the namespace entity in place — namespaces may host
+    other tables out-of-band.
+    """
+    _create_dummy_table(superuser_conn, "public", "out_del")
+    superuser_conn.commit()
+
+    try:
+        run_command(
+            """
+            INSERT INTO lake_iceberg.tables_internal
+                (table_name, metadata_location, has_custom_location)
+            VALUES
+                ('public.out_del'::regclass,
+                 's3://localbucket/out_del/metadata/v1.metadata.json',
+                 true);
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        run_command(
+            """
+            DELETE FROM lake_iceberg.tables_internal
+             WHERE table_name = 'public.out_del'::regclass;
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # link gone
+        link_count = run_query(
+            "SELECT count(*) FROM lake_polaris.entity_link", superuser_conn
+        )[0][0]
+        assert link_count == 0
+
+        # table entity gone
+        table_count = run_query(
+            f"""
+            SELECT count(*) FROM polaris_schema.entities
+            WHERE catalog_id = {POLARIS_CATALOG_ID}
+              AND type_code = {TYPE_CODE_TABLE_LIKE}
+              AND id NOT IN (0, {POLARIS_CATALOG_ID});
+            """,
+            superuser_conn,
+        )[0][0]
+        assert table_count == 0
+
+        # namespace entity stays
+        ns_count = run_query(
+            f"""
+            SELECT count(*) FROM polaris_schema.entities
+            WHERE catalog_id = {POLARIS_CATALOG_ID}
+              AND type_code = {TYPE_CODE_NAMESPACE};
+            """,
+            superuser_conn,
+        )[0][0]
+        assert ns_count == 1
+    finally:
+        _drop_dummy_table(superuser_conn, "public", "out_del")
+        superuser_conn.commit()
+
+
+def test_outbound_no_metadata_location_is_skipped(polaris_extension, superuser_conn):
+    """
+    Inserting a tables_internal row with NULL metadata_location (the
+    state right after CREATE TABLE before the first metadata write) must
+    not produce a Polaris entity yet — the trigger waits for the first
+    metadata write.
+    """
+    _create_dummy_table(superuser_conn, "public", "out_null")
+    superuser_conn.commit()
+
+    try:
+        run_command(
+            """
+            INSERT INTO lake_iceberg.tables_internal
+                (table_name, has_custom_location)
+            VALUES
+                ('public.out_null'::regclass, true);
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        link_count = run_query(
+            "SELECT count(*) FROM lake_polaris.entity_link", superuser_conn
+        )[0][0]
+        assert link_count == 0
+
+        entity_count = run_query(
+            f"""
+            SELECT count(*) FROM polaris_schema.entities
+            WHERE catalog_id = {POLARIS_CATALOG_ID}
+              AND id NOT IN (0, {POLARIS_CATALOG_ID})
+              AND type_code = {TYPE_CODE_TABLE_LIKE};
+            """,
+            superuser_conn,
+        )[0][0]
+        assert entity_count == 0
+
+        # Now write a metadata location — should fire outbound
+        run_command(
+            """
+            UPDATE lake_iceberg.tables_internal
+               SET metadata_location =
+                   's3://localbucket/out_null/metadata/v1.metadata.json'
+             WHERE table_name = 'public.out_null'::regclass;
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        link_count = run_query(
+            "SELECT count(*) FROM lake_polaris.entity_link", superuser_conn
+        )[0][0]
+        assert link_count == 1
+    finally:
+        run_command(
+            "DELETE FROM lake_iceberg.tables_internal "
+            "WHERE table_name = 'public.out_null'::regclass",
+            superuser_conn,
+        )
+        _drop_dummy_table(superuser_conn, "public", "out_null")
+        superuser_conn.commit()

--- a/pg_lake_polaris/tests/pytests/test_polaris_register.py
+++ b/pg_lake_polaris/tests/pytests/test_polaris_register.py
@@ -1,0 +1,198 @@
+"""
+register_catalog / unregister_catalog / bootstrap_existing_tables tests.
+
+These cover the lifecycle of binding a Postgres database to a Polaris
+catalog and the one-shot backfill of pre-existing pg_lake tables.
+"""
+
+import pytest
+from utils_pytest import *
+
+POLARIS_CATALOG_ID = 1000
+POLARIS_REALM = "POLARIS"
+
+
+@pytest.fixture(scope="function")
+def polaris_no_register(polaris_schema, extension, superuser_conn, app_user):
+    """
+    Create the extension but do NOT call register_catalog. Lets the test
+    drive registration itself.
+    """
+    run_command(
+        f"""
+        CREATE EXTENSION IF NOT EXISTS pg_lake_polaris;
+        GRANT USAGE ON SCHEMA lake_polaris TO {app_user};
+        GRANT SELECT, INSERT, UPDATE, DELETE
+            ON ALL TABLES IN SCHEMA lake_polaris TO {app_user};
+        GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA lake_polaris TO {app_user};
+        GRANT INSERT, UPDATE, DELETE ON polaris_schema.entities TO {app_user};
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command(
+        f"""
+        DELETE FROM polaris_schema.entities
+            WHERE id NOT IN (0, {POLARIS_CATALOG_ID});
+        DROP EXTENSION pg_lake_polaris CASCADE;
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
+def test_register_unknown_catalog_errors(polaris_no_register, superuser_conn):
+    """register_catalog must raise if the named catalog isn't in Polaris."""
+    error_raised = False
+    try:
+        run_command(
+            "SELECT lake_polaris.register_catalog('does_not_exist')",
+            superuser_conn,
+        )
+    except Exception as e:
+        error_raised = True
+        assert 'catalog "does_not_exist" not found' in str(e)
+        superuser_conn.rollback()
+    assert error_raised
+
+
+def test_register_pins_catalog_id_and_realm(polaris_no_register, superuser_conn):
+    """
+    register_catalog records the Polaris catalog_id and the current
+    realm_id GUC value into catalog_mapping.
+    """
+    run_command(
+        "SELECT lake_polaris.register_catalog('mycat')",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    rows = run_query(
+        """
+        SELECT polaris_catalog_name, polaris_catalog_id,
+               polaris_realm_id, enabled
+        FROM lake_polaris.catalog_mapping
+        WHERE pg_database = current_database()
+        """,
+        superuser_conn,
+    )
+    assert rows == [["mycat", POLARIS_CATALOG_ID, POLARIS_REALM, True]]
+
+
+def test_unregister_disables_outbound(polaris_extension, superuser_conn):
+    """
+    After unregister_catalog, INSERT into tables_internal must NOT
+    produce a Polaris entity. Re-registering re-enables.
+    """
+    run_command("CREATE TABLE public.unreg_t (a int)", superuser_conn)
+    superuser_conn.commit()
+
+    try:
+        run_command("SELECT lake_polaris.unregister_catalog()", superuser_conn)
+        superuser_conn.commit()
+
+        run_command(
+            """
+            INSERT INTO lake_iceberg.tables_internal
+                (table_name, metadata_location, has_custom_location)
+            VALUES
+                ('public.unreg_t'::regclass,
+                 's3://localbucket/unreg_t/metadata/v1.metadata.json',
+                 true);
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        link_count = run_query(
+            "SELECT count(*) FROM lake_polaris.entity_link",
+            superuser_conn,
+        )[0][0]
+        assert link_count == 0
+
+        # re-register and run the bootstrap to pick the table up
+        run_command(
+            "SELECT lake_polaris.register_catalog('mycat')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        link_count = run_query(
+            "SELECT count(*) FROM lake_polaris.entity_link",
+            superuser_conn,
+        )[0][0]
+        assert link_count == 1
+    finally:
+        run_command(
+            """
+            DELETE FROM lake_iceberg.tables_internal
+             WHERE table_name = 'public.unreg_t'::regclass;
+            DROP TABLE IF EXISTS public.unreg_t;
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+
+def test_bootstrap_backfills_preexisting_tables(polaris_no_register, superuser_conn):
+    """
+    register_catalog calls bootstrap_existing_tables() which must mirror
+    every pre-existing tables_internal row with a metadata_location into
+    Polaris.
+    """
+    run_command(
+        """
+        CREATE TABLE public.bs1 (a int);
+        CREATE TABLE public.bs2 (a int);
+        INSERT INTO lake_iceberg.tables_internal
+            (table_name, metadata_location, has_custom_location)
+        VALUES
+            ('public.bs1'::regclass,
+             's3://localbucket/bs1/metadata/v1.metadata.json', true),
+            ('public.bs2'::regclass,
+             's3://localbucket/bs2/metadata/v1.metadata.json', true);
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        run_command(
+            "SELECT lake_polaris.register_catalog('mycat')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        names = sorted(
+            row[0]
+            for row in run_query(
+                f"""
+                SELECT name FROM polaris_schema.entities
+                WHERE catalog_id = {POLARIS_CATALOG_ID}
+                  AND type_code = 7
+                """,
+                superuser_conn,
+            )
+        )
+        assert names == ["bs1", "bs2"]
+
+        link_count = run_query(
+            "SELECT count(*) FROM lake_polaris.entity_link",
+            superuser_conn,
+        )[0][0]
+        assert link_count == 2
+    finally:
+        run_command(
+            """
+            DELETE FROM lake_iceberg.tables_internal
+             WHERE table_name IN
+                ('public.bs1'::regclass, 'public.bs2'::regclass);
+            DROP TABLE IF EXISTS public.bs1;
+            DROP TABLE IF EXISTS public.bs2;
+            """,
+            superuser_conn,
+        )
+        superuser_conn.commit()

--- a/pg_lake_polaris/tests/pytests/test_polaris_register.py
+++ b/pg_lake_polaris/tests/pytests/test_polaris_register.py
@@ -35,9 +35,9 @@ def polaris_no_register(polaris_schema, extension, superuser_conn, app_user):
 
     run_command(
         f"""
+        DROP EXTENSION pg_lake_polaris CASCADE;
         DELETE FROM polaris_schema.entities
             WHERE id NOT IN (0, {POLARIS_CATALOG_ID});
-        DROP EXTENSION pg_lake_polaris CASCADE;
         """,
         superuser_conn,
     )


### PR DESCRIPTION
Work in progress, opening as draft so the branch does not get lost.

## Problem

pg_lake stores Iceberg metadata in `lake_iceberg.tables_internal`. When Apache Polaris runs co-resident in the same Postgres database (`polaris_schema.entities`), there is no path to keep the two catalogs in sync. Tables registered through pg_lake are invisible to Polaris clients, and metadata commits made through Polaris (external writers, REST clients) are invisible to pg_lake.

## Solution

Add a new optional extension `pg_lake_polaris` that mirrors metadata between the two catalogs:

- Outbound (pg_lake to Polaris) is via triggers on `tables_internal`.
- Inbound (Polaris to pg_lake) piggybacks on `sync_iceberg_metadata_from_external_write`, which is also added in this branch as a generic external-write entrypoint in pg_lake_table.
- Loop prevention is a process-global suppress flag, mirroring the `SkipIcebergDDLProcessing` pattern.

v0.1 limitations (single-instance Polaris ID allocator, scalar-only inbound CREATE, flat namespaces) are documented inline in the SQL.

The branch also pulls in supporting changes in pg_lake_table: external Iceberg write support via catalog UPDATE, a deletion queue for files unreferenced after external sync, and snapshot/SPI fixes surfaced while wiring this up.

### Setup

```sql
-- Optional: override the Polaris realm_id (default 'POLARIS').
SET pg_lake_polaris.realm_id = 'POLARIS';

-- Load the extension. pg_lake_iceberg and pg_lake_table are required.
CREATE EXTENSION pg_lake_polaris;

-- Pin this database to a Polaris catalog that already exists in
-- polaris_schema.entities. Installs the inbound trigger and mirrors
-- existing pg_lake Iceberg tables out to Polaris.
SELECT lake_polaris.register_catalog('mycat');
```

After `register_catalog`, pg_lake `CREATE TABLE ... USING iceberg` shows up as a table entity under the named Polaris catalog, and metadata commits made through Polaris are reflected back into `lake_iceberg.tables_internal`. To stop syncing, call `lake_polaris.unregister_catalog()`.

## Test plan

- [x] `pg_lake_polaris/tests/pytests/test_polaris_register.py`, `test_polaris_outbound.py`, `test_polaris_inbound.py`, `test_polaris_e2e.py`
- [x] `pg_lake_table/tests/pytests/test_external_write.py`
- [ ] Inbound INSERT path is not e2e-tested in v0.1; documented as a known limitation.