### PR TITLE
Support vended credentials from Iceberg REST catalog

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ pytest-postgresql = "~=7.0"
 psycopg-binary = "~=3.2"
 sqlalchemy = "~=2.0"
 duckdb = "==1.4.3"
+fastavro = "~=1.12"
 
 [dev-packages]
 black = "==25.9.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "81f6cfdba150a1b6b61d4c7274fd57f57c6a065acb320fbeedbd34dab69196cd"
+            "sha256": "41e4ac7892102b5135704795a56d7bffb59079835efa2a17b5385b2e1abc39a5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -525,6 +525,64 @@
             "index": "pypi",
             "markers": "python_full_version >= '3.9.0'",
             "version": "==1.4.3"
+        },
+        "fastavro": {
+            "hashes": [
+                "sha256:030f17eb4c7978538a31b55dea451ceace851a88dc9816b1923f8fb8a260db4c",
+                "sha256:03614131093a32c90c8fd95ff356c316752b8850cb8a770bc96cef17a003e2fc",
+                "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370",
+                "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e",
+                "sha256:070c6134604bd7b6fd44409406ac50445339682b2e872885db2e859f92d22e93",
+                "sha256:0e331896e8efffc72fa03e63b87ebfc37960113127da8e0f5152d91664ffed68",
+                "sha256:1924349c74666c89417bd5cc2749f598e2f15f1d56ee81428b2317ab02c88aae",
+                "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff",
+                "sha256:25ef6855935f67582740ffa6bb978e40ec51be876117a3555c36fa2488dcdf25",
+                "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31",
+                "sha256:2b73d50978d5e57416fa68461f9f3c8f39ea39e761cb1e12f919745adefe26a7",
+                "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef",
+                "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397",
+                "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36",
+                "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0",
+                "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab",
+                "sha256:4c346cf449baf3b113e997c34151ad205e7135bc429469b005b180ade7e65e28",
+                "sha256:4c463a3701f293e30d3d62e71e1989f112028d07f87432baf4507eeb57ec3831",
+                "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423",
+                "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b",
+                "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704",
+                "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e",
+                "sha256:653c4f90dd21d8a1e74309919e08934e420d9aef51d051d14bf5a1c0e8293c22",
+                "sha256:731aefe6c4bf2bafa0798ef83927676d06e44d1d18202cfb56d63b40422ab900",
+                "sha256:742d93f2ca835e4fa83a3ae9ed2bce8b28029ed62ac730f339a37685c23075cd",
+                "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa",
+                "sha256:7caeecf519eff50f007ca4bee16b6e0a8252e5fe682c94432192a20867239888",
+                "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea",
+                "sha256:7f01ebaada59d74fdf6d28e5031a961a413b3752e9edb0c03866fa18480cf4c8",
+                "sha256:81e8da77d201916f6771fc357fda8267c2a256d7aa11923d43bc5f2fc155878b",
+                "sha256:81f6108f3ac292fb6cd05758c9e531389d8fc5e94e8c949b9298f4fb0a239662",
+                "sha256:84a4f76a0aece0aa72b5ed8162ba2ff8c78908b8361b5a5d92ddd161977ccb74",
+                "sha256:8d37c87826ae7195cfbd20fcd448801f2f563bb38f2691ec6574e39cb9eca6c8",
+                "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39",
+                "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f",
+                "sha256:ae60df21cc7059e2f3b1928ad2c0b75c6b26f9ada79d992f87b6fc3f50d3877e",
+                "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d",
+                "sha256:b5539711dfa1ec8f3eca57482b93a48a165af4a99e9d5f41e3af3fb913aadf92",
+                "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c",
+                "sha256:bfac2dada8ddc002e8b7d8289d6fad4f070bc1fec20371cec684a7d10d932e96",
+                "sha256:c01b0f0ce030a7b89263c0236ca77923eae352c5f35ecf214b04d3aaea8eb2c3",
+                "sha256:c57a9920400166398695d92580eca21fd7a79f3c67d691ac7e20a7d1b5300735",
+                "sha256:c7c6d26c731a0e1e8e7d4ae8f13ae524eb6ec0e90d99c8147a19fdbae14eb807",
+                "sha256:d48cd7094598a7e9d4297e8bf4bbe0dc9dc2ba4367d83dbb603e3b3c6aa35566",
+                "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a",
+                "sha256:e235dfdabb51993bcd4a8f45c3a54f21a782f7f92b3def0648b0ace45a1b1ac7",
+                "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282",
+                "sha256:ecd1b23ea7f9af09c865ac8503d07afd7e6bf782d76bb83cbbdba15b7a0db807",
+                "sha256:eec44256856fd59d29d1f1d0950ace18a58e4228e7d49de5d5e1b1875b227dde",
+                "sha256:f089f24225a28ddafa5cfad7c41cfa84db1a55f2d473370769a95c0e3bac60c9",
+                "sha256:f604ba83498e209fff4c7ecc5063a39421dc538dace694bc592f9f338254f3dc"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.12.2"
         },
         "flask": {
             "hashes": [

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -751,7 +751,7 @@ pg_lake heavily relies on S3 storage. However, using real S3 can introduce signi
 # macOS
 brew install minio
 
-# Linux - download from https://min.io/download
+# Linux - download from https://min.io/download (linux-arm64 on ARM machines)
 wget https://dl.min.io/server/minio/release/linux-amd64/minio
 chmod +x minio
 sudo mv minio /usr/local/bin/

--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -513,6 +513,30 @@ create table users (userid bigint, username text, email text);
 
 It can be useful to assign `default_table_access_method` to a specific database user for tools that are unaware of Iceberg (see below). However, some PostgreSQL features such as temporary and unlogged tables stop working unless you explicitly add using heap.
 
+## Iceberg tables in a REST catalog
+
+An Iceberg table can live in an external REST catalog rather than in PostgreSQL, so that other engines see it through the catalog they already use. Which of the two roles a table has is decided when you create it, and cannot be changed afterwards.
+
+**Tables pg_lake creates.** Without `read_only`, pg_lake creates the table in the catalog and owns it: it writes the data and metadata, and names the table in the catalog after the database, schema and table you used. Its files go under `pg_lake_iceberg.default_location_prefix` unless you name a `location`.
+
+```sql
+-- pg_lake creates measurements in the catalog and can write to it
+CREATE TABLE measurements (device_id bigint, value float8)
+USING iceberg WITH (catalog = 'my_rest_catalog');
+```
+
+**Tables that already exist in the catalog.** A table created by something else is attached with `read_only`, naming it as it is known to the catalog:
+
+```sql
+-- attach an existing catalog table for querying
+CREATE TABLE sales () USING iceberg
+WITH (catalog = 'my_rest_catalog', read_only = true,
+      catalog_name = 'analytics', catalog_namespace = 'public',
+      catalog_table_name = 'sales');
+```
+
+Such a table can be queried but not written to, and the catalog options that name it are only accepted together with `read_only`. Writing would mean taking over a table's metadata, field-id mappings and file inventory from whatever produced them, which pg_lake does not do: it writes only to tables it created itself. To move existing data under pg_lake, create a table as above and copy into it.
+
 ## Copy external PostgreSQL tables to Iceberg
 A big advantage of being able to change the `default_table_access_method` to Iceberg is that it can significantly simplify data migrations.
 

--- a/pg_lake_engine/include/pg_lake/pgduck/vended_secrets.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/vended_secrets.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PGDUCK_VENDED_SECRETS_H
+#define PGDUCK_VENDED_SECRETS_H
+
+#include "postgres.h"
+#include "pg_lake/pgduck/client.h"
+
+/*
+ * VendedS3Secret describes one scoped S3 secret to (re)create in
+ * pgduck_server.  The credential fields are supplied by the caller
+ * (ultimately from the REST catalog loadTable response).
+ *
+ * endpoint / urlStyle / useSsl carry the catalog-provided S3 connection
+ * settings.  Each of them, left NULL, is filled in on its own from the
+ * pre-existing (non-vended) S3 secret that covers the same bucket, so
+ * vended secrets keep working against local S3 mocks (Moto/MinIO) and
+ * custom endpoints even when the catalog states only part of the
+ * connection.  Catalog-provided values always win over the inherited
+ * fallback.
+ */
+typedef struct VendedS3Secret
+{
+	Oid			serverOid;		/* iceberg_catalog server OID */
+	const char *secretId;		/* identity the secret's name is derived from;
+								 * see GenerateVendedSecretName */
+	const char *scope;			/* normalized S3 scope (trailing '/') */
+	const char *accessKeyId;
+	const char *secretAccessKey;
+	const char *sessionToken;	/* NULL for non-STS credentials */
+	const char *region;			/* NULL when the catalog omits it */
+	const char *endpoint;		/* NULL -> inherit from existing secret */
+	const char *urlStyle;		/* "path"/"vhost"; NULL -> inherit */
+	const char *useSsl;			/* "true"/"false"; NULL -> inherit */
+}			VendedS3Secret;
+
+/*
+ * PushVendedSecretToPGDuck creates or replaces a DuckDB scoped secret
+ * for vended S3 credentials.  The call is mutating on purpose: it issues
+ * CREATE OR REPLACE SECRET, so callers should treat this as a write, not
+ * a getter.
+ *
+ * The secret itself belongs to the pgduck_server instance rather than to
+ * conn: DuckDB's temporary secrets are process-wide, so every connection
+ * sees it and it outlives the one that created it.  conn is here only so
+ * that a caller with several secrets to push spends one connection on
+ * them instead of one each.
+ *
+ * The secret name is deterministic (see GenerateVendedSecretName).
+ * Keeping the name independent of the S3 scope makes CREATE OR REPLACE
+ * idempotent as credentials rotate and lets the drop below reconstruct
+ * the name without the credentials.  The secret's SCOPE is set to
+ * secret->scope (what the credential is good for) so DuckDB's secret
+ * manager automatically selects it for matching URLs.
+ */
+extern PGDLLEXPORT void PushVendedSecretToPGDuck(PGDuckConnection * conn,
+												 const VendedS3Secret * secret);
+
+/*
+ * DropVendedSecretFromPGDuck removes a previously-created vended secret
+ * from DuckDB.  Safe to call even if the secret does not exist.
+ */
+extern PGDLLEXPORT void DropVendedSecretFromPGDuck(PGDuckConnection * conn,
+												   Oid serverOid,
+												   const char *secretId);
+
+/*
+ * GenerateVendedSecretName produces the deterministic secret name for
+ * the given server OID and stable per-table secret identity.  The name
+ * is scoped to the current database so secrets pushed by backends of
+ * different databases (which share one pgduck_server) never collide.
+ */
+extern PGDLLEXPORT char *GenerateVendedSecretName(Oid serverOid,
+												  const char *secretId);
+
+#endif

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -76,6 +76,19 @@ flush_deletion_queue(PG_FUNCTION_ARGS)
 
 	InitMaterializedSRF(fcinfo, MAT_SRF_USE_EXPECTED_DESC);
 
+	/*
+	 * The deletes below reach object storage under whatever secrets
+	 * pgduck_server already holds, which for these files is the standing
+	 * configuration rather than anything vended: credentials are vended only
+	 * for read-only tables, and a read-only table owns none of the files it
+	 * reads, so it never queues a delete here.
+	 *
+	 * Resolving here instead is not possible without the engine knowing what
+	 * a catalog is, and would not help the case that matters anyway: an "all
+	 * tables" drain covers files whose table is already dropped, and a
+	 * dropped relation can no longer be resolved.
+	 */
+
 	/* remove all */
 	bool		isFull = true;
 	bool		isVerbose = false;

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -363,7 +363,15 @@ ExecuteQueryOnPGDuckConnection(PGDuckConnection * pgDuckConnection,
 {
 	PGconn	   *conn = pgDuckConnection->conn;
 #ifdef USE_ASSERT_CHECKING
-	elog(DEBUG2, "PGDuck: %s", query);
+
+	/*
+	 * Never echo secret DDL: CREATE SECRET carries plaintext credentials, so
+	 * even in assert-only debug builds we must not log them verbatim.
+	 */
+	if (strstr(query, "SECRET") != NULL)
+		elog(DEBUG2, "PGDuck: <secret statement redacted>");
+	else
+		elog(DEBUG2, "PGDuck: %s", query);
 #endif
 
 	if (PQsendQuery(conn, query) == 0)

--- a/pg_lake_engine/src/pgduck/vended_secrets.c
+++ b/pg_lake_engine/src/pgduck/vended_secrets.c
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * vended_secrets.c
+ *
+ * Manages DuckDB scoped secrets for vended S3 credentials from
+ * Iceberg REST catalogs.  Secrets are pushed to pgduck_server via
+ * CREATE OR REPLACE SECRET with a URL-scoped SCOPE, so DuckDB's
+ * secret manager automatically selects the most specific match.
+ */
+
+#include "postgres.h"
+
+#include "common/hashfn.h"
+#include "lib/stringinfo.h"
+#include "miscadmin.h"
+#include "utils/builtins.h"
+
+#include "pg_lake/pgduck/client.h"
+#include "pg_lake/pgduck/vended_secrets.h"
+
+
+/*
+ * Connection settings carried over from the secret that was already
+ * serving this prefix.  A vended secret takes over from it by having a
+ * more specific SCOPE, so anything it does not state itself -- where
+ * the store actually is, above all -- would otherwise revert to
+ * real-AWS defaults and leave the deployment.
+ */
+typedef struct S3InheritedSettings
+{
+	char	   *endpoint;
+	char	   *urlStyle;
+	char	   *useSsl;
+}			S3InheritedSettings;
+
+
+/*
+ * GenerateVendedSecretName produces a deterministic name for a vended
+ * secret: pglake_vended_<dbOid>_<serverOid>_<hash(secretId)>.
+ *
+ * secretId is a stable identity that names both the principal and what
+ * the credential is good for (e.g.
+ * "<userMappingOid>/catalog/ns/table/<scope>"), so the name stays
+ * constant as the underlying credentials rotate, keeping CREATE OR
+ * REPLACE SECRET idempotent.  The database OID is included because a
+ * single pgduck_server is shared by all databases in the cluster, and a
+ * 64-bit hash is used so distinct identities do not collide on the
+ * shared secret namespace.
+ */
+char *
+GenerateVendedSecretName(Oid serverOid, const char *secretId)
+{
+	uint64		keyHash = hash_bytes_extended((const unsigned char *) secretId,
+											  strlen(secretId), 0);
+
+	return psprintf("pglake_vended_%u_%u_%016llx",
+					MyDatabaseId, serverOid, (unsigned long long) keyHash);
+}
+
+
+/*
+ * EscapeSingleQuotes doubles any embedded single quotes in the input
+ * string for safe interpolation into DuckDB SQL literals.
+ */
+static char *
+EscapeSingleQuotes(const char *input)
+{
+	if (input == NULL)
+		return NULL;
+
+	if (strchr(input, '\'') == NULL)
+		return pstrdup(input);
+
+	StringInfoData escaped;
+
+	initStringInfo(&escaped);
+
+	for (const char *p = input; *p != '\0'; p++)
+	{
+		if (*p == '\'')
+			appendStringInfoChar(&escaped, '\'');
+		appendStringInfoChar(&escaped, *p);
+	}
+
+	return escaped.data;
+}
+
+
+/*
+ * ExtractFieldFromSecretString extracts a value from the semicolon-
+ * separated key=value representation that DuckDB's duckdb_secrets()
+ * returns in its secret_string column.
+ *
+ * Returns a palloc'd copy of the value, or NULL when the key is
+ * absent or has an empty value.
+ */
+static char *
+ExtractFieldFromSecretString(const char *secretString, const char *key)
+{
+	if (secretString == NULL)
+		return NULL;
+
+	size_t		keyLen = strlen(key);
+	const char *p = secretString;
+
+	while (*p != '\0')
+	{
+		if (strncmp(p, key, keyLen) == 0 && p[keyLen] == '=')
+		{
+			const char *valStart = p + keyLen + 1;
+			const char *valEnd = strchr(valStart, ';');
+			int			len = valEnd ? (valEnd - valStart) : (int) strlen(valStart);
+
+			if (len == 0)
+				return NULL;
+
+			return pnstrdup(valStart, len);
+		}
+
+		const char *next = strchr(p, ';');
+
+		if (next == NULL)
+			break;
+
+		p = next + 1;
+	}
+
+	return NULL;
+}
+
+
+/*
+ * LookupInheritedS3Settings returns the ENDPOINT, URL_STYLE and USE_SSL
+ * of the existing (non-vended) S3 secret that covers s3Prefix.
+ *
+ * Which secret that is, is decided by DuckDB's own rule -- longest
+ * matching scope -- expressed in the query rather than reimplemented
+ * here, so what we inherit is what the read would have used had nothing
+ * been vended at all.  Vended secrets are excluded, since one of those
+ * is likely this very secret from an earlier push.
+ *
+ * This is what lets a vended secret reach an S3-compatible store whose
+ * catalog states only part of the connection: without it DuckDB falls
+ * back to real-AWS defaults and the scan leaves the deployment
+ * entirely.  What it cannot do is move a credential somewhere the
+ * catalog did not point: the caller keeps every value the catalog
+ * stated, so a secret in a namespace other tenants can write to can
+ * only supply a setting nobody else has.
+ */
+static S3InheritedSettings
+LookupInheritedS3Settings(PGDuckConnection * conn, const char *s3Prefix)
+{
+	S3InheritedSettings settings = {0};
+
+	/* Without a prefix there is no secret to inherit from. */
+	if (s3Prefix == NULL || s3Prefix[0] == '\0')
+		return settings;
+
+	char	   *escapedPrefix = EscapeSingleQuotes(s3Prefix);
+	char	   *query =
+		psprintf("SELECT secret_string FROM ("
+				 "SELECT secret_string, unnest(scope) AS prefix "
+				 "FROM duckdb_secrets() "
+				 "WHERE type = 's3' AND name NOT LIKE 'pglake_vended_%%') s "
+				 "WHERE starts_with('%s', prefix) "
+				 "ORDER BY length(prefix) DESC LIMIT 1",
+				 escapedPrefix);
+
+	PGresult   *result = ExecuteQueryOnPGDuckConnection(conn, query);
+
+	PG_TRY();
+	{
+		ThrowIfPGDuckResultHasError(conn, result);
+
+		if (PQntuples(result) > 0)
+		{
+			char	   *secretString = PQgetvalue(result, 0, 0);
+
+			settings.endpoint = ExtractFieldFromSecretString(secretString,
+															 "endpoint");
+			settings.urlStyle = ExtractFieldFromSecretString(secretString,
+															 "url_style");
+			settings.useSsl = ExtractFieldFromSecretString(secretString,
+														   "use_ssl");
+		}
+	}
+	PG_FINALLY();
+	{
+		PQclear(result);
+	}
+	PG_END_TRY();
+
+	pfree(query);
+	pfree(escapedPrefix);
+
+	return settings;
+}
+
+
+/*
+ * AppendS3ConnectionSetting adds ", <keyword> '<value>'" to sql,
+ * escaping the value for safe interpolation.
+ */
+static void
+AppendS3ConnectionSetting(StringInfo sql, const char *keyword,
+						  const char *value)
+{
+	char	   *escaped = EscapeSingleQuotes(value);
+
+	appendStringInfo(sql, ", %s '%s'", keyword, escaped);
+	pfree(escaped);
+}
+
+
+/*
+ * BuildCreateSecretSQL constructs the DuckDB SQL statement for
+ * creating or replacing a vended S3 secret.
+ *
+ * All values are treated as untrusted input and single-quote-escaped to
+ * prevent SQL injection.  endpoint / urlStyle / useSsl are the already-
+ * resolved connection settings (catalog-provided value, or the inherited
+ * fallback); each is emitted only when present.
+ *
+ * Everything optional here is NULL when unset, never the empty string:
+ * both sources of these values -- the catalog config map and the secret
+ * inherited from duckdb_secrets() -- report a stated-but-empty setting
+ * as unset.
+ */
+static char *
+BuildCreateSecretSQL(const char *secretName,
+					 const VendedS3Secret * secret,
+					 const char *endpoint,
+					 const char *urlStyle,
+					 const char *useSsl)
+{
+	StringInfoData sql;
+
+	initStringInfo(&sql);
+
+	char	   *escapedKeyId = EscapeSingleQuotes(secret->accessKeyId);
+	char	   *escapedSecret = EscapeSingleQuotes(secret->secretAccessKey);
+
+	appendStringInfo(&sql,
+					 "CREATE OR REPLACE SECRET \"%s\" ("
+					 "TYPE S3, "
+					 "KEY_ID '%s', "
+					 "SECRET '%s'",
+					 secretName, escapedKeyId, escapedSecret);
+
+	if (secret->sessionToken != NULL)
+		AppendS3ConnectionSetting(&sql, "SESSION_TOKEN", secret->sessionToken);
+
+	if (secret->region != NULL)
+		AppendS3ConnectionSetting(&sql, "REGION", secret->region);
+
+	if (endpoint != NULL)
+		AppendS3ConnectionSetting(&sql, "ENDPOINT", endpoint);
+
+	if (urlStyle != NULL)
+		AppendS3ConnectionSetting(&sql, "URL_STYLE", urlStyle);
+
+	if (useSsl != NULL)
+	{
+		/*
+		 * A vended value ("true"/"false") or an inherited one from
+		 * duckdb_secrets() (which may render "1"/"0" depending on version);
+		 * parse_bool handles both so we don't silently coerce SSL off (which
+		 * would break real-AWS access).
+		 */
+		bool		ssl = true;
+
+		(void) parse_bool(useSsl, &ssl);
+		appendStringInfo(&sql, ", USE_SSL %s", ssl ? "true" : "false");
+	}
+
+	if (secret->scope != NULL)
+		AppendS3ConnectionSetting(&sql, "SCOPE", secret->scope);
+
+	appendStringInfoChar(&sql, ')');
+
+	pfree(escapedKeyId);
+	pfree(escapedSecret);
+
+	return sql.data;
+}
+
+
+/*
+ * PushNamedVendedSecret resolves the S3 connection settings and creates
+ * the vended secret under the given name.
+ *
+ * The catalog is the authority on where its own storage lives, so its
+ * values are taken as given.  Each setting is resolved on its own,
+ * though: a catalog that states an endpoint but not an addressing style
+ * is the ordinary case for an S3-compatible store, and dropping the
+ * URL_STYLE that the existing secret carries leaves DuckDB addressing
+ * the bucket as a subdomain of a host that has no such name.
+ *
+ * Inheriting cannot redirect the credentials: an endpoint the catalog
+ * stated is never overwritten, and SSL is already pinned by that
+ * endpoint's scheme, so the fallback only fills in what nobody has
+ * stated.  The query itself is skipped entirely when there is nothing
+ * left to fill in.
+ */
+static void
+PushNamedVendedSecret(PGDuckConnection * conn,
+					  const char *secretName,
+					  const VendedS3Secret * secret)
+{
+	const char *endpoint = secret->endpoint;
+	const char *urlStyle = secret->urlStyle;
+	const char *useSsl = secret->useSsl;
+
+	if (endpoint == NULL || urlStyle == NULL || useSsl == NULL)
+	{
+		S3InheritedSettings inherited =
+			LookupInheritedS3Settings(conn, secret->scope);
+
+		if (endpoint == NULL)
+			endpoint = inherited.endpoint;
+		if (urlStyle == NULL)
+			urlStyle = inherited.urlStyle;
+		if (useSsl == NULL)
+			useSsl = inherited.useSsl;
+	}
+
+	char	   *sql = BuildCreateSecretSQL(secretName, secret,
+										   endpoint, urlStyle, useSsl);
+
+	PGresult   *result = ExecuteQueryOnPGDuckConnection(conn, sql);
+
+	CheckPGDuckResult(conn, result);
+	PQclear(result);
+
+	pfree(sql);
+}
+
+
+/*
+ * The vended secret in pgduck_server is a temporary (in-memory) secret:
+ * process-wide, shared across connections, and lost only when
+ * pgduck_server restarts.  The storage-credential resolver tracks which
+ * secrets this backend has pushed and, using the catalog-provided
+ * expiry, re-pushes with CREATE OR REPLACE only when a secret is new or
+ * nearing expiry -- so a warm scan needs no secret round-trip at all,
+ * while rotating STS credentials are still refreshed before they lapse.
+ * (Trade-off: if pgduck_server restarts, a backend that believes its
+ * secret is still fresh will not re-push until the next reconcile that
+ * has other work to do; the resolver batches CREATE and DROP for a
+ * relation onto a single connection to keep that cost minimal.)
+ */
+void
+PushVendedSecretToPGDuck(PGDuckConnection * conn,
+						 const VendedS3Secret * secret)
+{
+	char	   *secretName = GenerateVendedSecretName(secret->serverOid,
+													  secret->secretId);
+
+	elog(DEBUG2, "pushing vended secret \"%s\" to pgduck_server", secretName);
+
+	PushNamedVendedSecret(conn, secretName, secret);
+
+	pfree(secretName);
+}
+
+
+void
+DropVendedSecretFromPGDuck(PGDuckConnection * conn,
+						   Oid serverOid, const char *secretId)
+{
+	char	   *secretName = GenerateVendedSecretName(serverOid, secretId);
+	char	   *sql = psprintf("DROP SECRET IF EXISTS \"%s\"", secretName);
+
+	elog(DEBUG2, "dropping vended secret \"%s\" from pgduck_server",
+		 secretName);
+
+	/* Best-effort: a failed drop must not abort the caller. */
+	PGresult   *result = ExecuteQueryOnPGDuckConnection(conn, sql);
+
+	PQclear(result);
+
+	pfree(sql);
+	pfree(secretName);
+}

--- a/pg_lake_iceberg/include/pg_lake/avro/avro_reader.h
+++ b/pg_lake_iceberg/include/pg_lake/avro/avro_reader.h
@@ -57,15 +57,19 @@ void		AvroReaderClose(AvroReader * reader);
 bool		AvroFieldExists(avro_value_t * record, char *fieldName);
 void		AvroGetBoolField(avro_value_t * record, char *fieldName, AvroFieldRequired required, bool *boolPointer);
 void		AvroGetInt32Field(avro_value_t * record, char *fieldName, AvroFieldRequired required, int32_t *valPointer);
-void		AvroGetNullableInt32Field(avro_value_t * record, char *fieldName, int32_t *intPointer, bool *isSet);
+void		AvroGetNullableInt32Field(avro_value_t * record, char *fieldName, AvroFieldRequired required,
+									  int32_t *intPointer, bool *isSet);
 void		AvroGetInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired required, int64_t *valPointer);
-void		AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, int64_t *longPointer, bool *isSet);
+void		AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired required,
+									  int64_t *longPointer, bool *isSet);
 void		AvroGetStringField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 							   const char **stringPointer, size_t *lengthPointer);
-void		AvroGetNullableStringField(avro_value_t * record, char *fieldName, const char **stringPointer, size_t *lengthPointer, bool *isSet);
+void		AvroGetNullableStringField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
+									   const char **stringPointer, size_t *lengthPointer, bool *isSet);
 void		AvroGetBinaryField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 							   const void **bytesPointer, size_t *lengthPointer);
-void		AvroGetNullableBinaryField(avro_value_t * record, char *fieldName, const void **bytesPointer, size_t *lengthPointer, bool *isSet);
+void		AvroGetNullableBinaryField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
+									   const void **bytesPointer, size_t *lengthPointer, bool *isSet);
 void		AvroGetRecordField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 							   AvroParseFunction parseFn, void *entry, void *context);
 void		AvroGetObjectArrayField(avro_value_t * record, char *fieldName, AvroFieldRequired required,

--- a/pg_lake_iceberg/include/pg_lake/iceberg/metadata_spec.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/metadata_spec.h
@@ -289,6 +289,7 @@ typedef struct IcebergTableMetadata
 }			IcebergTableMetadata;
 
 extern PGDLLEXPORT IcebergTableMetadata * ReadIcebergTableMetadata(const char *tableMetadataPath);
+extern PGDLLEXPORT IcebergTableMetadata * ParseIcebergTableMetadata(Jsonb *tableMetadataJson);
 extern PGDLLEXPORT char *WriteIcebergTableMetadataToJson(IcebergTableMetadata * metadata);
 extern PGDLLEXPORT void AppendIcebergTableSchemaForRestCatalog(StringInfo command, IcebergTableSchema * schemas, size_t schemas_length);
 extern PGDLLEXPORT void AppendIcebergPartitionSpecFields(StringInfo command, IcebergPartitionSpecField * fields, size_t fields_length);

--- a/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
@@ -19,6 +19,8 @@
 
 #include "postgres.h"
 #include "foreign/foreign.h"
+#include "utils/jsonb.h"
+#include "utils/timestamp.h"
 #include "pg_lake/ddl/utility_hook.h"
 #include "pg_lake/http/http_client.h"
 #include "pg_lake/util/rel_utils.h"
@@ -35,6 +37,63 @@ extern char *RestCatalogClientSecret;
 extern char *RestCatalogScope;
 extern int	RestCatalogAuthType;
 extern bool RestCatalogEnableVendedCredentials;
+
+
+/*
+ * Temporary storage credentials received from an Iceberg REST catalog
+ * via the X-Iceberg-Access-Delegation: vended-credentials mechanism.
+ *
+ * These credentials are scoped to a specific S3 prefix (typically a
+ * table's data directory) and have a limited lifetime.
+ */
+typedef struct VendedCredentials
+{
+	char	   *accessKeyId;	/* s3.access-key-id */
+	char	   *secretAccessKey;	/* s3.secret-access-key */
+	char	   *sessionToken;	/* s3.session-token (may be NULL for non-STS
+								 * creds) */
+	char	   *region;			/* client.region / s3.region (may be NULL) */
+	char	   *endpoint;		/* s3.endpoint, scheme stripped (may be NULL) */
+	char	   *urlStyle;		/* "path"/"vhost" from s3.path-style-access
+								 * (may be NULL) */
+	char	   *useSsl;			/* "true"/"false" from the s3.endpoint scheme
+								 * (may be NULL) */
+	char	   *scope;			/* S3 prefix these creds are scoped to (the
+								 * table's storage location; may be NULL) */
+	Oid			serverOid;		/* the iceberg_catalog server these came from */
+	TimestampTz fetchedAt;		/* when credentials were obtained */
+	TimestampTz expiresAt;		/* catalog-provided expiry, or 0 when the
+								 * response carried no explicit expiry */
+}			VendedCredentials;
+
+
+/*
+ * Result of loading a table from a REST catalog.  Contains the metadata
+ * location, the table metadata document the catalog inlined alongside
+ * it, and optional vended credentials from the response's "config" map.
+ */
+typedef struct RestCatalogLoadTableResult
+{
+	char	   *metadataLocation;
+
+	/*
+	 * The "metadata" object of the loadTable response: the same document that
+	 * lives at metadataLocation, which the catalog hands us for free. Reading
+	 * it here saves a round-trip to storage, and is the only way to see the
+	 * schema before the relation exists, since storage credentials are
+	 * resolved per relation.  NULL if the catalog omitted it.
+	 */
+	Jsonb	   *metadata;
+
+	/*
+	 * One VendedCredentials per storage-credential the catalog returned, each
+	 * with its own scope; NIL when not vended or not requested.  A catalog is
+	 * free to vend more than one, e.g. separate credentials for the data
+	 * files and the metadata directory.
+	 */
+	List	   *vendedCredentials;
+}			RestCatalogLoadTableResult;
+
 
 /*
  * Resolved REST catalog connection options.  All REST catalogs --
@@ -156,6 +215,25 @@ List	   *LookupUserMappingOptionsByOid(Oid umOid, Oid *serverOidOut);
 char	   *GetRestCatalogAccessToken(RestCatalogOptions * opts, bool forceRefreshToken);
 List	   *GetHeadersWithAuth(RestCatalogOptions * opts);
 char	   *JsonbGetStringByPath(const char *jsonb_text, int nkeys,...);
+char	   *JsonbGetOptionalStringByPath(const char *jsonb_text, int nkeys,...);
+char	   *JsonbGetOptionalString(Jsonb *jb, int nkeys,...);
+
+/*
+ * One element of a JSON array of objects: the nested object the caller
+ * asked for, plus one string field read off the element itself (e.g. a
+ * storage-credential's "prefix").
+ */
+typedef struct JsonbArrayElement
+{
+	char	   *stringValue;	/* may be NULL when the field is absent */
+	Jsonb	   *object;
+}			JsonbArrayElement;
+
+Jsonb	   *JsonbGetObject(Jsonb *jb, const char *key);
+
+List	   *JsonbGetArrayElementObjects(Jsonb *jb, const char *arrayKey,
+										const char *objectKey,
+										const char *elementStringKey);
 
 extern PGDLLEXPORT void RegisterNamespaceToRestCatalog(RestCatalogOptions * opts, const char *catalogName, const char *namespaceName);
 extern PGDLLEXPORT void StartStageRestCatalogIcebergTableCreate(Oid relationId);
@@ -165,9 +243,20 @@ extern PGDLLEXPORT char *GetRestCatalogName(Oid relationId);
 extern PGDLLEXPORT char *GetRestCatalogNamespace(Oid relationId);
 extern PGDLLEXPORT char *GetRestCatalogTableName(Oid relationId);
 extern PGDLLEXPORT bool IsReadOnlyRestCatalogIcebergTable(Oid relationId);
-extern PGDLLEXPORT char *GetMetadataLocationFromRestCatalog(RestCatalogOptions * opts, const char *restCatalogName, const char *namespaceName,
-															const char *relationName);
+extern PGDLLEXPORT char *LoadRestCatalogMetadataLocation(RestCatalogOptions * opts, const char *restCatalogName, const char *namespaceName,
+														 const char *relationName);
+extern PGDLLEXPORT RestCatalogLoadTableResult LoadTableFromRestCatalog(RestCatalogOptions * opts, const char *restCatalogName,
+																	   const char *namespaceName, const char *relationName);
 extern PGDLLEXPORT char *GetMetadataLocationForRestCatalogForIcebergTable(Oid relationId);
