### PR TITLE
Fix iceberg STRUCT text value escaping for embedded " and \

### DIFF
--- a/pg_lake_engine/src/pgduck/struct_conversion.c
+++ b/pg_lake_engine/src/pgduck/struct_conversion.c
@@ -212,7 +212,15 @@ StructOutForPGDuck(Datum myStruct, CopyDataFormat format)
 		/* Detect whether we need double quotes for this value */
 		bool		needQuotes = !IsContainerType(column_type);
 
-		/* And emit the string */
+		/*
+		 * Emit the value.  Scalar values are wrapped in "..." with backslash
+		 * escaping for embedded " and \, matching the convention used by
+		 * QuoteDuckDBStructKey for field names and ArrayOutForPGDuck for
+		 * array elements.  The struct literal travels through CSV on the wire
+		 * to pgduck_server, so DuckDB's struct parser sees the literal after
+		 * the outer CSV layer has un-doubled "".  CSV-style "" doubling here
+		 * would be stripped twice and lose the special characters.
+		 */
 		if (needQuotes)
 			appendStringInfoCharMacro(&buf, '"');
 		for (tmp = value; *tmp; tmp++)
@@ -220,7 +228,7 @@ StructOutForPGDuck(Datum myStruct, CopyDataFormat format)
 			char		ch = *tmp;
 
 			if (needQuotes && (ch == '"' || ch == '\\'))
-				appendStringInfoCharMacro(&buf, ch);
+				appendStringInfoCharMacro(&buf, '\\');
 			appendStringInfoCharMacro(&buf, ch);
 		}
 		if (needQuotes)

