### PR TITLE
Reduce CI flakiness in three iceberg test modules

### DIFF
--- a/pg_lake_table/tests/pytests/test_data_file_pruning.py
+++ b/pg_lake_table/tests/pytests/test_data_file_pruning.py
@@ -95,6 +95,7 @@ pruning_data = [
 
 # this test aims to ensure some common operators like =,>,<,>=,<=,IN,ANY,BETWEEN etc
 # is supported for different data types
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize("needs_quote, column_type, table_name, rows", pruning_data)
 def test_simple_data_pruning_for_data_types(
     installcheck,

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -4,6 +4,22 @@ import itertools
 import json
 import re
 import time
+import pytest
+
+
+# Several tests in this module create the same schemas (object_store_sc1,
+# object_store_sc2). When one test fails midway through and skips its DROP
+# SCHEMA cleanup, the next test fails immediately with "schema already exists",
+# which masks the original failure and produces a noisy cascade. Drop them
+# defensively before each test so a single failure does not poison the rest.
+@pytest.fixture(autouse=True)
+def drop_object_store_schemas(pg_conn):
+    run_command(
+        "DROP SCHEMA IF EXISTS object_store_sc1, object_store_sc2 CASCADE",
+        pg_conn,
+    )
+    pg_conn.commit()
+    yield
 
 
 # don't accept 'catalog_name', 'catalog_namespace', 'catalog_table_name'

--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -1171,6 +1171,7 @@ def test_complex_transaction(
     run_command("DROP SCHEMA IF EXISTS tx_demo CASCADE;", pg_conn)
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     "catalog",
     ["postgres", "rest"],


### PR DESCRIPTION
## Problem

CI on \`main\` has been flapping over the past few weeks. Three failure
modes account for most of the noise:

1. \`test_data_file_pruning.py::test_simple_data_pruning_for_data_types\` —
   fails with \`AssertionError: failed to refresh object catalog table\`
   when the object-store catalog refresh hasn't observed the pushed
   metadata yet. The structurally identical test in
   \`test_partition_pruning.py\` already has \`@pytest.mark.flaky(reruns=2)\`
   (added in bbd1176, May 8); this sibling was missed.
2. \`test_polaris_catalog_writable.py::test_sequences_serial_and_generated_columns[rest]\` —
   fails with \`AssertionError: Data file column stats mismatch\` when
   the pg_catalog data-file stats and the REST metadata diverge by a
   row, which I've seen on multiple unrelated PRs and on \`main\`
   (26891987114, 26848484450, 26773102088, 26753357058, 27272760340).
3. \`test_object_store_catalog.py::{test_schema_mismatch, test_partitioned_read_only, test_unsupported_modifications_for_read_only, test_multiple_readers_writers}\` —
   fails with \`psycopg2.errors.DuplicateSchema: schema \"object_store_sc1\" already exists\`.
   This isn't really a flaky test — it's a cascade. When an earlier
   test in the module fails midway through (most recently due to a
   missing \`pg_lake_ducklake\` extension), it skips its
   \`DROP SCHEMA ... CASCADE\` and the next several tests fail on the
   leftover schema instead of running.

## Solution

Three small, narrow changes:

- \`test_simple_data_pruning_for_data_types\`: add
  \`@pytest.mark.flaky(reruns=2)\` to match its sibling in
  \`test_partition_pruning.py\`.
- \`test_sequences_serial_and_generated_columns\`: add
  \`@pytest.mark.flaky(reruns=2)\`.
- \`test_object_store_catalog.py\`: add a module-scoped autouse fixture
  that runs \`DROP SCHEMA IF EXISTS object_store_sc1, object_store_sc2 CASCADE\`
  before each test. A single failure in this module no longer poisons
  the rest of it.

The first two are defensive masking and don't fix the underlying
race / consistency issue, but they match the prevailing convention in
the repo (\`pytest-rerunfailures\` was added in bbd1176 specifically for
this kind of test-harness-side flapping). The third is a real fix for
the cascade.

## Test plan

- [x] CI passes
- [x] None of the three target tests appear in subsequent failure logs