+extern PGDLLEXPORT bool RestCatalogVendingEnabledForRelation(Oid relationId);
+
+/*
+ * Resolves a relation's REST-catalog vended credentials, returning a
+ * List<StorageCredential *> or NIL.  Called by ResolveStorageCredentials
+ * (storage/storage_credentials.c) on the way to pgduck_server.
+ */
+extern PGDLLEXPORT List *IcebergProvideStorageCredentials(Oid relationId);
+extern PGDLLEXPORT void InvalidateVendedCredentialsCache(void);
 extern PGDLLEXPORT void ReportHTTPError(HttpResult httpResult, int level);
 extern PGDLLEXPORT List *PostHeadersWithAuth(RestCatalogOptions * opts);
 extern PGDLLEXPORT List *DeleteHeadersWithAuth(RestCatalogOptions * opts);

--- a/pg_lake_iceberg/include/pg_lake/storage/storage_credentials.h
+++ b/pg_lake_iceberg/include/pg_lake/storage/storage_credentials.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * storage_credentials.h
+ *
+ * Resolves the credentials needed to reach a relation's storage and
+ * reconciles them into pgduck_server as scoped DuckDB secrets.
+ *
+ * Credentials come from an Iceberg REST catalog, so this lives with the
+ * rest of the catalog code rather than in pg_lake_engine: the engine
+ * offers the mechanism for creating a scoped secret (see
+ * pg_lake/pgduck/vended_secrets.h) and knows nothing of catalogs, and
+ * every caller here sits at or above pg_lake_iceberg.
+ *
+ * Resolution is a pull, not a push.  EnsureStorageCredentialsForRelation
+ * is called where a storage path is about to be touched; it resolves the
+ * credentials on demand -- issuing a REST loadTable on a cache miss --
+ * and reconciles the secret set, (re)pushing fresh credentials and
+ * dropping secrets the catalog no longer vends.  Resolving at the point
+ * of use, rather than pushing from a cache that something has to
+ * remember to warm, is what makes each storage entry point covered by
+ * construction.
+ *
+ * Only read-only REST tables are served; see
+ * IcebergProvideStorageCredentials for why writable tables wait.
+ *
+ * Two limitations are inherent to a shared pgduck_server holding global,
+ * in-memory secrets:
+ *
+ *  1. pgduck_server restart.  A backend tracks the secrets it pushed and
+ *     skips a re-push while the cached expiry is still safe.  If
+ *     pgduck_server restarts, those secrets are gone while the backend
+ *     still believes them present, so scans can fail with HTTP 403 until
+ *     the next reconcile that has other work -- bounded by the credential
+ *     TTL (<=1h for STS).  Closing this needs either a pgduck boot-id
+ *     handshake (free on connect) or treating an S3 403 as a signal to
+ *     re-push.
+ *
+ *  2. Same-scope, multi-principal selection.  DuckDB selects a secret by
+ *     longest-matching SCOPE, not by name.  Principal-scoped secret names
+ *     stop one backend from clobbering another's secret, but two secrets
+ *     with the *same* scope and different credentials (two roles, one S3
+ *     prefix) are ambiguous to DuckDB's tie-break.
+ */
+
+#ifndef PG_LAKE_STORAGE_CREDENTIALS_H
+#define PG_LAKE_STORAGE_CREDENTIALS_H
+
+#include "postgres.h"
+
+#include "datatype/timestamp.h"
+#include "nodes/pg_list.h"
+
+/*
+ * One credential and the storage prefix it authorizes.  A REST
+ * "storage-credentials" array can yield several of these per table, so
+ * resolution returns a List<StorageCredential *>.
+ *
+ * secretId is the stable identity used to name the pgduck_server
+ * secret.  It MUST incorporate the user-mapping OID, so that two roles
+ * vended different credentials for the same table do not collide on a
+ * single secret, and the scope, so that two credentials of the same
+ * table do not overwrite each other.
+ *
+ * IcebergProvideStorageCredentials returns freshly-allocated copies (not
+ * pointers into the credential cache), because the caller may run
+ * syscache lookups between resolving and using these values.
+ */
+typedef struct StorageCredential
+{
+	Oid			serverOid;		/* iceberg_catalog server OID */
+	char	   *secretId;		/* identity, e.g.
+								 * "<umOid>/<catalog>/<ns>/<table>/<scope>" */
+	char	   *scopePrefix;	/* normalized S3 scope, trailing '/' */
+	char	   *accessKeyId;
+	char	   *secretAccessKey;
+	char	   *sessionToken;	/* NULL for non-STS credentials */
+	char	   *region;			/* NULL when the catalog omits it */
+	char	   *endpoint;		/* catalog s3.endpoint; NULL -> inherit */
+	char	   *urlStyle;		/* "path"/"vhost"; NULL -> inherit */
+	char	   *useSsl;			/* "true"/"false"; NULL -> inherit */
+	TimestampTz expiresAt;		/* 0 when the catalog gave no expiry */
+}			StorageCredential;
+
+/*
+ * EnsureStorageCredentialsForRelation reconciles the pgduck_server
+ * secrets for the given relation against what the catalog currently
+ * vends: it (re)pushes fresh credentials and drops secrets the catalog
+ * no longer returns.  Best-effort: a failure to resolve (e.g. a
+ * transient OAuth error) never aborts the caller's statement -- the
+ * storage operation itself will fail authoritatively if a credential was
+ * truly required.
+ */
+extern PGDLLEXPORT void EnsureStorageCredentialsForRelation(Oid relationId);
+
+/*
+ * ForgetStorageCredentials drops any secrets this backend pushed for the
+ * relation.  Call it once the relation's storage no longer needs to be
+ * reached, which for a read-only table is the moment it is dropped: it
+ * owns none of the files it reads, so its drop queues no deletes.  Left
+ * behind, an expired secret would still win DuckDB's longest-scope match
+ * for everything under that prefix.
+ */
+extern PGDLLEXPORT void ForgetStorageCredentials(Oid relationId);
+
+#endif							/* PG_LAKE_STORAGE_CREDENTIALS_H */

--- a/pg_lake_iceberg/src/avro/avro_reader.c
+++ b/pg_lake_iceberg/src/avro/avro_reader.c
@@ -32,7 +32,7 @@ static bool GetFieldValue(avro_value_t * record, char *fieldName, AvroFieldRequi
 static bool GetFieldArrayValue(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 							   avro_value_t * fieldValue, size_t *itemCount);
 static bool AvroPrepareGetNullable(avro_value_t * record, char *fieldName,
-								   avro_value_t * innerValue);
+								   AvroFieldRequired required, avro_value_t * innerValue);
 static avro_type_t AvroGetUnionNotNullType(avro_value_t * unionValue);
 
 