--- a/pg_lake_table/tests/pytests/test_iceberg_types.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_types.py
@@ -1029,7 +1029,11 @@ def test_iceberg_struct_text_value_with_quote_and_backslash(pg_conn, s3, extensi
     run_command(f"CREATE SCHEMA {schema}", pg_conn)
     pg_conn.commit()
 
-    run_command(f"CREATE TYPE {schema}.val_field_t AS (k int, txt text)", pg_conn)
+    run_command(f"CREATE TYPE {schema}.inner_t AS (m int, label text)", pg_conn)
+    run_command(
+        f"CREATE TYPE {schema}.val_field_t AS (k int, txt text, child {schema}.inner_t)",
+        pg_conn,
+    )
     pg_conn.commit()
 
     run_command(
@@ -1046,16 +1050,20 @@ def test_iceberg_struct_text_value_with_quote_and_backslash(pg_conn, s3, extensi
     )
     pg_conn.commit()
 
+    # The child field exercises the recursive path: a nested struct's text
+    # is emitted by a recursive StructOutForPGDuck call and then placed bare
+    # (no extra quoting) inside the outer struct, so the inner-level escapes
+    # must survive the outer CSV pass unchanged.
     insert_values = f"""
         VALUES
-            (3,  ROW(30, 'has " quote')::{schema}.val_field_t),
-            (11, ROW(11, '"only"')::{schema}.val_field_t),
-            (12, ROW(12, '""')::{schema}.val_field_t),
-            (13, ROW(13, 'multi " " " quote')::{schema}.val_field_t),
-            (14, ROW(14, '"\\"''')::{schema}.val_field_t),
-            (15, ROW(15, '"' || CHR(10) || '"')::{schema}.val_field_t),
-            (16, ROW(16, 'back\\slash')::{schema}.val_field_t),
-            (17, ROW(17, 'trailing\\')::{schema}.val_field_t)
+            (3,  ROW(30, 'has " quote', NULL)::{schema}.val_field_t),
+            (11, ROW(11, '"only"', ROW(110, 'inner " quote')::{schema}.inner_t)::{schema}.val_field_t),
+            (12, ROW(12, '""', ROW(120, 'inner \\\\ slash')::{schema}.inner_t)::{schema}.val_field_t),
+            (13, ROW(13, 'multi " " " quote', NULL)::{schema}.val_field_t),
+            (14, ROW(14, '"\\"''', ROW(140, '"\\\\"')::{schema}.inner_t)::{schema}.val_field_t),
+            (15, ROW(15, '"' || CHR(10) || '"', NULL)::{schema}.val_field_t),
+            (16, ROW(16, 'back\\slash', ROW(160, 'inner trailing\\\\')::{schema}.inner_t)::{schema}.val_field_t),
+            (17, ROW(17, 'trailing\\', ROW(170, NULL)::{schema}.inner_t)::{schema}.val_field_t)
     """
 
     run_command(
@@ -1069,7 +1077,8 @@ def test_iceberg_struct_text_value_with_quote_and_backslash(pg_conn, s3, extensi
     pg_conn.commit()
 
     query = f"""
-        SELECT id, length((s).txt), (s).txt
+        SELECT id, length((s).txt), (s).txt,
+               ((s).child).m, length(((s).child).label), ((s).child).label
           FROM {schema}.val_struct
          ORDER BY id
     """

--- a/pg_lake_table/tests/pytests/test_iceberg_types.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_types.py
@@ -1009,6 +1009,78 @@ def test_iceberg_types_composite(pg_conn, create_helper_functions, s3, extension
     assert len(results) == 0
 
 
+def test_iceberg_struct_text_value_with_quote_and_backslash(pg_conn, s3, extension):
+    """
+    STRUCT text fields containing the characters " or \\ must round-trip
+    through Iceberg with the special characters preserved.
+
+    The struct literal travels from pg_lake to pgduck_server inside an outer
+    CSV field, so each scalar value inside the struct must use backslash
+    escaping (\\" / \\\\) — the CSV layer un-doubles "" once on the receive
+    side, leaving DuckDB's struct parser to consume the backslash form.
+    Emitting CSV-style "" doubling at the inner layer would be stripped twice
+    and silently drop the special characters.
+
+    Reproduces: https://github.com/Snowflake-Labs/pg_lake/issues/347
+    """
+    schema = "test_iceberg_struct_text_value"
+    location = f"s3://{TEST_BUCKET}/{schema}/"
+
+    run_command(f"CREATE SCHEMA {schema}", pg_conn)
+    pg_conn.commit()
+
+    run_command(f"CREATE TYPE {schema}.val_field_t AS (k int, txt text)", pg_conn)
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        CREATE TABLE {schema}.val_struct (id int, s {schema}.val_field_t)
+        USING iceberg
+        WITH (location = '{location}')
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        INSERT INTO {schema}.val_struct VALUES
+            (3,  ROW(30, 'has " quote')::{schema}.val_field_t),
+            (11, ROW(11, '"only"')::{schema}.val_field_t),
+            (12, ROW(12, '""')::{schema}.val_field_t),
+            (13, ROW(13, 'multi " " " quote')::{schema}.val_field_t),
+            (14, ROW(14, '"\\"''')::{schema}.val_field_t),
+            (15, ROW(15, '"' || CHR(10) || '"')::{schema}.val_field_t),
+            (16, ROW(16, 'back\\slash')::{schema}.val_field_t),
+            (17, ROW(17, 'trailing\\')::{schema}.val_field_t)
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        f"""
+        SELECT id, length((s).txt), (s).txt
+          FROM {schema}.val_struct
+         ORDER BY id
+        """,
+        pg_conn,
+    )
+    assert result == [
+        [3, 11, 'has " quote'],
+        [11, 6, '"only"'],
+        [12, 2, '""'],
+        [13, 17, 'multi " " " quote'],
+        [14, 4, '"\\"\''],
+        [15, 3, '"\n"'],
+        [16, 10, "back\\slash"],
+        [17, 9, "trailing\\"],
+    ]
+
+    run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 def test_iceberg_types_converted_to_string(
     pg_conn, create_helper_functions, s3, extension
 ):

--- a/pg_lake_table/tests/pytests/test_iceberg_types.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_types.py
@@ -1040,11 +1040,14 @@ def test_iceberg_struct_text_value_with_quote_and_backslash(pg_conn, s3, extensi
         """,
         pg_conn,
     )
+    run_command(
+        f"CREATE TABLE {schema}.val_struct_heap (id int, s {schema}.val_field_t)",
+        pg_conn,
+    )
     pg_conn.commit()
 
-    run_command(
-        f"""
-        INSERT INTO {schema}.val_struct VALUES
+    insert_values = f"""
+        VALUES
             (3,  ROW(30, 'has " quote')::{schema}.val_field_t),
             (11, ROW(11, '"only"')::{schema}.val_field_t),
             (12, ROW(12, '""')::{schema}.val_field_t),
@@ -1053,29 +1056,29 @@ def test_iceberg_struct_text_value_with_quote_and_backslash(pg_conn, s3, extensi
             (15, ROW(15, '"' || CHR(10) || '"')::{schema}.val_field_t),
             (16, ROW(16, 'back\\slash')::{schema}.val_field_t),
             (17, ROW(17, 'trailing\\')::{schema}.val_field_t)
-        """,
+    """
+
+    run_command(
+        f"INSERT INTO {schema}.val_struct {insert_values}",
+        pg_conn,
+    )
+    run_command(
+        f"INSERT INTO {schema}.val_struct_heap {insert_values}",
         pg_conn,
     )
     pg_conn.commit()
 
-    result = run_query(
-        f"""
+    query = f"""
         SELECT id, length((s).txt), (s).txt
           FROM {schema}.val_struct
          ORDER BY id
-        """,
+    """
+    assert_query_results_on_tables(
+        query,
         pg_conn,
+        [f"{schema}.val_struct"],
+        [f"{schema}.val_struct_heap"],
     )
-    assert result == [
-        [3, 11, 'has " quote'],
-        [11, 6, '"only"'],
-        [12, 2, '""'],
-        [13, 17, 'multi " " " quote'],
-        [14, 4, '"\\"\''],
-        [15, 3, '"\n"'],
-        [16, 10, "back\\slash"],
-        [17, 9, "trailing\\"],
-    ]
 
     run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
     pg_conn.commit()


### PR DESCRIPTION
## Problem

A STRUCT-typed column in an Iceberg table corrupts text fields containing
`"` or `\` on read: the special characters are silently dropped and the
returned value is shorter than what was written. Heap tables with the same
composite type round-trip correctly, so the bug is in pg_lake's STRUCT
emission path.

Reported in #347; field-name escaping was fixed by #297, but value
escaping was deferred.

## Solution

`StructOutForPGDuck` wrapped scalar values in `"..."` and escaped embedded
`"` and `\` by CSV-style doubling. The struct literal travels through an
outer CSV field on the way to pgduck_server, so the receive side un-doubles
`""` once before DuckDB sees the literal. One layer of escaping then gets
stripped twice and the special characters are dropped on read.

Switch the value-emit loop to backslash escaping (`\"` and `\\`), matching
`QuoteDuckDBStructKey` for field names and `ArrayOutForPGDuck` for array
elements that travel the same CSV path.

```sql
-- before: characters dropped on read
CREATE TYPE val_field_t AS (k int, txt text);
CREATE TABLE t (id int, s val_field_t) USING iceberg;
INSERT INTO t VALUES (1, ROW(1, 'has " quote')::val_field_t);
SELECT length((s).txt), (s).txt FROM t;
--  10 | has  quote        (was)
--  11 | has " quote       (now)
```

## Test plan

- [x] `pg_lake_table/tests/pytests/test_iceberg_types.py::test_iceberg_struct_text_value_with_quote_and_backslash` covers the reproducer from #347 plus backslash and trailing-backslash cases. Confirmed it fails on main and passes with the fix.
- [x] `test_duckdb_reserved_keywords.py` (47 tests) and `test_duckdb_reserved_keyword_copy.py` (32 tests) still pass.
- [x] `test_complex_types.py`, `test_create_table.py`, `test_fieldselect_pushdown.py` still pass.

Fixes #347