### PR TITLE
Backport #377: postgres_scanner: convert PostGIS geometry to canonical WKB

### DIFF
--- a/.github/actions/build-and-push-image/action.yml
+++ b/.github/actions/build-and-push-image/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       working-directory: ./docker
       run: |
-        GHCR_TOKEN=$(echo ${{ inputs.github_token }} | base64)
+        GHCR_TOKEN=$(echo -n "${{ inputs.github_token }}" | base64 -w 0)
         
         TAG=${{ hashFiles('docker/Dockerfile') }}-${{ inputs.base_image_name }}
         HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://ghcr.io/v2/${{ inputs.org_name }}/${{ inputs.final_image_name }}/manifests/$TAG)

--- a/duckdb_pglake/patches/duckdb-postgres/postgis-geometry-wkb.patch
+++ b/duckdb_pglake/patches/duckdb-postgres/postgis-geometry-wkb.patch
@@ -1,0 +1,58 @@
+Convert PostGIS geometry columns to canonical WKB on the server side.
+
+PostGIS emits EWKB (with the SRID flag bit and an embedded SRID prefix when
+set), but DuckDB spatial expects standard WKB. Without conversion, scans of
+PostGIS geometry columns fail with "invalid WKB format" errors.
+
+We tag PostGIS geometry columns with a new POSTGIS_GEOMETRY annotation at
+type-resolution time, and rewrite the projection in the COPY query to wrap
+those columns in ST_AsBinary(...), which returns canonical ISO WKB as bytea.
+The existing BLOB reader path then transports the bytes unchanged.
+
+Note: ST_AsBinary drops the SRID. If SRID preservation is needed, a separate
+column or in-reader EWKB stripping would be required.
+
+diff --git a/src/include/postgres_utils.hpp b/src/include/postgres_utils.hpp
+--- a/src/include/postgres_utils.hpp
++++ b/src/include/postgres_utils.hpp
+@@ -35,7 +35,8 @@ enum class PostgresTypeAnnotation {
+ 	GEOM_BOX,
+ 	GEOM_PATH,
+ 	GEOM_POLYGON,
+-	GEOM_CIRCLE
++	GEOM_CIRCLE,
++	POSTGIS_GEOMETRY
+ };
+
+ struct PostgresType {
+diff --git a/src/postgres_utils.cpp b/src/postgres_utils.cpp
+--- a/src/postgres_utils.cpp
++++ b/src/postgres_utils.cpp
+@@ -157,6 +157,7 @@ LogicalType PostgresUtils::TypeToLogicalType(optional_ptr<PostgresTransaction> t
+ 		postgres_type.info = PostgresTypeAnnotation::JSONB;
+ 		return LogicalType::VARCHAR;
+ 	} else if (pgtypename == "geometry") {
++		postgres_type.info = PostgresTypeAnnotation::POSTGIS_GEOMETRY;
+ 		return GetGeometryType();
+ 	} else if (pgtypename == "date") {
+ 		return LogicalType::DATE;
+diff --git a/src/postgres_scanner.cpp b/src/postgres_scanner.cpp
+--- a/src/postgres_scanner.cpp
++++ b/src/postgres_scanner.cpp
+@@ -242,7 +242,15 @@ static void PostgresInitInternal(ClientContext &context, const PostgresBindData
+ 				col_names += "ctid";
+ 			}
+ 		} else {
+-			col_names += KeywordHelper::WriteQuoted(bind_data->names[column_id], '"');
++			auto quoted_name = KeywordHelper::WriteQuoted(bind_data->names[column_id], '"');
++			if (bind_data->postgres_types[column_id].info == PostgresTypeAnnotation::POSTGIS_GEOMETRY) {
++				// PostGIS emits EWKB by default (with SRID prefix when set), but DuckDB
++				// spatial expects standard WKB. Use ST_AsBinary() server-side to get
++				// canonical WKB and avoid "invalid WKB format" downstream.
++				col_names += "ST_AsBinary(" + quoted_name + ")";
++				continue;
++			}
++			col_names += quoted_name;
+ 			if (bind_data->postgres_types[column_id].info == PostgresTypeAnnotation::CAST_TO_VARCHAR) {
+ 				col_names += "::VARCHAR";
+ 			} else if (bind_data->types[column_id].id() == LogicalTypeId::LIST) {

--- a/pgduck_server/tests/pytests/test_postgres_scanner_geometry.py
+++ b/pgduck_server/tests/pytests/test_postgres_scanner_geometry.py
@@ -1,0 +1,146 @@
+"""
+Verify postgres_scan handles PostGIS geometry columns correctly.
+
+PostGIS emits EWKB (with the SRID flag bit and embedded SRID) for binary
+output, but DuckDB spatial expects standard WKB. The scanner rewrites
+geometry projections as ST_AsBinary(col) so canonical WKB reaches DuckDB.
+
+Without that rewrite, scans of any geometry column with SRID set fail with
+"invalid WKB format".
+"""
+
+import pytest
+from utils_pytest import *
+
+
+def _connstr():
+    return (
+        f"host={server_params.PG_HOST} "
+        f"port={server_params.PG_PORT} "
+        f"dbname={server_params.PG_DATABASE} "
+        f"user={server_params.PG_USER} "
+        f"password={server_params.PG_PASSWORD}"
+    )
+
+
+def _scan(table, schema="public"):
+    return f"postgres_scan('{_connstr()}', '{schema}', '{table}')"
+
+
+@pytest.fixture(scope="module")
+def pg_geom_tables(postgres, postgis_extension):
+    """Create PostGIS-backed test tables on the upstream Postgres."""
+    conn = open_pg_conn()
+    conn.autocommit = True
+    cur = conn.cursor()
+
+    cur.execute("DROP TABLE IF EXISTS scanner_geom_basic")
+    cur.execute(
+        "CREATE TABLE scanner_geom_basic (" "  id int PRIMARY KEY," "  g geometry" ")"
+    )
+    # Mix of SRIDs (0, 4326), 2D/3D/M dimensions, varied types,
+    # plus a NULL row to ensure null handling is preserved.
+    cur.execute(
+        "INSERT INTO scanner_geom_basic VALUES "
+        "(1, ST_GeomFromText('POINT(1 2)')),"  # SRID 0
+        "(2, ST_GeomFromText('POINT(3 4)', 4326)),"  # SRID 4326
+        "(3, ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2)', 4326)),"
+        "(4, ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 4326)),"
+        "(5, ST_GeomFromText('POINT Z(1 2 3)', 4326)),"  # 3D
+        "(6, ST_GeomFromText('POINT M(1 2 3)', 4326)),"  # M dim
+        "(7, NULL)"
+    )
+
+    cur.execute("DROP TABLE IF EXISTS scanner_geom_typed")
+    cur.execute(
+        "CREATE TABLE scanner_geom_typed ("
+        "  id int PRIMARY KEY,"
+        "  g geometry(Point, 4326)"
+        ")"
+    )
+    cur.execute(
+        "INSERT INTO scanner_geom_typed VALUES "
+        "(1, ST_SetSRID(ST_MakePoint(10, 20), 4326)),"
+        "(2, ST_SetSRID(ST_MakePoint(-1.5, 47.0), 4326))"
+    )
+
+    cur.close()
+    conn.close()
+
+    yield
+
+    conn = open_pg_conn()
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS scanner_geom_basic")
+    cur.execute("DROP TABLE IF EXISTS scanner_geom_typed")
+    cur.close()
+    conn.close()
+
+
+# -------------------------------------------------------------------
+# Geometry columns return canonical WKB readable by DuckDB spatial
+# -------------------------------------------------------------------
+
+
+def test_geometry_count(pg_geom_tables, pgduck_conn):
+    """Sanity: scan completes and row count matches (no WKB parse error)."""
+    scan = _scan("scanner_geom_basic")
+    rows = perform_query_on_cursor(f"SELECT count(*) FROM {scan}", pgduck_conn)
+    assert rows == [("7",)]
+
+
+def test_geometry_roundtrip_to_wkt(pg_geom_tables, pgduck_conn):
+    """
+    DuckDB spatial parses the bytes via ST_GeomFromWKB and round-trips them
+    to WKT. Anything other than canonical WKB would either fail to parse or
+    produce malformed text — either way the assert below catches it.
+
+    Note: ST_AsBinary drops SRID, so we compare WKT geometry only.
+    """
+    scan = _scan("scanner_geom_basic")
+    rows = perform_query_on_cursor(
+        f"SELECT id, ST_AsText(ST_GeomFromWKB(g)) " f"FROM {scan} ORDER BY id",
+        pgduck_conn,
+    )
+    assert rows == [
+        ("1", "POINT (1 2)"),
+        ("2", "POINT (3 4)"),
+        ("3", "LINESTRING (0 0, 1 1, 2 2)"),
+        ("4", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"),
+        ("5", "POINT Z (1 2 3)"),
+        ("6", "POINT M (1 2 3)"),
+        ("7", None),
+    ]
+
+
+def test_geometry_typed_column(pg_geom_tables, pgduck_conn):
+    """Typed geometry(Point,4326) columns round-trip the same way."""
+    scan = _scan("scanner_geom_typed")
+    rows = perform_query_on_cursor(
+        f"SELECT id, ST_AsText(ST_GeomFromWKB(g)) " f"FROM {scan} ORDER BY id",
+        pgduck_conn,
+    )
+    assert rows == [
+        ("1", "POINT (10 20)"),
+        ("2", "POINT (-1.5 47)"),
+    ]
+
+
+def test_geometry_blob_alias(pg_geom_tables, pgduck_conn):
+    """The scanned column is a blob (WKB bytes), not a struct or text."""
+    scan = _scan("scanner_geom_typed")
+    rows = perform_query_on_cursor(f"SELECT typeof(g) FROM {scan} LIMIT 1", pgduck_conn)
+    # postgres-scanner exposes geometry as a BLOB aliased "WKB_BLOB";
+    # DuckDB reports the alias as the type name.
+    assert rows[0][0] in ("WKB_BLOB", "BLOB")
+
+
+def test_geometry_filter_pushdown(pg_geom_tables, pgduck_conn):
+    """Projection rewrite must coexist with a non-geometry WHERE filter."""
+    scan = _scan("scanner_geom_basic")
+    rows = perform_query_on_cursor(
+        f"SELECT id, ST_AsText(ST_GeomFromWKB(g)) " f"FROM {scan} WHERE id = 2",
+        pgduck_conn,
+    )
+    assert rows == [("2", "POINT (3 4)")]


### PR DESCRIPTION
Backport of 13c71e3 (#377) to release-3.3.

## Summary
- Converts PostGIS geometry to canonical WKB in postgres_scanner
- Adds DuckDB-postgres patch and pytest coverage

## Test plan
- [ ] CI passes on release-3.3