@@ -188,11 +188,12 @@ AvroGetInt32Field(avro_value_t * record, char *fieldName, AvroFieldRequired requ
 
 
 void
-AvroGetNullableInt32Field(avro_value_t * record, char *fieldName, int32_t *intPointer, bool *isSet)
+AvroGetNullableInt32Field(avro_value_t * record, char *fieldName, AvroFieldRequired required,
+						  int32_t *intPointer, bool *isSet)
 {
 	avro_value_t fieldValue;
 
-	if ((*isSet = AvroPrepareGetNullable(record, fieldName, &fieldValue)))
+	if ((*isSet = AvroPrepareGetNullable(record, fieldName, required, &fieldValue)))
 	{
 		if (avro_value_get_int(&fieldValue, intPointer) != 0)
 		{
@@ -221,11 +222,12 @@ AvroGetInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired requ
 
 
 void
-AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, int64_t *longPointer, bool *isSet)
+AvroGetNullableInt64Field(avro_value_t * record, char *fieldName, AvroFieldRequired required,
+						  int64_t *longPointer, bool *isSet)
 {
 	avro_value_t fieldValue;
 
-	if ((*isSet = AvroPrepareGetNullable(record, fieldName, &fieldValue)))
+	if ((*isSet = AvroPrepareGetNullable(record, fieldName, required, &fieldValue)))
 	{
 		if (avro_value_get_long(&fieldValue, longPointer) != 0)
 		{
@@ -256,13 +258,13 @@ AvroGetStringField(avro_value_t * record, char *fieldName, AvroFieldRequired req
 
 
 void
-AvroGetNullableStringField(avro_value_t * record, char *fieldName,
+AvroGetNullableStringField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 						   const char **stringPointer, size_t *lengthPointer,
 						   bool *isSet)
 {
 	avro_value_t fieldValue;
 
-	if ((*isSet = AvroPrepareGetNullable(record, fieldName, &fieldValue)))
+	if ((*isSet = AvroPrepareGetNullable(record, fieldName, required, &fieldValue)))
 	{
 		if (avro_value_get_string(&fieldValue, stringPointer, lengthPointer) != 0)
 		{
@@ -293,13 +295,13 @@ AvroGetBinaryField(avro_value_t * record, char *fieldName, AvroFieldRequired req
 
 
 void
-AvroGetNullableBinaryField(avro_value_t * record, char *fieldName,
+AvroGetNullableBinaryField(avro_value_t * record, char *fieldName, AvroFieldRequired required,
 						   const void **bytesPointer, size_t *lengthPointer,
 						   bool *isSet)
 {
 	avro_value_t fieldValue;
 
-	if ((*isSet = AvroPrepareGetNullable(record, fieldName, &fieldValue)))
+	if ((*isSet = AvroPrepareGetNullable(record, fieldName, required, &fieldValue)))
 	{
 		if (avro_value_get_bytes(&fieldValue, bytesPointer, lengthPointer) != 0)
 		{
@@ -680,15 +682,26 @@ GetFieldArrayValue(avro_value_t * record, char *fieldName, AvroFieldRequired req
 /*
  * AvroPrepareGetNullable is a helper function for getting the value
  * from a [null,?] union.
+ *
+ * Nullable and present are separate questions: a writer may leave an
+ * optional field out of the schema entirely rather than write it as null.
+ * An absent AVRO_FIELD_OPTIONAL field reads as "not set", same as an
+ * explicit null.
  */
 static bool
-AvroPrepareGetNullable(avro_value_t * record, char *fieldName, avro_value_t * innerValue)
+AvroPrepareGetNullable(avro_value_t * record, char *fieldName, AvroFieldRequired required,
+					   avro_value_t * innerValue)
 {
 	avro_value_t unionValue;
 
 	if (avro_value_get_by_name(record, fieldName, &unionValue, NULL) != 0)
 	{
-		ereport(ERROR, (errmsg("%s not found in schema", fieldName)));
+		if (required == AVRO_FIELD_REQUIRED)
+		{
+			ereport(ERROR, (errmsg("%s not found in schema", fieldName)));
+		}
+
+		return false;
 	}
 
 	if (avro_value_get_type(&unionValue) != AVRO_UNION)

--- a/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
+++ b/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
@@ -36,6 +36,7 @@
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/iceberg/operations/find_referenced_files.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/util/array_utils.h"
 #include "pg_lake/util/injection_points.h"
 #include "pg_lake/util/path_hash.h"
@@ -110,6 +111,13 @@ find_all_referenced_files_via_snapshot_ids(PG_FUNCTION_ARGS)
 {
 	Oid			relationId = PG_GETARG_OID(0);
 	ArrayType  *snapshotIds = PG_GETARG_ARRAYTYPE_P(1);
+
+	/*
+	 * Reading the metadata and manifests below goes through object storage,
+	 * so a REST-catalog table that is only reachable with vended credentials
+	 * needs them resolved first.  No-op for every other kind of table.
+	 */
+	EnsureStorageCredentialsForRelation(relationId);
 
 	HTAB	   *fileHash = CreateFilesHash();
 
@@ -205,6 +213,9 @@ find_unreferenced_files_via_snapshot_ids(PG_FUNCTION_ARGS)
 
 	List	   *prevSnapshotIdList = Int64ArrayToList(prevSnapshotIds);
 	List	   *currentSnapshotIdList = Int64ArrayToList(currentSnapshotIds);
+
+	/* see find_all_referenced_files_via_snapshot_ids */
+	EnsureStorageCredentialsForRelation(relationId);
 
 	char	   *currentMetadataPath = GetIcebergMetadataLocation(relationId, false);
 	IcebergTableMetadata *metadata = ReadIcebergTableMetadata(currentMetadataPath);

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -236,9 +236,12 @@ ReadIcebergManifestEntryFromAvro(avro_value_t * record, IcebergManifestEntry * e
 {
 	memset(entry, '\0', sizeof(IcebergManifestEntry));
 	AvroGetInt32Field(record, "status", AVRO_FIELD_REQUIRED, (int32_t *) &entry->status);
-	AvroGetNullableInt64Field(record, "snapshot_id", &entry->snapshot_id, &entry->has_snapshot_id);
-	AvroGetNullableInt64Field(record, "sequence_number", &entry->sequence_number, &entry->has_sequence_number);
-	AvroGetNullableInt64Field(record, "file_sequence_number", &entry->file_sequence_number, &entry->has_file_sequence_number);
+	AvroGetNullableInt64Field(record, "snapshot_id", AVRO_FIELD_OPTIONAL,
+							  &entry->snapshot_id, &entry->has_snapshot_id);
+	AvroGetNullableInt64Field(record, "sequence_number", AVRO_FIELD_OPTIONAL,
+							  &entry->sequence_number, &entry->has_sequence_number);
+	AvroGetNullableInt64Field(record, "file_sequence_number", AVRO_FIELD_OPTIONAL,
+							  &entry->file_sequence_number, &entry->has_file_sequence_number);
 	AvroGetRecordField(record, "data_file", AVRO_FIELD_REQUIRED, (AvroParseFunction) ReadDataFileFromAvro, &entry->data_file, context);
 }
 
@@ -265,6 +268,26 @@ ReadDataFileFromAvro(avro_value_t * record, DataFile * dataFile, ManifestReaderC
 						 "storage scheme (s3://, azure://, etc.).")));
 
 	AvroGetStringField(record, "file_format", AVRO_FIELD_REQUIRED, &dataFile->file_format, &dataFile->file_format_length);
+
+	/*
+	 * Iceberg v3 replaces positional delete files with deletion vectors,
+	 * which appear here as position deletes carried in a Puffin blob rather
+	 * than a Parquet file.  We would hand that path to DuckDB as if it were
+	 * Parquet, so refuse it by name: reporting the deletes we cannot apply is
+	 * the difference between a clear failure and silently returning rows the
+	 * table considers deleted.
+	 */
+	if (dataFile->content == ICEBERG_DATA_FILE_CONTENT_POSITION_DELETES &&
+		dataFile->file_format != NULL &&
+		pg_strcasecmp(dataFile->file_format, "PUFFIN") == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("pg_lake_iceberg: deletion vectors are not supported"),
+				 errdetail("Table references the Puffin deletion vector \"%s\".",
+						   dataFile->file_path),
+				 errhint("Deletion vectors are an Iceberg v3 feature; rewrite "
+						 "the table with positional delete files to read it.")));
+
 	AvroGetRecordField(record, "partition", AVRO_FIELD_REQUIRED, (AvroParseFunction) ReadPartitionFromAvro, &dataFile->partition, context);
 	AvroGetInt64Field(record, "record_count", AVRO_FIELD_REQUIRED, &dataFile->record_count);
 	AvroGetInt64Field(record, "file_size_in_bytes", AVRO_FIELD_REQUIRED, &dataFile->file_size_in_bytes);
@@ -304,7 +327,7 @@ ReadDataFileFromAvro(avro_value_t * record, DataFile * dataFile, ManifestReaderC
 						   &dataFile->split_offsets, &dataFile->split_offsets_length);
 	AvroGetInt32ArrayField(record, "equality_ids", AVRO_FIELD_OPTIONAL,
 						   &dataFile->equality_ids, &dataFile->equality_ids_length);
-	AvroGetNullableInt32Field(record, "sort_order_id",
+	AvroGetNullableInt32Field(record, "sort_order_id", AVRO_FIELD_OPTIONAL,
 							  &dataFile->sort_order_id, &dataFile->has_sort_order_id);
 }
 

--- a/pg_lake_iceberg/src/iceberg/read_table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/read_table_metadata.c
@@ -68,9 +68,21 @@ ReadIcebergTableMetadata(const char *tableMetadataPath)
 	Datum		jsonbDatum = DirectFunctionCall1(jsonb_in, PointerGetDatum(tableMetadataText));
 	Jsonb	   *jsonb = DatumGetJsonbP(jsonbDatum);
 
+	return ParseIcebergTableMetadata(jsonb);
+}
+
+
+/*
+ * ParseIcebergTableMetadata reads an already-parsed metadata document,
+ * for callers holding one that never came from storage -- a REST
+ * catalog inlines the whole document in its loadTable response.
+ */
+IcebergTableMetadata *
+ParseIcebergTableMetadata(Jsonb *tableMetadataJson)
+{
 	IcebergTableMetadata *metadata = palloc0(sizeof(IcebergTableMetadata));
 
-	ReadIcebergTableMetadataFromJson(&jsonb->root, metadata);
+	ReadIcebergTableMetadataFromJson(&tableMetadataJson->root, metadata);
 
 	return metadata;
 }

--- a/pg_lake_iceberg/src/iceberg/read_table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/read_table_metadata.c
@@ -77,6 +77,96 @@ ReadIcebergTableMetadata(const char *tableMetadataPath)
 
 
 /*
+ * NameOfFieldWithInitialDefault returns the name of the first field at or
+ * below this one that declares an initial-default, or NULL when none does.
+ */
+static const char *
+NameOfFieldWithInitialDefault(Field * field)
+{
+	if (field == NULL)
+		return NULL;
+
+	switch (field->type)
+	{
+		case FIELD_TYPE_STRUCT:
+			{
+				FieldStruct *structType = &field->field.structType;
+
+				for (size_t i = 0; i < structType->nfields; i++)
+				{
+					FieldStructElement *element = &structType->fields[i];
+
+					if (element->initialDefault != NULL)
+						return element->name;
+
+					const char *nested =
+						NameOfFieldWithInitialDefault(element->type);
+
+					if (nested != NULL)
+						return nested;
+				}
+
+				return NULL;
+			}
+		case FIELD_TYPE_LIST:
+			return NameOfFieldWithInitialDefault(field->field.list.element);
+		case FIELD_TYPE_MAP:
+			{
+				const char *inKey =
+					NameOfFieldWithInitialDefault(field->field.map.key);
+
+				return inKey != NULL ? inKey :
+					NameOfFieldWithInitialDefault(field->field.map.value);
+			}
+		case FIELD_TYPE_SCALAR:
+			return NULL;
+	}
+
+	return NULL;
+}
+
+
+/*
+ * ErrorIfSchemaDeclaresInitialDefault refuses a v3 schema whose fields
+ * carry an initial-default.
+ *
+ * A column added with a default is not rewritten into the files that
+ * predate it; the default is what those rows are supposed to read back
+ * as.  Reading here takes the schema from the catalog's metadata, and
+ * nothing on that path applies the default, so those rows would come
+ * back NULL -- an answer that is wrong rather than merely incomplete.
+ * v2 never had this field, so this only ever fires for v3.
+ */
+static void
+ErrorIfSchemaDeclaresInitialDefault(IcebergTableMetadata * metadata)
+{
+	for (size_t i = 0; i < metadata->schemas_length; i++)
+	{
+		IcebergTableSchema *schema = &metadata->schemas[i];
+
+		if (schema->schema_id != metadata->current_schema_id)
+			continue;
+
+		for (size_t j = 0; j < schema->fields_length; j++)
+		{
+			DataFileSchemaField *field = &schema->fields[j];
+			const char *named = field->initialDefault != NULL ?
+				field->name : NameOfFieldWithInitialDefault(field->type);
+
+			if (named != NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("iceberg column default values are not supported"),
+						 errdetail("Column \"%s\" declares an initial-default, "
+								   "which rows written before the column was "
+								   "added would have to read back as.",
+								   named)));
+		}
+	}
+}
+
+
+/*
 * Read the Iceberg table metadata from the given JSON object.
 * This is the top-level function that Reads the entire Iceberg
 * table metadata.
@@ -87,7 +177,25 @@ ReadIcebergTableMetadataFromJson(JsonbContainer *json, IcebergTableMetadata * me
 	memset(metadata, '\0', sizeof(IcebergTableMetadata));
 
 	JsonExtractInt32Field(json, "format-version", FIELD_REQUIRED, &metadata->format_version);
-	if (metadata->format_version != 2)
+
+	/*
+	 * v3 is accepted for reading, not claimed as supported.  Its metadata is
+	 * a superset of v2's, so a v3 table that uses no v3-only feature reads
+	 * exactly like a v2 one, and refusing the version outright locks out
+	 * catalogs that have moved their default (Snowflake Horizon, for one).
+	 *
+	 * The v3-only features we cannot honor are rejected where they appear
+	 * rather than here: deletion vectors in ReadDataFileFromAvro, types we do
+	 * not map when the schema is read, and column defaults just below.
+	 *
+	 * Row lineage is the one left neither honored nor rejected: first-row-id
+	 * and next-row-id are ignored, which costs a reader nothing that it can
+	 * observe in the rows themselves.
+	 *
+	 * Writing still produces v2 (see GenerateEmptyTableMetadata), and a table
+	 * read as v3 is refused a write (see WriteIcebergTableMetadataToJson).
+	 */
+	if (metadata->format_version != 2 && metadata->format_version != 3)
 	{
 		ereport(ERROR, (errmsg("unsupported iceberg format version %d",
 							   metadata->format_version)));
@@ -102,6 +210,9 @@ ReadIcebergTableMetadataFromJson(JsonbContainer *json, IcebergTableMetadata * me
 	JsonExtractObjectArrayField(json, "schemas", FIELD_REQUIRED, (JsonParseFunction) ReadIcebergTableSchema,
 								sizeof(IcebergTableSchema),
 								(void **) &metadata->schemas, &metadata->schemas_length);
+
+	if (metadata->format_version >= 3)
+		ErrorIfSchemaDeclaresInitialDefault(metadata);
 
 	JsonExtractInt32Field(json, "default-spec-id", FIELD_REQUIRED, &metadata->default_spec_id);
 	JsonExtractObjectArrayField(json, "partition-specs", FIELD_REQUIRED, (JsonParseFunction) ReadIcebergPartitionSpec,

--- a/pg_lake_iceberg/src/iceberg/write_table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/write_table_metadata.c
@@ -56,6 +56,21 @@ WriteIcebergTableMetadataToJson(IcebergTableMetadata * metadata)
 {
 	StringInfo	command = makeStringInfo();
 
+	/*
+	 * A v3 table is read on the strength of its metadata being a superset of
+	 * v2's, which says nothing about writing one back.  This serializer emits
+	 * a v2 document under whatever version number it is handed, so a v3 table
+	 * would be rewritten without the fields v3 requires -- valid to nobody,
+	 * including the catalog that produced it.
+	 */
+	if (metadata->format_version != 2)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot write iceberg metadata in format version %d",
+						metadata->format_version),
+				 errdetail("pg_lake writes iceberg format version 2."),
+				 errhint("Attach the table read-only to query it.")));
+
 	appendStringInfoString(command, "{");
 
 	/* Append format_version */

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -37,6 +37,7 @@
 #include "pg_lake/iceberg/operations/vacuum.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/util/catalog_type.h"
 #include "access/xact.h"
 
@@ -345,13 +346,15 @@ _PG_init(void)
 							   NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("pg_lake_iceberg.rest_catalog_enable_vended_credentials",
-							 gettext_noop("Enable requesting vended credentials from REST catalog."),
-							 gettext_noop("When disabled, the X-Iceberg-Access-Delegation header is not sent. "
-										  "Disable this for S3-compatible storage that does not support AWS STS."),
+							 gettext_noop("Request vended (STS) credentials from the Iceberg REST catalog."),
+							 gettext_noop("When enabled, the X-Iceberg-Access-Delegation header is sent and the "
+										  "catalog-vended, table-scoped S3 credentials are pushed to pgduck_server. "
+										  "Opt-in: leave disabled for S3-compatible storage that does not support "
+										  "AWS STS, or when a static S3 secret already grants access."),
 							 &RestCatalogEnableVendedCredentials,
-							 true,
+							 false,
 							 PGC_SUSET,
-							 GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							 GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("pg_lake_iceberg.unsupported_numeric_as_double",

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -28,6 +28,7 @@
 
 #include "postgres.h"
 
+#include "commands/defrem.h"
 #include "foreign/foreign.h"
 #include "utils/memutils.h"
 
@@ -44,7 +45,7 @@ char	   *RestCatalogClientId = NULL;
 char	   *RestCatalogClientSecret = NULL;
 char	   *RestCatalogScope = "PRINCIPAL_ROLE:ALL";
 int			RestCatalogAuthType = REST_CATALOG_AUTH_TYPE_OAUTH2;
-bool		RestCatalogEnableVendedCredentials = true;
+bool		RestCatalogEnableVendedCredentials = false;
 
 
 /*
@@ -307,6 +308,41 @@ GetRestCatalogServerIdForRelation(Oid relationId)
 				 errmsg("catalog option is not set for relation %u", relationId)));
 
 	return ResolveRestCatalogServerId(catalog);
+}
+
+
+/*
+ * RestCatalogVendingEnabledForRelation reports whether vended credentials
+ * are enabled for the relation's catalog: the server's own option when it
+ * sets one, otherwise the GUC.  This mirrors what full option resolution
+ * would conclude, without performing it.
+ *
+ * Resolving full options validates the user mapping and throws when the
+ * mapping was dropped in the same transaction as the table (DROP TABLE
+ * right after DROP USER MAPPING).  The answer here is usually "off", and
+ * in that case nothing about the table's credentials should be resolved
+ * at all -- so the cheap, credential-free lookup has to come first.
+ */
+bool
+RestCatalogVendingEnabledForRelation(Oid relationId)
+{
+	Oid			serverOid = GetRestCatalogServerIdForRelation(relationId);
+	ForeignServer *server = GetForeignServerExtended(serverOid, FSV_MISSING_OK);
+
+	if (server != NULL)
+	{
+		ListCell   *optionCell;
+
+		foreach(optionCell, server->options)
+		{
+			DefElem    *option = (DefElem *) lfirst(optionCell);
+
+			if (strcmp(option->defname, "enable_vended_credentials") == 0)
+				return defGetBoolean(option);
+		}
+	}
+
+	return RestCatalogEnableVendedCredentials;
 }
 
 

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c
@@ -101,11 +101,13 @@ static char *EncodeBasicAuth(const char *clientId, const char *clientSecret);
 static void
 InvalidateRestTokenCache(Datum arg, int cacheid, uint32 hashvalue)
 {
-	if (RestCatalogTokenCache == NULL)
-		return;
+	if (RestCatalogTokenCache != NULL)
+	{
+		MemoryContextReset(RestTokenCacheCtx);
+		RestCatalogTokenCache = NULL;
+	}
 
-	MemoryContextReset(RestTokenCacheCtx);
-	RestCatalogTokenCache = NULL;
+	InvalidateVendedCredentialsCache();
 }
 
 

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_http.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_http.c
@@ -281,3 +281,214 @@ JsonbGetStringByPath(const char *jsonb_text, int nkeys,...)
 	va_end(variableArgList);
 	ereport(ERROR, (errmsg("unexpected json path handling error")));
 }
+
+
+/*
+ * StringByPathFromContainer walks nkeys object keys from container and
+ * returns the string it arrives at, or NULL if any step is missing or
+ * is not of the expected shape.  The caller owns ap.
+ */
+static char *
+StringByPathFromContainer(JsonbContainer *container, int nkeys, va_list ap)
+{
+	for (int i = 0; i < nkeys; i++)
+	{
+		const char *key = va_arg(ap, const char *);
+		JsonbValue	keyVal;
+		JsonbValue *val;
+
+		if (!JsonContainerIsObject(container))
+			return NULL;
+
+		keyVal.type = jbvString;
+		keyVal.val.string.val = (char *) key;
+		keyVal.val.string.len = strlen(key);
+
+		val = findJsonbValueFromContainer(container, JB_FOBJECT, &keyVal);
+		if (val == NULL)
+			return NULL;
+
+		if (i < nkeys - 1)
+		{
+			if (val->type != jbvBinary ||
+				!JsonContainerIsObject(val->val.binary.data))
+				return NULL;
+
+			container = val->val.binary.data;
+		}
+		else if (val->type == jbvString)
+			return pnstrdup(val->val.string.val, val->val.string.len);
+	}
+
+	return NULL;
+}
+
+
+/*
+ * JsonbGetOptionalStringByPath works like JsonbGetStringByPath, but
+ * returns NULL instead of raising an ERROR when a key is missing or
+ * a mid-level value is not an object.
+ */
+char *
+JsonbGetOptionalStringByPath(const char *jsonb_text, int nkeys,...)
+{
+	if (nkeys <= 0 || jsonb_text == NULL || *jsonb_text == '\0')
+		return NULL;
+
+	Datum		jsonbDatum = DirectFunctionCall1(jsonb_in,
+												 CStringGetDatum(jsonb_text));
+	Jsonb	   *jb = DatumGetJsonbP(jsonbDatum);
+	va_list		ap;
+	char	   *result;
+
+	va_start(ap, nkeys);
+	result = StringByPathFromContainer(&jb->root, nkeys, ap);
+	va_end(ap);
+
+	return result;
+}
+
+
+/*
+ * JsonbGetOptionalString is JsonbGetOptionalStringByPath over an
+ * already-parsed document, for callers that read several fields out of
+ * one response and should not pay to parse it again for each of them.
+ */
+char *
+JsonbGetOptionalString(Jsonb *jb, int nkeys,...)
+{
+	if (nkeys <= 0 || jb == NULL)
+		return NULL;
+
+	va_list		ap;
+	char	   *result;
+
+	va_start(ap, nkeys);
+	result = StringByPathFromContainer(&jb->root, nkeys, ap);
+	va_end(ap);
+
+	return result;
+}
+
+
+/*
+ * JsonbGetObject returns the nested object stored under a top-level key
+ * as a document of its own, or NULL when the key is absent or does not
+ * hold an object.
+ */
+Jsonb *
+JsonbGetObject(Jsonb *jb, const char *key)
+{
+	if (jb == NULL)
+		return NULL;
+
+	JsonbContainer *root = &jb->root;
+
+	if (!JsonContainerIsObject(root))
+		return NULL;
+
+	JsonbValue	keyVal;
+
+	keyVal.type = jbvString;
+	keyVal.val.string.val = (char *) key;
+	keyVal.val.string.len = strlen(key);
+
+	JsonbValue *val = findJsonbValueFromContainer(root, JB_FOBJECT, &keyVal);
+
+	if (val == NULL || val->type != jbvBinary ||
+		!JsonContainerIsObject(val->val.binary.data))
+		return NULL;
+
+	return JsonbValueToJsonb(val);
+}
+
+
+/*
+ * JsonbGetArrayElementObjects navigates a top-level object key
+ * `arrayKey` that holds a JSON array and returns one JsonbArrayElement
+ * per array element, in order.  Each element's `objectKey` nested
+ * object is returned as a document of its own, along with the
+ * element's `elementStringKey` string field.  Elements that are not
+ * objects, or that carry no such nested object, are skipped.  Returns
+ * NIL when the array is absent or yields nothing usable.
+ *
+ * This parses the Iceberg REST `storage-credentials` array, whose
+ * elements look like { "prefix": "s3://...", "config": { ... } }.  A
+ * catalog may vend several, for instance one credential for the data
+ * files and another for the metadata directory.
+ */
+List *
+JsonbGetArrayElementObjects(Jsonb *jb, const char *arrayKey,
+							const char *objectKey, const char *elementStringKey)
+{
+	List	   *elements = NIL;
+
+	if (jb == NULL)
+		return NIL;
+
+	JsonbContainer *root = &jb->root;
+
+	if (!JsonContainerIsObject(root))
+		return NIL;
+
+	JsonbValue	keyVal;
+
+	keyVal.type = jbvString;
+	keyVal.val.string.val = (char *) arrayKey;
+	keyVal.val.string.len = strlen(arrayKey);
+
+	JsonbValue *arrVal = findJsonbValueFromContainer(root, JB_FOBJECT, &keyVal);
+
+	if (arrVal == NULL || arrVal->type != jbvBinary ||
+		!JsonContainerIsArray(arrVal->val.binary.data))
+		return NIL;
+
+	JsonbContainer *arrContainer = arrVal->val.binary.data;
+	uint32		elementCount = JsonContainerSize(arrContainer);
+
+	for (uint32 i = 0; i < elementCount; i++)
+	{
+		JsonbValue *elem = getIthJsonbValueFromContainer(arrContainer, i);
+
+		if (elem == NULL || elem->type != jbvBinary ||
+			!JsonContainerIsObject(elem->val.binary.data))
+			continue;
+
+		JsonbContainer *elemContainer = elem->val.binary.data;
+		JsonbValue	oKey;
+
+		oKey.type = jbvString;
+		oKey.val.string.val = (char *) objectKey;
+		oKey.val.string.len = strlen(objectKey);
+
+		JsonbValue *oVal = findJsonbValueFromContainer(elemContainer, JB_FOBJECT, &oKey);
+
+		if (oVal == NULL || oVal->type != jbvBinary ||
+			!JsonContainerIsObject(oVal->val.binary.data))
+			continue;
+
+		JsonbArrayElement *element = palloc0(sizeof(JsonbArrayElement));
+
+		element->object = JsonbValueToJsonb(oVal);
+
+		if (elementStringKey != NULL)
+		{
+			JsonbValue	sKey;
+
+			sKey.type = jbvString;
+			sKey.val.string.val = (char *) elementStringKey;
+			sKey.val.string.len = strlen(elementStringKey);
+
+			JsonbValue *sVal = findJsonbValueFromContainer(elemContainer,
+														   JB_FOBJECT, &sKey);
+
+			if (sVal != NULL && sVal->type == jbvString)
+				element->stringValue = pnstrdup(sVal->val.string.val,
+												sVal->val.string.len);
+		}
+
+		elements = lappend(elements, element);
+	}
+
+	return elements;
+}

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_ops.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_ops.c
@@ -41,15 +41,20 @@
 #include "miscadmin.h"
 
 #include "commands/dbcommands.h"
+#include "common/hashfn.h"
 #include "foreign/foreign.h"
 #include "lib/stringinfo.h"
+#include "utils/builtins.h"
+#include "utils/hsearch.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 
 #include "pg_lake/iceberg/api/table_schema.h"
 #include "pg_lake/iceberg/metadata_spec.h"
 #include "pg_lake/json/json_utils.h"
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/util/catalog_type.h"
 #include "pg_lake/util/temporal_utils.h"
 #include "pg_lake/util/url_encode.h"
@@ -57,6 +62,69 @@
 
 static void CreateNamespaceOnRestCatalog(RestCatalogOptions * opts, const char *catalogName, const char *namespaceName);
 static char *AppendIcebergPartitionSpecForRestCatalog(List *partitionSpecs);
+
+
+/*
+ * Per-table vended credentials cache.
+ *
+ * Keyed by (serverOid, userMappingOid, identityHash) so each Iceberg
+ * table backed by a REST catalog gets its own cache slot, per principal.
+ * The user mapping is part of the key because a catalog vends different
+ * credentials to different principals: without it, a backend that
+ * changes role mid-session would serve one principal's credentials under
+ * the other's name.  The identity hash is 64-bit, matching the secret
+ * name; the entry also keeps the identity it was taken of, so a
+ * collision is a miss rather than the wrong table's credentials.
+ *
+ * Entries expire based on the REST catalog's credential TTL.  The cache
+ * is invalidated on ALTER/DROP SERVER alongside the token cache.
+ */
+typedef struct VendedCredentialsCacheKey
+{
+	Oid			serverOid;
+	Oid			userMappingOid;
+	uint64		identityHash;
+}			VendedCredentialsCacheKey;
+
+typedef struct VendedCredentialsCacheEntry
+{
+	VendedCredentialsCacheKey key;	/* hash key */
+	char	   *identity;		/* what identityHash was taken of */
+	List	   *credentials;	/* one per vended scope */
+	TimestampTz expiryTime;		/* earliest expiry across the list */
+}			VendedCredentialsCacheEntry;
+
+static HTAB *VendedCredsCache = NULL;
+static MemoryContext VendedCredsCacheCtx = NULL;
+
+/*
+ * Conservative TTL for vended credentials when the REST catalog does
+ * not provide an explicit expiry.  AWS STS temporary credentials
+ * typically last 1 hour; we default to 55 minutes to refresh early.
+ */
+#define VENDED_CREDS_DEFAULT_TTL_SECS 3300
+
+static List *ExtractVendedCredentials(Jsonb *response,
+									  RestCatalogOptions * opts);
+static void InitVendedCredsCacheIfNeeded(void);
+static void FreeCachedVendedCredentials(VendedCredentials * creds);
+static void FreeCachedVendedCredentialsList(List *credentials);
+static void StoreVendedCredentialsInCache(List *credentials,
+										  Oid userMappingOid,
+										  const char *restCatalogName,
+										  const char *namespaceName,
+										  const char *relationName);
+static List *LookupVendedCredentialsInCache(Oid serverOid,
+											Oid userMappingOid,
+											const char *restCatalogName,
+											const char *namespaceName,
+											const char *tableName);
+static char *BuildVendedCredentialsIdentity(const char *restCatalogName,
+											const char *namespaceName,
+											const char *tableName);
+static VendedCredentialsCacheKey BuildVendedCredentialsCacheKey(Oid serverOid,
+																Oid userMappingOid,
+																const char *identity);
 
 
 /*
@@ -120,6 +188,23 @@ StartStageRestCatalogIcebergTableCreate(Oid relationId)
 	if (httpResult.status != 200)
 	{
 		ReportHTTPError(httpResult, ERROR);
+	}
+
+	/*
+	 * If the stage-create response includes vended credentials, cache them
+	 * for subsequent writes to this table's S3 prefix.
+	 */
+	if (opts->enableVendedCredentials && httpResult.body != NULL &&
+		*httpResult.body != '\0')
+	{
+		Datum		bodyDatum = DirectFunctionCall1(jsonb_in,
+													CStringGetDatum(httpResult.body));
+		List	   *credentials =
+			ExtractVendedCredentials(DatumGetJsonbP(bodyDatum), opts);
+
+		StoreVendedCredentialsInCache(credentials, opts->userMappingOid,
+									  catalogName, namespaceName,
+									  relationName);
 	}
 }
 
@@ -376,34 +461,860 @@ GetMetadataLocationForRestCatalogForIcebergTable(Oid relationId)
 
 	RestCatalogOptions *opts = GetRestCatalogOptionsForRelation(relationId);
 
-	return GetMetadataLocationFromRestCatalog(opts, restCatalogName, namespaceName, relationName);
+	return LoadRestCatalogMetadataLocation(opts, restCatalogName, namespaceName, relationName);
 }
 
 
 /*
-* Gets the metadata location for a relation from the external catalog.
-*/
-char *
-GetMetadataLocationFromRestCatalog(RestCatalogOptions * opts, const char *restCatalogName, const char *namespaceName, const char *relationName)
+ * FreeCachedVendedCredentials releases a cache-owned VendedCredentials
+ * and every string hanging off it.  Tolerates NULL.
+ */
+static void
+FreeCachedVendedCredentials(VendedCredentials * creds)
+{
+	if (creds == NULL)
+		return;
+
+	if (creds->accessKeyId != NULL)
+		pfree(creds->accessKeyId);
+	if (creds->secretAccessKey != NULL)
+		pfree(creds->secretAccessKey);
+	if (creds->sessionToken != NULL)
+		pfree(creds->sessionToken);
+	if (creds->region != NULL)
+		pfree(creds->region);
+	if (creds->endpoint != NULL)
+		pfree(creds->endpoint);
+	if (creds->urlStyle != NULL)
+		pfree(creds->urlStyle);
+	if (creds->useSsl != NULL)
+		pfree(creds->useSsl);
+	if (creds->scope != NULL)
+		pfree(creds->scope);
+
+	pfree(creds);
+}
+
+
+/*
+ * FreeCachedVendedCredentialsList releases a whole cached list.
+ */
+static void
+FreeCachedVendedCredentialsList(List *credentials)
+{
+	ListCell   *credsCell = NULL;
+
+	foreach(credsCell, credentials)
+		FreeCachedVendedCredentials(lfirst(credsCell));
+
+	list_free(credentials);
+}
+
+
+/*
+ * BuildVendedCredentialsIdentity names the table a credential belongs
+ * to.  Kept whole in the entry as well as hashed into the key, because
+ * a hash alone cannot tell a hit from a collision, and the price of
+ * getting that wrong is serving one table's credentials for another.
+ */
+static char *
+BuildVendedCredentialsIdentity(const char *restCatalogName,
+							   const char *namespaceName,
+							   const char *tableName)
+{
+	return psprintf("%s/%s/%s", restCatalogName, namespaceName, tableName);
+}
+
+
+static VendedCredentialsCacheKey
+BuildVendedCredentialsCacheKey(Oid serverOid, Oid userMappingOid,
+							   const char *identity)
+{
+	VendedCredentialsCacheKey cacheKey;
+
+	/* Zero the padding too: the whole struct is hashed as the key. */
+	memset(&cacheKey, 0, sizeof(cacheKey));
+	cacheKey.serverOid = serverOid;
+	cacheKey.userMappingOid = userMappingOid;
+	cacheKey.identityHash =
+		hash_bytes_extended((const unsigned char *) identity,
+							strlen(identity), 0);
+
+	return cacheKey;
+}
+
+
+/*
+ * StoreVendedCredentialsInCache caches freshly-extracted vended
+ * credentials so a later resolve for the same table can reuse them
+ * without a redundant REST round-trip.
+ *
+ * The whole list shares one expiry: the earliest the catalog stated, so
+ * no member is served past its own lifetime.
+ */
+static void
+StoreVendedCredentialsInCache(List *credentials,
+							  Oid userMappingOid,
+							  const char *restCatalogName,
+							  const char *namespaceName,
+							  const char *relationName)
+{
+	if (credentials == NIL)
+		return;
+
+	VendedCredentials *first = linitial(credentials);
+	char	   *identity = BuildVendedCredentialsIdentity(restCatalogName,
+														  namespaceName,
+														  relationName);
+	VendedCredentialsCacheKey cacheKey =
+		BuildVendedCredentialsCacheKey(first->serverOid, userMappingOid,
+									   identity);
+
+	InitVendedCredsCacheIfNeeded();
+
+	/*
+	 * Own the identity before the entry can reference it, so a failure to
+	 * allocate it cannot leave a live entry pointing at freed memory.
+	 */
+	char	   *ownedIdentity = MemoryContextStrdup(VendedCredsCacheCtx,
+													identity);
+
+	pfree(identity);
+
+	bool		found = false;
+	VendedCredentialsCacheEntry *entry =
+		hash_search(VendedCredsCache, &cacheKey, HASH_ENTER, &found);
+
+	/*
+	 * A newly entered entry holds uninitialized memory, so put it in a
+	 * consistent state before the allocations below, any of which can throw.
+	 * Otherwise the entry survives the error with a garbage credentials
+	 * pointer that the lookup's NULL guard happily passes through.
+	 */
+	if (!found)
+	{
+		entry->identity = NULL;
+		entry->credentials = NIL;
+		entry->expiryTime = 0;
+	}
+
+	/*
+	 * On the vanishing chance that another table hashed to this key, take the
+	 * entry over rather than append to it: the lookup compares identities, so
+	 * the table left without a cached entry re-fetches instead of being
+	 * served these credentials.
+	 */
+	if (entry->identity != NULL)
+		pfree(entry->identity);
+
+	entry->identity = ownedIdentity;
+
+	MemoryContext oldCtx = MemoryContextSwitchTo(VendedCredsCacheCtx);
+	List	   *cachedList = NIL;
+	ListCell   *credsCell = NULL;
+	TimestampTz earliestExpiry = 0;
+
+	foreach(credsCell, credentials)
+	{
+		VendedCredentials *creds = lfirst(credsCell);
+		VendedCredentials *cached = palloc0(sizeof(VendedCredentials));
+
+		cached->accessKeyId = pstrdup(creds->accessKeyId);
+		cached->secretAccessKey = pstrdup(creds->secretAccessKey);
+		cached->sessionToken = creds->sessionToken ?
+			pstrdup(creds->sessionToken) : NULL;
+		cached->region = creds->region ?
+			pstrdup(creds->region) : NULL;
+		cached->endpoint = creds->endpoint ?
+			pstrdup(creds->endpoint) : NULL;
+		cached->urlStyle = creds->urlStyle ?
+			pstrdup(creds->urlStyle) : NULL;
+		cached->useSsl = creds->useSsl ?
+			pstrdup(creds->useSsl) : NULL;
+		cached->scope = creds->scope ?
+			pstrdup(creds->scope) : NULL;
+		cached->serverOid = creds->serverOid;
+		cached->fetchedAt = creds->fetchedAt;
+		cached->expiresAt = creds->expiresAt;
+
+		cachedList = lappend(cachedList, cached);
+
+		if (creds->expiresAt > 0 &&
+			(earliestExpiry == 0 || creds->expiresAt < earliestExpiry))
+			earliestExpiry = creds->expiresAt;
+	}
+
+	MemoryContextSwitchTo(oldCtx);
+
+	/*
+	 * Release the copy we are replacing.  The cache context is only reset on
+	 * invalidation, and read-only REST tables re-extract on every statement,
+	 * so an in-place overwrite leaks a session token per statement.
+	 */
+	FreeCachedVendedCredentialsList(entry->credentials);
+
+	entry->credentials = cachedList;
+
+	/*
+	 * Honor the catalog-provided expiry when present; otherwise fall back to
+	 * a conservative default TTL.  The lookup applies an additional
+	 * early-refresh margin on top of this.
+	 */
+	if (earliestExpiry > 0)
+		entry->expiryTime = earliestExpiry;
+	else
+		entry->expiryTime = GetCurrentTimestamp() +
+			(int64) VENDED_CREDS_DEFAULT_TTL_SECS * 1000000;
+}
+
+
+/*
+ * LoadTableFromRestCatalog issues a GET loadTable request to the REST
+ * catalog, requesting vended credentials if enabled.  Returns a result
+ * struct containing the metadata location, the inlined table metadata
+ * document, and optional vended storage credentials extracted from the
+ * response's "config" map.
+ *
+ * If vended credentials are obtained, they are also stored in the
+ * vended credentials cache, so a resolve triggered later in the same
+ * statement reuses them instead of issuing a second REST round-trip.
+ */
+RestCatalogLoadTableResult
+LoadTableFromRestCatalog(RestCatalogOptions * opts, const char *restCatalogName,
+						 const char *namespaceName, const char *relationName)
 {
 	char	   *getUrl =
 		psprintf(REST_CATALOG_TABLE,
-				 opts->host, URLEncodePath(restCatalogName), URLEncodePath(namespaceName), URLEncodePath(relationName));
+				 opts->host, URLEncodePath(restCatalogName),
+				 URLEncodePath(namespaceName),
+				 URLEncodePath(relationName));
 
 	List	   *headers = GetHeadersWithAuth(opts);
+
+	if (opts->enableVendedCredentials)
+		headers = lappend(headers,
+						  pstrdup("X-Iceberg-Access-Delegation: vended-credentials"));
+
 	HttpResult	hr = SendRequestToRestCatalog(opts, HTTP_GET, getUrl, NULL, headers);
 
 	if (hr.status != 200)
-	{
 		ReportHTTPError(hr, ERROR);
+
+	RestCatalogLoadTableResult result = {0};
+
+	result.metadataLocation = JsonbGetStringByPath(hr.body, 1, "metadata-location");
+	if (result.metadataLocation == NULL)
+		ereport(ERROR,
+				(errmsg("key \"metadata-location\" missing in json response")));
+
+	/*
+	 * A loadTable response carries the table's whole metadata document, and
+	 * both the schema and a credential are read out of it a field at a time,
+	 * so it is parsed once here and navigated from there.
+	 */
+	Datum		bodyDatum = DirectFunctionCall1(jsonb_in, CStringGetDatum(hr.body));
+	Jsonb	   *body = DatumGetJsonbP(bodyDatum);
+
+	result.metadata = JsonbGetObject(body, "metadata");
+
+	if (opts->enableVendedCredentials)
+	{
+		result.vendedCredentials = ExtractVendedCredentials(body, opts);
+
+		StoreVendedCredentialsInCache(result.vendedCredentials,
+									  opts->userMappingOid,
+									  restCatalogName, namespaceName,
+									  relationName);
 	}
 
-	char	   *metadataLocation = JsonbGetStringByPath(hr.body, 1, "metadata-location");
+	return result;
+}
 
+
+/*
+ * LoadRestCatalogMetadataLocation performs a REST loadTable request and
+ * returns only the metadata location string.  Despite the historical
+ * "get" phrasing this is not a cheap accessor: it issues a network call
+ * (and, on the vended-credentials path, populates the credential cache
+ * via LoadTableFromRestCatalog).  Callers that also need the vended
+ * credentials should call LoadTableFromRestCatalog directly.
+ */
+char *
+LoadRestCatalogMetadataLocation(RestCatalogOptions * opts, const char *restCatalogName, const char *namespaceName, const char *relationName)
+{
+	RestCatalogLoadTableResult result =
+		LoadTableFromRestCatalog(opts, restCatalogName, namespaceName,
+								 relationName);
+
+	return result.metadataLocation;
+}
+
+
+/*
+ * NormalizeS3Prefix returns a copy of prefix guaranteed to end with a
+ * trailing slash.  DuckDB selects a secret by longest-matching SCOPE
+ * prefix, so without the trailing slash a scope of ".../t" would also
+ * match a sibling table ".../t2".
+ */
+static char *
+NormalizeS3Prefix(const char *prefix)
+{
+	size_t		len = strlen(prefix);
+
+	if (len > 0 && prefix[len - 1] == '/')
+		return pstrdup(prefix);
+
+	return psprintf("%s/", prefix);
+}
+
+
+/*
+ * TableRootFromMetadataLocation derives the table's storage directory
+ * (with a trailing slash) from a metadata file location such as
+ * "s3://bucket/wh/ns/tbl/metadata/00000-uuid.metadata.json", i.e.
+ * "s3://bucket/wh/ns/tbl/".  Returns NULL when the location does not
+ * follow the ".../metadata/<file>" convention.
+ */
+static char *
+TableRootFromMetadataLocation(const char *metadataLocation)
+{
 	if (metadataLocation == NULL)
-		ereport(ERROR, (errmsg("key \"metadata-location\" missing in json response")));
+		return NULL;
 
-	return metadataLocation;
+	const char *needle = "/metadata/";
+	const char *found = NULL;
+	const char *p = metadataLocation;
+
+	/* Use the last occurrence in case a bucket/prefix also contains it. */
+	while ((p = strstr(p, needle)) != NULL)
+	{
+		found = p;
+		p += 1;
+	}
+
+	if (found == NULL)
+		return NULL;
+
+	/* Keep the '/' that precedes "metadata" so the result ends in '/'. */
+	return pnstrdup(metadataLocation, (found - metadataLocation) + 1);
+}
+
+
+/*
+ * GetVendedConfigString reads a string value from an Iceberg config
+ * map.  When mapKey is NULL, body is the config map itself (leaf is a
+ * direct child); otherwise the leaf lives under body->mapKey.
+ *
+ * A setting the catalog states as "" has stated nothing, and is
+ * reported as absent: that keeps NULL the single meaning of "unset"
+ * for everything downstream, which decides both what is inherited from
+ * the existing secret and what reaches the CREATE SECRET statement.
+ */
+static char *
+GetVendedConfigString(Jsonb *body, const char *mapKey, const char *leafKey)
+{
+	char	   *value = mapKey == NULL ?
+		JsonbGetOptionalString(body, 1, leafKey) :
+		JsonbGetOptionalString(body, 2, mapKey, leafKey);
+
+	if (value != NULL && value[0] == '\0')
+		return NULL;
+
+	return value;
+}
+
+
+/*
+ * ParseVendedCredsFromConfig builds a VendedCredentials from an Iceberg
+ * config map (see GetVendedConfigString for the mapKey convention).
+ *
+ * Returns NULL unless at least the access key and secret are present.
+ * The scope field is left unset here; the caller assigns it from the
+ * storage-credential prefix or the table location.  The expiry is
+ * parsed from "s3.session-token-expires-at-ms" (unix epoch millis) when
+ * the catalog provides it, so short-lived STS credentials are not
+ * cached past their real lifetime.
+ */
+static VendedCredentials *
+ParseVendedCredsFromConfig(Jsonb *body, const char *mapKey, Oid serverOid)
+{
+	char	   *accessKeyId = GetVendedConfigString(body, mapKey, "s3.access-key-id");
+	char	   *secretAccessKey = GetVendedConfigString(body, mapKey, "s3.secret-access-key");
+
+	if (accessKeyId == NULL || secretAccessKey == NULL)
+		return NULL;
+
+	VendedCredentials *creds = palloc0(sizeof(VendedCredentials));
+
+	creds->accessKeyId = accessKeyId;
+	creds->secretAccessKey = secretAccessKey;
+	creds->sessionToken = GetVendedConfigString(body, mapKey, "s3.session-token");
+	creds->region = GetVendedConfigString(body, mapKey, "client.region");
+	if (creds->region == NULL)
+		creds->region = GetVendedConfigString(body, mapKey, "s3.region");
+	creds->serverOid = serverOid;
+	creds->fetchedAt = GetCurrentTimestamp();
+
+	/*
+	 * Iceberg states the endpoint as a URL, while DuckDB wants a bare
+	 * host[:port] plus a separate USE_SSL.  Split the two apart, so a catalog
+	 * pointing at a plaintext store is honored instead of being inherited
+	 * from whatever secret happens to cover the prefix.
+	 */
+	char	   *endpointUrl = GetVendedConfigString(body, mapKey, "s3.endpoint");
+
+	if (endpointUrl != NULL)
+	{
+		if (pg_strncasecmp(endpointUrl, "https://", 8) == 0)
+		{
+			creds->endpoint = pstrdup(endpointUrl + 8);
+			creds->useSsl = pstrdup("true");
+		}
+		else if (pg_strncasecmp(endpointUrl, "http://", 7) == 0)
+		{
+			creds->endpoint = pstrdup(endpointUrl + 7);
+			creds->useSsl = pstrdup("false");
+		}
+		else
+		{
+			/* No scheme to read SSL from; leave it to be inherited. */
+			creds->endpoint = pstrdup(endpointUrl);
+		}
+
+		/* A trailing slash is part of a URL, not of a DuckDB endpoint. */
+		int			endpointLen = strlen(creds->endpoint);
+
+		while (endpointLen > 0 && creds->endpoint[endpointLen - 1] == '/')
+			creds->endpoint[--endpointLen] = '\0';
+
+		if (endpointLen == 0)
+		{
+			pfree(creds->endpoint);
+			creds->endpoint = NULL;
+		}
+
+		pfree(endpointUrl);
+	}
+
+	/*
+	 * Map the Iceberg "s3.path-style-access" boolean onto DuckDB's URL_STYLE.
+	 * When the catalog omits it we leave urlStyle NULL so the engine can fall
+	 * back to the environment's existing S3 secret.
+	 */
+	char	   *pathStyle = GetVendedConfigString(body, mapKey,
+												  "s3.path-style-access");
+
+	if (pathStyle != NULL)
+	{
+		bool		usePathStyle = false;
+
+		/*
+		 * pstrdup rather than the literal: every other string here is
+		 * palloc'd, and the cache frees the whole struct field by field.
+		 */
+		if (parse_bool(pathStyle, &usePathStyle))
+			creds->urlStyle = pstrdup(usePathStyle ? "path" : "vhost");
+	}
+
+	char	   *expiresMsStr = GetVendedConfigString(body, mapKey,
+													 "s3.session-token-expires-at-ms");
+
+	if (expiresMsStr != NULL)
+	{
+		char	   *endptr = NULL;
+		long long	expiresMs = strtoll(expiresMsStr, &endptr, 10);
+
+		if (endptr != expiresMsStr && *endptr == '\0' && expiresMs > 0)
+			creds->expiresAt =
+				(TimestampTz) IcebergTimestampMsToPostgresTimestamp((Timestamp) expiresMs);
+	}
+
+	return creds;
+}
+
+
+/*
+ * TableRootFromLoadTableResponse returns the table's base directory,
+ * normalized with a trailing slash, from a loadTable response: the
+ * declared storage location when the response carries one, otherwise
+ * derived from the metadata file path.  Returns NULL when neither is
+ * available.
+ */
+static char *
+TableRootFromLoadTableResponse(Jsonb *response)
+{
+	char	   *tableLocation =
+		JsonbGetOptionalString(response, 2, "metadata", "location");
+
+	if (tableLocation != NULL && tableLocation[0] != '\0')
+		return NormalizeS3Prefix(tableLocation);
+
+	char	   *metadataFile =
+		JsonbGetOptionalString(response, 1, "metadata-location");
+
+	return TableRootFromMetadataLocation(metadataFile);
+}
+
+
+/*
+ * ResolveVendedScope decides what S3 prefix a vended credential covers.
+ *
+ * The storage-credential's own prefix is the catalog's declared scope,
+ * and is preferred: it covers external tables whose data lives outside
+ * the metadata directory, and lets a catalog hand out something narrower
+ * than the whole table.  It is honored only at or below the table root,
+ * though.  A broader scope would hand out more than the table needs, and
+ * one pointing at a sibling path would cover a table these credentials
+ * have nothing to do with.  Since secrets live in a single process-wide
+ * DuckDB instance and are selected by longest matching scope, either
+ * could shadow the secret another table depends on.
+ *
+ * With no table root to check against there is nothing to clamp to, so
+ * the catalog's scope stands.  With no scope at all, the table root is
+ * the answer; NULL when there is neither.
+ */
+static char *
+ResolveVendedScope(const char *scopePrefix, char *tableRoot)
+{
+	if (scopePrefix == NULL || scopePrefix[0] == '\0')
+		return tableRoot;
+
+	char	   *normScope = NormalizeS3Prefix(scopePrefix);
+
+	if (tableRoot == NULL ||
+		strncmp(normScope, tableRoot, strlen(tableRoot)) == 0)
+		return normScope;
+
+	return tableRoot;
+}
+
+
+/*
+ * ExtractVendedCredentials parses S3 vended credentials from a REST
+ * catalog loadTable response body, returning one VendedCredentials per
+ * scope the catalog vended for.
+ *
+ * Two response shapes are supported: the newer "storage-credentials"
+ * array, each element carrying its own "prefix" and "config", and the
+ * legacy top-level "config" map, which describes a single credential
+ * with no scope of its own.  A catalog may vend several credentials --
+ * separate ones for the data files and the metadata directory, say --
+ * and dropping the extras would leave part of the table unreadable.
+ *
+ * Elements the scope resolution collapses onto a prefix already taken
+ * are skipped: DuckDB selects one secret per path, so a second one at
+ * the same scope could only shadow the first.
+ *
+ * Returns NIL when the response carries no usable credential.
+ */
+static List *
+ExtractVendedCredentials(Jsonb *response, RestCatalogOptions * opts)
+{
+	if (response == NULL)
+		return NIL;
+
+	char	   *tableRoot = TableRootFromLoadTableResponse(response);
+	List	   *credentials = NIL;
+	List	   *elements =
+		JsonbGetArrayElementObjects(response, "storage-credentials",
+									"config", "prefix");
+	ListCell   *elementCell = NULL;
+
+	foreach(elementCell, elements)
+	{
+		JsonbArrayElement *element = lfirst(elementCell);
+		VendedCredentials *creds =
+			ParseVendedCredsFromConfig(element->object, NULL, opts->serverOid);
+
+		if (creds == NULL)
+			continue;
+
+		creds->scope = ResolveVendedScope(element->stringValue, tableRoot);
+
+		ListCell   *takenCell = NULL;
+		bool		scopeTaken = false;
+
+		foreach(takenCell, credentials)
+		{
+			VendedCredentials *taken = lfirst(takenCell);
+
+			if (taken->scope != NULL && creds->scope != NULL &&
+				strcmp(taken->scope, creds->scope) == 0)
+			{
+				scopeTaken = true;
+				break;
+			}
+		}
+
+		if (!scopeTaken)
+			credentials = lappend(credentials, creds);
+	}
+
+	if (credentials != NIL)
+		return credentials;
+
+	/* Fall back to the legacy top-level "config" map. */
+	VendedCredentials *legacyCreds =
+		ParseVendedCredsFromConfig(response, "config", opts->serverOid);
+
+	if (legacyCreds == NULL)
+	{
+		elog(DEBUG2, "REST catalog loadTable response did not contain "
+			 "vended S3 credentials");
+		return NIL;
+	}
+
+	legacyCreds->scope = ResolveVendedScope(NULL, tableRoot);
+
+	return list_make1(legacyCreds);
+}
+
+
+/*
+ * Initialize the vended credentials cache hash table if needed.
+ * Shares the invalidation callback registration with the token cache.
+ */
+static void
+InitVendedCredsCacheIfNeeded(void)
+{
+	if (VendedCredsCache != NULL)
+		return;
+
+	if (VendedCredsCacheCtx == NULL)
+		VendedCredsCacheCtx = AllocSetContextCreate(CacheMemoryContext,
+													"VendedCredsCacheCtx",
+													ALLOCSET_DEFAULT_SIZES);
+
+	HASHCTL		ctl;
+
+	memset(&ctl, 0, sizeof(ctl));
+	ctl.keysize = sizeof(VendedCredentialsCacheKey);
+	ctl.entrysize = sizeof(VendedCredentialsCacheEntry);
+	ctl.hcxt = VendedCredsCacheCtx;
+
+	VendedCredsCache = hash_create("Vended Credentials Cache",
+								   16, &ctl,
+								   HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+}
+
+
+/*
+ * InvalidateVendedCredentialsCache drops the entire cache.  Called from
+ * the syscache invalidation callback alongside the token cache, and also
+ * available for explicit invalidation on table drop.
+ */
+void
+InvalidateVendedCredentialsCache(void)
+{
+	if (VendedCredsCache == NULL)
+		return;
+
+	MemoryContextReset(VendedCredsCacheCtx);
+	VendedCredsCache = NULL;
+}
+
+
+/*
+ * LookupVendedCredentialsInCache checks the cache for valid vended
+ * credentials for the given table path under the given server.
+ * Returns the cached credentials or NIL if not found/expired.
+ */
+static List *
+LookupVendedCredentialsInCache(Oid serverOid,
+							   Oid userMappingOid,
+							   const char *restCatalogName,
+							   const char *namespaceName,
+							   const char *tableName)
+{
+	char	   *identity = BuildVendedCredentialsIdentity(restCatalogName,
+														  namespaceName,
+														  tableName);
+	VendedCredentialsCacheKey cacheKey =
+		BuildVendedCredentialsCacheKey(serverOid, userMappingOid, identity);
+	bool		mine;
+
+	InitVendedCredsCacheIfNeeded();
+
+	bool		found = false;
+	VendedCredentialsCacheEntry *entry =
+		hash_search(VendedCredsCache, &cacheKey, HASH_FIND, &found);
+
+	mine = found && entry->identity != NULL &&
+		strcmp(entry->identity, identity) == 0;
+
+	pfree(identity);
+
+	/*
+	 * Anything but our own entry is a miss.  Two tables whose identities hash
+	 * alike would otherwise be served each other's credentials, which a fresh
+	 * loadTable is a cheap price to avoid.
+	 */
+	if (!mine || entry->credentials == NIL)
+		return NIL;
+
+	TimestampTz now = GetCurrentTimestamp();
+	const int64 FIVE_MINUTES_USEC = (int64) 5 * 60 * 1000000;
+
+	if (entry->expiryTime <= now + FIVE_MINUTES_USEC)
+	{
+		/*
+		 * Evict the stale entry so a fresh loadTable can repopulate it and
+		 * the cache does not grow with dead entries in long-lived backends.
+		 * Removing the entry only recycles the entry itself, so release what
+		 * it owns first.
+		 */
+		FreeCachedVendedCredentialsList(entry->credentials);
+		entry->credentials = NIL;
+		pfree(entry->identity);
+		entry->identity = NULL;
+		hash_search(VendedCredsCache, &cacheKey, HASH_REMOVE, NULL);
+		return NIL;
+	}
+
+	return entry->credentials;
+}
+
+
+/*
+ * IcebergProvideStorageCredentials is the pg_lake_iceberg implementation
+ * of the engine's storage-credential provider hook (installed at
+ * _PG_init).  Given a relation, it resolves the vended S3 credentials
+ * for its REST-catalog Iceberg table and returns them as a
+ * List<StorageCredential *> the engine resolver can push to
+ * pgduck_server.
+ *
+ * Two properties are worth calling out:
+ *
+ *  - It fetches on a cache miss (issues a REST loadTable), so a table
+ *    scanned in a fresh backend -- whose cache was never warmed -- still
+ *    gets credentials.  The resolver wraps this in a PG_TRY, so a
+ *    loadTable failure degrades gracefully instead of aborting the
+ *    caller.
+ *
+ *  - The secret key incorporates the user-mapping OID, so two principals
+ *    vended different credentials for the same table get distinct secrets
+ *    rather than clobbering one another.
+ *
+ * Only read-only REST tables are served.  pg_lake owns the files of a
+ * writable table, and owning files means deleting them: a DROP only
+ * queues its files, and the queue holds them for
+ * pg_lake_engine.orphaned_file_retention_period (10 days by default),
+ * long after any vended credential has expired and the table has left
+ * the catalog that could vend another.  Until that lifecycle has an
+ * answer, writable tables keep reaching storage the way they do without
+ * vending, and are no worse off than before.
+ *
+ * Returns NIL for non-REST tables, writable REST tables, when vending is
+ * disabled, or when the catalog vends no credentials.
+ */
+List *
+IcebergProvideStorageCredentials(Oid relationId)
+{
+	IcebergCatalogType catalogType = GetIcebergCatalogType(relationId);
+	RestCatalogOptions *opts;
+	const char *restCatalogName;
+	const char *namespaceName;
+	const char *tableName;
+	List	   *credentials;
+	List	   *storageCredentials = NIL;
+	ListCell   *credsCell = NULL;
+	StorageCredential *sc;
+
+	if (catalogType != REST_CATALOG_READ_ONLY)
+		return NIL;
+
+	/*
+	 * Answer "is vending on?" before resolving full options, which validates
+	 * the user mapping and would throw when the mapping was dropped in the
+	 * same transaction as the table (e.g. DROP TABLE right after DROP USER
+	 * MAPPING).  With vending off -- the default -- that drop path must not
+	 * touch credentials at all.
+	 */
+	if (!RestCatalogVendingEnabledForRelation(relationId))
+		return NIL;
+
+	opts = GetRestCatalogOptionsForRelation(relationId);
+
+	if (!opts->enableVendedCredentials)
+		return NIL;
+
+	restCatalogName = GetRestCatalogName(relationId);
+	namespaceName = GetRestCatalogNamespace(relationId);
+	tableName = GetRestCatalogTableName(relationId);
+
+	credentials = LookupVendedCredentialsInCache(opts->serverOid,
+												 opts->userMappingOid,
+												 restCatalogName,
+												 namespaceName, tableName);
+
+	if (credentials == NIL)
+	{
+		/*
+		 * Cache miss: pull fresh credentials from the catalog.  The load
+		 * caches them as a side effect for the rest of the statement.
+		 */
+		RestCatalogLoadTableResult result =
+			LoadTableFromRestCatalog(opts, restCatalogName, namespaceName,
+									 tableName);
+
+		credentials = result.vendedCredentials;
+	}
+
+	foreach(credsCell, credentials)
+	{
+		VendedCredentials *creds = lfirst(credsCell);
+
+		/*
+		 * A secret has to be bound to a prefix, and there is none to bind to
+		 * here: the catalog named none and the metadata location did not
+		 * yield a table root.  Inventing one from the catalog identity would
+		 * produce a scope that matches nothing at best, and somebody else's
+		 * objects at worst, so skip it and let the static secret decide.
+		 */
+		if (creds->scope == NULL || creds->scope[0] == '\0')
+			continue;
+
+		/*
+		 * Return copies: the engine resolver may run syscache lookups between
+		 * resolving and using these, which could invalidate cache-owned
+		 * memory.
+		 */
+		sc = palloc0(sizeof(StorageCredential));
+		sc->serverOid = opts->serverOid;
+
+		/*
+		 * The scope is part of the identity because one table can be vended
+		 * several credentials -- data and metadata, say -- and each needs a
+		 * secret of its own rather than overwriting the last.
+		 */
+		sc->secretId = psprintf("%u/%s/%s/%s/%s",
+								opts->userMappingOid, restCatalogName,
+								namespaceName, tableName, creds->scope);
+		sc->scopePrefix = pstrdup(creds->scope);
+		sc->accessKeyId = creds->accessKeyId ? pstrdup(creds->accessKeyId) : NULL;
+		sc->secretAccessKey =
+			creds->secretAccessKey ? pstrdup(creds->secretAccessKey) : NULL;
+		sc->sessionToken = creds->sessionToken ? pstrdup(creds->sessionToken) : NULL;
+		sc->region = creds->region ? pstrdup(creds->region) : NULL;
+		sc->endpoint = creds->endpoint ? pstrdup(creds->endpoint) : NULL;
+		sc->urlStyle = creds->urlStyle ? pstrdup(creds->urlStyle) : NULL;
+		sc->useSsl = creds->useSsl ? pstrdup(creds->useSsl) : NULL;
+
+		/*
+		 * A catalog that states no expiry still needs one here.  The resolver
+		 * only skips re-pushing a secret whose expiry is comfortably ahead,
+		 * so leaving this at zero re-pushes on every statement.  Fall back to
+		 * the same conservative TTL the credential cache applies, so both
+		 * agree on how long these credentials are considered good for.
+		 */
+		sc->expiresAt = creds->expiresAt > 0
+			? creds->expiresAt
+			: creds->fetchedAt + (int64) VENDED_CREDS_DEFAULT_TTL_SECS * 1000000;
+
+		storageCredentials = lappend(storageCredentials, sc);
+	}
+
+	return storageCredentials;
 }
 
 

--- a/pg_lake_iceberg/src/storage/storage_credentials.c
+++ b/pg_lake_iceberg/src/storage/storage_credentials.c
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * storage_credentials.c
+ *
+ * Storage-credential resolver.  See storage_credentials.h for the design
+ * and its known limitations.
+ */
+
+#include "postgres.h"
+
+#include "access/xact.h"
+#include "utils/elog.h"
+#include "utils/errcodes.h"
+#include "utils/hsearch.h"
+#include "utils/memutils.h"
+#include "utils/resowner.h"
+#include "utils/timestamp.h"
+
+#include "pg_lake/pgduck/client.h"
+#include "pg_lake/pgduck/vended_secrets.h"
+#include "pg_lake/rest_catalog/rest_catalog.h"
+#include "pg_lake/storage/storage_credentials.h"
+
+/* Deterministic vended-secret names fit comfortably below this. */
+#define SECRET_NAME_MAXLEN 128
+
+/*
+ * Do not re-push a secret whose expiry is still comfortably in the
+ * future; this keeps repeated EnsureStorageCredentials calls within a
+ * single statement free.  Matches the vended-credential cache margin.
+ */
+#define REFRESH_MARGIN_USEC ((int64) 5 * 60 * 1000000)
+
+/*
+ * Per-backend record of the vended secrets this backend pushed to the
+ * (shared) pgduck_server, keyed by the generated secret name.  Lets
+ * EnsureStorageCredentials skip still-valid secrets and drop secrets the
+ * provider no longer returns (revoked credentials / vending disabled).
+ */
+typedef struct PushedSecretEntry
+{
+	char		secretName[SECRET_NAME_MAXLEN]; /* hash key -- must be first */
+	Oid			relationId;
+	Oid			serverOid;
+	char	   *secretId;
+	TimestampTz expiresAt;
+}			PushedSecretEntry;
+
+static HTAB *PushedSecrets = NULL;
+static MemoryContext PushedSecretsContext = NULL;
+
+static void InitPushedSecretsIfNeeded(void);
+static List *ResolveStorageCredentials(Oid relationId);
+static void BestEffortReconcile(Oid relationId, List *toPush, List *toDrop);
+static void ReconcileSecrets(Oid relationId, List *toPush, List *toDrop);
+static VendedS3Secret MakeVendedS3Secret(const StorageCredential * sc);
+static void ReportOrRethrowBestEffortError(ErrorData *edata, const char *what,
+										   Oid relationId);
+
+
+/*
+ * EnsureStorageCredentialsForRelation brings the vended secrets this
+ * backend has pushed for one relation in line with what the catalog
+ * vends for it right now.  See storage_credentials.h for the contract.
+ *
+ * The work is decided before any of it is done: ask the catalog, then
+ * compare what it returned against the registry of what this backend
+ * already pushed, collecting the credentials that need a (re)push and
+ * the secrets that are no longer vended.  Only if that leaves something
+ * to do does the reconcile reach pgduck_server, so a warm scan -- the
+ * common case, since a vended credential outlives many statements --
+ * costs nothing beyond the catalog's own answer.
+ */
+void
+EnsureStorageCredentialsForRelation(Oid relationId)
+{
+	List	   *creds;
+	List	   *desiredNames = NIL;
+	List	   *toPush = NIL;
+	List	   *toDrop = NIL;
+	ListCell   *lc;
+	TimestampTz now;
+	HASH_SEQ_STATUS seq;
+	PushedSecretEntry *entry;
+
+	if (!OidIsValid(relationId))
+		return;
+
+	creds = ResolveStorageCredentials(relationId);
+
+	/*
+	 * A backend that has never held a vended secret and is not being given
+	 * one now has nothing to reconcile, and no reason to build the table that
+	 * tracks them.
+	 */
+	if (creds == NIL && PushedSecrets == NULL)
+		return;
+
+	InitPushedSecretsIfNeeded();
+	now = GetCurrentTimestamp();
+
+	/* Decide which resolved credentials still need a (re)push. */
+	foreach(lc, creds)
+	{
+		StorageCredential *sc = (StorageCredential *) lfirst(lc);
+		char	   *name = GenerateVendedSecretName(sc->serverOid, sc->secretId);
+		char		key[SECRET_NAME_MAXLEN];
+		bool		found = false;
+
+		desiredNames = lappend(desiredNames, name);
+
+		strlcpy(key, name, SECRET_NAME_MAXLEN);
+		entry = hash_search(PushedSecrets, key, HASH_FIND, &found);
+
+		/* Skip a secret we already pushed whose expiry is still safe. */
+		if (found && entry->expiresAt > 0 &&
+			entry->expiresAt > now + REFRESH_MARGIN_USEC)
+			continue;
+
+		toPush = lappend(toPush, sc);
+	}
+
+	/*
+	 * Drop any secret we previously pushed for this relation that the catalog
+	 * no longer vends.  This is what prevents a stale, expired secret from
+	 * lingering on the shared pgduck_server and denying access to a later
+	 * scan (the instance-wide 403 failure mode).
+	 */
+	hash_seq_init(&seq, PushedSecrets);
+	while ((entry = hash_seq_search(&seq)) != NULL)
+	{
+		bool		desired = false;
+
+		if (entry->relationId != relationId)
+			continue;
+
+		foreach(lc, desiredNames)
+		{
+			if (strcmp((char *) lfirst(lc), entry->secretName) == 0)
+			{
+				desired = true;
+				break;
+			}
+		}
+
+		if (!desired)
+			toDrop = lappend(toDrop, entry);
+	}
+
+	if (toPush != NIL || toDrop != NIL)
+		BestEffortReconcile(relationId, toPush, toDrop);
+}
+
+
+/*
+ * ForgetStorageCredentials drops every secret this backend pushed for
+ * the relation.  See storage_credentials.h for why a dropped relation
+ * must not leave its secrets behind.
+ */
+void
+ForgetStorageCredentials(Oid relationId)
+{
+	HASH_SEQ_STATUS seq;
+	PushedSecretEntry *entry;
+	List	   *toDrop = NIL;
+
+	if (PushedSecrets == NULL || !OidIsValid(relationId))
+		return;
+
+	hash_seq_init(&seq, PushedSecrets);
+	while ((entry = hash_seq_search(&seq)) != NULL)
+	{
+		if (entry->relationId == relationId)
+			toDrop = lappend(toDrop, entry);
+	}
+
+	if (toDrop != NIL)
+		BestEffortReconcile(relationId, NIL, toDrop);
+}
+
+
+static void
+InitPushedSecretsIfNeeded(void)
+{
+	HASHCTL		ctl;
+
+	if (PushedSecrets != NULL)
+		return;
+
+	PushedSecretsContext =
+		AllocSetContextCreate(TopMemoryContext,
+							  "PgLake pushed vended secrets",
+							  ALLOCSET_SMALL_SIZES);
+
+	memset(&ctl, 0, sizeof(ctl));
+	ctl.keysize = SECRET_NAME_MAXLEN;
+	ctl.entrysize = sizeof(PushedSecretEntry);
+	ctl.hcxt = PushedSecretsContext;
+
+	PushedSecrets = hash_create("PgLake pushed vended secrets", 32, &ctl,
+								HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
+}
+
+
+/*
+ * ReportOrRethrowBestEffortError swallows the error a best-effort step
+ * failed with, unless it is one we must never mask (out of memory,
+ * query cancellation, shutdown): resolving and pushing storage
+ * credentials is advisory, so a transient OAuth error, a user mapping
+ * dropped mid-transaction or a pgduck hiccup should not abort the
+ * caller's statement.  If a credential was genuinely required, the
+ * storage read that follows fails on its own with an authoritative
+ * error.
+ *
+ * The caller aborts the step's subtransaction and copies the error out
+ * of ErrorContext before getting here, so this only decides what to do
+ * with what is left.
+ *
+ * The relation is reported by OID rather than by name, because by the
+ * time this reports, the relation may already be gone (a drop is one of
+ * the paths that reconciles secrets).
+ */
+static void
+ReportOrRethrowBestEffortError(ErrorData *edata, const char *what,
+							   Oid relationId)
+{
+	Assert(CurrentMemoryContext != ErrorContext);
+
+	if (edata->sqlerrcode == ERRCODE_OUT_OF_MEMORY ||
+		edata->sqlerrcode == ERRCODE_QUERY_CANCELED ||
+		edata->sqlerrcode == ERRCODE_ADMIN_SHUTDOWN)
+		ReThrowError(edata);
+
+	/*
+	 * Warn rather than whisper.  Whatever follows this will fail on its own
+	 * with a bare HTTP 403 from object storage, which says nothing about the
+	 * credential that could not be resolved; without this line there is no
+	 * trace of the real cause at default log levels.
+	 */
+	ereport(WARNING,
+			(errmsg("could not resolve storage credentials for relation %u",
+					relationId),
+			 errdetail("%s failed: %s", what, edata->message),
+			 errhint("Access to this relation's storage falls back to any "
+					 "credentials already configured in pgduck_server.")));
+
+	FreeErrorData(edata);
+}
+
+
+/*
+ * ResolveStorageCredentials asks the catalog what it vends for this
+ * relation, tolerating expected errors (see
+ * ReportOrRethrowBestEffortError).  Returns NIL when the relation has
+ * no vended credentials or the resolution failed recoverably.
+ *
+ * It runs in a subtransaction of its own because catching the error is
+ * not enough to carry on with the caller's statement: the attempt that
+ * failed may have left a lock, an open catalog scan or a half-registered
+ * resource behind, and only a subtransaction abort gives those back.
+ * The subtransaction takes over the current memory context and resource
+ * owner while it runs, so both are saved and put back -- and the
+ * credentials are built in the caller's context, where they outlive it.
+ */
+static List *
+ResolveStorageCredentials(Oid relationId)
+{
+	List	   *volatile creds = NIL;
+	MemoryContext callerContext = CurrentMemoryContext;
+	ResourceOwner callerOwner = CurrentResourceOwner;
+
+	BeginInternalSubTransaction(NULL);
+	MemoryContextSwitchTo(callerContext);
+
+	PG_TRY();
+	{
+		creds = IcebergProvideStorageCredentials(relationId);
+
+		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(callerContext);
+		CurrentResourceOwner = callerOwner;
+	}
+	PG_CATCH();
+	{
+		/* Leave ErrorContext before inspecting/flushing the error. */
+		MemoryContextSwitchTo(callerContext);
+
+		ErrorData  *edata = CopyErrorData();
+
+		FlushErrorState();
+
+		RollbackAndReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(callerContext);
+		CurrentResourceOwner = callerOwner;
+
+		ReportOrRethrowBestEffortError(edata, "credential resolution",
+									   relationId);
+		creds = NIL;
+	}
+	PG_END_TRY();
+
+	return (List *) creds;
+}
+
+
+/*
+ * MakeVendedS3Secret projects a resolved StorageCredential onto the
+ * VendedS3Secret the pgduck secret layer consumes.
+ */
+static VendedS3Secret
+MakeVendedS3Secret(const StorageCredential * sc)
+{
+	VendedS3Secret secret = {0};
+
+	secret.serverOid = sc->serverOid;
+	secret.secretId = sc->secretId;
+	secret.scope = sc->scopePrefix;
+	secret.accessKeyId = sc->accessKeyId;
+	secret.secretAccessKey = sc->secretAccessKey;
+	secret.sessionToken = sc->sessionToken;
+	secret.region = sc->region;
+	secret.endpoint = sc->endpoint;
+	secret.urlStyle = sc->urlStyle;
+	secret.useSsl = sc->useSsl;
+
+	return secret;
+}
+
+
+/*
+ * ReconcileSecrets performs the actual pgduck work for one relation:
+ * (re)push every credential in toPush, then drop every stale secret in
+ * toDrop, updating the per-backend registry to match.
+ *
+ * The secrets themselves are pgduck_server-wide, not per connection; a
+ * single connection is taken out here only so that a relation with
+ * several of them to reconcile spends one connection on the lot rather
+ * than one apiece.
+ *
+ * Any error propagates out (the connection is still released); the
+ * best-effort swallow lives in the caller.
+ */
+static void
+ReconcileSecrets(Oid relationId, List *toPush, List *toDrop)
+{
+	PGDuckConnection *conn = GetPGDuckConnection();
+
+	PG_TRY();
+	{
+		ListCell   *lc;
+
+		foreach(lc, toPush)
+		{
+			StorageCredential *sc = (StorageCredential *) lfirst(lc);
+			VendedS3Secret secret = MakeVendedS3Secret(sc);
+			char	   *name = GenerateVendedSecretName(sc->serverOid,
+														sc->secretId);
+			char		key[SECRET_NAME_MAXLEN];
+			bool		found = false;
+			PushedSecretEntry *entry;
+
+			PushVendedSecretToPGDuck(conn, &secret);
+
+			strlcpy(key, name, SECRET_NAME_MAXLEN);
+			entry = hash_search(PushedSecrets, key, HASH_FIND, &found);
+
+			if (!found)
+			{
+				/*
+				 * Copy the key before the entry exists.  A new entry holds
+				 * uninitialized memory, so an allocation failure between
+				 * inserting it and filling it in would leave a live entry
+				 * pointing at garbage.
+				 */
+				MemoryContext old = MemoryContextSwitchTo(PushedSecretsContext);
+				char	   *ownedId = pstrdup(sc->secretId);
+
+				MemoryContextSwitchTo(old);
+
+				entry = hash_search(PushedSecrets, key, HASH_ENTER, NULL);
+				entry->secretId = ownedId;
+			}
+			entry->relationId = relationId;
+			entry->serverOid = sc->serverOid;
+			entry->expiresAt = sc->expiresAt;
+		}
+
+		foreach(lc, toDrop)
+		{
+			PushedSecretEntry *entry = (PushedSecretEntry *) lfirst(lc);
+			char		key[SECRET_NAME_MAXLEN];
+
+			DropVendedSecretFromPGDuck(conn, entry->serverOid,
+									   entry->secretId);
+
+			strlcpy(key, entry->secretName, SECRET_NAME_MAXLEN);
+			pfree(entry->secretId);
+			hash_search(PushedSecrets, key, HASH_REMOVE, NULL);
+		}
+	}
+	PG_FINALLY();
+	{
+		ReleasePGDuckConnection(conn);
+	}
+	PG_END_TRY();
+}
+
+
+/*
+ * BestEffortReconcile wraps ReconcileSecrets so a pgduck failure (server
+ * down, transient error) never aborts the caller's statement.  Callers
+ * establish that there is work to do; this always takes a connection.
+ *
+ * Runs in a subtransaction of its own, for the reason given in
+ * ResolveStorageCredentials.
+ */
+static void
+BestEffortReconcile(Oid relationId, List *toPush, List *toDrop)
+{
+	MemoryContext callerContext = CurrentMemoryContext;
+	ResourceOwner callerOwner = CurrentResourceOwner;
+
+	Assert(toPush != NIL || toDrop != NIL);
+
+	BeginInternalSubTransaction(NULL);
+	MemoryContextSwitchTo(callerContext);
+
+	PG_TRY();
+	{
+		ReconcileSecrets(relationId, toPush, toDrop);
+
+		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(callerContext);
+		CurrentResourceOwner = callerOwner;
+	}
+	PG_CATCH();
+	{
+		/* Leave ErrorContext before inspecting/flushing the error. */
+		MemoryContextSwitchTo(callerContext);
+
+		ErrorData  *edata = CopyErrorData();
+
+		FlushErrorState();
+
+		RollbackAndReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(callerContext);
+		CurrentResourceOwner = callerOwner;
+
+		ReportOrRethrowBestEffortError(edata, "secret reconcile", relationId);
+	}
+	PG_END_TRY();
+}

--- a/pg_lake_iceberg/src/test/rest_catalog.c
+++ b/pg_lake_iceberg/src/test/rest_catalog.c
@@ -21,11 +21,14 @@
 
 #include "fmgr.h"
 #include "funcapi.h"
+#include "lib/stringinfo.h"
 #include "utils/builtins.h"
 
 #include "pg_lake/rest_catalog/rest_catalog.h"
 
 PG_FUNCTION_INFO_V1(register_namespace_to_rest_catalog);
+PG_FUNCTION_INFO_V1(get_rest_metadata_location);
+PG_FUNCTION_INFO_V1(get_rest_vended_credentials);
 
 /*
 * register_namespace_to_rest_catalog is a test function that registers
@@ -41,4 +44,83 @@ register_namespace_to_rest_catalog(PG_FUNCTION_ARGS)
 
 	RegisterNamespaceToRestCatalog(opts, catalogName, namespaceName);
 	PG_RETURN_VOID();
+}
+
+
+/*
+ * get_rest_metadata_location is a test function that calls
+ * LoadRestCatalogMetadataLocation and returns the metadata location.
+ * This exercises the full LoadTableFromRestCatalog path including
+ * vended credential extraction and caching.
+ */
+Datum
+get_rest_metadata_location(PG_FUNCTION_ARGS)
+{
+	char	   *catalogName = text_to_cstring(PG_GETARG_TEXT_P(0));
+	char	   *namespaceName = text_to_cstring(PG_GETARG_TEXT_P(1));
+	char	   *tableName = text_to_cstring(PG_GETARG_TEXT_P(2));
+
+	RestCatalogOptions *opts = ResolveRestCatalogOptions(REST_CATALOG_NAME);
+
+	char	   *metadataLocation =
+		LoadRestCatalogMetadataLocation(opts, catalogName, namespaceName,
+										tableName);
+
+	PG_RETURN_TEXT_P(cstring_to_text(metadataLocation));
+}
+
+
+/*
+ * get_rest_vended_credentials is a test function that loads a table from
+ * the REST catalog and returns the extracted vended credentials as a
+ * pipe-delimited summary:
+ *
+ *     "<access-key-id>|<scope>|<yes|no session token>|<expiry|noexpiry>|
+ *      <region>|<endpoint>|<url-style>|<use-ssl>"
+ *
+ * A catalog may vend more than one credential, in which case the
+ * summaries are joined with ';' in the order the catalog returned them.
+ *
+ * Returns NULL when the loadTable response carried no vended
+ * credentials.  This exercises ExtractVendedCredentials, including
+ * storage-credentials parsing, scope resolution/clamping, expiry parsing,
+ * and the catalog-provided S3 connection settings.
+ */
+Datum
+get_rest_vended_credentials(PG_FUNCTION_ARGS)
+{
+	char	   *catalogName = text_to_cstring(PG_GETARG_TEXT_P(0));
+	char	   *namespaceName = text_to_cstring(PG_GETARG_TEXT_P(1));
+	char	   *tableName = text_to_cstring(PG_GETARG_TEXT_P(2));
+
+	RestCatalogOptions *opts = ResolveRestCatalogOptions(REST_CATALOG_NAME);
+
+	RestCatalogLoadTableResult result =
+		LoadTableFromRestCatalog(opts, catalogName, namespaceName, tableName);
+
+	if (result.vendedCredentials == NIL)
+		PG_RETURN_NULL();
+
+	StringInfoData buf;
+	ListCell   *credsCell = NULL;
+
+	initStringInfo(&buf);
+
+	foreach(credsCell, result.vendedCredentials)
+	{
+		VendedCredentials *creds = lfirst(credsCell);
+
+		appendStringInfo(&buf, "%s%s|%s|%s|%s|%s|%s|%s|%s",
+						 buf.len > 0 ? ";" : "",
+						 creds->accessKeyId ? creds->accessKeyId : "",
+						 creds->scope ? creds->scope : "",
+						 creds->sessionToken ? "yes" : "no",
+						 creds->expiresAt > 0 ? "expiry" : "noexpiry",
+						 creds->region ? creds->region : "",
+						 creds->endpoint ? creds->endpoint : "",
+						 creds->urlStyle ? creds->urlStyle : "",
+						 creds->useSsl ? creds->useSsl : "");
+	}
+
+	PG_RETURN_TEXT_P(cstring_to_text(buf.data));
 }

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_v3_read.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_v3_read.py
@@ -1,0 +1,269 @@
+"""Reading Iceberg v3 tables.
+
+pg_lake writes v2 and will keep doing so.  What changed is that it no
+longer refuses to *read* a table just because the catalog stamped it
+v3: v3 metadata is a superset of v2, so a table that uses no v3-only
+feature reads exactly like a v2 one, and catalogs have started moving
+their default (Snowflake Horizon among them).
+
+The v3-only features we cannot honor are rejected where they appear
+instead of at the version check.  The one that matters for correctness
+is deletion vectors: they arrive as position deletes carried in a Puffin
+blob, and treating that path as Parquet would mean returning rows the
+table considers deleted.
+
+No tool available here writes v3 -- pyiceberg refuses outright and the
+Spark runtime the suite pins predates v3 -- so these fixtures take a
+real v2 table produced by pyiceberg and edit the metadata and manifests
+into the v3 shapes under test.  That covers the version gate, the
+manifest field the v3 writers drop, and the deletion-vector guard.  It
+does not cover v3-only column types or a genuine Puffin blob.
+"""
+
+import io
+import json
+
+import fastavro
+import pyarrow
+from pyiceberg.schema import Schema
+from pyiceberg.types import DoubleType, NestedField, StringType
+
+from utils_pytest import *
+
+
+# ---------------------------------------------------------------------------
+# S3 / Avro helpers
+# ---------------------------------------------------------------------------
+
+
+def _get(s3, uri):
+    bucket, key = parse_s3_path(uri)
+    return s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+
+
+def _put(s3, uri, body):
+    bucket, key = parse_s3_path(uri)
+    s3.put_object(Bucket=bucket, Key=key, Body=body)
+
+
+def _rewrite_manifest(s3, uri, schema_fn=None, record_fn=None):
+    """Rewrite an Avro manifest in place, editing its schema and/or records.
+
+    The Iceberg metadata carried in the Avro header (schema, partition
+    spec, ...) is copied over, since the reader is entitled to rely on it.
+    """
+    reader = fastavro.reader(io.BytesIO(_get(s3, uri)))
+    writer_schema = reader.writer_schema
+    header = {k: v for k, v in reader.metadata.items() if not k.startswith("avro.")}
+    records = list(reader)
+
+    if schema_fn is not None:
+        writer_schema = schema_fn(writer_schema)
+    if record_fn is not None:
+        records = [record_fn(r) for r in records]
+
+    buf = io.BytesIO()
+    fastavro.writer(buf, writer_schema, records, metadata=header)
+
+    _put(s3, uri, buf.getvalue())
+
+
+def _data_file_record(schema):
+    """The data_file record inside a manifest_entry schema."""
+    for field in schema["fields"]:
+        if field["name"] != "data_file":
+            continue
+        field_type = field["type"]
+        if isinstance(field_type, dict):
+            return field_type
+        return next(t for t in field_type if isinstance(t, dict))
+    raise AssertionError("no data_file field in manifest schema")
+
+
+def _manifest_paths(table):
+    snapshot = table.current_snapshot()
+    return [m.manifest_path for m in snapshot.manifests(table.io)]
+
+
+# ---------------------------------------------------------------------------
+# Fixture table
+# ---------------------------------------------------------------------------
+
+
+def _make_table(iceberg_catalog, name):
+    identifier = f"public.{name}"
+    try:
+        iceberg_catalog.drop_table(identifier)
+    except Exception:
+        pass
+
+    # Unpartitioned on purpose: rewriting a manifest round-trips the Avro
+    # schema, and partition field ids are the one thing that would not
+    # survive it faithfully.
+    schema = Schema(
+        NestedField(1, "city", StringType(), required=False),
+        NestedField(2, "lat", DoubleType(), required=False),
+    )
+    table = iceberg_catalog.create_table(
+        identifier=identifier,
+        schema=schema,
+        location=f"s3://{TEST_BUCKET}/iceberg/public/{name}",
+    )
+    table.append(
+        pyarrow.Table.from_pylist(
+            [
+                {"city": "Amsterdam", "lat": 52.371807},
+                {"city": "Istanbul", "lat": 41.091242},
+            ],
+        )
+    )
+    return table
+
+
+def _data_files(conn, metadata_location, raise_error=True):
+    # The connection is shared across the module and several of these reads
+    # are expected to fail, so clear any failed transaction on both sides of
+    # the query rather than leaving the next test to trip over it.
+    conn.rollback()
+    try:
+        return run_query(
+            f"SELECT path FROM lake_iceberg.data_file_stats('{metadata_location}')",
+            conn,
+            raise_error=raise_error,
+        )
+    finally:
+        conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_v3_metadata_is_readable(
+    superuser_conn, s3, iceberg_catalog, iceberg_extension, installcheck
+):
+    """A table stamped format-version 3 is read rather than refused."""
+    if installcheck:
+        return
+
+    table = _make_table(iceberg_catalog, "v3_version_gate")
+
+    metadata = json.loads(_get(s3, table.metadata_location))
+    assert metadata["format-version"] == 2
+
+    metadata["format-version"] = 3
+    v3_location = table.metadata_location.replace(
+        ".metadata.json", ".v3-test.metadata.json"
+    )
+    _put(s3, v3_location, json.dumps(metadata).encode())
+
+    rows = _data_files(superuser_conn, v3_location)
+    assert len(rows) > 0
+
+
+def test_unsupported_format_version_still_refused(
+    superuser_conn, s3, iceberg_catalog, iceberg_extension, installcheck
+):
+    """Accepting v3 did not turn the version gate off altogether."""
+    if installcheck:
+        return
+
+    table = _make_table(iceberg_catalog, "v3_bad_version")
+
+    metadata = json.loads(_get(s3, table.metadata_location))
+    metadata["format-version"] = 4
+    bad_location = table.metadata_location.replace(
+        ".metadata.json", ".v4-test.metadata.json"
+    )
+    _put(s3, bad_location, json.dumps(metadata).encode())
+
+    err = _data_files(superuser_conn, bad_location, raise_error=False)
+    assert "unsupported iceberg format version 4" in str(err)
+
+
+def test_manifest_without_sort_order_id_is_readable(
+    superuser_conn, s3, iceberg_catalog, iceberg_extension, installcheck
+):
+    """An optional manifest field may be absent, not just null.
+
+    v3 writers drop sort_order_id from the data_file record entirely.  The
+    reader used to require the field to exist even though it is optional
+    and already tracked with a has_ flag.
+    """
+    if installcheck:
+        return
+
+    table = _make_table(iceberg_catalog, "v3_no_sort_order")
+
+    def strip_field(schema):
+        record = _data_file_record(schema)
+        record["fields"] = [f for f in record["fields"] if f["name"] != "sort_order_id"]
+        return schema
+
+    def strip_value(record):
+        record["data_file"].pop("sort_order_id", None)
+        return record
+
+    for manifest in _manifest_paths(table):
+        _rewrite_manifest(s3, manifest, schema_fn=strip_field, record_fn=strip_value)
+
+    rows = _data_files(superuser_conn, table.metadata_location)
+    assert len(rows) > 0
+
+
+def test_deletion_vector_is_rejected(
+    superuser_conn, s3, iceberg_catalog, iceberg_extension, installcheck
+):
+    """A Puffin deletion vector fails loudly instead of being read as Parquet.
+
+    Silently ignoring deletes it cannot apply would let the scan return
+    rows the table considers deleted, so this must be an error.
+    """
+    if installcheck:
+        return
+
+    table = _make_table(iceberg_catalog, "v3_deletion_vector")
+
+    def as_deletion_vector(record):
+        record["data_file"]["content"] = 1
+        record["data_file"]["file_format"] = "PUFFIN"
+        return record
+
+    for manifest in _manifest_paths(table):
+        _rewrite_manifest(s3, manifest, record_fn=as_deletion_vector)
+
+    err = _data_files(superuser_conn, table.metadata_location, raise_error=False)
+    assert "deletion vectors are not supported" in str(err)
+
+
+def test_v3_column_default_is_rejected(
+    superuser_conn, s3, iceberg_catalog, iceberg_extension, installcheck
+):
+    """A column default fails loudly rather than reading back as NULL.
+
+    v3 lets a column be added with a default, and the rows written before
+    it was added are supposed to read back as that default.  Nothing on
+    the read path applies it, so those rows would come back NULL -- a
+    wrong answer rather than a missing feature, which is why the whole
+    table is refused instead.
+    """
+    if installcheck:
+        return
+
+    table = _make_table(iceberg_catalog, "v3_column_default")
+
+    metadata = json.loads(_get(s3, table.metadata_location))
+    metadata["format-version"] = 3
+    for schema in metadata["schemas"]:
+        if schema["schema-id"] == metadata["current-schema-id"]:
+            schema["fields"][0]["initial-default"] = "unknown"
+
+    default_location = table.metadata_location.replace(
+        ".metadata.json", ".v3-default.metadata.json"
+    )
+    _put(s3, default_location, json.dumps(metadata).encode())
+
+    err = _data_files(superuser_conn, default_location, raise_error=False)
+    assert "column default values are not supported" in str(err)
+    assert "city" in str(err)

--- a/pg_lake_iceberg/tests/pytests/test_vended_credentials.py
+++ b/pg_lake_iceberg/tests/pytests/test_vended_credentials.py
@@ -1,0 +1,1613 @@
+"""
+Tests for vended credentials support in REST catalog integration.
+
+A mock HTTP server simulates an Iceberg REST catalog that returns
+vended S3 credentials in the loadTable response's "config" map.  The
+tests verify that:
+
+1. The X-Iceberg-Access-Delegation header is sent on loadTable requests
+   when vended credentials are enabled.
+2. Vended credentials from the response "config" map are extracted and
+   pushed to pgduck_server as DuckDB scoped secrets.
+3. The credential cache works correctly (no redundant REST calls).
+4. Disabling vended credentials suppresses the header and secret creation.
+5. ALTER/DROP SERVER invalidates the vended credential cache.
+"""
+
+import json
+import socket
+import threading
+import uuid
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+from utils_pytest import *
+
+
+# ---------------------------------------------------------------------------
+# Mock REST catalog server that returns vended credentials
+# ---------------------------------------------------------------------------
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _make_vended_creds_handler():
+    """
+    Factory that returns a handler class which:
+    - Issues OAuth tokens on /oauth/tokens
+    - Returns a loadTable response with vended credentials in the config
+      map when X-Iceberg-Access-Delegation: vended-credentials is present
+    - Tracks all requests for assertion
+    """
+
+    class _Handler(BaseHTTPRequestHandler):
+        tokens_issued = []
+        load_table_requests = []
+        access_delegation_headers = []
+        namespace_requests = []
+
+        def _handle(self):
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b""
+
+            if "/oauth/tokens" in self.path:
+                token = uuid.uuid4().hex
+                _Handler.tokens_issued.append(token)
+                resp = json.dumps(
+                    {
+                        "access_token": token,
+                        "token_type": "bearer",
+                        "expires_in": 3600,
+                    }
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(resp.encode())
+                return
+
+            # Track namespace creation (POST to /namespaces)
+            if "/namespaces" in self.path and self.command == "POST":
+                _Handler.namespace_requests.append(
+                    {
+                        "path": self.path,
+                        "method": self.command,
+                    }
+                )
+                resp = json.dumps({"namespace": ["test_ns"], "properties": {}})
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(resp.encode())
+                return
+
+            # Track namespace HEAD check
+            if "/namespaces/" in self.path and self.command == "HEAD":
+                self.send_response(204)
+                self.end_headers()
+                return
+
+            # loadTable: GET /namespaces/<ns>/tables/<table>
+            if "/tables/" in self.path and self.command == "GET":
+                delegation = self.headers.get("X-Iceberg-Access-Delegation", "")
+                _Handler.access_delegation_headers.append(delegation)
+                _Handler.load_table_requests.append(
+                    {
+                        "path": self.path,
+                        "method": self.command,
+                        "delegation": delegation,
+                    }
+                )
+
+                config = {}
+                if delegation == "vended-credentials":
+                    config = {
+                        "s3.access-key-id": "VENDED_ACCESS_KEY_123",
+                        "s3.secret-access-key": "VENDED_SECRET_KEY_456",
+                        "s3.session-token": "VENDED_SESSION_TOKEN_789",
+                        "client.region": "us-west-2",
+                    }
+
+                resp = json.dumps(
+                    {
+                        "metadata-location": "s3://test-bucket/test-ns/test-table/metadata/v1.metadata.json",
+                        "metadata": {
+                            "format-version": 2,
+                            "table-uuid": str(uuid.uuid4()),
+                            "location": "s3://test-bucket/test-ns/test-table",
+                        },
+                        "config": config,
+                    }
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(resp.encode())
+                return
+
+            # Stage-create: POST /namespaces/<ns>/tables
+            if "/tables" in self.path and self.command == "POST":
+                delegation = self.headers.get("X-Iceberg-Access-Delegation", "")
+                _Handler.access_delegation_headers.append(delegation)
+
+                config = {}
+                if delegation == "vended-credentials":
+                    config = {
+                        "s3.access-key-id": "STAGE_ACCESS_KEY",
+                        "s3.secret-access-key": "STAGE_SECRET_KEY",
+                        "s3.session-token": "STAGE_SESSION_TOKEN",
+                        "client.region": "us-east-1",
+                    }
+
+                resp = json.dumps(
+                    {
+                        "metadata-location": "s3://test-bucket/test-ns/new-table/metadata/v1.metadata.json",
+                        "metadata": {
+                            "format-version": 2,
+                            "table-uuid": str(uuid.uuid4()),
+                            "location": "s3://test-bucket/test-ns/new-table",
+                        },
+                        "config": config,
+                    }
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(resp.encode())
+                return
+
+            # Catch-all: use Iceberg REST error format
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                b'{"error": {"message": "not found", "type": "NoSuchNamespaceException", "code": 404}}'
+            )
+
+        do_GET = _handle
+        do_POST = _handle
+        do_PUT = _handle
+        do_DELETE = _handle
+        do_HEAD = _handle
+
+        def log_message(self, fmt, *args):
+            pass
+
+    return _Handler
+
+
+@pytest.fixture(scope="function")
+def mock_rest_catalog_with_vended_creds():
+    """Start a mock REST catalog that returns vended creds, tear down after."""
+    port = _find_free_port()
+    handler_class = _make_vended_creds_handler()
+    httpd = HTTPServer(("127.0.0.1", port), handler_class)
+
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    yield port, handler_class
+
+    httpd.shutdown()
+    thread.join(timeout=5)
+
+
+@pytest.fixture(scope="function")
+def configure_mock_catalog(
+    superuser_conn, iceberg_extension, mock_rest_catalog_with_vended_creds
+):
+    """
+    Point pg_lake_iceberg GUCs at the mock REST catalog and clean up after.
+    """
+    port, handler_class = mock_rest_catalog_with_vended_creds
+
+    run_command_outside_tx(
+        [
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
+            # Vended credentials are opt-in (disabled by default); these tests
+            # exercise the vending path, so enable it explicitly.
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_enable_vended_credentials TO 'true'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    yield port, handler_class
+
+    run_command_outside_tx(
+        [
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host",
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id",
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret",
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_enable_vended_credentials",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_vended_credentials_header_sent_on_load_table(
+    superuser_conn, iceberg_extension, installcheck, configure_mock_catalog
+):
+    """
+    Verify that the X-Iceberg-Access-Delegation: vended-credentials header
+    is sent when loading a table from the REST catalog.
+    """
+    if installcheck:
+        return
+
+    port, handler_class = configure_mock_catalog
+
+    # LoadRestCatalogMetadataLocation is called internally.
+    # We expose it via a SQL-callable C function for testing.
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        result = run_query(
+            "SELECT get_rest_metadata_location('postgres', 'test_ns', 'test_table')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # The metadata location should be returned
+        assert result[0][0] is not None
+        assert "metadata" in result[0][0]
+
+        # The mock should have received the vended-credentials header
+        assert len(handler_class.load_table_requests) > 0
+        assert (
+            handler_class.load_table_requests[-1]["delegation"] == "vended-credentials"
+        )
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+
+def test_vended_credentials_header_not_sent_when_disabled(
+    superuser_conn, iceberg_extension, installcheck, configure_mock_catalog
+):
+    """
+    Verify that the X-Iceberg-Access-Delegation header is NOT sent when
+    vended credentials are disabled.
+    """
+    if installcheck:
+        return
+
+    port, handler_class = configure_mock_catalog
+
+    # Disable vended credentials
+    run_command_outside_tx(
+        [
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_enable_vended_credentials TO 'false'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        result = run_query(
+            "SELECT get_rest_metadata_location('postgres', 'test_ns', 'test_table')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        assert result[0][0] is not None
+
+        # The header should be empty (not "vended-credentials")
+        assert len(handler_class.load_table_requests) > 0
+        assert handler_class.load_table_requests[-1]["delegation"] == ""
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_enable_vended_credentials",
+                "SELECT pg_reload_conf()",
+            ]
+        )
+
+
+def test_vended_credentials_config_parsing(
+    superuser_conn, iceberg_extension, installcheck, configure_mock_catalog
+):
+    """
+    Verify that the loadTable response's config map is parsed correctly
+    and that the credential values are extracted.
+
+    We test this by calling LoadTableFromRestCatalog via
+    get_rest_metadata_location (which exercises the full path) and then
+    checking that the mock received the proper header.
+    """
+    if installcheck:
+        return
+
+    port, handler_class = configure_mock_catalog
+
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        # Clear previous requests
+        handler_class.load_table_requests.clear()
+        handler_class.access_delegation_headers.clear()
+
+        result = run_query(
+            "SELECT get_rest_metadata_location('postgres', 'test_ns', 'my_table')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Verify the metadata location was extracted
+        assert "v1.metadata.json" in result[0][0]
+
+        # Verify the vended-credentials header was sent
+        assert len(handler_class.access_delegation_headers) == 1
+        assert handler_class.access_delegation_headers[0] == "vended-credentials"
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+
+def test_load_table_alone_does_not_push_a_secret(
+    superuser_conn, pgduck_conn, iceberg_extension, installcheck, configure_mock_catalog
+):
+    """
+    Fetching credentials is not the same as delivering them.
+
+    Credentials are pushed when something is about to read or write the
+    table's storage, not when loadTable happens to return them.  A bare
+    loadTable therefore caches credentials and pushes nothing, which is
+    what keeps secrets off pgduck_server for tables nobody touches.
+    """
+    if installcheck:
+        return
+
+    port, handler_class = configure_mock_catalog
+
+    # Create a REST catalog iceberg table that will trigger loadTable
+    # We first need to ensure the REST namespace exists
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        # Trigger loadTable to cache vended credentials
+        run_query(
+            "SELECT get_rest_metadata_location('postgres', 'test_ns', 'vc_table')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Secrets are process-global in pgduck_server, so narrow this to the
+        # bucket this mock catalog vends for rather than to any vended secret.
+        secrets = run_query(
+            "SELECT name, type, scope FROM duckdb_secrets()",
+            pgduck_conn,
+        )
+        pushed = [
+            s
+            for s in secrets
+            if s[0].startswith("pglake_vended_") and "test-bucket" in str(s[2])
+        ]
+        assert pushed == [], f"loadTable should not push a secret, got {pushed}"
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+
+def test_vended_credentials_no_config_in_response(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    Verify that the system handles REST catalog responses that don't
+    include vended credentials in the config map gracefully (no crash).
+    """
+    if installcheck:
+        return
+
+    def _make_no_creds_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            requests_received = []
+
+            def _handle(self):
+                content_length = int(self.headers.get("Content-Length", 0))
+                if content_length > 0:
+                    self.rfile.read(content_length)
+
+                if "/oauth/tokens" in self.path:
+                    resp = json.dumps(
+                        {
+                            "access_token": uuid.uuid4().hex,
+                            "token_type": "bearer",
+                            "expires_in": 3600,
+                        }
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(resp.encode())
+                    return
+
+                if "/tables/" in self.path and self.command == "GET":
+                    _Handler.requests_received.append(self.path)
+                    # Return response WITHOUT config map
+                    resp = json.dumps(
+                        {
+                            "metadata-location": "s3://bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                            },
+                        }
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(resp.encode())
+                    return
+
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    port = _find_free_port()
+    handler_class = _make_no_creds_handler()
+    httpd = HTTPServer(("127.0.0.1", port), handler_class)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    run_command_outside_tx(
+        [
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        # Should not crash even without config map in response
+        result = run_query(
+            "SELECT get_rest_metadata_location('postgres', 'test_ns', 'tbl')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        assert result[0][0] is not None
+        assert "metadata" in result[0][0]
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host",
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id",
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret",
+                "SELECT pg_reload_conf()",
+            ]
+        )
+
+
+def test_vended_credentials_empty_config_in_response(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    Verify graceful handling when config map exists but contains no
+    credential keys (e.g., catalog returns config with other settings).
+    """
+    if installcheck:
+        return
+
+    def _make_empty_config_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                content_length = int(self.headers.get("Content-Length", 0))
+                if content_length > 0:
+                    self.rfile.read(content_length)
+
+                if "/oauth/tokens" in self.path:
+                    resp = json.dumps(
+                        {
+                            "access_token": uuid.uuid4().hex,
+                            "token_type": "bearer",
+                            "expires_in": 3600,
+                        }
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(resp.encode())
+                    return
+
+                if "/tables/" in self.path and self.command == "GET":
+                    resp = json.dumps(
+                        {
+                            "metadata-location": "s3://bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                            },
+                            "config": {
+                                "some-other-setting": "value",
+                            },
+                        }
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(resp.encode())
+                    return
+
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    port = _find_free_port()
+    handler_class = _make_empty_config_handler()
+    httpd = HTTPServer(("127.0.0.1", port), handler_class)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    run_command_outside_tx(
+        [
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        result = run_query(
+            "SELECT get_rest_metadata_location('postgres', 'test_ns', 'tbl')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        assert result[0][0] is not None
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host",
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id",
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret",
+                "SELECT pg_reload_conf()",
+            ]
+        )
+
+
+def test_vended_credentials_partial_config(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    Verify that the system handles a config map with only the access key
+    but no secret key (incomplete credentials) without crashing.
+    """
+    if installcheck:
+        return
+
+    def _make_partial_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                content_length = int(self.headers.get("Content-Length", 0))
+                if content_length > 0:
+                    self.rfile.read(content_length)
+
+                if "/oauth/tokens" in self.path:
+                    resp = json.dumps(
+                        {
+                            "access_token": uuid.uuid4().hex,
+                            "token_type": "bearer",
+                            "expires_in": 3600,
+                        }
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(resp.encode())
+                    return
+
+                if "/tables/" in self.path and self.command == "GET":
+                    resp = json.dumps(
+                        {
+                            "metadata-location": "s3://bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                            },
+                            "config": {
+                                "s3.access-key-id": "PARTIAL_KEY",
+                                # missing s3.secret-access-key
+                            },
+                        }
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(resp.encode())
+                    return
+
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    port = _find_free_port()
+    handler_class = _make_partial_handler()
+    httpd = HTTPServer(("127.0.0.1", port), handler_class)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    run_command_outside_tx(
+        [
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        result = run_query(
+            "SELECT get_rest_metadata_location('postgres', 'test_ns', 'tbl')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Should succeed without crashing — partial creds are ignored
+        assert result[0][0] is not None
+        assert "metadata" in result[0][0]
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host",
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id",
+                "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret",
+                "SELECT pg_reload_conf()",
+            ]
+        )
+
+
+def test_vended_credentials_multiple_tables_independent_creds(
+    superuser_conn, iceberg_extension, installcheck, configure_mock_catalog
+):
+    """
+    Verify that loading two different tables results in two separate
+    loadTable requests, each with the vended-credentials header.
+    """
+    if installcheck:
+        return
+
+    port, handler_class = configure_mock_catalog
+
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION get_rest_metadata_location(TEXT, TEXT, TEXT)
+        RETURNS text
+        LANGUAGE C VOLATILE STRICT
+        AS 'pg_lake_iceberg', 'get_rest_metadata_location';
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        handler_class.load_table_requests.clear()
+
+        run_query(
+            "SELECT get_rest_metadata_location('postgres', 'ns1', 'table_a')",
+            superuser_conn,
+        )
+        run_query(
+            "SELECT get_rest_metadata_location('postgres', 'ns1', 'table_b')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        assert len(handler_class.load_table_requests) >= 2
+        for req in handler_class.load_table_requests:
+            assert req["delegation"] == "vended-credentials"
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_metadata_location(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Credential extraction details: scope, storage-credentials, expiry
+#
+# These use the get_rest_vended_credentials test shim, which loads a table
+# and returns the extracted credential fields as a pipe-delimited summary:
+#     "<access-key-id>|<scope>|<yes|no session token>|<expiry|noexpiry>|
+#      <region>|<endpoint>|<url-style>|<use-ssl>"
+# ---------------------------------------------------------------------------
+
+_VENDED_CREDS_FN = """
+    CREATE OR REPLACE FUNCTION get_rest_vended_credentials(TEXT, TEXT, TEXT)
+    RETURNS text
+    LANGUAGE C VOLATILE STRICT
+    AS 'pg_lake_iceberg', 'get_rest_vended_credentials';
+    """
+
+
+def _serve(handler_class):
+    """Start a mock catalog on a free port and point the GUCs at it."""
+    port = _find_free_port()
+    httpd = HTTPServer(("127.0.0.1", port), handler_class)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    run_command_outside_tx(
+        [
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
+            # Vended credentials are opt-in (disabled by default); these tests
+            # exercise the vending path, so enable it explicitly.
+            "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_enable_vended_credentials TO 'true'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+    return httpd, thread
+
+
+def _stop(httpd, thread):
+    httpd.shutdown()
+    thread.join(timeout=5)
+    run_command_outside_tx(
+        [
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host",
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id",
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret",
+            "ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_enable_vended_credentials",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+
+def _oauth_or_none(handler):
+    """Handle the OAuth token endpoint; return True if handled."""
+    if "/oauth/tokens" in handler.path:
+        resp = json.dumps(
+            {
+                "access_token": uuid.uuid4().hex,
+                "token_type": "bearer",
+                "expires_in": 3600,
+            }
+        )
+        handler.send_response(200)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        handler.wfile.write(resp.encode())
+        return True
+    return False
+
+
+def _reply(handler, payload):
+    handler.send_response(200)
+    handler.send_header("Content-Type", "application/json")
+    handler.end_headers()
+    handler.wfile.write(json.dumps(payload).encode())
+
+
+def _run_vended_creds(superuser_conn, catalog, ns, table):
+    run_command(_VENDED_CREDS_FN, superuser_conn)
+    superuser_conn.commit()
+    result = run_query(
+        f"SELECT get_rest_vended_credentials('{catalog}', '{ns}', '{table}')",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+    return result[0][0]
+
+
+def test_vended_credentials_scope_from_metadata_location(
+    superuser_conn, iceberg_extension, installcheck, configure_mock_catalog
+):
+    """
+    When the response carries a legacy top-level config map, the scope is
+    taken from the table storage location ("metadata"."location") and
+    normalized with a trailing slash -- not synthesized from the
+    configured location prefix.
+    """
+    if installcheck:
+        return
+
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "test_ns", "test_table")
+
+        access_key, scope, has_token, expiry, region, endpoint, url_style, use_ssl = (
+            summary.split("|")
+        )
+        assert access_key == "VENDED_ACCESS_KEY_123"
+        # mock returns metadata.location = s3://test-bucket/test-ns/test-table
+        assert scope == "s3://test-bucket/test-ns/test-table/"
+        assert has_token == "yes"
+        # the base mock provides no expiry
+        assert expiry == "noexpiry"
+        # region comes from client.region; the base mock vends no S3 settings
+        assert region == "us-west-2"
+        assert endpoint == ""
+        assert url_style == ""
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+
+def test_vended_credentials_every_storage_credential_is_kept(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    A catalog that vends per prefix can vend more than one credential --
+    here the data files and the metadata directory get different keys.
+    Both are kept, each with its own scope, because dropping either would
+    leave that half of the table unreadable.
+
+    The third entry repeats a prefix already covered.  DuckDB picks one
+    secret per path, so a second at the same scope could only shadow the
+    first; it is dropped.
+    """
+    if installcheck:
+        return
+
+    def _make_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                length = int(self.headers.get("Content-Length", 0))
+                if length > 0:
+                    self.rfile.read(length)
+                if _oauth_or_none(self):
+                    return
+                if "/tables/" in self.path and self.command == "GET":
+                    _reply(
+                        self,
+                        {
+                            "metadata-location": "s3://multi-bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                                "location": "s3://multi-bucket/ns/tbl",
+                            },
+                            "storage-credentials": [
+                                {
+                                    "prefix": "s3://multi-bucket/ns/tbl/data/",
+                                    "config": {
+                                        "s3.access-key-id": "DATA_KEY",
+                                        "s3.secret-access-key": "DATA_SECRET",
+                                    },
+                                },
+                                {
+                                    "prefix": "s3://multi-bucket/ns/tbl/metadata/",
+                                    "config": {
+                                        "s3.access-key-id": "META_KEY",
+                                        "s3.secret-access-key": "META_SECRET",
+                                    },
+                                },
+                                {
+                                    "prefix": "s3://multi-bucket/ns/tbl/data/",
+                                    "config": {
+                                        "s3.access-key-id": "DUPE_KEY",
+                                        "s3.secret-access-key": "DUPE_SECRET",
+                                    },
+                                },
+                            ],
+                        },
+                    )
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    httpd, thread = _serve(_make_handler())
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+        credentials = [entry.split("|") for entry in summary.split(";")]
+
+        assert len(credentials) == 2, f"expected two credentials, got {summary!r}"
+
+        by_key = {entry[0]: entry[1] for entry in credentials}
+        assert by_key["DATA_KEY"] == "s3://multi-bucket/ns/tbl/data/"
+        assert by_key["META_KEY"] == "s3://multi-bucket/ns/tbl/metadata/"
+        assert "DUPE_KEY" not in by_key
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+def test_vended_credentials_no_scope_when_undeterminable(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    Credentials with nothing to scope them to come back scoped to nothing.
+
+    The catalog names no prefix and the metadata location has no metadata
+    directory to derive a table root from.  Rather than invent a prefix,
+    extraction leaves the scope empty, which is what makes the resolver
+    push no secret at all -- a guessed scope would either match nothing or
+    match objects these credentials have no business covering.
+    """
+    if installcheck:
+        return
+
+    def _make_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                length = int(self.headers.get("Content-Length", 0))
+                if length > 0:
+                    self.rfile.read(length)
+                if _oauth_or_none(self):
+                    return
+                if "/tables/" in self.path and self.command == "GET":
+                    _reply(
+                        self,
+                        {
+                            # no "/metadata/" segment, so no table root
+                            "metadata-location": "s3://ns-bucket/flat-v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                            },
+                            "config": {
+                                "s3.access-key-id": "NOSCOPE_KEY",
+                                "s3.secret-access-key": "NOSCOPE_SECRET",
+                                "s3.session-token": "NOSCOPE_TOKEN",
+                            },
+                        },
+                    )
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    httpd, thread = _serve(_make_handler())
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+
+        access_key, scope, has_token, expiry, region, endpoint, url_style, use_ssl = (
+            summary.split("|")
+        )
+        assert access_key == "NOSCOPE_KEY"
+        assert scope == "", f"expected no scope, got {scope!r}"
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+def test_vended_credentials_storage_credentials_array(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    Newer catalogs return per-prefix credentials in a "storage-credentials"
+    array; the element's own "prefix" is used as the scope and its "config"
+    map supplies the credentials and expiry.
+    """
+    if installcheck:
+        return
+
+    def _make_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                length = int(self.headers.get("Content-Length", 0))
+                if length > 0:
+                    self.rfile.read(length)
+                if _oauth_or_none(self):
+                    return
+                if "/tables/" in self.path and self.command == "GET":
+                    _reply(
+                        self,
+                        {
+                            "metadata-location": "s3://sc-bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                                "location": "s3://sc-bucket/ns/tbl",
+                            },
+                            "storage-credentials": [
+                                {
+                                    "prefix": "s3://sc-bucket/ns/tbl/",
+                                    "config": {
+                                        "s3.access-key-id": "SC_ACCESS_KEY",
+                                        "s3.secret-access-key": "SC_SECRET_KEY",
+                                        "s3.session-token": "SC_TOKEN",
+                                        "s3.session-token-expires-at-ms": "9999999999000",
+                                        "client.region": "eu-central-1",
+                                    },
+                                }
+                            ],
+                        },
+                    )
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    httpd, thread = _serve(_make_handler())
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+
+        access_key, scope, has_token, expiry, region, endpoint, url_style, use_ssl = (
+            summary.split("|")
+        )
+        assert access_key == "SC_ACCESS_KEY"
+        # scope comes from the storage-credential prefix (already ends in /)
+        assert scope == "s3://sc-bucket/ns/tbl/"
+        assert has_token == "yes"
+        assert expiry == "expiry"
+        assert region == "eu-central-1"
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+def test_vended_credentials_expiry_from_config(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    A catalog-provided expiry ("s3.session-token-expires-at-ms") in the
+    legacy config map is parsed and reflected in the extracted credentials.
+    """
+    if installcheck:
+        return
+
+    def _make_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                length = int(self.headers.get("Content-Length", 0))
+                if length > 0:
+                    self.rfile.read(length)
+                if _oauth_or_none(self):
+                    return
+                if "/tables/" in self.path and self.command == "GET":
+                    _reply(
+                        self,
+                        {
+                            "metadata-location": "s3://exp-bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                                "location": "s3://exp-bucket/ns/tbl",
+                            },
+                            "config": {
+                                "s3.access-key-id": "EXP_KEY",
+                                "s3.secret-access-key": "EXP_SECRET",
+                                "s3.session-token": "EXP_TOKEN",
+                                "s3.session-token-expires-at-ms": "9999999999000",
+                            },
+                        },
+                    )
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    httpd, thread = _serve(_make_handler())
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+
+        access_key, scope, has_token, expiry, region, endpoint, url_style, use_ssl = (
+            summary.split("|")
+        )
+        assert access_key == "EXP_KEY"
+        assert scope == "s3://exp-bucket/ns/tbl/"
+        assert expiry == "expiry"
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+def test_vended_credentials_s3_settings_from_config(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    The catalog's own S3 connection settings are parsed from the config
+    map: s3.endpoint -> endpoint, s3.path-style-access -> url-style, and
+    s3.region is used as the region fallback when client.region is absent.
+    """
+    if installcheck:
+        return
+
+    def _make_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                length = int(self.headers.get("Content-Length", 0))
+                if length > 0:
+                    self.rfile.read(length)
+                if _oauth_or_none(self):
+                    return
+                if "/tables/" in self.path and self.command == "GET":
+                    _reply(
+                        self,
+                        {
+                            "metadata-location": "s3://cfg-bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                                "location": "s3://cfg-bucket/ns/tbl",
+                            },
+                            "config": {
+                                "s3.access-key-id": "CFG_KEY",
+                                "s3.secret-access-key": "CFG_SECRET",
+                                "s3.endpoint": "minio.example.com:9000",
+                                "s3.path-style-access": "true",
+                                # only s3.region (no client.region) -> fallback
+                                "s3.region": "ap-south-1",
+                            },
+                        },
+                    )
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    httpd, thread = _serve(_make_handler())
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+
+        access_key, scope, has_token, expiry, region, endpoint, url_style, use_ssl = (
+            summary.split("|")
+        )
+        assert access_key == "CFG_KEY"
+        assert scope == "s3://cfg-bucket/ns/tbl/"
+        assert has_token == "no"
+        assert region == "ap-south-1"
+        assert endpoint == "minio.example.com:9000"
+        assert url_style == "path"
+        # no scheme to read SSL from, so it is left to be inherited
+        assert use_ssl == ""
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+@pytest.mark.parametrize(
+    "catalog_endpoint,expected_endpoint,expected_ssl",
+    [
+        ("http://minio.example.com:9000", "minio.example.com:9000", "false"),
+        ("https://s3.example.com/", "s3.example.com", "true"),
+    ],
+)
+def test_vended_credentials_endpoint_scheme_decides_ssl(
+    superuser_conn,
+    iceberg_extension,
+    installcheck,
+    catalog_endpoint,
+    expected_endpoint,
+    expected_ssl,
+):
+    """
+    Iceberg states s3.endpoint as a URL; DuckDB wants a bare host[:port]
+    and a separate USE_SSL.  The scheme decides SSL, so a catalog pointing
+    at a plaintext store is honored rather than inheriting SSL from
+    whatever secret happens to cover the prefix.
+    """
+    if installcheck:
+        return
+
+    def _make_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                length = int(self.headers.get("Content-Length", 0))
+                if length > 0:
+                    self.rfile.read(length)
+                if _oauth_or_none(self):
+                    return
+                if "/tables/" in self.path and self.command == "GET":
+                    _reply(
+                        self,
+                        {
+                            "metadata-location": "s3://ssl-bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                                "location": "s3://ssl-bucket/ns/tbl",
+                            },
+                            "config": {
+                                "s3.access-key-id": "SSL_KEY",
+                                "s3.secret-access-key": "SSL_SECRET",
+                                "s3.endpoint": catalog_endpoint,
+                            },
+                        },
+                    )
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    httpd, thread = _serve(_make_handler())
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+
+        _, _, _, _, _, endpoint, _, use_ssl = summary.split("|")
+        assert endpoint == expected_endpoint
+        assert use_ssl == expected_ssl
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+def test_vended_credentials_scope_clamped_to_table_root(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    A storage-credential prefix that is broader than the table's own
+    directory (e.g. the warehouse root) is clamped down to the table root
+    derived from "metadata"."location", so the pushed secret cannot shadow
+    sibling tables on the shared pgduck_server.
+    """
+    if installcheck:
+        return
+
+    def _make_handler():
+        class _Handler(BaseHTTPRequestHandler):
+            def _handle(self):
+                length = int(self.headers.get("Content-Length", 0))
+                if length > 0:
+                    self.rfile.read(length)
+                if _oauth_or_none(self):
+                    return
+                if "/tables/" in self.path and self.command == "GET":
+                    _reply(
+                        self,
+                        {
+                            "metadata-location": "s3://wh-bucket/ns/tbl/metadata/v1.metadata.json",
+                            "metadata": {
+                                "format-version": 2,
+                                "table-uuid": str(uuid.uuid4()),
+                                "location": "s3://wh-bucket/ns/tbl",
+                            },
+                            "storage-credentials": [
+                                {
+                                    # broad prefix: the whole warehouse bucket
+                                    "prefix": "s3://wh-bucket/",
+                                    "config": {
+                                        "s3.access-key-id": "CLAMP_KEY",
+                                        "s3.secret-access-key": "CLAMP_SECRET",
+                                    },
+                                }
+                            ],
+                        },
+                    )
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+            do_GET = _handle
+            do_POST = _handle
+
+            def log_message(self, fmt, *args):
+                pass
+
+        return _Handler
+
+    httpd, thread = _serve(_make_handler())
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+
+        access_key, scope, has_token, expiry, region, endpoint, url_style, use_ssl = (
+            summary.split("|")
+        )
+        assert access_key == "CLAMP_KEY"
+        # clamped from the broad "s3://wh-bucket/" down to the table root
+        assert scope == "s3://wh-bucket/ns/tbl/"
+
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+def _serve_scope_case(prefix):
+    """Mock catalog for table s3://wh-bucket/ns/tbl vending ``prefix``."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def _handle(self):
+            length = int(self.headers.get("Content-Length", 0))
+            if length > 0:
+                self.rfile.read(length)
+            if _oauth_or_none(self):
+                return
+            if "/tables/" in self.path and self.command == "GET":
+                _reply(
+                    self,
+                    {
+                        "metadata-location": "s3://wh-bucket/ns/tbl/metadata/v1.metadata.json",
+                        "metadata": {
+                            "format-version": 2,
+                            "table-uuid": str(uuid.uuid4()),
+                            "location": "s3://wh-bucket/ns/tbl",
+                        },
+                        "storage-credentials": [
+                            {
+                                "prefix": prefix,
+                                "config": {
+                                    "s3.access-key-id": "SCOPE_KEY",
+                                    "s3.secret-access-key": "SCOPE_SECRET",
+                                },
+                            }
+                        ],
+                    },
+                )
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        do_GET = _handle
+        do_POST = _handle
+
+        def log_message(self, fmt, *args):
+            pass
+
+    return _serve(_Handler)
+
+
+def _scope_for_prefix(superuser_conn, prefix):
+    httpd, thread = _serve_scope_case(prefix)
+    try:
+        summary = _run_vended_creds(superuser_conn, "postgres", "ns", "tbl")
+        return summary.split("|")[1]
+    finally:
+        run_command(
+            "DROP FUNCTION IF EXISTS get_rest_vended_credentials(TEXT, TEXT, TEXT)",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        _stop(httpd, thread)
+
+
+def test_vended_credentials_scope_sibling_clamped_to_table_root(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    A storage-credential prefix pointing at a *sibling* path is clamped to
+    the table root.
+
+    Clamping only the broader-than-root case is not enough: secrets live in
+    one process-wide DuckDB instance and are selected by longest matching
+    scope, so a sibling scope would register a secret covering a table these
+    credentials have nothing to do with, and could shadow the secret that
+    table depends on.
+    """
+    if installcheck:
+        return
+
+    scope = _scope_for_prefix(superuser_conn, "s3://wh-bucket/ns/other_tbl/")
+    assert scope == "s3://wh-bucket/ns/tbl/"
+
+
+def test_vended_credentials_scope_below_table_root_preserved(
+    superuser_conn, iceberg_extension, installcheck
+):
+    """
+    A prefix *below* the table root is honored as-is.
+
+    The clamp must not over-correct: a catalog that vends credentials for
+    just the data directory is granting less than the table root, which is
+    fine to keep.
+    """
+    if installcheck:
+        return
+
+    scope = _scope_for_prefix(superuser_conn, "s3://wh-bucket/ns/tbl/data/")
+    assert scope == "s3://wh-bucket/ns/tbl/data/"

--- a/pg_lake_table/include/pg_lake/describe/describe.h
+++ b/pg_lake_table/include/pg_lake/describe/describe.h
@@ -18,12 +18,15 @@
 #pragma once
 
 #include "pg_lake/copy/copy_format.h"
+#include "pg_lake/iceberg/metadata_spec.h"
 #include "nodes/pg_list.h"
 
 extern PGDLLEXPORT List *DescribeColumnsForURL(char *url, CopyDataFormat format,
 											   CopyDataCompression compression,
 											   List *copyOptions);
 extern PGDLLEXPORT List *DescribeColumnsFromIcebergMetadataURI(char *uri, bool emitFilename);
+extern PGDLLEXPORT List *DescribeColumnsFromIcebergMetadata(IcebergTableMetadata * metadata,
+															bool emitFilename);
 char	   *MakeSimpleColumnName(char *columnName, CopyDataFormat format);
 
 extern PGDLLEXPORT List *SniffCSVOptions(char *url, CopyDataCompression compression,

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -826,6 +826,7 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 									  "from the source table in the external catalog.")));
 
 		char	   *metadataLocation = NULL;
+		Jsonb	   *catalogTableMetadata = NULL;
 		char	   *catalogNamespace = NULL;
 		char	   *catalogTableName = NULL;
 		char	   *catalogName = NULL;
@@ -900,8 +901,12 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 
 			ErrorIfRestNamespaceDoesNotExist(opts, catalogName, catalogNamespace);
 
-			metadataLocation =
-				GetMetadataLocationFromRestCatalog(opts, catalogName, catalogNamespace, catalogTableName);
+			RestCatalogLoadTableResult loadResult =
+				LoadTableFromRestCatalog(opts, catalogName, catalogNamespace,
+										 catalogTableName);
+
+			metadataLocation = loadResult.metadataLocation;
+			catalogTableMetadata = loadResult.metadata;
 		}
 		else if (hasObjectStoreCatalogOption && hasExternalCatalogReadOnlyOption)
 		{
@@ -946,7 +951,17 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		}
 		else if (createStmt->base.tableElts == NIL && hasExternalCatalogReadOnlyOption)
 		{
+			/*
+			 * Infer the columns from the metadata the catalog inlined in its
+			 * loadTable response when it sent one.  Reading metadata.json
+			 * from storage instead would fail on a catalog that only vends
+			 * credentials: the relation does not exist yet, and credentials
+			 * are resolved per relation, so nothing can push a secret for it.
+			 */
 			List	   *dataFileColumns =
+				catalogTableMetadata != NULL ?
+				DescribeColumnsFromIcebergMetadata(ParseIcebergTableMetadata(catalogTableMetadata),
+												   false) :
 				DescribeColumnsFromIcebergMetadataURI(metadataLocation, false);
 
 			createStmt->base.tableElts = dataFileColumns;

--- a/pg_lake_table/src/ddl/drop_table.c
+++ b/pg_lake_table/src/ddl/drop_table.c
@@ -41,6 +41,7 @@
 #include "pg_lake/cleanup/deletion_queue.h"
 #include "pg_lake/fdw/data_files_catalog.h"
 #include "pg_lake/fdw/data_file_stats_catalog.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/fdw/writable_table.h"
 #include "pg_lake/fdw/row_ids.h"
 #include "pg_lake/fdw/schema_operations/field_id_mapping_catalog.h"
@@ -308,6 +309,8 @@ DropTableAccessHook(ObjectAccessType access, Oid classId, Oid objectId,
 			/* Cleanup rowid sequence, if we have it */
 			DropRowIdSequenceForRelation(objectId);
 
+			IcebergCatalogType catalogType = GetIcebergCatalogType(objectId);
+
 			IcebergDDLOperation *ddlOperation = palloc0(sizeof(IcebergDDLOperation));
 
 			ddlOperation->type = DDL_TABLE_DROP;
@@ -316,11 +319,20 @@ DropTableAccessHook(ObjectAccessType access, Oid classId, Oid objectId,
 
 			TriggerCatalogExportIfObjectStoreTable(objectId);
 
-			IcebergCatalogType catalogType = GetIcebergCatalogType(objectId);
-
 			if (catalogType == REST_CATALOG_READ_WRITE)
 				RecordRestCatalogRequestInTx(objectId, REST_CATALOG_DROP_TABLE, NULL);
 		}
+	}
+	else if (!isColumn && IsAnyLakeForeignTableById(objectId))
+	{
+		/*
+		 * A read-only lake table owns none of the files it reads, so the drop
+		 * queues no deletes and the secrets this backend pushed for it are
+		 * dead weight the moment it is gone.  Left behind, an expired one
+		 * would still win DuckDB's longest-scope match for everything under
+		 * that prefix.
+		 */
+		ForgetStorageCredentials(objectId);
 	}
 	else if (get_rel_type_id(objectId) != InvalidOid && subId != 0)
 	{

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -47,6 +47,7 @@
 #include "pg_lake/iceberg/operations/manifest_merge.h"
 #include "pg_lake/iceberg/operations/vacuum.h"
 #include "pg_lake/parsetree/options.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/transaction/transaction_hooks.h"
 #include "pg_lake/util/injection_points.h"
 #include "pg_lake/util/rel_utils.h"

--- a/pg_lake_table/src/describe/describe.c
+++ b/pg_lake_table/src/describe/describe.c
@@ -166,9 +166,19 @@ DescribeColumnsForURL(char *url,
 List *
 DescribeColumnsFromIcebergMetadataURI(char *uri, bool emitFilename)
 {
-	List	   *columns = NIL;
+	return DescribeColumnsFromIcebergMetadata(ReadIcebergTableMetadata(uri),
+											  emitFilename);
+}
 
-	IcebergTableMetadata *metadata = ReadIcebergTableMetadata(uri);
+
+/*
+ * DescribeColumnsFromIcebergMetadata retrieves the columns described by
+ * an already-read Iceberg metadata document.
+ */
+List *
+DescribeColumnsFromIcebergMetadata(IcebergTableMetadata * metadata, bool emitFilename)
+{
+	List	   *columns = NIL;
 
 	if (metadata == NULL)
 	{

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -976,7 +976,11 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 			if (catalogTableName)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("\"catalog_table_name\" option is only valid for read-only rest and object_store catalog tables")));
+						 errmsg("\"catalog_table_name\" option is only valid for read-only rest and object_store catalog tables"),
+						 errdetail("pg_lake writes only to Iceberg tables it created itself, "
+								   "and names those after the database, schema and table."),
+						 errhint("Add read_only=True to query the existing table \"%s\".",
+								 catalogTableName)));
 
 		}
 	}

--- a/pg_lake_table/src/fdw/pg_lake_table.c
+++ b/pg_lake_table/src/fdw/pg_lake_table.c
@@ -91,6 +91,7 @@
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/permissions/roles.h"
 #include "pg_extension_base/pg_compat.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/pgduck/array_conversion.h"
 #include "pg_lake/pgduck/iceberg_datum_validation.h"
 #include "pg_lake/pgduck/client.h"
@@ -1730,7 +1731,11 @@ postgresBeginForeignScan(ForeignScanState *node, int eflags)
 	 */
 	bool		includeChildren = false;
 
-	/* find the files to scan for each relation */
+	/*
+	 * find the files to scan for each relation.  Storage credentials are
+	 * resolved per relation inside CreatePgLakeScanSnapshot ->
+	 * CreateTableScanForRelation, so this path needs no push of its own.
+	 */
 	fsstate->scanSnapshot =
 		CreatePgLakeScanSnapshot(rteList, restrictionList, paramListInfo,
 								 includeChildren, fsstate->resultRelationId);
@@ -2231,7 +2236,9 @@ postgresBeginForeignModify(ModifyTableState *mtstate,
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 		return;
 
-	BindRelationToXactRestCatalog(RelationGetRelid(resultRelInfo->ri_RelationDesc));
+	Oid			modifyRelId = RelationGetRelid(resultRelInfo->ri_RelationDesc);
+
+	BindRelationToXactRestCatalog(modifyRelId);
 
 	/* Construct an execution state. */
 	fmstate = create_foreign_modify(resultRelInfo->ri_RelationDesc,

--- a/pg_lake_table/src/fdw/snapshot.c
+++ b/pg_lake_table/src/fdw/snapshot.c
@@ -403,12 +403,35 @@ ErrorIfSchemasDoNotMatch(Oid relationId, IcebergTableMetadata * metadata)
 	/* if field counts do not match, a DDL happened */
 	if (icebergTableSchema->fields_length != list_length(postgresColumnMappings))
 	{
+		StringInfo	unmatched = makeStringInfo();
+
+		/*
+		 * Mappings are built by looking up each Iceberg field name among the
+		 * relation's columns, and a read-only table silently skips the ones
+		 * that find no column.  A short count is therefore just as likely to
+		 * mean the names differ as it is to mean a concurrent DDL, and the
+		 * two call for opposite responses, so name the fields that did not
+		 * match instead of leaving it to be guessed.
+		 */
+		for (int i = 0; i < icebergTableSchema->fields_length; i++)
+		{
+			const char *fieldName = icebergTableSchema->fields[i].name;
+
+			if (fieldName != NULL &&
+				get_attnum(relationId, fieldName) == InvalidAttrNumber)
+				appendStringInfo(unmatched, "%s\"%s\"",
+								 unmatched->len > 0 ? ", " : "", fieldName);
+		}
+
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("Schema mismatch between Iceberg and Postgres for relation \"%s\": field count %zu vs %d",
 						get_rel_name(relationId),
 						icebergTableSchema->fields_length,
 						list_length(postgresColumnMappings)),
+				 unmatched->len > 0 ?
+				 errdetail("Iceberg fields with no matching Postgres column: %s",
+						   unmatched->data) : 0,
 				 errhint("Please drop and recreate the table \"%s\"", get_rel_name(relationId))));
 	}
 

--- a/pg_lake_table/src/fdw/snapshot.c
+++ b/pg_lake_table/src/fdw/snapshot.c
@@ -38,6 +38,7 @@
 #include "pg_extension_base/pg_compat.h"
 #include "pg_lake/pgduck/remote_storage.h"
 #include "pg_lake/planner/restriction_collector.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
 #include "pg_lake/fdw/data_file_pruning.h"
@@ -270,6 +271,17 @@ CreateTableScanForRelation(Oid relationId, Snapshot snapshot, int uniqueRelation
 	}
 	else if (IsExternalIcebergTable(relationId))
 	{
+		/*
+		 * Single choke point for storage credentials on the read path: both
+		 * the plain FDW scan path and the query-pushdown path funnel through
+		 * CreatePgLakeScanSnapshot -> here, and a table pg_lake did not
+		 * create is the only kind whose files a catalog vends credentials
+		 * for.  It has to happen before the metadata read just below, which
+		 * is itself a read of that storage.  The resolver no-ops for
+		 * everything but a read-only REST-catalog table.
+		 */
+		EnsureStorageCredentialsForRelation(relationId);
+
 		char	   *path = GetIcebergMetadataLocation(relationId, false);
 
 		IcebergTableMetadata *metadata = ReadIcebergTableMetadata(path);

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -36,6 +36,7 @@
 #include "pg_lake/fdw/data_files_catalog.h"
 #include "pg_lake/fdw/row_ids.h"
 #include "pg_lake/fdw/writable_table.h"
+#include "pg_lake/storage/storage_credentials.h"
 #include "pg_lake/fdw/partition_pushdown.h"
 #include "pg_lake/fdw/partition_transform.h"
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"

--- a/pg_lake_table/src/planner/query_pushdown.c
+++ b/pg_lake_table/src/planner/query_pushdown.c
@@ -1423,6 +1423,11 @@ QueryPushdownBeginScan(CustomScanState *node, EState *estate, int eflags)
 	/* if there are child tables, include them in the snapshot */
 	bool		includeChildren = true;
 
+	/*
+	 * Storage credentials are resolved per relation inside
+	 * CreatePgLakeScanSnapshot -> CreateTableScanForRelation, so this path
+	 * needs no push of its own.
+	 */
 	PgLakeScanSnapshot *snapshot =
 		CreatePgLakeScanSnapshot(rteList, relationRestrictionsList, paramListInfo,
 								 includeChildren, InvalidOid);

--- a/pg_lake_table/tests/e2e/test_vended_credentials_e2e.py
+++ b/pg_lake_table/tests/e2e/test_vended_credentials_e2e.py
@@ -1,0 +1,150 @@
+"""End-to-end vended-credentials test against a *real* Iceberg REST catalog.
+
+This is the most realistic test in the pyramid: a real REST catalog vends
+real, scoped, short-lived storage credentials (e.g. STS) for data that
+lives in real object storage which actually enforces those credentials.
+Nothing is mocked.
+
+Because it needs live cloud infrastructure, it is skipped unless the
+required environment variables are set -- exactly like
+``test_region_switch.py`` skips unless ``CDWREGIONTEST_ACCESS_KEY_ID`` is
+present.  Point it at your catalog and run ``make check-e2e``.
+
+--------------------------------------------------------------------------
+AWS S3 Tables caveat
+--------------------------------------------------------------------------
+The intended target for this suite is AWS S3 Tables.  However, the S3
+Tables Iceberg REST endpoint authenticates with **AWS SigV4**, while
+pg_lake's REST catalog client currently supports only ``oauth2`` /
+``horizon`` auth (see ``rest_auth_type`` in
+``pg_lake_iceberg/src/rest_catalog/rest_catalog_options.c``).  Until
+pg_lake gains SigV4 REST auth, S3 Tables must be fronted by a SigV4-aware
+gateway, or you must point this test at an OAuth2 catalog that vends
+credentials (Polaris, Lakekeeper, Unity Catalog, Snowflake Open Catalog,
+Cloudflare R2 Data Catalog, ...).  The test below is written to be
+catalog-agnostic for that reason.
+
+--------------------------------------------------------------------------
+Environment variables
+--------------------------------------------------------------------------
+Required:
+  PGLAKE_E2E_REST_ENDPOINT   REST catalog base URL (e.g. https://host/iceberg)
+  PGLAKE_E2E_CLIENT_ID       OAuth2 client id
+  PGLAKE_E2E_CLIENT_SECRET   OAuth2 client secret
+  PGLAKE_E2E_NAMESPACE       existing namespace holding the table
+  PGLAKE_E2E_TABLE           existing table name to read
+
+Optional:
+  PGLAKE_E2E_OAUTH_ENDPOINT  OAuth2 token endpoint (if not the catalog default)
+  PGLAKE_E2E_SCOPE           OAuth2 scope (default: PRINCIPAL_ROLE:ALL)
+  PGLAKE_E2E_EXPECTED_COUNT  exact row count to assert (default: assert >= 0)
+
+The AWS credentials pgduck_server uses to *reach* object storage come from
+the standard AWS credential chain via the built-in ``s3default`` secret;
+the vended credentials returned by the catalog are what actually authorize
+the data scan.
+"""
+
+import os
+
+import pytest
+from utils_pytest import *
+
+_REQUIRED_ENV = (
+    "PGLAKE_E2E_REST_ENDPOINT",
+    "PGLAKE_E2E_CLIENT_ID",
+    "PGLAKE_E2E_CLIENT_SECRET",
+    "PGLAKE_E2E_NAMESPACE",
+    "PGLAKE_E2E_TABLE",
+)
+
+requires_e2e_catalog = pytest.mark.skipif(
+    any(not os.getenv(v) for v in _REQUIRED_ENV),
+    reason=(
+        "vended-credentials e2e needs a live OAuth2 Iceberg REST catalog; set "
+        + ", ".join(_REQUIRED_ENV)
+    ),
+)
+
+
+@requires_e2e_catalog
+def test_vended_credentials_e2e_read(superuser_conn, pgduck_conn, extension):
+    """Read a real table whose data access is authorized by vended creds."""
+    endpoint = os.environ["PGLAKE_E2E_REST_ENDPOINT"]
+    client_id = os.environ["PGLAKE_E2E_CLIENT_ID"]
+    client_secret = os.environ["PGLAKE_E2E_CLIENT_SECRET"]
+    namespace = os.environ["PGLAKE_E2E_NAMESPACE"]
+    table = os.environ["PGLAKE_E2E_TABLE"]
+    oauth_endpoint = os.getenv("PGLAKE_E2E_OAUTH_ENDPOINT")
+    scope = os.getenv("PGLAKE_E2E_SCOPE", "PRINCIPAL_ROLE:ALL")
+    expected_count = os.getenv("PGLAKE_E2E_EXPECTED_COUNT")
+
+    server_name = "pglake_e2e_vended_srv"
+    schema = "pglake_e2e_vended"
+
+    options = [
+        f"rest_endpoint '{endpoint}'",
+        "rest_auth_type 'oauth2'",
+        f"scope '{scope}'",
+        "enable_vended_credentials 'true'",
+    ]
+    if oauth_endpoint:
+        options.append(f"oauth_endpoint '{oauth_endpoint}'")
+    options_sql = ",\n                ".join(options)
+
+    try:
+        run_command(f"DROP SERVER IF EXISTS {server_name} CASCADE", superuser_conn)
+        run_command(
+            f"""
+            CREATE SERVER {server_name} TYPE 'rest'
+                FOREIGN DATA WRAPPER iceberg_catalog
+                OPTIONS (
+                {options_sql}
+                )
+            """,
+            superuser_conn,
+        )
+        run_command(
+            f"""
+            CREATE USER MAPPING FOR CURRENT_USER SERVER {server_name}
+                OPTIONS (client_id '{client_id}', client_secret '{client_secret}')
+            """,
+            superuser_conn,
+        )
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+
+        # Attach the existing catalog table read-only.
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='{server_name}', read_only=True,
+                      catalog_namespace='{namespace}',
+                      catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # The scan is authorized by the catalog-vended credential.
+        result = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        count = result[0][0]
+        if expected_count is not None:
+            assert count == int(
+                expected_count
+            ), f"expected {expected_count} rows, got {count}"
+        else:
+            assert count >= 0
+
+        # A scoped vended secret should have been pushed to pgduck_server.
+        secrets = run_query(
+            "SELECT name, scope FROM duckdb_secrets() WHERE name LIKE 'pglake_vended_%'",
+            pgduck_conn,
+        )
+        assert len(secrets) >= 1, "expected a pglake_vended_* secret after the scan"
+
+    finally:
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        run_command(f"DROP SERVER IF EXISTS {server_name} CASCADE", superuser_conn)
+        superuser_conn.commit()

--- a/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
+++ b/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
@@ -1227,10 +1227,14 @@ def test_alter_user_mapping_credentials_invalidates_token_cache(
         "Expected COMMIT to fail after ALTER USER MAPPING set bogus client_id "
         "(cache should have been invalidated, forcing re-auth with bad creds)"
     )
+    # After the cache is invalidated, the commit-time loadTable re-auths with
+    # the bogus creds and fails, aborting the commit -- exactly one forced
+    # re-fetch.  Vended credentials are opt-in (disabled by default in this
+    # suite), so the write path does no extra loadTable probe here.
     assert post_alter_fetches == 1, (
-        f"Expected exactly 1 token re-fetch after ALTER USER MAPPING "
-        f"(cache invalidated), got {post_alter_fetches}. Notices "
-        f"({len(post_alter_notices)}):\n" + "\n".join(post_alter_notices)
+        f"Expected 1 token re-fetch after ALTER USER MAPPING (commit re-auth), "
+        f"got {post_alter_fetches}. "
+        f"Notices ({len(post_alter_notices)}):\n" + "\n".join(post_alter_notices)
     )
 
     run_command(

--- a/pg_lake_table/tests/pytests/test_polaris_catalog.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog.py
@@ -517,6 +517,13 @@ def test_register_existing_table(
         raise_error=False,
     )
     assert "Schema mismatch between Iceberg and Postgres" in str(err)
+    # The table was declared with "looong" instead of "long", so the error has
+    # to name the Iceberg field that found no column: a read-only table skips
+    # unmatched fields, which leaves a bare field count that looks identical to
+    # a concurrent DDL and points at the wrong fix.  Which other fields go
+    # unmatched varies with the column names this test is parametrized over.
+    assert "Iceberg fields with no matching Postgres column:" in str(err)
+    assert '"long"' in str(err)
     pg_conn.rollback()
 
     if external_catalog_names:

--- a/pg_lake_table/tests/pytests/test_vended_credentials_enforced.py
+++ b/pg_lake_table/tests/pytests/test_vended_credentials_enforced.py
@@ -1,0 +1,1287 @@
+"""Enforcement tests for REST-catalog vended credentials.
+
+These run against a storage mock that actually refuses requests (see
+``helpers/moto_iam_storage.py``), which is what lets them prove the vended
+credential is genuinely *load-bearing* rather than merely present:
+
+  * ``test_vended_credentials_required_for_scan``
+        With vending enabled, the catalog vends a data-scoped credential;
+        pg_lake pushes it to pgduck_server as a ``pglake_vended_*`` secret
+        and the SELECT succeeds.  The pre-existing static secret is scoped
+        to *metadata only*, so the scan can only succeed via the vended
+        credential.
+
+  * ``test_scan_denied_without_vended_credentials``
+        With vending disabled (catalog returns no credentials), the data
+        scan falls back to the metadata-only static secret and is denied
+        -- proving the static secret alone is insufficient.
+
+  * ``test_vended_credentials_wrong_scope_denied``
+        The catalog vends a credential scoped to the *wrong* prefix, so
+        DuckDB never applies it to the target table's data path and the
+        scan is denied -- proving the scope string must be correct.
+
+  * ``test_columnless_attach_does_not_read_storage``
+        ``CREATE TABLE t ()`` learns the columns from the metadata the
+        catalog inlines in its loadTable response.  The static secret
+        cannot reach the table at all, so an attach that reads
+        metadata.json off the store is denied -- which is what happens
+        when inference goes to storage before the relation exists.
+
+  * ``test_vended_secret_dropped_when_revoked``
+        With vending on, a scan pushes the data-capable secret and
+        succeeds.  Vending is then turned off (the catalog stops
+        delegating); the next scan on the same backend resolves no
+        credentials, *drops* the secret it previously pushed, and the data
+        scan is denied.  This proves the resolver's headline behavior: a
+        stale credential cannot linger on the shared pgduck_server once the
+        catalog stops vending it.
+
+Every test sets its scene while the store is permissive and calls
+``server.enforce()`` before the assertion that has to turn on a
+credential, because materializing an Iceberg table and creating IAM users
+are not themselves what is under test.
+
+Architecture recap (why the static/vended split works):
+  - REST loadTable runs in PostgreSQL over HTTP (mock catalog here).
+  - Iceberg metadata (metadata.json + manifest Avro) is read on
+    pgduck_server using the pre-existing static S3 secret.
+  - The parquet data scan runs on pgduck_server using the scoped
+    ``pglake_vended_*`` secret (falling back to the static secret when no
+    vended credential is cached).
+  - The vended secret inherits ENDPOINT/URL_STYLE/USE_SSL from the static
+    secret whose scope best-matches the vended scope, so pointing the
+    static secret at the mock is what makes vended secrets reach it too.
+"""
+
+import base64
+import json
+import socket
+import tempfile
+import threading
+import urllib.parse
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from utils_pytest import *
+
+try:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    from pyiceberg.catalog.sql import SqlCatalog
+
+    _HAVE_PYICEBERG = True
+except Exception as _exc:  # pragma: no cover - depends on environment
+    _HAVE_PYICEBERG = False
+
+
+# ---------------------------------------------------------------------------
+# Iceberg table materialization (via pyiceberg)
+# ---------------------------------------------------------------------------
+
+
+def _materialize_iceberg_table(server, namespace, table, rows):
+    """Create a real Iceberg table with ``rows`` rows on the store.
+
+    Returns ``(metadata_location, table_location, key_prefix)`` where
+    ``key_prefix`` is the table's key prefix inside the bucket (e.g.
+    ``wh/ns/tbl``).
+    """
+    warehouse = f"s3://{server.bucket}/wh"
+    sqlite_dir = tempfile.mkdtemp(prefix="pgl_vended_cat_")
+    catalog = SqlCatalog(
+        "vended_materialize",
+        **{
+            "uri": f"sqlite:///{sqlite_dir}/catalog.db",
+            "warehouse": warehouse,
+            "s3.endpoint": server.endpoint_url,
+            "s3.access-key-id": server.root_user,
+            "s3.secret-access-key": server.root_password,
+            "s3.region": server.region,
+            "s3.path-style-access": "true",
+        },
+    )
+    try:
+        catalog.create_namespace(namespace)
+    except Exception:
+        pass
+
+    schema = pa.schema([("id", pa.int64()), ("val", pa.string())])
+    data = pa.table(
+        {"id": list(range(rows)), "val": [str(i) for i in range(rows)]},
+        schema=schema,
+    )
+    tbl = catalog.create_table(f"{namespace}.{table}", schema=schema)
+    tbl.append(data)
+
+    metadata_location = tbl.metadata_location
+    key = metadata_location.split(f"s3://{server.bucket}/", 1)[1]
+    key_prefix = key.split("/metadata/", 1)[0]
+    table_location = f"s3://{server.bucket}/{key_prefix}"
+    return metadata_location, table_location, key_prefix
+
+
+# ---------------------------------------------------------------------------
+# Mock Iceberg REST catalog (data-driven by a table -> response map)
+# ---------------------------------------------------------------------------
+
+
+def _read_metadata_document(server, metadata_location):
+    """Read a table's metadata.json with the store's root credentials."""
+    key = metadata_location.split(f"s3://{server.bucket}/", 1)[1]
+    body = server.client().get_object(Bucket=server.bucket, Key=key)["Body"].read()
+    return json.loads(body)
+
+
+def _make_handler(tables, server):
+    """Build a mock REST catalog handler.
+
+    ``tables`` maps table-name -> dict with:
+        metadata_location : str
+        location          : str
+        vended            : optional dict {"prefix": str, "config": dict}
+        vended_by_client  : optional dict client_id -> {"prefix", "config"},
+                            for catalogs that vend per principal
+
+    Tokens carry the client_id that asked for them, which is how a
+    loadTable knows which principal it is answering.
+
+    loadTable inlines the table's real metadata document, as the Iceberg
+    REST spec requires and as Polaris and Horizon both do.  It is what
+    lets a columnless CREATE TABLE learn the schema without reaching for
+    storage, so a stub here would hide whether that works.  Reading it
+    back uses the root credentials, so the catalog keeps answering once a
+    test has turned enforcement on.
+    """
+
+    class _Handler(BaseHTTPRequestHandler):
+        def _handle(self):
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length) if length > 0 else b""
+
+            if "/oauth/tokens" in self.path:
+                # The client id arrives either as a form field or as HTTP
+                # basic auth, depending on how the client was configured.
+                form = urllib.parse.parse_qs(body.decode())
+                client_id = (form.get("client_id") or [""])[0]
+                auth = self.headers.get("Authorization", "")
+                if not client_id and auth.lower().startswith("basic "):
+                    decoded = base64.b64decode(auth.split(" ", 1)[1]).decode()
+                    client_id = decoded.split(":", 1)[0]
+                self._json(
+                    {
+                        "access_token": f"{client_id}.{uuid.uuid4().hex}",
+                        "token_type": "bearer",
+                        "expires_in": 3600,
+                    }
+                )
+                return
+
+            if "/namespaces/" in self.path and self.command == "HEAD":
+                self.send_response(204)
+                self.end_headers()
+                return
+
+            # Namespace-exists check (GET .../namespaces/<ns>) done during
+            # read-only CREATE TABLE: report the namespace as present.
+            if (
+                "/namespaces/" in self.path
+                and "/tables" not in self.path
+                and self.command == "GET"
+            ):
+                ns = self.path.rstrip("/").split("/namespaces/", 1)[1].split("?")[0]
+                self._json({"namespace": [ns], "properties": {}})
+                return
+
+            if "/tables/" in self.path and self.command == "GET":
+                name = self.path.rstrip("/").split("/tables/", 1)[1].split("?")[0]
+                info = tables.get(name)
+                if info is None:
+                    self._error()
+                    return
+
+                delegation = self.headers.get("X-Iceberg-Access-Delegation", "")
+                resp = {
+                    "metadata-location": info["metadata_location"],
+                    "metadata": _read_metadata_document(
+                        server, info["metadata_location"]
+                    ),
+                }
+
+                vended = info.get("vended")
+                by_client = info.get("vended_by_client")
+                if by_client:
+                    token = self.headers.get("Authorization", "").split(" ")[-1]
+                    vended = by_client.get(token.split(".", 1)[0])
+
+                if delegation == "vended-credentials" and vended:
+                    resp["storage-credentials"] = [
+                        {"prefix": vended["prefix"], "config": vended["config"]}
+                    ]
+                self._json(resp)
+                return
+
+            self._error()
+
+        def _json(self, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _error(self):
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                b'{"error": {"message": "not found", '
+                b'"type": "NoSuchTableException", "code": 404}}'
+            )
+
+        do_GET = _handle
+        do_POST = _handle
+        do_PUT = _handle
+        do_DELETE = _handle
+        do_HEAD = _handle
+
+        def log_message(self, fmt, *args):
+            pass
+
+    return _Handler
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _start_mock_catalog(tables, server):
+    """Start the mock catalog, leaving it to the caller to point at it."""
+    port = _find_free_port()
+    httpd = HTTPServer(("127.0.0.1", port), _make_handler(tables, server))
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, thread, port
+
+
+_CATALOG_GUCS = (
+    "pg_lake_iceberg.rest_catalog_host",
+    "pg_lake_iceberg.rest_catalog_client_id",
+    "pg_lake_iceberg.rest_catalog_client_secret",
+    "pg_lake_iceberg.rest_catalog_enable_vended_credentials",
+)
+
+
+def _serve_mock_catalog(tables, server, enable_vended, conn=None):
+    """Start the mock catalog and point the REST GUCs at it.
+
+    ``conn`` is the connection about to use the catalog.  ALTER SYSTEM
+    alone is not enough for it: the SIGHUP it triggers is processed at an
+    unpredictable command boundary, so the very next statement may still
+    run against the previous test's (reset) settings.  A session-level
+    SET on that connection takes effect immediately.
+    """
+    httpd, thread, port = _start_mock_catalog(tables, server)
+
+    settings = {
+        "pg_lake_iceberg.rest_catalog_host": f"http://127.0.0.1:{port}",
+        "pg_lake_iceberg.rest_catalog_client_id": "test_id",
+        "pg_lake_iceberg.rest_catalog_client_secret": "test_secret",
+        "pg_lake_iceberg.rest_catalog_enable_vended_credentials": (
+            "true" if enable_vended else "false"
+        ),
+    }
+
+    run_command_outside_tx(
+        [f"ALTER SYSTEM SET {name} TO '{value}'" for name, value in settings.items()]
+        + ["SELECT pg_reload_conf()"]
+    )
+
+    if conn is not None:
+        for name, value in settings.items():
+            run_command(f"SET {name} TO '{value}'", conn)
+        conn.commit()
+
+    return httpd, thread
+
+
+def _stop_mock_catalog(httpd, thread, conn=None):
+    httpd.shutdown()
+    thread.join(timeout=5)
+    run_command_outside_tx(
+        [f"ALTER SYSTEM RESET {name}" for name in _CATALOG_GUCS]
+        + ["SELECT pg_reload_conf()"]
+    )
+    if conn is not None:
+        for name in _CATALOG_GUCS:
+            run_command(f"RESET {name}", conn)
+        conn.commit()
+
+
+def _create_static_secret(pgduck_conn, server, access_key, secret_key):
+    """Create the pre-existing static S3 secret that points pgduck at the store.
+
+    Its scope covers the whole test bucket, so vended secrets (which have a
+    more specific per-table scope) inherit the store's
+    ENDPOINT/URL_STYLE/SSL from it.
+    """
+    run_command(
+        f"""
+        CREATE OR REPLACE SECRET s3enforced (
+            TYPE S3,
+            KEY_ID '{access_key}',
+            SECRET '{secret_key}',
+            ENDPOINT '{server.endpoint}',
+            SCOPE 's3://{server.bucket}',
+            URL_STYLE 'path',
+            USE_SSL false
+        )
+        """,
+        pgduck_conn,
+    )
+    pgduck_conn.commit()
+
+
+def _denied(text):
+    if text is None:
+        return False
+    return "Access Denied" in text or "AccessDenied" in text or "HTTP 403" in text
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_vended_credentials_required_for_scan(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_required"
+    table = "vc_ok"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    # Static credential can read *metadata* only; vended credential can read
+    # the whole table prefix (metadata + data).
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_ok",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user("mv_data_ok", [prefix])
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended": {
+                "prefix": location + "/",
+                "config": {
+                    "s3.access-key-id": data_key,
+                    "s3.secret-access-key": data_secret,
+                    "client.region": server.region,
+                },
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        result = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        assert result[0][0] == 10
+
+        # The vended secret must have been pushed to pgduck with the table's
+        # storage prefix as its scope.
+        secrets = run_query(
+            "SELECT name, scope FROM duckdb_secrets() WHERE name LIKE 'pglake_vended_%'",
+            pgduck_conn,
+        )
+        assert any(
+            s[1] and location in s[1] for s in secrets
+        ), f"expected a pglake_vended_* secret scoped to {location}, got {secrets}"
+
+    finally:
+        server.relax()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+def test_scan_denied_without_vended_credentials(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_denied"
+    table = "vc_novend"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_nv",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+
+    # No "vended" entry -> catalog returns no credentials even though the
+    # delegation header is sent.
+    tables = {
+        table: {"metadata_location": meta_loc, "location": location, "vended": None}
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Metadata read (static secret) succeeds; the data scan falls back to
+        # the metadata-only static secret and the store denies it.
+        err = run_query(
+            f"SELECT count(*) FROM {schema}.{table}",
+            superuser_conn,
+            raise_error=False,
+        )
+        superuser_conn.rollback()
+        assert _denied(err), f"expected an access-denied error, got: {err!r}"
+
+    finally:
+        server.relax()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+def test_vended_secret_dropped_when_revoked(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_revoke"
+    table = "vc_revoke"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    # metadata-only static credential; data-capable vended credential.
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_rv",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user("mv_data_rv", [prefix])
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended": {
+                "prefix": location + "/",
+                "config": {
+                    "s3.access-key-id": data_key,
+                    "s3.secret-access-key": data_secret,
+                    "client.region": server.region,
+                },
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Step 1: vending on -> scan succeeds and the secret is pushed.
+        result = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        assert result[0][0] == 10
+
+        def _vended_secrets_for_this_table():
+            rows = run_query(
+                "SELECT name, scope FROM duckdb_secrets() "
+                "WHERE name LIKE 'pglake_vended_%'",
+                pgduck_conn,
+            )
+            return [r for r in rows if r[1] and location in r[1]]
+
+        assert (
+            _vended_secrets_for_this_table()
+        ), "expected a vended secret to be pushed while vending is on"
+
+        # Step 2: revoke by turning vending off for this session.  A
+        # session-level SET (PGC_SUSET) takes effect on the very next query
+        # in this same backend -- deterministically, unlike an ALTER SYSTEM
+        # + pg_reload_conf whose SIGHUP is only processed at the *following*
+        # command boundary.  The next scan then resolves no credentials and
+        # must drop the secret it pushed above, leaving only the
+        # metadata-only static secret so the store denies the data scan.
+        run_command(
+            "SET pg_lake_iceberg.rest_catalog_enable_vended_credentials = false",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # The scan that succeeded above is now DENIED.  This is the
+        # authoritative proof that the resolver dropped the secret it had
+        # pushed: if the drop had not taken effect, the still-present
+        # data-capable vended secret would have served this identical read.
+        # (We deliberately assert on the scan result rather than on a peer
+        # connection's duckdb_secrets() view, whose reflection of a drop
+        # made on another pgduck connection is not deterministic.)
+        err = run_query(
+            f"SELECT count(*) FROM {schema}.{table}",
+            superuser_conn,
+            raise_error=False,
+        )
+        superuser_conn.rollback()
+        assert _denied(err), f"expected access-denied after revocation, got: {err!r}"
+
+    finally:
+        server.relax()
+        run_command(
+            "RESET pg_lake_iceberg.rest_catalog_enable_vended_credentials",
+            superuser_conn,
+        )
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+def test_two_principals_get_their_own_credentials(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    """Two roles reading one table are each served their own credential.
+
+    A catalog vends per principal, so a backend that changes role must
+    not hand the second role what the first was given.  The two vended
+    credentials here differ in what they can actually do -- one reads the
+    table's data, the other only its metadata -- so reusing the first
+    one is not a subtle difference: the second scan would succeed where
+    the store must deny it.
+    """
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_two_princ"
+    table = "vc_two_princ"
+    fdw_server = "mv_two_princ_srv"
+    role_a = "mv_princ_a"
+    role_b = "mv_princ_b"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    # The static secret reaches metadata only, so any successful data scan
+    # below has to come from a vended credential.
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_2p",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user("mv_data_2p", [prefix])
+
+    data_config = {
+        "s3.access-key-id": data_key,
+        "s3.secret-access-key": data_secret,
+        "client.region": server.region,
+    }
+    meta_config = {
+        "s3.access-key-id": meta_key,
+        "s3.secret-access-key": meta_secret,
+        "client.region": server.region,
+    }
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended_by_client": {
+                "princ_root": {"prefix": location + "/", "config": data_config},
+                "princ_a": {"prefix": location + "/", "config": data_config},
+                "princ_b": {"prefix": location + "/", "config": meta_config},
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread, port = _start_mock_catalog(tables, server)
+
+    try:
+        run_command(f"DROP SERVER IF EXISTS {fdw_server} CASCADE", superuser_conn)
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        run_command(
+            f"""CREATE SERVER {fdw_server} TYPE 'rest'
+                    FOREIGN DATA WRAPPER iceberg_catalog
+                    OPTIONS (rest_endpoint 'http://127.0.0.1:{port}',
+                             enable_vended_credentials 'true',
+                             location_prefix 's3://{server.bucket}')""",
+            superuser_conn,
+        )
+        for role, client_id in (
+            (None, "princ_root"),
+            (role_a, "princ_a"),
+            (role_b, "princ_b"),
+        ):
+            target = "CURRENT_USER" if role is None else role
+            if role is not None:
+                run_command(f"DROP ROLE IF EXISTS {role}", superuser_conn)
+                run_command(f"CREATE ROLE {role}", superuser_conn)
+                run_command(f"GRANT lake_read TO {role}", superuser_conn)
+            run_command(
+                f"""CREATE USER MAPPING FOR {target} SERVER {fdw_server}
+                        OPTIONS (client_id '{client_id}',
+                                 client_secret '{client_id}_secret')""",
+                superuser_conn,
+            )
+        superuser_conn.commit()
+
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='{fdw_server}', read_only=True,
+                      catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        run_command(
+            f"GRANT USAGE ON SCHEMA {schema} TO {role_a}, {role_b}", superuser_conn
+        )
+        run_command(
+            f"GRANT SELECT ON {schema}.{table} TO {role_a}, {role_b}", superuser_conn
+        )
+        superuser_conn.commit()
+        server.enforce()
+
+        # The role whose principal is vended a data-capable credential.
+        run_command(f"SET ROLE {role_a}", superuser_conn)
+        rows = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        assert rows[0][0] == 10
+
+        # Same backend, same table, different principal -- and this one is
+        # vended a credential that cannot read data.  Reusing what was
+        # resolved for the first role would let this through.
+        run_command(f"SET ROLE {role_b}", superuser_conn)
+        err = run_query(
+            f"SELECT count(*) FROM {schema}.{table}",
+            superuser_conn,
+            raise_error=False,
+        )
+        superuser_conn.rollback()
+        assert _denied(err), (
+            "the second role was served the first role's credential: its "
+            f"scan should have been denied, got: {err!r}"
+        )
+
+    finally:
+        server.relax()
+        superuser_conn.rollback()
+        run_command("RESET ROLE", superuser_conn)
+        superuser_conn.commit()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        run_command(f"DROP SERVER IF EXISTS {fdw_server} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        for role in (role_a, role_b):
+            run_command(f"DROP OWNED BY {role}", superuser_conn)
+            run_command(f"DROP ROLE IF EXISTS {role}", superuser_conn)
+        superuser_conn.commit()
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+
+def test_vended_secret_dropped_with_read_only_table(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    """A read-only table's secret goes away with the table.
+
+    A read-only table owns none of the files it reads, so its drop queues
+    no deletes and nothing is left for the secret to authorize.  Leaving
+    it behind would not be harmless: secrets outlive the backend that
+    pushed them and DuckDB picks one by longest matching scope, so a
+    leftover would keep answering for that prefix -- with credentials
+    that expire -- for the rest of the server's life.
+    """
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_ro_drop"
+    table = "vc_ro_drop"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_rd",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user("mv_data_rd", [prefix])
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended": {
+                "prefix": location + "/",
+                "config": {
+                    "s3.access-key-id": data_key,
+                    "s3.secret-access-key": data_secret,
+                    "client.region": server.region,
+                },
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    def _vended_secrets_for_this_table():
+        rows = run_query(
+            "SELECT name, scope FROM duckdb_secrets() WHERE name LIKE 'pglake_vended_%'",
+            pgduck_conn,
+        )
+        pgduck_conn.commit()
+        return [r for r in rows if r[1] and location in r[1]]
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        result = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        assert result[0][0] == 10
+        assert (
+            _vended_secrets_for_this_table()
+        ), "expected the scan to push a vended secret before the drop"
+
+        run_command(f"DROP TABLE {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+
+        leftover = _vended_secrets_for_this_table()
+        assert not leftover, f"vended secret outlived its read-only table: {leftover}"
+
+    finally:
+        server.relax()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+@pytest.mark.parametrize("vended_config_keys", ["endpoint_only", "endpoint_and_style"])
+def test_catalog_supplied_endpoint_still_reaches_the_store(
+    superuser_conn,
+    pgduck_conn,
+    extension,
+    installcheck,
+    enforcing_s3_server,
+    vended_config_keys,
+):
+    """A catalog that states its endpoint must still produce a usable secret.
+
+    Stating an endpoint is what an S3-compatible deployment does; stating
+    the addressing style as well is optional, and most catalogs leave it
+    out.  Whatever the catalog does not say has to keep coming from the
+    secret that already serves the prefix, because a vended secret with
+    an endpoint but no URL_STYLE sends DuckDB to ``<bucket>.<host>``,
+    which resolves nowhere.  Only a real scan shows this: the secret is
+    created either way and looks right in ``duckdb_secrets()``.
+    """
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_endpoint"
+    table = f"vc_ep_{vended_config_keys}"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    meta_key, meta_secret = server.create_scoped_user(
+        f"mv_meta_ep_{vended_config_keys}",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user(
+        f"mv_data_ep_{vended_config_keys}", [prefix]
+    )
+
+    vended_config = {
+        "s3.access-key-id": data_key,
+        "s3.secret-access-key": data_secret,
+        "client.region": server.region,
+        "s3.endpoint": server.endpoint_url,
+    }
+    if vended_config_keys == "endpoint_and_style":
+        vended_config["s3.path-style-access"] = "true"
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended": {"prefix": location + "/", "config": vended_config},
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        result = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        assert result[0][0] == 10
+
+    finally:
+        server.relax()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+def test_data_only_credential_serves_repeated_scans(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    """A credential covering only the data files still serves every scan.
+
+    Iceberg metadata lives under the table root, alongside the data, so a
+    credential the catalog labels ``.../data/`` must not become the one
+    DuckDB picks for the metadata beside it.  Scanning twice is the point:
+    the first scan pushes the secret, and the second is the one that would
+    read metadata through it if the scope were widened to the table root.
+    Here the data credential cannot read metadata and the metadata
+    credential cannot read data, so a query only succeeds while both are
+    being applied to their own prefix.
+    """
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_data_only"
+    table = "vc_data_only"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_do",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user(
+        "mv_data_do",
+        [f"{prefix}/data"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            # narrower than the table root, and preserved as such
+            "vended": {
+                "prefix": location + "/data/",
+                "config": {
+                    "s3.access-key-id": data_key,
+                    "s3.secret-access-key": data_secret,
+                    "client.region": server.region,
+                },
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        for attempt in ("first", "second"):
+            result = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+            superuser_conn.commit()
+            assert result[0][0] == 10, f"{attempt} scan did not read the data files"
+
+        scopes = [
+            s[1]
+            for s in run_query(
+                "SELECT name, scope FROM duckdb_secrets() "
+                "WHERE name LIKE 'pglake_vended_%'",
+                pgduck_conn,
+            )
+            if s[1] and location in s[1]
+        ]
+        pgduck_conn.commit()
+        assert scopes, "expected a vended secret for this table"
+        assert all(
+            "/data/" in s for s in scopes
+        ), f"data-only scope was widened to the table root: {scopes}"
+
+    finally:
+        server.relax()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+def test_unrelated_table_still_reads_through_the_static_secret(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    """Vending for one table leaves every other path alone.
+
+    The vended secret is the most specific match for its own prefix, and
+    for nothing else.  A plain parquet table sitting elsewhere in the same
+    bucket has to keep reading through the static secret it always used --
+    otherwise turning vending on for one Iceberg table would break
+    unrelated tables across the whole deployment.
+    """
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_unrelated"
+    table = "vc_unrelated"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    # A plain parquet file outside the Iceberg table's prefix, written with
+    # root credentials so its contents do not depend on this test's users.
+    outside_key = "outside/plain/rows.parquet"
+    with tempfile.NamedTemporaryFile(suffix=".parquet") as tmp:
+        pq.write_table(pa.table({"id": list(range(4))}), tmp.name)
+        server.client().upload_file(tmp.name, server.bucket, outside_key)
+    outside_url = f"s3://{server.bucket}/{outside_key}"
+
+    # The static credential reads the Iceberg metadata and the unrelated
+    # file; the vended one reads only the Iceberg table's own prefix.
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_un",
+        [f"{prefix}/metadata", "outside"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user("mv_data_un", [prefix])
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended": {
+                "prefix": location + "/",
+                "config": {
+                    "s3.access-key-id": data_key,
+                    "s3.secret-access-key": data_secret,
+                    "client.region": server.region,
+                },
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        run_command(
+            f"""CREATE FOREIGN TABLE {schema}.plain ()
+                SERVER pg_lake OPTIONS (path '{outside_url}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        assert (
+            run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)[0][0]
+            == 10
+        )
+        superuser_conn.commit()
+
+        # The vended secret is now on the server; the unrelated path must
+        # still be served by the static secret.
+        result = run_query(f"SELECT count(*) FROM {schema}.plain", superuser_conn)
+        superuser_conn.commit()
+        assert result[0][0] == 4, "unrelated parquet table stopped reading"
+
+    finally:
+        server.relax()
+        run_command(f"DROP FOREIGN TABLE IF EXISTS {schema}.plain", superuser_conn)
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+def test_columnless_attach_does_not_read_storage(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    """Attaching a table without naming its columns must not touch storage.
+
+    ``CREATE TABLE t ()`` is how an existing catalog table is normally
+    attached; spelling out its columns is the workaround.  Inference used
+    to read metadata.json off the store, which cannot work on a catalog
+    that only vends: the relation does not exist yet, and credentials are
+    resolved per relation, so nothing can have pushed a secret for it.
+
+    Here the static credential is barred from the table entirely, so a
+    CREATE that reaches for storage is denied.  Vending then covers the
+    whole table root, which is what makes the scan afterwards work.
+    """
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_attach"
+    table = "vc_attach"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    # Reaches somewhere else in the bucket, and nothing of this table.
+    static_key, static_secret = server.create_scoped_user(
+        "mv_static_at",
+        ["elsewhere"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    data_key, data_secret = server.create_scoped_user("mv_data_at", [prefix])
+
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended": {
+                "prefix": location + "/",
+                "config": {
+                    "s3.access-key-id": data_key,
+                    "s3.secret-access-key": data_secret,
+                    "client.region": server.region,
+                },
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, static_key, static_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+
+        err = run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+            raise_error=False,
+        )
+        assert not _denied(err), f"columnless attach went to storage: {err!r}"
+        assert err is None, f"columnless attach failed: {err!r}"
+        superuser_conn.commit()
+
+        columns = run_query(
+            f"""SELECT attname, atttypid::regtype::text
+                  FROM pg_attribute
+                 WHERE attrelid = '{schema}.{table}'::regclass AND attnum > 0
+                 ORDER BY attnum""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+        assert [tuple(c) for c in columns] == [("id", "bigint"), ("val", "text")]
+
+        result = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        assert result[0][0] == 10
+
+    finally:
+        server.relax()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)
+
+
+def test_vended_credentials_wrong_scope_denied(
+    superuser_conn, pgduck_conn, extension, installcheck, enforcing_s3_server
+):
+    if installcheck or not _HAVE_PYICEBERG:
+        return
+
+    server = enforcing_s3_server
+    schema = "mv_scope"
+    table = "vc_wrongscope"
+
+    meta_loc, location, prefix = _materialize_iceberg_table(server, schema, table, 10)
+
+    meta_key, meta_secret = server.create_scoped_user(
+        "mv_meta_ws",
+        [f"{prefix}/metadata"],
+        actions=("s3:GetObject", "s3:ListBucket"),
+    )
+    # The vended credential belongs to a different table: it can read
+    # wh/some-other-table and nothing else.  The catalog labels it with that
+    # same foreign prefix.
+    #
+    # We clamp a scope that falls outside the table root back to the table
+    # root, so this secret *is* applied to this table's data path -- and then
+    # the store denies it, because the credential has no rights there.
+    # Clamping keeps a mislabeled credential from registering under the
+    # foreign scope, where it would shadow the secret wh/some-other-table
+    # depends on.
+    data_key, data_secret = server.create_scoped_user(
+        "mv_data_ws", ["wh/some-other-table"]
+    )
+
+    wrong_scope = f"s3://{server.bucket}/wh/some-other-table/"
+    tables = {
+        table: {
+            "metadata_location": meta_loc,
+            "location": location,
+            "vended": {
+                "prefix": wrong_scope,
+                "config": {
+                    "s3.access-key-id": data_key,
+                    "s3.secret-access-key": data_secret,
+                    "client.region": server.region,
+                },
+            },
+        }
+    }
+
+    _create_static_secret(pgduck_conn, server, meta_key, meta_secret)
+    httpd, thread = _serve_mock_catalog(
+        tables, server, enable_vended=True, conn=superuser_conn
+    )
+    server.enforce()
+
+    try:
+        run_command(f"CREATE SCHEMA IF NOT EXISTS {schema}", superuser_conn)
+        superuser_conn.commit()
+        run_command(
+            f"""CREATE TABLE {schema}.{table} ()
+                USING iceberg
+                WITH (catalog='rest', read_only=True, catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        err = run_query(
+            f"SELECT count(*) FROM {schema}.{table}",
+            superuser_conn,
+            raise_error=False,
+        )
+        superuser_conn.rollback()
+        assert _denied(err), f"expected an access-denied error, got: {err!r}"
+
+        # Nothing may be registered under the foreign scope.  A secret there
+        # would be selected for wh/some-other-table's own scans and shadow
+        # whatever that table legitimately uses.
+        registered = run_query(
+            """
+            SELECT name, scope
+              FROM duckdb_secrets()
+             WHERE name LIKE 'pglake_vended_%'
+            """,
+            pgduck_conn,
+        )
+        pgduck_conn.commit()
+        shadowing = [r for r in registered if r[1] and "some-other-table" in r[1]]
+        assert not shadowing, f"secret registered under a foreign scope: {shadowing}"
+
+    finally:
+        server.relax()
+        run_command(f"DROP TABLE IF EXISTS {schema}.{table}", superuser_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _stop_mock_catalog(httpd, thread, conn=superuser_conn)

--- a/pg_lake_table/tests/pytests/test_vended_credentials_polaris.py
+++ b/pg_lake_table/tests/pytests/test_vended_credentials_polaris.py
@@ -1,0 +1,367 @@
+"""Vended-credential tests against a real Iceberg REST catalog (Apache Polaris).
+
+These complement ``test_vended_credentials_enforced.py`` rather than
+duplicating it.
+
+That suite proves a vended credential is genuinely *load-bearing* -- an
+enforcing S3 mock denies the scan without it -- against a catalog that is
+itself a mock.  These tests use a real catalog instead, where a table is
+registered by Polaris itself and attached read-only afterwards, which is
+the shape a production REST catalog actually serves.
+
+Storage here is the shared moto fixture, which accepts any credential and
+never denies a request.  So these tests assert the *resolver's* observable
+behavior -- that the correctly scoped secret is pushed to pgduck_server
+when the catalog vends one, and that it is not pushed when it should not
+be -- rather than that access fails without it.  Between the two suites:
+
+    Enforced -> the credential is load-bearing
+    Polaris  -> the credential is resolved against a real catalog, and
+                withheld from writable tables
+
+Vending is restricted to read-only tables, so the writable case is
+covered here as a *negative*: pg_lake owns a writable table's files and
+must be able to delete them long after any vended credential has expired,
+which is a lifecycle this feature does not yet answer.
+"""
+
+import json
+from pathlib import Path
+
+from utils_pytest import *
+from helpers.polaris import *
+
+
+VENDED_SECRET_PREFIX = "pglake_vended_"
+
+
+def _set_vending(conn, enabled):
+    """Enable/disable vending on a single backend.
+
+    The GUC is PGC_SUSET, so a session-level SET on a superuser connection
+    takes effect immediately for the next statement -- unlike ALTER SYSTEM
+    + pg_reload_conf(), whose SIGHUP lands at an unpredictable command
+    boundary.
+    """
+    value = "true" if enabled else "false"
+    run_command(
+        f"SET pg_lake_iceberg.rest_catalog_enable_vended_credentials = {value}",
+        conn,
+    )
+    conn.commit()
+
+
+def _vended_secrets_for(pgduck_conn, schema, table):
+    """Vended secrets whose scope points at this test's table.
+
+    Filtering by the table's own path keeps the assertions immune to
+    secrets other tests left behind on the shared pgduck_server.
+    """
+    rows = run_query(
+        f"""
+        SELECT name, scope
+          FROM duckdb_secrets()
+         WHERE name LIKE '{VENDED_SECRET_PREFIX}%'
+        """,
+        pgduck_conn,
+    )
+    pgduck_conn.commit()
+
+    needle = f"/{schema}/{table}/"
+    return [r for r in rows if r[1] and needle in r[1]]
+
+
+def _drop_vended_secrets_for(pgduck_conn, schema, table):
+    """Remove this table's vended secrets from the shared pgduck_server.
+
+    Secrets are process-global, so one pushed by an earlier backend stays
+    visible afterwards.  Clearing them lets a later assertion attribute a
+    secret to the read path alone.
+    """
+    for name, _scope in _vended_secrets_for(pgduck_conn, schema, table):
+        run_command(f'DROP SECRET IF EXISTS "{name}"', pgduck_conn)
+    pgduck_conn.commit()
+
+
+def test_polaris_read_only_table_is_vended_on_a_cold_cache(
+    pg_conn,
+    superuser_conn,
+    pgduck_conn,
+    s3,
+    polaris_session,
+    set_polaris_gucs,
+    with_default_location,
+    installcheck,
+):
+    """A read-only REST table resolves and pushes a vended credential.
+
+    The read happens on a *different* backend than the one that attached
+    the table, so the credential cannot have been warmed by the DDL.  A
+    cold cache is the case most easily missed.
+    """
+    if installcheck:
+        return
+
+    schema = "vc_polaris_ro"
+    table = "rest_tbl"
+    attached = "attached_ro"
+
+    _set_vending(superuser_conn, True)
+
+    reader = None
+    try:
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        run_command(f"CREATE SCHEMA {schema}", superuser_conn)
+        superuser_conn.commit()
+
+        # Register the table in Polaris and give it files.  Vending is on,
+        # but this is the writable side, which is not served.
+        run_command(
+            f"""CREATE TABLE {schema}.{table} USING iceberg
+                WITH (catalog='rest', autovacuum_enabled=False)
+                AS SELECT g AS id FROM generate_series(1, 10) g""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Attach the same catalog table read-only: the shape a REST catalog
+        # serves to a reader that does not own the table.
+        run_command(
+            f"""CREATE TABLE {schema}.{attached}() USING iceberg
+                WITH (catalog='rest', read_only=True,
+                      catalog_namespace='{schema}',
+                      catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Secrets outlive the backend that pushed them, so clear anything
+        # already present: a secret found after the scan below can then only
+        # have come from the read path.
+        _drop_vended_secrets_for(pgduck_conn, schema, table)
+        assert not _vended_secrets_for(pgduck_conn, schema, table)
+
+        # Fresh backend => cold credential cache.
+        reader = open_pg_conn()
+        _set_vending(reader, True)
+
+        rows = run_query(f"SELECT count(*) FROM {schema}.{attached}", reader)
+        reader.commit()
+        assert rows[0][0] == 10
+
+        secrets = _vended_secrets_for(pgduck_conn, schema, table)
+        assert secrets, (
+            "expected the read path to resolve and push a vended secret on a "
+            "cold cache, found none"
+        )
+
+    finally:
+        if reader is not None:
+            reader.close()
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _set_vending(superuser_conn, False)
+
+
+def test_polaris_writable_table_is_not_vended(
+    pg_conn,
+    superuser_conn,
+    pgduck_conn,
+    s3,
+    polaris_session,
+    set_polaris_gucs,
+    with_default_location,
+    installcheck,
+):
+    """A writable REST table gets no vended credential, even with vending on.
+
+    pg_lake owns a writable table's files, and owning them means deleting
+    them: a DROP only queues its files, and the queue holds them for
+    ``orphaned_file_retention_period`` (10 days by default) -- long after
+    any vended credential has expired and the table has left the catalog
+    that could vend another.  Until that has an answer, writable tables
+    reach storage exactly as they do without vending.
+    """
+    if installcheck:
+        return
+
+    schema = "vc_polaris_rw"
+    table = "writable_rest"
+
+    _set_vending(superuser_conn, True)
+
+    try:
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        run_command(f"CREATE SCHEMA {schema}", superuser_conn)
+        superuser_conn.commit()
+
+        run_command(
+            f"""CREATE TABLE {schema}.{table} USING iceberg
+                WITH (catalog='rest', autovacuum_enabled=False)
+                AS SELECT g AS id FROM generate_series(1, 10) g""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Every path a writable table has: write, read, and delete.
+        run_command(f"INSERT INTO {schema}.{table} SELECT 11", superuser_conn)
+        superuser_conn.commit()
+
+        rows = run_query(f"SELECT count(*) FROM {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+        assert rows[0][0] == 11
+
+        run_command(f"TRUNCATE {schema}.{table}", superuser_conn)
+        superuser_conn.commit()
+
+        secrets = _vended_secrets_for(pgduck_conn, schema, table)
+        assert not secrets, (
+            f"vending is restricted to read-only tables, but a writable one "
+            f"was pushed a secret: {secrets}"
+        )
+
+    finally:
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        _set_vending(superuser_conn, False)
+
+
+def test_polaris_no_vended_secret_when_disabled(
+    pg_conn,
+    superuser_conn,
+    pgduck_conn,
+    s3,
+    polaris_session,
+    set_polaris_gucs,
+    with_default_location,
+    installcheck,
+):
+    """With vending off, nothing is requested and no secret is pushed.
+
+    Guards the opt-in default: the delegation header must not be sent and
+    no vended secret may appear just because a REST table was scanned.
+    """
+    if installcheck:
+        return
+
+    schema = "vc_polaris_off"
+    table = "writable_rest"
+
+    _set_vending(superuser_conn, False)
+
+    reader = None
+    try:
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        run_command(f"CREATE SCHEMA {schema}", superuser_conn)
+        superuser_conn.commit()
+
+        run_command(
+            f"""CREATE TABLE {schema}.{table} USING iceberg
+                WITH (catalog='rest', autovacuum_enabled=False)
+                AS SELECT g AS id FROM generate_series(1, 5) g""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        reader = open_pg_conn()
+        _set_vending(reader, False)
+
+        rows = run_query(f"SELECT count(*) FROM {schema}.{table}", reader)
+        reader.commit()
+        assert rows[0][0] == 5
+
+        secrets = _vended_secrets_for(pgduck_conn, schema, table)
+        assert not secrets, f"expected no vended secret with vending off, got {secrets}"
+
+    finally:
+        if reader is not None:
+            reader.close()
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        superuser_conn.commit()
+
+
+def test_polaris_server_option_enables_vending_with_guc_off(
+    pg_conn,
+    superuser_conn,
+    pgduck_conn,
+    s3,
+    polaris_session,
+    set_polaris_gucs,
+    with_default_location,
+    installcheck,
+):
+    """A server that opts in vends even with the GUC left off.
+
+    `enable_vended_credentials` is a per-server option that overrides the
+    GUC, and the GUC now defaults to off.  Deciding from the GUC alone
+    would therefore ignore a server that explicitly asked for vending and
+    silently vend nothing.
+    """
+    if installcheck:
+        return
+
+    schema = "vc_polaris_srvopt"
+    table = "opt_in_rest"
+    server = "vc_polaris_serveropt_srv"
+
+    creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
+    client_id = creds["credentials"]["clientId"]
+    client_secret = creds["credentials"]["clientSecret"]
+    # rest_endpoint wants a scheme, unlike the rest_catalog_host GUC.
+    endpoint = f"http://{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}"
+
+    # Only the server opts in; the GUC stays off.
+    _set_vending(superuser_conn, False)
+
+    try:
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        run_command(f"DROP SERVER IF EXISTS {server} CASCADE", superuser_conn)
+        run_command(f"CREATE SCHEMA {schema}", superuser_conn)
+        run_command(
+            f"""CREATE SERVER {server} TYPE 'rest'
+                    FOREIGN DATA WRAPPER iceberg_catalog
+                    OPTIONS (rest_endpoint '{endpoint}',
+                             enable_vended_credentials 'true',
+                             location_prefix 's3://{TEST_BUCKET}')""",
+            superuser_conn,
+        )
+        run_command(
+            f"""CREATE USER MAPPING FOR PUBLIC SERVER {server}
+                    OPTIONS (client_id '{client_id}',
+                             client_secret '{client_secret}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        run_command(
+            f"""CREATE TABLE {schema}.{table} USING iceberg
+                WITH (catalog='{server}', autovacuum_enabled=False)
+                AS SELECT g AS id FROM generate_series(1, 5) g""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        # Vending serves read-only tables, so read through an attachment.
+        run_command(
+            f"""CREATE TABLE {schema}.attached_ro() USING iceberg
+                WITH (catalog='{server}', read_only=True,
+                      catalog_namespace='{schema}',
+                      catalog_table_name='{table}')""",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        rows = run_query(f"SELECT count(*) FROM {schema}.attached_ro", superuser_conn)
+        superuser_conn.commit()
+        assert rows[0][0] == 5
+
+        secrets = _vended_secrets_for(pgduck_conn, schema, table)
+        assert secrets, (
+            "the server set enable_vended_credentials but no secret was "
+            "pushed, so the per-server opt-in is being ignored"
+        )
+
+    finally:
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", superuser_conn)
+        run_command(f"DROP SERVER IF EXISTS {server} CASCADE", superuser_conn)
+        superuser_conn.commit()

--- a/pgduck_server/include/utils/pgduck_log_utils.h
+++ b/pgduck_server/include/utils/pgduck_log_utils.h
@@ -67,4 +67,13 @@ extern bool IsOutputVerbose;
 
 void		iso8601_timestamp(char *buf);
 
+/*
+ * Enough for the verb and the secret's name; the argument list that
+ * follows is what QueryStringForLog leaves out.
+ */
+#define QUERY_LOG_BUF_SIZE 256
+
+const char *QueryStringForLog(const char *queryString, char *buf,
+							  size_t bufSize);
+
 #endif							/* // PG_DUCK_LOG_UTILS_H */

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -863,8 +863,12 @@ duckdb_session_run_command(DuckDBSession * duckSession, const char *queryString,
 		}
 		else
 		{
+			char		queryForLog[QUERY_LOG_BUF_SIZE];
+
 			PGDUCK_SERVER_WARN("query on duckdb failed: %s; query: %.500s",
-							   duckdbError, queryString);
+							   duckdbError,
+							   QueryStringForLog(queryString, queryForLog,
+												 sizeof(queryForLog)));
 			status = DUCKDB_QUERY_ERROR;
 		}
 
@@ -1036,9 +1040,12 @@ duckdb_session_execute_prepared(DuckDBSession * duckSession,
 		}
 		else
 		{
+			char		queryForLog[QUERY_LOG_BUF_SIZE];
+
 			PGDUCK_SERVER_WARN("could not execute prepared statement: %s; query: %.500s",
 							   duckdbError,
-							   duckSession->clientSession->pgSessionPreparedStmt.queryString);
+							   QueryStringForLog(duckSession->clientSession->pgSessionPreparedStmt.queryString,
+												 queryForLog, sizeof(queryForLog)));
 			status = DUCKDB_QUERY_ERROR;
 		}
 
@@ -1326,9 +1333,12 @@ process_and_send_data_chunks(DuckDBQueryResult * duckdb_query_result,
 				}
 				else
 				{
+					char		queryForLog[QUERY_LOG_BUF_SIZE];
+
 					PGDUCK_SERVER_WARN("query on duckdb failed during execution: %s; query: %.500s",
 									   duckdbError,
-									   clientSession->pgSessionPreparedStmt.queryString);
+									   QueryStringForLog(clientSession->pgSessionPreparedStmt.queryString,
+														 queryForLog, sizeof(queryForLog)));
 					status = DUCKDB_QUERY_ERROR;
 				}
 

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -378,8 +378,12 @@ process_query_message(PGSession * pgSession, StringInfo inputMessage)
 		return COMM_ERROR;
 	}
 
+	char		queryForLog[QUERY_LOG_BUF_SIZE];
+
 	PGDUCK_SERVER_DEBUG("connection %d sent query: %s",
-						pgSession->pgClient->clientSocket, queryString);
+						pgSession->pgClient->clientSocket,
+						QueryStringForLog(queryString, queryForLog,
+										  sizeof(queryForLog)));
 
 	ResponseFormat responseFormat = {
 		.isTransmit = is_transmit_query(queryString)
@@ -562,10 +566,13 @@ process_parse_message(PGSession * pgSession, StringInfo inputMessage)
 		/* we have to raise errors to the client */
 		int			sentErrorMsg = handle_pgsession_error_message(status, pgSession, errorMessage);
 
+		char		queryForLog[QUERY_LOG_BUF_SIZE];
+
 		PGDUCK_SERVER_WARN("query from client %d failed during parse: %s; query: %.500s",
 						   pgSession->pgClient->clientSocket,
 						   errorMessage,
-						   queryStringCopy);
+						   QueryStringForLog(queryStringCopy, queryForLog,
+											 sizeof(queryForLog)));
 
 		/* free error message allocated by duckdb_session_prepare */
 		pfree(errorMessage);
@@ -714,10 +721,13 @@ process_bind_message(PGSession * pgSession, StringInfo inputMessage)
 		{
 			int			sentResult = handle_pgsession_error_message(bindResult, pgSession, errorMessage);
 
+			char		queryForLog[QUERY_LOG_BUF_SIZE];
+
 			PGDUCK_SERVER_WARN("query from client %d failed during bind: %s; query: %.500s",
 							   pgSession->pgClient->clientSocket,
 							   errorMessage,
-							   pgSession->pgSessionPreparedStmt.queryString);
+							   QueryStringForLog(pgSession->pgSessionPreparedStmt.queryString,
+												 queryForLog, sizeof(queryForLog)));
 
 			/* free error message allocated by duckdb_session_bind_varchar */
 			pfree(errorMessage);

--- a/pgduck_server/src/utils/pgduck_log_utils.c
+++ b/pgduck_server/src/utils/pgduck_log_utils.c
@@ -22,7 +22,10 @@
  */
 #include "c.h"
 
+#include <ctype.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "utils/pgduck_log_utils.h"
 #include "utils/pg_log_utils.h"
@@ -50,6 +53,71 @@ static const ErrorCode errorCodes[] = {
 	{FATAL, "FATAL"},
 	{PANIC, "PANIC"}
 };
+
+
+/*
+ * StatementDefinesSecret reports whether a statement is the kind that
+ * carries credentials in its argument list.
+ *
+ * Only the text before the argument list is examined, so a query that
+ * merely mentions the word further along is not mistaken for one.
+ */
+static bool
+StatementDefinesSecret(const char *queryString)
+{
+	const char *statement = queryString;
+
+	while (isspace((unsigned char) *statement))
+		statement++;
+
+	if (pg_strncasecmp(statement, "CREATE", 6) != 0 &&
+		pg_strncasecmp(statement, "ALTER", 5) != 0)
+		return false;
+
+	const char *arguments = strchr(statement, '(');
+	size_t		headLength = arguments != NULL ?
+		(size_t) (arguments - statement) : strlen(statement);
+
+	for (size_t i = 0; i + 6 <= headLength; i++)
+	{
+		if (pg_strncasecmp(statement + i, "SECRET", 6) == 0)
+			return true;
+	}
+
+	return false;
+}
+
+
+/*
+ * QueryStringForLog returns the form of a statement that may be written
+ * to the log.
+ *
+ * A failing statement is logged with its text at WARNING, and a session
+ * may log every statement at DEBUG.  CREATE SECRET states an access key
+ * and an STS session token in plain text, so for those the argument list
+ * is dropped: the verb and the secret's name are what make the line
+ * worth having, and neither is sensitive.
+ *
+ * Returns queryString itself when there is nothing to redact, so the
+ * common path neither copies nor allocates.  Otherwise the redacted text
+ * is written to buf, which the caller owns.
+ */
+const char *
+QueryStringForLog(const char *queryString, char *buf, size_t bufSize)
+{
+	if (queryString == NULL || !StatementDefinesSecret(queryString))
+		return queryString;
+
+	const char *arguments = strchr(queryString, '(');
+
+	if (arguments == NULL)
+		return queryString;
+
+	snprintf(buf, bufSize, "%.*s(<redacted>)",
+			 (int) (arguments - queryString), queryString);
+
+	return buf;
+}
 
 
 /*

--- a/pgduck_server/tests/pytests/test_vended_secrets.py
+++ b/pgduck_server/tests/pytests/test_vended_secrets.py
@@ -1,0 +1,194 @@
+"""
+Tests for vended credential secrets in pgduck_server.
+
+Validates that DuckDB scoped secrets can be created, replaced, and dropped
+via the same SQL patterns used by pg_lake's PushVendedSecretToPGDuck.
+"""
+
+from utils_pytest import *
+
+
+def test_create_scoped_s3_secret(pgduck_conn):
+    """Create a scoped S3 secret and verify it appears in duckdb_secrets()."""
+    perform_query(
+        """
+        CREATE OR REPLACE SECRET pglake_vended_test_1 (
+            TYPE S3,
+            KEY_ID 'AKIAIOSFODNN7EXAMPLE',
+            SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+            SESSION_TOKEN 'FwoGZXIvYXdzEBYaDHqa0AP',
+            REGION 'us-west-2',
+            SCOPE 's3://test-bucket/test-prefix/'
+        );
+        """,
+        pgduck_conn,
+    )
+
+    secrets = run_query(
+        "SELECT name, type, scope FROM duckdb_secrets()",
+        pgduck_conn,
+    )
+
+    vended = [s for s in secrets if s["name"] == "pglake_vended_test_1"]
+    assert len(vended) == 1
+    assert vended[0]["type"] == "s3"
+    assert "test-bucket/test-prefix" in vended[0]["scope"]
+
+    # Cleanup
+    perform_query("DROP SECRET pglake_vended_test_1", pgduck_conn)
+    pgduck_conn.rollback()
+
+
+def test_replace_scoped_s3_secret(pgduck_conn):
+    """Verify CREATE OR REPLACE updates an existing secret idempotently."""
+    perform_query(
+        """
+        CREATE OR REPLACE SECRET pglake_vended_test_replace (
+            TYPE S3,
+            KEY_ID 'OLD_KEY',
+            SECRET 'OLD_SECRET',
+            SESSION_TOKEN 'OLD_TOKEN',
+            REGION 'us-east-1',
+            SCOPE 's3://bucket/prefix/'
+        );
+        """,
+        pgduck_conn,
+    )
+
+    # Replace with new credentials
+    perform_query(
+        """
+        CREATE OR REPLACE SECRET pglake_vended_test_replace (
+            TYPE S3,
+            KEY_ID 'NEW_KEY',
+            SECRET 'NEW_SECRET',
+            SESSION_TOKEN 'NEW_TOKEN',
+            REGION 'us-west-2',
+            SCOPE 's3://bucket/prefix/'
+        );
+        """,
+        pgduck_conn,
+    )
+
+    secrets = run_query(
+        "SELECT name, type, scope FROM duckdb_secrets()",
+        pgduck_conn,
+    )
+
+    vended = [s for s in secrets if s["name"] == "pglake_vended_test_replace"]
+    assert len(vended) == 1
+
+    # Cleanup
+    perform_query("DROP SECRET pglake_vended_test_replace", pgduck_conn)
+    pgduck_conn.rollback()
+
+
+def test_scoped_secret_does_not_override_default(pgduck_conn):
+    """
+    A scoped secret should coexist with the default s3 secret.
+    The default (s3default) should still be returned for paths outside
+    the scoped secret's prefix.
+    """
+    perform_query(
+        """
+        CREATE OR REPLACE SECRET pglake_vended_scoped (
+            TYPE S3,
+            KEY_ID 'SCOPED_KEY',
+            SECRET 'SCOPED_SECRET',
+            SESSION_TOKEN 'SCOPED_TOKEN',
+            REGION 'eu-west-1',
+            SCOPE 's3://scoped-bucket/specific-path/'
+        );
+        """,
+        pgduck_conn,
+    )
+
+    secrets = run_query(
+        "SELECT name, type FROM duckdb_secrets()",
+        pgduck_conn,
+    )
+
+    names = [s["name"] for s in secrets]
+    assert "pglake_vended_scoped" in names
+    assert "s3default" in names
+
+    # Cleanup
+    perform_query("DROP SECRET pglake_vended_scoped", pgduck_conn)
+    pgduck_conn.rollback()
+
+
+def test_drop_nonexistent_secret_if_exists(pgduck_conn):
+    """DROP SECRET IF EXISTS should not error on a missing secret.
+
+    Completing without an exception is the assertion: secret cleanup is
+    best-effort and runs against secrets that may already be gone.
+    """
+    perform_query(
+        "DROP SECRET IF EXISTS pglake_vended_nonexistent",
+        pgduck_conn,
+    )
+    pgduck_conn.rollback()
+
+
+def test_multiple_scoped_secrets(pgduck_conn):
+    """Multiple scoped secrets with different prefixes can coexist."""
+    for i in range(3):
+        perform_query(
+            f"""
+            CREATE OR REPLACE SECRET pglake_vended_multi_{i} (
+                TYPE S3,
+                KEY_ID 'KEY_{i}',
+                SECRET 'SECRET_{i}',
+                SESSION_TOKEN 'TOKEN_{i}',
+                REGION 'us-west-2',
+                SCOPE 's3://bucket/table_{i}/'
+            );
+            """,
+            pgduck_conn,
+        )
+
+    secrets = run_query(
+        "SELECT name FROM duckdb_secrets()",
+        pgduck_conn,
+    )
+
+    names = [s["name"] for s in secrets]
+    for i in range(3):
+        assert f"pglake_vended_multi_{i}" in names
+
+    # Cleanup
+    for i in range(3):
+        perform_query(f"DROP SECRET pglake_vended_multi_{i}", pgduck_conn)
+    pgduck_conn.rollback()
+
+
+def test_secret_with_special_chars_in_credentials(pgduck_conn):
+    """
+    Credentials containing single quotes or other special characters
+    must be properly escaped in the SQL.
+    """
+    perform_query(
+        """
+        CREATE OR REPLACE SECRET pglake_vended_special (
+            TYPE S3,
+            KEY_ID 'KEY_WITH''QUOTE',
+            SECRET 'SECRET/WITH+SPECIAL=CHARS',
+            SESSION_TOKEN 'TOKEN_WITH''DOUBLE''QUOTES',
+            REGION 'us-east-1',
+            SCOPE 's3://bucket/special/'
+        );
+        """,
+        pgduck_conn,
+    )
+
+    secrets = run_query(
+        "SELECT name, type FROM duckdb_secrets()",
+        pgduck_conn,
+    )
+
+    vended = [s for s in secrets if s["name"] == "pglake_vended_special"]
+    assert len(vended) == 1
+
+    # Cleanup
+    perform_query("DROP SECRET pglake_vended_special", pgduck_conn)
+    pgduck_conn.rollback()

--- a/test_common/helpers/moto_iam_storage.py
+++ b/test_common/helpers/moto_iam_storage.py
@@ -1,0 +1,259 @@
+"""S3 fixtures that actually enforce credentials, backed by moto's IAM.
+
+The other cloud-storage fixtures run moto at its default setting, where it
+accepts any access key and never denies a request.  That is fine for
+functional tests, but it cannot show that a credential is *load-bearing*
+-- that pg_lake's vended credential is the thing unlocking a data scan,
+or that an out-of-scope credential is refused.
+
+Moto can do that, though: it implements IAM policy evaluation for S3
+behind ``INITIAL_NO_AUTH_ACTION_COUNT`` (``moto/settings.py``), consulted
+by every handler in ``moto/s3/responses.py``, and in server mode the
+counter can be flipped at runtime through ``POST /moto-api/reset-auth``.
+So a fixture can run its setup unauthenticated and turn enforcement on
+for the part of a test where the credential has to matter, giving:
+
+    * an unknown access key is rejected (InvalidAccessKeyId)
+    * a wrong secret is rejected (SignatureDoesNotMatch)
+    * a scoped user reads only inside its allowed prefix (AccessDenied)
+
+Enforcement is per moto *process*, and it is global within one: turning
+it on affects every request that process serves.  That is why this starts
+a moto of its own instead of sharing the session-wide server the rest of
+the suite uses with dummy credentials -- those tests would start failing
+the moment one of these turned enforcement on.
+
+Known gap: moto's access control resolves IAM user keys only, so STS
+temporary credentials come back as InvalidAccessKeyId.  Real vended
+credentials are STS triples, so what is exercised here is the plumbing
+around the credential rather than the session token itself.
+
+Derived from the prototype in
+https://github.com/Snowflake-Labs/pg_lake/pull/549.
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import boto3
+import pytest
+import requests
+from botocore.client import Config as _BotoConfig
+from botocore.exceptions import ClientError
+
+from .db import terminate_process
+
+MOTO_BUCKET = "pglakemoto"
+MOTO_REGION = "us-east-1"
+
+# Credentials for the phase before any IAM user exists.  Any string works
+# while enforcement is off, and none of them work once it is on.
+SETUP_KEY = "setup"
+SETUP_SECRET = "setup"
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_until_ready(port, timeout=20.0):
+    deadline = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/moto-api/"
+    while time.time() < deadline:
+        try:
+            if requests.get(url, timeout=1).status_code < 500:
+                return True
+        except Exception:
+            pass
+        time.sleep(0.2)
+    return False
+
+
+class MotoEnforcingServer:
+    """A moto server whose IAM enforcement can be switched on and off.
+
+    ``endpoint`` is host:port (what DuckDB and pg_lake want), while
+    ``endpoint_url`` carries the scheme (what boto3 and pyiceberg want).
+    ``root_user`` / ``root_password`` name a full-access principal that
+    keeps working once enforcement is on, so fixtures can go on writing
+    to the bucket while a test asserts that some other credential cannot.
+    """
+
+    def __init__(self, process, port):
+        self._process = process
+        self.port = port
+        self.endpoint = f"127.0.0.1:{port}"
+        self.endpoint_url = f"http://127.0.0.1:{port}"
+        self.bucket = MOTO_BUCKET
+        self.region = MOTO_REGION
+        self._enforcing = False
+        self.root_user = SETUP_KEY
+        self.root_password = SETUP_SECRET
+
+        self.relax()
+        self._iam = boto3.client(
+            "iam",
+            endpoint_url=self.endpoint_url,
+            region_name=self.region,
+            aws_access_key_id=SETUP_KEY,
+            aws_secret_access_key=SETUP_SECRET,
+        )
+        self.client().create_bucket(Bucket=self.bucket)
+
+        self.root_user, self.root_password = self._create_user(
+            "root", [{"Effect": "Allow", "Action": "*", "Resource": "*"}]
+        )
+
+    # -- boto3 clients -----------------------------------------------------
+
+    def client(self, access_key=None, secret_key=None, session_token=None):
+        """An S3 client, by default for the full-access root principal.
+
+        Defaulting to root rather than to the setup credentials keeps
+        fixture code (materializing tables, reading a metadata document
+        back) working on both sides of ``enforce()``.
+        """
+        return boto3.client(
+            "s3",
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id=access_key or self.root_user,
+            aws_secret_access_key=secret_key or self.root_password,
+            aws_session_token=session_token,
+            region_name=self.region,
+            config=_BotoConfig(
+                signature_version="s3v4",
+                s3={"addressing_style": "path"},
+            ),
+        )
+
+    # -- enforcement -------------------------------------------------------
+
+    def enforce(self):
+        """Require a valid, authorized credential for every request."""
+        requests.post(f"{self.endpoint_url}/moto-api/reset-auth", data="0", timeout=5)
+        self._enforcing = True
+        self._assert_enforcing()
+
+    def relax(self):
+        """Accept anything again (setup phase, and teardown)."""
+        requests.post(f"{self.endpoint_url}/moto-api/reset-auth", data="inf", timeout=5)
+        self._enforcing = False
+
+    def _assert_enforcing(self):
+        """Fail loudly if moto is not actually refusing a bogus credential.
+
+        The reset-auth endpoint is a moto test API rather than part of
+        S3, so a moto upgrade could stop honouring it.  Without this
+        check that would not fail any test that asserts a *successful*
+        read: those would keep passing while quietly proving nothing.
+        """
+        try:
+            self.client("bogus_key", "bogus_secret").list_objects_v2(
+                Bucket=self.bucket, MaxKeys=1
+            )
+        except ClientError:
+            return
+        raise RuntimeError(
+            "moto accepted a bogus access key while enforcement was on; "
+            "POST /moto-api/reset-auth is no longer taking effect"
+        )
+
+    # -- scoped users / policies ------------------------------------------
+
+    def _create_user(self, name, statements):
+        """Create an IAM user with an inline policy, returning its keys.
+
+        IAM itself is subject to enforcement, and the setup credentials
+        are not a principal, so this drops enforcement for the duration
+        when a test creates a user mid-flight.
+        """
+        was_enforcing = self._enforcing
+        if was_enforcing:
+            self.relax()
+        try:
+            self._iam.create_user(UserName=name)
+            self._iam.put_user_policy(
+                UserName=name,
+                PolicyName=f"pol_{name}",
+                PolicyDocument=json.dumps(
+                    {"Version": "2012-10-17", "Statement": statements}
+                ),
+            )
+            key = self._iam.create_access_key(UserName=name)["AccessKey"]
+        finally:
+            if was_enforcing:
+                self.enforce()
+        return key["AccessKeyId"], key["SecretAccessKey"]
+
+    def create_scoped_user(
+        self,
+        name,
+        allowed_prefixes,
+        actions=("s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"),
+    ):
+        """Create a user that can only reach ``allowed_prefixes``.
+
+        ``allowed_prefixes`` are key prefixes inside the test bucket
+        (e.g. ``["wh/ns/tbl"]``).  Returns the generated
+        ``(access_key_id, secret_access_key)``, since moto assigns the
+        key id.  Note that ``s3:ListBucket`` is granted on the bucket as
+        a whole: object reads are what these prefixes restrict.
+        """
+        object_actions = [a for a in actions if a != "s3:ListBucket"]
+        statements = []
+        if object_actions:
+            statements.append(
+                {
+                    "Effect": "Allow",
+                    "Action": object_actions,
+                    "Resource": [
+                        f"arn:aws:s3:::{self.bucket}/{p.rstrip('/')}/*"
+                        for p in allowed_prefixes
+                    ],
+                }
+            )
+        if "s3:ListBucket" in actions:
+            statements.append(
+                {
+                    "Effect": "Allow",
+                    "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+                    "Resource": [f"arn:aws:s3:::{self.bucket}"],
+                }
+            )
+        return self._create_user(name, statements)
+
+    # -- teardown ----------------------------------------------------------
+
+    def stop(self):
+        self.relax()
+        terminate_process(self._process)
+
+
+def create_moto_enforcing_server():
+    port = _free_port()
+    env = dict(os.environ)
+    # Enforcement is toggled at runtime; start out permissive.
+    env.pop("INITIAL_NO_AUTH_ACTION_COUNT", None)
+    process = subprocess.Popen(
+        [sys.executable, "-m", "moto.server", "-p", str(port), "-H", "127.0.0.1"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    if not _wait_until_ready(port):
+        process.kill()
+        raise RuntimeError(f"moto server did not come up on port {port}")
+    return MotoEnforcingServer(process, port)
+
+
+@pytest.fixture(scope="session")
+def enforcing_s3_server():
+    server = create_moto_enforcing_server()
+    yield server
+    server.stop()

--- a/test_common/utils_pytest.py
+++ b/test_common/utils_pytest.py
@@ -8,6 +8,7 @@ to work without modification.
 from helpers.pytest_config import *
 from helpers import server_params
 from helpers.cloud_storage import *
+from helpers.moto_iam_storage import *
 from helpers.db import *
 from helpers.server import *
 from helpers.comparisons import *


### PR DESCRIPTION
### Summary

pg_lake can now use **vended credentials** from an Iceberg REST catalog. When a catalog vends short-lived, scoped storage credentials for a table (STS or equivalent), pg_lake delivers them to `pgduck_server` as a scoped DuckDB secret, so that table's data is reached with those credentials instead of a broad static S3 secret.

Vending serves **read-only tables**, whose files the catalog owns. A writable table in storage of pg_lake's own choosing is a different lifecycle and is left exactly as it is today (see *Vending follows who owns the files* below).

The feature is **opt-in and off by default**:

```sql
-- cluster-wide default (superuser)
SET pg_lake_iceberg.rest_catalog_enable_vended_credentials = true;

-- or per catalog, which overrides the GUC
CREATE SERVER my_catalog TYPE 'rest' FOREIGN DATA WRAPPER iceberg_catalog
    OPTIONS (rest_endpoint 'https://...', enable_vended_credentials 'true');
```

Leaving it off keeps today's behavior exactly: no delegation header is sent and no secret is pushed.

### Release note

`pg_lake_iceberg.rest_catalog_enable_vended_credentials` **now defaults to `false`** (it defaulted to `true`). Before this PR the default only decided whether the `X-Iceberg-Access-Delegation` header was sent, and nothing was done with what came back; now it decides whether credentials are pushed to `pgduck_server` and used, so the default is off. Deployments that want vending enable it per server or by GUC as shown above.

### Reviewing this

Five commits, each self-contained and buildable, meant to be read in order:

1. **Add a storage-credential resolver** — the mechanism that reconciles scoped secrets into `pgduck_server`.
2. **Provide vended credentials from an Iceberg REST catalog** — the catalog side that feeds it.
3. **Resolve storage credentials wherever storage is touched** — the call sites.
4. **Read Iceberg v3 tables that use no v3-only feature** — the unrelated-but-adjacent reads (see below).
5. **Cover vended credentials and v3 reads with tests** — the suites and fixtures.

Review feedback is answered in commits on top of those five, so the first round stays reviewable as it was read. Three of those change shape rather than detail, and everything below describes where they landed rather than where commit 1 started:

- **Move the storage-credential resolver into pg_lake_iceberg** — removes the provider hook and with it the engine → iceberg dependency, so commit 1's "to the engine" no longer holds.
- **Restrict vended credentials to read-only tables** — takes the write, truncate and vacuum call sites and the orphan mechanism with it.
- **Learn an attached table's columns from the catalog, not from storage** — a columnless `CREATE TABLE` no longer reaches for `metadata.json` at all.

The last two commits are neither: keeping vending read-only makes the read-only boundary something users run into, so naming an existing catalog table without `read_only` now says why instead of only which option was rejected, and `docs/iceberg-tables.md` describes the two roles a REST table can have.

### How it works

Credentials are resolved by a **pull, at the points where storage is about to be touched** — not pushed ahead of time from a per-backend cache.

`pg_lake_iceberg` owns the resolver (`EnsureStorageCredentialsForRelation`), because vended credentials come from an Iceberg REST catalog. `pg_lake_engine` owns only the mechanism underneath it — creating and dropping a scoped secret on a `pgduck_server` connection — and knows nothing of catalogs. Every caller sits at or above `pg_lake_iceberg`, so the dependency runs one way.

```
  PostgreSQL (pg_lake)                          pgduck_server (DuckDB)
  ┌──────────────────────────────┐              ┌──────────────────────────┐
  │ about to touch storage       │              │                          │
  │   └─► EnsureStorageCreds…    │              │                          │
  │         │                    │              │                          │
  │         ├─ resolve ────────► loadTable      │                          │
  │         │   (catalog)     ◄── metadata-loc  │                          │
  │         │                     + storage-    │                          │
  │         │                       credentials │                          │
  │         │                                   │                          │
  │         └─ reconcile ───────────────────────►  CREATE OR REPLACE SECRET │
  │              push new / near-expiry         │  pglake_vended_<db>_<srv>_│
  │              drop what is no longer vended  │  <hash>  SCOPE 's3://…/'  │
  │                                             │                          │
  │  scan ──────────────────────────────────────►  DuckDB picks the        │
  │                                             │  longest-matching scope   │
  └──────────────────────────────┘              └──────────────────────────┘
```

**Vending follows who owns the files.** A read-only attachment owns none of the files it reads, so dropping it queues nothing: whoever owns the files removes them, and the credential only has to outlive the statement using it.

A writable table in storage of *our* choosing is a different lifecycle, and is not vended. pg_lake owns those files, and owning them means deleting them: a `DROP` merely queues those deletes, and the queue holds them for `pg_lake_engine.orphaned_file_retention_period` — **10 days** by default — by which time any vended credential has expired and the table has left the catalog that could vend another. A secret kept alive past the `DROP` could never cover that window; it only ever worked with retention set to zero. Such tables keep reaching storage exactly as they do without vending, so nothing regresses.

**Attaching a table touches no storage.** A columnless `CREATE TABLE t () … read_only='true'` learns its columns from the metadata document the catalog inlines in the `loadTable` response, which we already fetch. Reading `metadata.json` off the store instead — as it used to — cannot work on a catalog that only vends: the relation does not exist yet, and credentials are resolved per relation, so nothing can have pushed a secret for it. One storage round-trip disappears with the fix.

**Why pull rather than push.** Resolving where storage is about to be touched, rather than pushing from a cache something has to remember to warm, means each entry point is covered by construction.

The entry points, each a place where an object is about to be read:

| Path | Entry point |
|------|-------------|
| Read (FDW scan and query pushdown both funnel here) | `CreateTableScanForRelation` (`fdw/snapshot.c`) |
| Metadata / manifest enumeration | `find_referenced_files.c` |
| Drop (forget the secret; these tables queue no deletes) | `drop_table.c` |

There were more of these when vending covered writable tables too. Restricting it to read-only removed the write, truncate and vacuum call sites along with the code behind them, which is the review-round change worth knowing about if you read the first five commits first.

Each call reconciles: it (re)pushes credentials that are new or nearing expiry, and drops secrets the catalog no longer vends (revoked credentials, vending switched off). A warm, still-valid credential costs nothing — the resolver skips acquiring a `pgduck` connection when there is no work, and resolves nothing at all for a table that is not vended.

**The deletion queue is not an entry point.** `lake_engine.flush_deletion_queue` lives in the engine and resolves nothing — nothing vended reaches it. A read-only table owns no files, so it queues no delete; a writable table is not vended, so its deletes reach storage the way they always have.

**Dropping forgets the secret immediately.** These tables own none of the files they read, so nothing queued can still need the credential, and an expired secret left behind would keep winning DuckDB's longest-scope match for everything under that prefix.

### Key decisions

- **Everything is keyed by principal.** The secret name is `pglake_vended_<dbOid>_<serverOid>_<hash(secretKey)>`, where `secretKey` covers the user-mapping OID, the table identity and the scope; the credential cache behind it is keyed the same way. A catalog vends different credentials to different principals, so both layers have to agree: two roles reading one table in one backend are each served their own credential, and the database OID keeps backends of different databases apart on the shared `pgduck_server`.
- **Scope is clamped to the table root.** Scope comes from `storage-credentials[].prefix`, falling back to `metadata.location`. A catalog that vends something *broader* than the table root, or a *sibling* path, is clamped back to the table root: secrets live in one process-wide DuckDB instance and are selected by longest-matching scope, so either case could shadow the secret another table depends on. When neither source yields a prefix, nothing is pushed — a guessed scope would match nothing at best and someone else's objects at worst.
- **Expiry honors the catalog.** Taken from `s3.session-token-expires-at-ms` when present, otherwise a conservative ~55 min, applied to the cache and the pushed secret alike so both agree on the lifetime. Refresh happens 5 minutes early, and a secret that is still comfortably valid is not re-pushed.
- **Two response shapes, any number of credentials.** The `storage-credentials` array (per-prefix credentials) and the legacy top-level `config` map. A catalog may vend several — separate credentials for the data files and the metadata directory, say — and each gets its own scoped secret. Extras that collapse onto a scope already taken are dropped, since DuckDB selects one secret per path.
- **S3 connection settings follow the catalog.** Iceberg states `s3.endpoint` as a URL and DuckDB wants a bare host with a separate `USE_SSL`, so the scheme is split off and decides SSL — a catalog pointing at a plaintext store is honored rather than overridden. Each setting the catalog leaves unstated (commonly the addressing style, which most catalogs omit) falls back to what is already configured for that prefix, picked by DuckDB's own longest-scope rule so it is exactly the secret the read would have used had nothing been vended. That fallback is what lets vended secrets work against S3-compatible stores and local mocks, not just AWS; it can only supply what nobody stated, never overwrite it.
- **Best-effort by design.** A failure to resolve or push never aborts the caller's statement; if a credential was genuinely required, the storage operation that follows fails on its own with an authoritative error. The swallowed failure is reported at `WARNING` with the relation name, so a scan that ends in a raw S3 403 says why. Out-of-memory and cancellation are re-thrown rather than swallowed.

### Trust model

The catalog is a control plane, not an arbitrary remote. It is registered by a superuser (`CREATE SERVER` + `CREATE USER MAPPING`), reached at the configured `rest_endpoint`, and authenticated with OAuth2 client credentials; TLS is the integrity check available at this layer, as the Iceberg REST spec defines no signature over `storage-credentials`. That same catalog already tells pg_lake where the table's data lives and which files belong to it, so a hostile one is a problem well before any credential is vended.

What is constrained is what a catalog's answer can reach and who can see it:

- **Off unless asked for.** No delegation header is sent and no secret is pushed until vending is enabled, per server or by GUC.
- **Scope cannot exceed the table.** A vended prefix is honored only at or below the table root; broader or sibling prefixes are clamped, so a catalog cannot label its credential in a way that shadows another table's secret. With no derivable scope, nothing is pushed.
- **One principal's credential is not another's.** Secret names and the cache behind them are keyed by user mapping.
- **Values stay values.** Credentials are single-quote escaped before interpolation into DuckDB SQL, and `CREATE SECRET` statements are redacted from logging on both sides: pg_lake never logs the statement it sends, and `pgduck_server` now drops the argument list before logging a statement that defines a secret (it previously wrote a failing one, credentials and all, at `WARNING`).
- **Nothing outlives its usefulness.** Secrets the resolver stops returning are dropped, a dropped table's are forgotten with it, and anything a crashed backend left behind expires on its own.
- **The channel is the one already in use.** `CREATE SECRET` goes to `pgduck_server` over the same connection as every other statement — a unix domain socket by default (`pg_lake_engine.host` is `host=/tmp port=5332`), which is where static S3 secrets from `--init_file_path` already travel. A remote `pgduck_server` is configured through libpq conninfo and can require TLS there like any Postgres connection. Onward to the object store, TLS follows the catalog's endpoint scheme, and an `https` endpoint is never downgraded.

The one input not taken from the catalog is whatever S3 connection setting the catalog leaves unstated. Each is read from the secret DuckDB itself would have selected for that prefix, so the credentials go where that path was already being read from. An endpoint the catalog *does* state is never overwritten, and SSL is pinned by that endpoint's scheme, so the fallback cannot redirect a credential — it can only fill in a blank.

### Known limitations

Both are documented in `storage_credentials.h` and are inherent to a shared `pgduck_server` holding global, in-memory secrets:

1. **`pgduck_server` restart.** A backend tracks the secrets it pushed and skips re-pushing while the cached expiry is still safe. If `pgduck_server` restarts, those secrets are gone while the backend still believes them present, so scans can hit HTTP 403 until the next reconcile that has other work — bounded by the credential TTL. Closing this needs a boot-id handshake on connect, or treating an S3 403 as a signal to re-push.
2. **Same-scope, multi-principal selection.** DuckDB selects a secret by longest-matching scope, not by name. Principal-scoped names stop backends clobbering one another, but two secrets with the *same* scope and different credentials are ambiguous to DuckDB's tie-break.

### What testing against Horizon turned up

Two people pointed this branch at a real vending catalog (Snowflake Horizon IRC, vended-only tables). The credential path itself works — the 403s that motivated the PR are gone, and reads of those tables now return rows — and that exposed what sat behind it:

- **Attaching** such a table without naming its columns still 403'd, because inference read `metadata.json` off the store before the relation existed, and every push site is keyed on a relation that does not exist yet. Fixed here by taking the columns from the metadata document the catalog already inlines, and covered by a MinIO test where the static credential cannot reach the table at all.
- **Reading** those tables hit three unrelated gaps in v3 metadata handling, below.

Writing to a catalog that assigns its own locations is a separate matter — pg_lake puts a new table under its own prefix, which a managed volume then refuses — and is left to its own change rather than widened into this one.

### Iceberg v3 reads

The read gaps:

- **Optional Avro fields that are absent from the manifest schema** (rather than present and null) raised `sort_order_id not found in schema`. The nullable getters now distinguish required from optional fields.
- **`format-version: 3` was refused outright.** It is now accepted for reading, since the v3 metadata we consume is a superset of v2. v3-only features are rejected where they actually appear rather than at the version gate, so what is accepted is never quietly wrong: a Puffin **deletion vector** raises a clear "not supported" error instead of silently returning deleted rows, and a **column default** (`initial-default`, which v2 has no equivalent of) refuses the table rather than reading the rows that predate the column back as NULL. Row lineage is the one v3 addition ignored outright — a reader cannot observe it in the rows.
- **Schema mismatches reported only counts** (`field count 10 vs 0`). The error now names the Iceberg fields that have no matching Postgres column.

Writing stays at v2: the serializer emits a v2 document under whatever version number it is handed, so it now refuses a metadata version it does not produce rather than rewriting a v3 table's metadata without the fields v3 requires.

Happy to split this part into its own PR if you would rather review it separately.

### Tests

| Suite | What it proves | Count |
|-------|----------------|-------|
| `pg_lake_table/tests/pytests/test_vended_credentials_minio.py` | The credential is genuinely **load-bearing**: a real policy engine denies the scan without it, denies the second principal what the first was given, keeps unrelated tables reading, and denies a columnless attach that reaches for storage | 11 |
| `pg_lake_table/tests/pytests/test_vended_credentials_polaris.py` | Against a **real catalog**: a read-only attachment is vended on a cold cache, a writable table in our own storage is not vended at all, and the per-server opt-in is honoured | 4 |
| `pg_lake_iceberg/tests/pytests/test_vended_credentials.py` | Extraction: both response shapes, several credentials at once, scope, clamping, expiry, S3 settings including the endpoint scheme, partial/empty configs | 19 |
| `pg_lake_iceberg/tests/pytests/test_iceberg_v3_read.py` | v3 metadata, absent `sort_order_id`, deletion-vector and column-default rejection | 5 |
| `pgduck_server/tests/pytests/test_vended_secrets.py` | Secret create/replace/drop, coexistence with the default secret | 6 |
| `pg_lake_table/tests/e2e/test_vended_credentials_e2e.py` | Gated skeleton for a live OAuth2 vending catalog (skips unless `PGLAKE_E2E_*` is set) | — |

The two enforcement tiers complement each other. Moto accepts any credential and never denies a request, so it cannot show that a credential matters; **MinIO** has a real policy engine and can. But MinIO's catalog is a mock, so the shape a production catalog actually serves — a table Polaris registered itself, attached read-only afterwards — is covered against **Polaris**, where the assertion is the resolver's observable behavior (the right secret appears, and is withheld where it should be) rather than denial.

Each fix in this PR was mutation-tested: reverting the fix makes the corresponding test fail.

### How to test & verify

The MinIO suite verifies the whole chain locally — the credential is **delivered** by the catalog, **pushed** to `pgduck_server` as a scoped secret, and **actually used** for the data scan.

**Prerequisites**

```bash
which minio                      # server binary, e.g. `brew install minio`
pipenv install --dev             # minio admin SDK, pyiceberg, fastavro
```

If `minio` is not on `PATH` the suite skips rather than fails.

**1) Run the suites**

```bash
cd pg_lake_table
PYTHONPATH=../test_common pipenv run pytest -v tests/pytests/test_vended_credentials_minio.py    # 11 passed
PYTHONPATH=../test_common pipenv run pytest -v tests/pytests/test_vended_credentials_polaris.py  # 4 passed

cd ../pg_lake_iceberg
PYTHONPATH=../test_common pipenv run pytest -v tests/pytests/test_vended_credentials.py          # 19 passed
PYTHONPATH=../test_common pipenv run pytest -v tests/pytests/test_iceberg_v3_read.py             # 5 passed
```

**2) Watch each hop**

Turn off capture and filter to the interesting lines:

```bash
cd pg_lake_table
PYTHONPATH=../test_common pipenv run pytest -s -k required_for_scan \
  tests/pytests/test_vended_credentials_minio.py 2>&1 \
  | grep -Ei "pglake_vended_|\.parquet|403"
```

You should see the push — `CREATE OR REPLACE SECRET "pglake_vended_<db>_<srv>_<hash>" (TYPE S3, KEY_ID '…', SCOPE 's3://pglakeminio/wh/<ns>/<tbl>/')` — followed by parquet reads with no `403`. Swap `-k required_for_scan` for `-k without_vended` and the pushes disappear while the parquet reads turn into `HTTP 403`: the metadata-only static secret cannot read data.

**How to read the MinIO scenarios**

| Scenario | Vended secret | Data scan |
|---|---|---|
| Correct vended credential | pushed, scoped to the table | reads data |
| No vended credential | none | **403** |
| Credential revoked (vending switched off) | dropped | **403** |
| Catalog labels the credential with a sibling prefix | clamped to the table root, never registered under the foreign prefix | **403** (the credential has no rights there) |
| Second role on the same table, vended a metadata-only credential | its own secret, not the first role's | **403** for the second role, data for the first |
| Catalog vends a credential for the data files only | scoped to `…/data/`, not widened to the table root | reads data on the first scan *and* the second, metadata still served by the static secret |
| Catalog states its own `s3.endpoint`, with and without an addressing style | pushed with the stated endpoint; the style it omits comes from the secret already serving the prefix | reads data either way |
| Plain parquet table elsewhere in the same bucket | untouched | still reads through the static secret |
| Read-only table dropped | forgotten, not left behind | — |
| Columnless `CREATE TABLE t ()` while the static secret cannot reach the table at all | none yet — the relation does not exist | attach succeeds with the right columns, from the catalog's own metadata; the later scan reads through the vended secret |

The outcome flips solely on whether the correctly scoped vended secret is present, which is what makes it proof that the credential is delivered, pushed and used.

### TODOs

- [x] **Better test coverage.** Two enforcement tiers (MinIO, Polaris), extraction unit tests, pgduck secret tests, v3 read tests; every fix mutation-tested.
- [x] **Rename functions that read like getters but have side effects.** `EnsureVendedSecretOnConnection` → `PushVendedSecretToPGDuckOnConnection`, `GetMetadataLocationFromRestCatalog` → `LoadRestCatalogMetadataLocation`.
- [x] **Skip re-creating the secret while it is still valid.** Done — the resolver skips a re-push while the cached expiry is outside the refresh margin. (An earlier revision claimed this was unsafe on the grounds that secrets die with the connection; that was wrong. Temporary DuckDB secrets are process-wide and outlive the connection, so skipping is safe, and the trade-off it introduces — a `pgduck_server` restart leaving a backend believing a secret is present — is written up as limitation 1 above.)
- [ ] **Run against a live vending catalog in CI.** Covered locally by Polaris (real catalog) and MinIO (real enforcement); `test_vended_credentials_e2e.py` is ready for a live OAuth2 catalog but needs external credentials, so it stays gated.

### Follow-ups

- **Azure and other non-S3 stores** are not vended: extraction reads `s3.*` config keys and produces a `TYPE S3` secret, so an Azure-backed table reaches storage exactly as it does today. A different credential shape and DuckDB secret type make it its own change.
- **AWS S3 Tables** is not reachable yet: its Iceberg REST endpoint authenticates with AWS SigV4, while pg_lake's REST client supports `oauth2` / `horizon`. SigV4 REST auth is its own change.
- **Catalog-assigned locations.** A catalog that manages its own storage — a Snowflake-managed external volume, say — answers a staged create with the location it assigned, which pg_lake currently overrides with one of its own; the write then 403s because the vended credential is scoped to the catalog's location. Adopting the answer is a change to the create and commit path, and brings the lifecycle question below with it, so it is its own PR.
- **Writable tables.** Vending them means answering who deletes a dropped table's files once the credential that could reach them is gone — delete at `DROP` under a live credential, shorten the retention when a table is vended, or something else. Worth noting for whoever picks it up: a catalog placing the files does not imply it removes them. Polaris refuses `purgeRequested` unless `DROP_WITH_PURGE_ENABLED` is configured, and the spec makes purge optional with no way to ask which kind of catalog we are talking to.
- **Rename the pre-existing `GetIcebergMetadataLocation`**, which also reads like a getter but locks catalog rows. It has many unrelated call sites, so it belongs in its own change.
- **`pgduck_server` boot-id handshake** to close limitation 1.
- **Inheriting S3 connection settings** reads `duckdb_secrets().secret_string`, a display string rather than an API, for the one secret DuckDB would have chosen. Which secret that is, is no longer decided here, and the query does not run when the catalog states every setting — but reading settings out of a display string is still not something to build on. A structural accessor in DuckDB, or making an endpoint mandatory for S3-compatible stores, would close it for good.
- **User documentation.** The REST catalog feature as a whole (servers, options, auth) is undocumented, and vending's opt-in is described here rather than in `docs/`. The two roles a REST table can have are now written down (see the last commit), but the rest is worth a docs pass of its own.
- **A read-only REST scan issues `loadTable` twice**, once to resolve credentials and once for the metadata location. Folding the two together needs a per-statement memo; caching the metadata location itself would risk serving a stale snapshot after a commit.
