### PR TITLE
pg_lake_iceberg: add compatibility_mode table option (nested uuid -> text)

### DIFF
--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -208,6 +208,14 @@ composites, arrays of composites, composites containing arrays, maps with a
 `uuid` are rebuilt as fresh types; your own `CREATE TYPE` definitions are never
 modified. Containers with no nested `uuid` are left untouched.
 
+When a column is rewritten, pg_lake emits a `NOTICE` naming the old and new
+type, so the change is never silent. For a rebuilt composite or map the column's
+declared type becomes a generated type (shown as `lake_struct.*` / `map_type.*`
+in `\d`), not your original named type: you can still read individual fields
+(e.g. `(meta).event_id`), but you cannot cast the whole value back to the named
+type. This matches how the existing numeric-to-`double` conversion already treats
+composite columns.
+
 ```sql
 CREATE TYPE event_meta AS (event_id uuid, source text);
 

--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -72,6 +72,7 @@ Iceberg tables support the following options when creating the table:
 | location             | URL prefix for the Iceberg table (e.g. `s3://mybucket/measurements`) |
 | max_snapshot_age     | Maximum age (in seconds) of snapshots to retain. When set to `0`, old snapshots are automatically expired during writes. Overrides the `pg_lake_iceberg.max_snapshot_age` GUC for this table. |
 | out_of_range_values  | How to handle values that fall outside the Iceberg-representable range. Valid values: `error` (default), `clamp`. See [Out-of-range value handling](#out-of-range-value-handling). |
+| compatibility_mode   | Rewrite column types so the Iceberg table is consumable by a downstream engine with narrower type limitations. Valid values: `auto` (default), `snowflake`. See [Compatibility mode](#compatibility-mode). |
 
 Additionally, when creating the Iceberg table from a file, the following options are supported along with the format-specific options listed in the [data lake formats](../docs/file-formats-reference) section:
 
@@ -183,6 +184,51 @@ The default `error` mode ensures data integrity by catching unexpected values ea
 - Your pipeline produces sentinel values like `infinity` that you want silently mapped to the Iceberg boundary
 - You are migrating data from PostgreSQL heap tables that might contain `infinity` or extreme dates and want to complete the migration without errors
 - You prefer silent adjustments over strict error handling
+
+
+## Compatibility mode
+
+Iceberg supports the full range of column types that pg_lake maps, but some
+engines that read pg_lake's Iceberg tables have narrower limitations. The
+`compatibility_mode` table option opts a table into a set of type rewrites that
+keep its Iceberg schema consumable by such an engine.
+
+The supported modes are:
+
+| Mode        | Effect |
+| ----------- | ------ |
+| `auto`      | Default (also used when the option is unset). pg_lake decides what the table's downstream needs; today this means no rewrites are applied. |
+| `snowflake` | A `uuid` that appears **nested** inside an array, map, or composite type is stored as `text`. A **top-level** `uuid` column is left as a native Iceberg `uuid` (Snowflake's native UUID handles that case). |
+
+This addresses [Snowflake's UUID limitation](https://docs.snowflake.com/en/sql-reference/data-types-uuid#limitations-for-the-uuid-data-type): UUID values cannot be stored inside semi-structured or structured data types.
+
+The rewrite is applied recursively at every nesting level (arrays, maps,
+composites, arrays of composites, composites containing arrays, maps with a
+`uuid` key or value, and so on). Composite and map types that contain a nested
+`uuid` are rebuilt as fresh types; your own `CREATE TYPE` definitions are never
+modified. Containers with no nested `uuid` are left untouched.
+
+```sql
+CREATE TYPE event_meta AS (event_id uuid, source text);
+
+CREATE TABLE events (
+  id      uuid,         -- top-level: stays uuid
+  tags    uuid[],       -- nested: stored as text[]
+  meta    event_meta    -- nested: event_id stored as text, source stays text
+)
+USING iceberg WITH (compatibility_mode = 'snowflake');
+```
+
+The rewrite also applies to columns added later with `ALTER TABLE ... ADD COLUMN`:
+
+```sql
+ALTER TABLE events ADD COLUMN related_ids uuid[];  -- stored as text[]
+```
+
+`compatibility_mode` composes with the numeric-to-`double` conversion and with
+`out_of_range_values` handling: a single column can have nested `uuid` fields
+rewritten to `text`, unsupported `numeric` fields rewritten to `double
+precision`, and temporal/`NaN` values clamped at write time, all at once.
 
 
 ## Loading data into an Iceberg table

--- a/pg_lake_engine/include/pg_lake/util/rel_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/rel_utils.h
@@ -47,14 +47,14 @@ extern PGDLLEXPORT void ErrorIfTypeUnsupportedNumericForIcebergTables(int32 typm
 extern PGDLLEXPORT void MaybeConvertUnsupportedNumericColumnsToDouble(List *columnDefList);
 extern PGDLLEXPORT PGType MaybeConvertType(PGType type, char *columnName);
 
-/* leaf rule for ConvertTypeTree; see rel_utils.c */
+/* leaf rule for GenerateIcebergStorageType; see rel_utils.c */
 typedef bool (*TypeLeafConverter) (Oid typeOid, int32 typeMod, int level,
 								   void *context,
 								   Oid *outOid, int32 *outMod);
 
-extern PGDLLEXPORT bool ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
-										TypeLeafConverter leafConv, void *context,
-										Oid *outTypeOid, int32 *outTypeMod);
+extern PGDLLEXPORT bool GenerateIcebergStorageType(Oid typeOid, int32 typeMod, int level,
+												   TypeLeafConverter leafConv, void *context,
+												   Oid *outTypeOid, int32 *outTypeMod);
 extern PGDLLEXPORT void SetColumnDefTypeNameFromOid(ColumnDef *columnDef,
 													Oid typeOid, int32 typmod);
 extern PGDLLEXPORT PgLakeTableProperties GetPgLakeTableProperties(Oid relationId);

--- a/pg_lake_engine/include/pg_lake/util/rel_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/rel_utils.h
@@ -55,6 +55,8 @@ typedef bool (*TypeLeafConverter) (Oid typeOid, int32 typeMod, int level,
 extern PGDLLEXPORT bool ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
 										TypeLeafConverter leafConv, void *context,
 										Oid *outTypeOid, int32 *outTypeMod);
+extern PGDLLEXPORT void SetColumnDefTypeNameFromOid(ColumnDef *columnDef,
+													Oid typeOid, int32 typmod);
 extern PGDLLEXPORT PgLakeTableProperties GetPgLakeTableProperties(Oid relationId);
 
 /* range var help */

--- a/pg_lake_engine/src/utils/rel_utils.c
+++ b/pg_lake_engine/src/utils/rel_utils.c
@@ -440,7 +440,7 @@ FindOrCreateCompositeTypeFromColumnDefs(List *coldeflist)
 
 
 /*
- * ConvertTypeTree recursively rewrites a (typeOid, typeMod) by applying a
+ * GenerateIcebergStorageType recursively rewrites a (typeOid, typeMod) by applying a
  * caller-supplied leaf rule to every scalar leaf, while handling the container
  * structure (array / map / domain / composite) itself.  Returns true and fills
  * *outTypeOid / *outTypeMod when anything was rewritten; false (outputs
@@ -459,7 +459,7 @@ FindOrCreateCompositeTypeFromColumnDefs(List *coldeflist)
  * one structural traversal and cannot drift out of coverage.  The container
  * rules are:
  *
- *   array of X                  -> array of ConvertTypeTree(X) at level + 1
+ *   array of X                  -> array of GenerateIcebergStorageType(X) at level + 1
  *   map (domain over array)     -> new map via GetOrCreatePGMapType, key/value
  *                                  converted at level + 1
  *   domain (non-map)            -> unwrap and recurse into base at same level
@@ -472,9 +472,9 @@ FindOrCreateCompositeTypeFromColumnDefs(List *coldeflist)
  * whenever a nested field changes.
  */
 bool
-ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
-				TypeLeafConverter leafConv, void *context,
-				Oid *outTypeOid, int32 *outTypeMod)
+GenerateIcebergStorageType(Oid typeOid, int32 typeMod, int level,
+						   TypeLeafConverter leafConv, void *context,
+						   Oid *outTypeOid, int32 *outTypeMod)
 {
 	/* leaf rule first; the callback returns false for container types */
 	if (leafConv(typeOid, typeMod, level, context, outTypeOid, outTypeMod))
@@ -488,8 +488,8 @@ ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
 		Oid			rewrittenElementOid;
 		int32		rewrittenElementMod;
 
-		if (ConvertTypeTree(elemType, typeMod, level + 1, leafConv, context,
-							&rewrittenElementOid, &rewrittenElementMod))
+		if (GenerateIcebergStorageType(elemType, typeMod, level + 1, leafConv, context,
+									   &rewrittenElementOid, &rewrittenElementMod))
 		{
 			*outTypeOid = get_array_type(rewrittenElementOid);
 			*outTypeMod = -1;
@@ -509,14 +509,14 @@ ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
 		Oid			rewrittenValueOid;
 		int32		rewrittenValueMod;
 
-		bool		keyRewritten = ConvertTypeTree(origKeyType.postgresTypeOid,
-												   origKeyType.postgresTypeMod,
-												   level + 1, leafConv, context,
-												   &rewrittenKeyOid, &rewrittenKeyMod);
-		bool		valueRewritten = ConvertTypeTree(origValueType.postgresTypeOid,
-													 origValueType.postgresTypeMod,
-													 level + 1, leafConv, context,
-													 &rewrittenValueOid, &rewrittenValueMod);
+		bool		keyRewritten = GenerateIcebergStorageType(origKeyType.postgresTypeOid,
+															  origKeyType.postgresTypeMod,
+															  level + 1, leafConv, context,
+															  &rewrittenKeyOid, &rewrittenKeyMod);
+		bool		valueRewritten = GenerateIcebergStorageType(origValueType.postgresTypeOid,
+																origValueType.postgresTypeMod,
+																level + 1, leafConv, context,
+																&rewrittenValueOid, &rewrittenValueMod);
 
 		if (!keyRewritten && !valueRewritten)
 			return false;
@@ -541,8 +541,8 @@ ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
 		int32		baseMod = typeMod;
 		Oid			baseType = getBaseTypeAndTypmod(typeOid, &baseMod);
 
-		return ConvertTypeTree(baseType, baseMod, level, leafConv, context,
-							   outTypeOid, outTypeMod);
+		return GenerateIcebergStorageType(baseType, baseMod, level, leafConv, context,
+										  outTypeOid, outTypeMod);
 	}
 
 	/* composite: rebuild with rewritten fields if any field changes */
@@ -565,8 +565,8 @@ ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
 			Oid			rewrittenFieldOid;
 			int32		rewrittenFieldMod;
 
-			if (ConvertTypeTree(fieldType, fieldMod, level + 1, leafConv, context,
-								&rewrittenFieldOid, &rewrittenFieldMod))
+			if (GenerateIcebergStorageType(fieldType, fieldMod, level + 1, leafConv, context,
+										   &rewrittenFieldOid, &rewrittenFieldMod))
 			{
 				fieldType = rewrittenFieldOid;
 				fieldMod = rewrittenFieldMod;
@@ -621,7 +621,7 @@ SetColumnDefTypeNameFromOid(ColumnDef *columnDef, Oid typeOid, int32 typmod)
 
 
 /*
- * NumericLeafToDouble is the ConvertTypeTree leaf rule for the unsupported
+ * NumericLeafToDouble is the GenerateIcebergStorageType leaf rule for the unsupported
  * numeric -> float8 pass.  Numeric is never a container, so it applies at any
  * nesting level; level and context are unused.
  */
@@ -643,7 +643,7 @@ NumericLeafToDouble(Oid typeOid, int32 typeMod, int level, void *context,
 /*
  * MaybeConvertType recursively converts a type that contains unsupported
  * numerics.  Returns a PGType with the replacement OID, or with InvalidOid
- * when no conversion is needed.  Thin wrapper over ConvertTypeTree with the
+ * when no conversion is needed.  Thin wrapper over GenerateIcebergStorageType with the
  * numeric leaf rule; columnName is retained for call-site readability.
  */
 PGType
@@ -652,8 +652,8 @@ MaybeConvertType(PGType type, char *columnName)
 	Oid			convOid;
 	int32		convMod;
 
-	if (ConvertTypeTree(type.postgresTypeOid, type.postgresTypeMod, 0,
-						NumericLeafToDouble, NULL, &convOid, &convMod))
+	if (GenerateIcebergStorageType(type.postgresTypeOid, type.postgresTypeMod, 0,
+								   NumericLeafToDouble, NULL, &convOid, &convMod))
 		return MakePGType(convOid, convMod);
 
 	return MakePGTypeOid(InvalidOid);

--- a/pg_lake_engine/src/utils/rel_utils.c
+++ b/pg_lake_engine/src/utils/rel_utils.c
@@ -31,6 +31,7 @@
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
 #include "utils/syscache.h"
@@ -595,6 +596,31 @@ ConvertTypeTree(Oid typeOid, int32 typeMod, int level,
 
 
 /*
+ * SetColumnDefTypeNameFromOid replaces columnDef->typeName with a TypeName for
+ * (typeOid, typmod), allocating the new node in the same memory context as the
+ * ColumnDef itself rather than in CurrentMemoryContext.
+ *
+ * The type-rewrite passes run from a utility hook and mutate ColumnDefs that
+ * belong to the incoming parse tree.  That parse tree can outlive
+ * CurrentMemoryContext (e.g. a cached/prepared utility statement, or DDL run
+ * via SPI), so a typeName allocated in the transient context would dangle once
+ * that context is reset, leaving the longer-lived ColumnDef pointing at freed
+ * memory.  Anchoring the allocation to the ColumnDef's own context keeps their
+ * lifetimes in sync.
+ */
+void
+SetColumnDefTypeNameFromOid(ColumnDef *columnDef, Oid typeOid, int32 typmod)
+{
+	MemoryContext nodeContext = GetMemoryChunkContext(columnDef);
+	MemoryContext oldContext = MemoryContextSwitchTo(nodeContext);
+
+	columnDef->typeName = makeTypeNameFromOid(typeOid, typmod);
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+
+/*
  * NumericLeafToDouble is the ConvertTypeTree leaf rule for the unsupported
  * numeric -> float8 pass.  Numeric is never a container, so it applies at any
  * nesting level; level and context are unused.
@@ -693,6 +719,7 @@ MaybeConvertUnsupportedNumericColumnsToDouble(List *columnDefList)
 						 "exact decimal semantics.",
 						 DUCKDB_MAX_NUMERIC_PRECISION)));
 
-		columnDef->typeName = makeTypeNameFromOid(converted.postgresTypeOid, converted.postgresTypeMod);
+		SetColumnDefTypeNameFromOid(columnDef, converted.postgresTypeOid,
+									converted.postgresTypeMod);
 	}
 }

--- a/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "postgres.h"
+
+#include "nodes/pg_list.h"
+
+/*
+ * Name of the per-table iceberg option that selects a compatibility mode.
+ * Defined here so option validation (pg_lake_table) and the conversion logic
+ * share a single source of truth.
+ */
+#define ICEBERG_COMPATIBILITY_MODE_OPTION "compatibility_mode"
+
+/*
+ * IcebergCompatibilityMode selects how column types are rewritten so the
+ * resulting Iceberg table is consumable by a particular downstream engine.
+ *
+ *   ICEBERG_COMPAT_AUTO       default (option unset or 'auto'): let pg_lake
+ *                             decide what the table's downstream needs.  Today
+ *                             that resolves to no rewrites, but this is the
+ *                             hook where future auto-detection (e.g. of a
+ *                             Snowflake-managed catalog) would live.
+ *   ICEBERG_COMPAT_SNOWFLAKE  rewrite types Snowflake cannot represent inside
+ *                             structured types (nested uuid -> text)
+ */
+typedef enum IcebergCompatibilityMode
+{
+	ICEBERG_COMPAT_AUTO = 0,
+	ICEBERG_COMPAT_SNOWFLAKE,
+}			IcebergCompatibilityMode;
+
+extern PGDLLEXPORT IcebergCompatibilityMode ParseIcebergCompatibilityMode(const char *optionValue);
+extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromCreateOptions(List *options);
+extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromRelation(Oid relationId);
+extern PGDLLEXPORT void ApplyIcebergTableCompatibilityModeForSchema(List *columnDefList,
+																	IcebergCompatibilityMode mode);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
@@ -49,5 +49,5 @@ typedef enum IcebergCompatibilityMode
 extern PGDLLEXPORT IcebergCompatibilityMode ParseIcebergCompatibilityMode(const char *optionValue);
 extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromCreateOptions(List *options);
 extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromRelation(Oid relationId);
-extern PGDLLEXPORT void ApplyIcebergTableCompatibilityModeForSchema(List *columnDefList,
-																	IcebergCompatibilityMode mode);
+extern PGDLLEXPORT void ApplyIcebergTableTypeConversions(List *columnDefList,
+														 IcebergCompatibilityMode mode);

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -277,7 +277,7 @@ ApplyIcebergTableCompatibilityModeForSchema(List *columnDefList,
 							&convertedOid, &convertedMod))
 		{
 			ErrorIfColumnRewriteUnsafe(columnDef);
-			columnDef->typeName = makeTypeNameFromOid(convertedOid, convertedMod);
+			SetColumnDefTypeNameFromOid(columnDef, convertedOid, convertedMod);
 		}
 	}
 }

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -35,6 +35,16 @@
  * supplies the per-mode leaf rule.  Out-of-range value handling, timetz
  * normalization, and numeric->double live elsewhere and compose on top of
  * this pass (each leaves the fields it does not touch alone).
+ *
+ * Rewriting a column means swapping only its typeName, which is sound only if
+ * nothing else on the column is bound to the original type.  Any column we
+ * actually rewrite is therefore screened by ErrorIfColumnRewriteUnsafe, which
+ * refuses columns carrying a DEFAULT / GENERATED / IDENTITY expression (there
+ * is no implicit uuid->text cast for core to re-coerce them through).  This is
+ * reachable only from user-authored DDL: callers that build Iceberg tables
+ * programmatically construct each column from type/typmod/collation alone and
+ * never attach these clauses, so the check there is a defensive invariant, not
+ * an error path users of those callers can hit.
  */
 
 #include "postgres.h"
@@ -137,6 +147,71 @@ NestedUuidToText(Oid typeOid, int32 typeMod, int level, void *context,
 
 
 /*
+ * ErrorIfColumnRewriteUnsafe refuses to rewrite a column whose declared type
+ * carries a clause whose meaning is bound to that type.
+ *
+ * Changing a column's type underneath a DEFAULT or GENERATED expression is only
+ * safe if the expression's result can be coerced to the new type the way the
+ * core CREATE/ALTER path expects.  numeric->double gets away with it because
+ * numeric->float8 is an implicit cast; but there is NO implicit or assignment
+ * cast from uuid to text, so a uuid-typed DEFAULT/GENERATED on a column we
+ * rewrite to text would either change the stored semantics or (more often) fail
+ * later with a confusing "default expression is of type uuid[]" error from
+ * core.  We fail fast with an actionable message instead.
+ *
+ * Identity is impossible here (it requires an integer type, never a column that
+ * contains a uuid) but is covered defensively so future leaf rules stay safe.
+ *
+ * Only user-authored DDL can reach this: callers that generate Iceberg tables
+ * programmatically build columns from type/typmod/collation alone and never
+ * attach a DEFAULT / GENERATED / IDENTITY, so for them this is unreachable.
+ *
+ * At this pre-transform stage these clauses live as Constraint nodes in
+ * columnDef->constraints; transformColumnDefinition() only fills the cooked
+ * raw_default/generated/identity fields later, but we check those too in case
+ * the pass is ever fed an already-transformed ColumnDef.
+ */
+static void
+ErrorIfColumnRewriteUnsafe(ColumnDef *columnDef)
+{
+	const char *clause = NULL;
+	ListCell   *lc;
+
+	if (columnDef->raw_default != NULL || columnDef->cooked_default != NULL)
+		clause = "a DEFAULT";
+	else if (columnDef->generated != '\0')
+		clause = "a GENERATED";
+	else if (columnDef->identity != '\0')
+		clause = "an IDENTITY";
+
+	foreach(lc, columnDef->constraints)
+	{
+		Constraint *con = lfirst_node(Constraint, lc);
+
+		if (con->contype == CONSTR_DEFAULT)
+			clause = "a DEFAULT";
+		else if (con->contype == CONSTR_GENERATED)
+			clause = "a GENERATED";
+		else if (con->contype == CONSTR_IDENTITY)
+			clause = "an IDENTITY";
+	}
+
+	if (clause == NULL)
+		return;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("compatibility_mode cannot rewrite column \"%s\"",
+					columnDef->colname),
+			 errdetail("The column has %s expression bound to its original type, "
+					   "which would no longer match once a nested uuid is "
+					   "rewritten to text.", clause),
+			 errhint("Drop the expression, or keep the uuid at the top level "
+					 "of the column (top-level uuid columns are left unchanged).")));
+}
+
+
+/*
  * ApplyIcebergTableCompatibilityModeForSchema rewrites the column TYPES of a
  * ColumnDef list in place according to the compatibility mode.  Top-level
  * columns are processed at level 0; nested types are rewritten as needed.
@@ -146,6 +221,10 @@ NestedUuidToText(Oid typeOid, int32 typeMod, int level, void *context,
  * ConvertTypeTree; this pass only supplies the per-mode leaf rule.  The two run
  * as independent passes on the same list and compose (each leaves untouched the
  * fields the other rewrote).
+ *
+ * Swapping only typeName is sound only for columns that carry nothing else
+ * bound to the original type, so any column we actually rewrite is first run
+ * through ErrorIfColumnRewriteUnsafe.
  */
 void
 ApplyIcebergTableCompatibilityModeForSchema(List *columnDefList,
@@ -196,6 +275,9 @@ ApplyIcebergTableCompatibilityModeForSchema(List *columnDefList,
 
 		if (ConvertTypeTree(typeOid, typmod, 0, leafConv, NULL,
 							&convertedOid, &convertedMod))
+		{
+			ErrorIfColumnRewriteUnsafe(columnDef);
 			columnDef->typeName = makeTypeNameFromOid(convertedOid, convertedMod);
+		}
 	}
 }

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -55,6 +55,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/parsenodes.h"
 #include "parser/parse_type.h"
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
@@ -270,6 +271,17 @@ ApplyIcebergTableTypeConversions(List *columnDefList,
 							&convertedOid, &convertedMod))
 		{
 			ErrorIfColumnRewriteUnsafe(columnDef);
+
+			ereport(NOTICE,
+					(errmsg("column \"%s\" type %s rewritten to %s for "
+							"compatibility_mode 'snowflake'",
+							columnDef->colname,
+							format_type_be(typeOid),
+							format_type_be(convertedOid)),
+					 errdetail("Snowflake cannot store a uuid inside an array, map, "
+							   "or composite; a top-level uuid column is left "
+							   "unchanged.")));
+
 			SetColumnDefTypeNameFromOid(columnDef, convertedOid, convertedMod);
 		}
 	}

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * compatibility_mode.c
+ *  Per-table Iceberg "compatibility mode" type rewrites.
+ *
+ * Iceberg itself supports the full PostgreSQL type surface we map, but some
+ * downstream engines that read our Iceberg tables have narrower limitations.
+ * When a table is created (or altered) with the `compatibility_mode` option,
+ * pg_lake rewrites the affected column TYPES so the Iceberg schema stays
+ * consumable by that engine.
+ *
+ * Currently the only mode is 'snowflake'.  Snowflake cannot store a UUID
+ * inside a semi-structured or structured type, so a uuid that appears nested
+ * inside an array, map, or composite is rewritten to text.  A top-level uuid
+ * column is left untouched (Snowflake's native UUID handles that fine).
+ *
+ * The structural recursion (array / map / domain / composite) lives in
+ * ConvertTypeTree, shared with the numeric->double pass; this module only
+ * supplies the per-mode leaf rule.  Out-of-range value handling, timetz
+ * normalization, and numeric->double live elsewhere and compose on top of
+ * this pass (each leaves the fields it does not touch alone).
+ */
+
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "catalog/pg_type.h"
+#include "foreign/foreign.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "parser/parse_type.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "utils/typcache.h"
+
+#include "pg_lake/iceberg/compatibility_mode.h"
+#include "pg_lake/parsetree/options.h"
+#include "pg_lake/util/rel_utils.h"
+#include "pg_lake/util/table_type.h"
+
+
+/*
+ * ParseIcebergCompatibilityMode maps an option string to the enum.  NULL (the
+ * option being absent) and 'auto' both mean ICEBERG_COMPAT_AUTO, the default.
+ * An unrecognized value is a hard error so the accepted set lives in exactly
+ * one place; option validation in pg_lake_table calls straight into this.
+ */
+IcebergCompatibilityMode
+ParseIcebergCompatibilityMode(const char *optionValue)
+{
+	if (optionValue == NULL)
+		return ICEBERG_COMPAT_AUTO;
+
+	if (strcmp(optionValue, "auto") == 0)
+		return ICEBERG_COMPAT_AUTO;
+
+	if (strcmp(optionValue, "snowflake") == 0)
+		return ICEBERG_COMPAT_SNOWFLAKE;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("invalid %s option: \"%s\"",
+					ICEBERG_COMPATIBILITY_MODE_OPTION, optionValue),
+			 errhint("Valid values are \"auto\" and \"snowflake\".")));
+
+	return ICEBERG_COMPAT_AUTO; /* keep the compiler happy */
+}
+
+
+/*
+ * IcebergCompatibilityModeFromCreateOptions reads the option out of a CREATE
+ * statement's WITH (...) DefElem list.
+ */
+IcebergCompatibilityMode
+IcebergCompatibilityModeFromCreateOptions(List *options)
+{
+	return ParseIcebergCompatibilityMode(
+										 GetStringOption(options, ICEBERG_COMPATIBILITY_MODE_OPTION, false));
+}
+
+
+/*
+ * IcebergCompatibilityModeFromRelation reads the option from an existing
+ * relation's stored foreign-table options.  Returns AUTO for non-iceberg
+ * relations (e.g. during ALTER on an unrelated table).
+ */
+IcebergCompatibilityMode
+IcebergCompatibilityModeFromRelation(Oid relationId)
+{
+	if (!IsIcebergTable(relationId))
+		return ICEBERG_COMPAT_AUTO;
+
+	ForeignTable *foreignTable = GetForeignTable(relationId);
+
+	return ParseIcebergCompatibilityMode(
+										 GetStringOption(foreignTable->options, ICEBERG_COMPATIBILITY_MODE_OPTION, false));
+}
+
+
+/*
+ * NestedUuidToText is the snowflake compatibility leaf rule for ConvertTypeTree.
+ * A uuid is rewritten to text only when nested (level > 0): Snowflake forbids a
+ * UUID inside a semi-structured or structured type, but a top-level uuid column
+ * maps to Snowflake's native UUID and is left untouched.  All container
+ * traversal (arrays, maps, domains, composites, dropped-attribute handling) is
+ * done by ConvertTypeTree, so this rule only classifies scalar leaves.
+ */
+static bool
+NestedUuidToText(Oid typeOid, int32 typeMod, int level, void *context,
+				 Oid *outOid, int32 *outMod)
+{
+	if (typeOid == UUIDOID && level > 0)
+	{
+		*outOid = TEXTOID;
+		*outMod = -1;
+		return true;
+	}
+
+	return false;
+}
+
+
+/*
+ * ApplyIcebergTableCompatibilityModeForSchema rewrites the column TYPES of a
+ * ColumnDef list in place according to the compatibility mode.  Top-level
+ * columns are processed at level 0; nested types are rewritten as needed.
+ * AUTO currently resolves to no rewrites, so only 'snowflake' does any work.
+ *
+ * The structural recursion is shared with the numeric->double pass via
+ * ConvertTypeTree; this pass only supplies the per-mode leaf rule.  The two run
+ * as independent passes on the same list and compose (each leaves untouched the
+ * fields the other rewrote).
+ */
+void
+ApplyIcebergTableCompatibilityModeForSchema(List *columnDefList,
+											IcebergCompatibilityMode mode)
+{
+	ListCell   *cell;
+	TypeLeafConverter leafConv;
+
+	switch (mode)
+	{
+		case ICEBERG_COMPAT_SNOWFLAKE:
+			leafConv = NestedUuidToText;
+			break;
+
+		case ICEBERG_COMPAT_AUTO:
+		default:
+			/* AUTO currently resolves to no rewrites */
+			return;
+	}
+
+	foreach(cell, columnDefList)
+	{
+		if (!IsA(lfirst(cell), ColumnDef))
+			continue;
+
+		ColumnDef  *columnDef = (ColumnDef *) lfirst(cell);
+
+		if (columnDef->typeName == NULL)
+			continue;
+
+		int32		typmod = 0;
+
+		/*
+		 * missing_ok lookup: pseudo-types like serial are not resolvable
+		 * before transformColumnDefinition() runs, and they are never uuid.
+		 */
+		Type		tup = LookupTypeName(NULL, columnDef->typeName, &typmod, true);
+
+		if (!HeapTupleIsValid(tup))
+			continue;
+
+		Oid			typeOid = ((Form_pg_type) GETSTRUCT(tup))->oid;
+
+		ReleaseSysCache(tup);
+
+		Oid			convertedOid;
+		int32		convertedMod;
+
+		if (ConvertTypeTree(typeOid, typmod, 0, leafConv, NULL,
+							&convertedOid, &convertedMod))
+			columnDef->typeName = makeTypeNameFromOid(convertedOid, convertedMod);
+	}
+}

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -212,7 +212,7 @@ ErrorIfColumnRewriteUnsafe(ColumnDef *columnDef)
 
 
 /*
- * ApplyIcebergTableCompatibilityModeForSchema rewrites the column TYPES of a
+ * ApplyIcebergTableTypeConversions rewrites the column TYPES of a
  * ColumnDef list in place according to the compatibility mode.  Top-level
  * columns are processed at level 0; nested types are rewritten as needed.
  * AUTO currently resolves to no rewrites, so only 'snowflake' does any work.
@@ -227,23 +227,16 @@ ErrorIfColumnRewriteUnsafe(ColumnDef *columnDef)
  * through ErrorIfColumnRewriteUnsafe.
  */
 void
-ApplyIcebergTableCompatibilityModeForSchema(List *columnDefList,
-											IcebergCompatibilityMode mode)
+ApplyIcebergTableTypeConversions(List *columnDefList,
+								 IcebergCompatibilityMode mode)
 {
 	ListCell   *cell;
-	TypeLeafConverter leafConv;
 
-	switch (mode)
-	{
-		case ICEBERG_COMPAT_SNOWFLAKE:
-			leafConv = NestedUuidToText;
-			break;
+	/* AUTO currently resolves to no rewrites; only snowflake does any work */
+	if (mode != ICEBERG_COMPAT_SNOWFLAKE)
+		return;
 
-		case ICEBERG_COMPAT_AUTO:
-		default:
-			/* AUTO currently resolves to no rewrites */
-			return;
-	}
+	TypeLeafConverter leafConv = NestedUuidToText;
 
 	foreach(cell, columnDefList)
 	{

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -31,7 +31,7 @@
  * column is left untouched (Snowflake's native UUID handles that fine).
  *
  * The structural recursion (array / map / domain / composite) lives in
- * ConvertTypeTree, shared with the numeric->double pass; this module only
+ * GenerateIcebergStorageType, shared with the numeric->double pass; this module only
  * supplies the per-mode leaf rule.  Out-of-range value handling, timetz
  * normalization, and numeric->double live elsewhere and compose on top of
  * this pass (each leaves the fields it does not touch alone).
@@ -125,12 +125,12 @@ IcebergCompatibilityModeFromRelation(Oid relationId)
 
 
 /*
- * NestedUuidToText is the snowflake compatibility leaf rule for ConvertTypeTree.
+ * NestedUuidToText is the snowflake compatibility leaf rule for GenerateIcebergStorageType.
  * A uuid is rewritten to text only when nested (level > 0): Snowflake forbids a
  * UUID inside a semi-structured or structured type, but a top-level uuid column
  * maps to Snowflake's native UUID and is left untouched.  All container
  * traversal (arrays, maps, domains, composites, dropped-attribute handling) is
- * done by ConvertTypeTree, so this rule only classifies scalar leaves.
+ * done by GenerateIcebergStorageType, so this rule only classifies scalar leaves.
  */
 static bool
 NestedUuidToText(Oid typeOid, int32 typeMod, int level, void *context,
@@ -219,7 +219,7 @@ ErrorIfColumnRewriteUnsafe(ColumnDef *columnDef)
  * AUTO currently resolves to no rewrites, so only 'snowflake' does any work.
  *
  * The structural recursion is shared with the numeric->double pass via
- * ConvertTypeTree; this pass only supplies the per-mode leaf rule.  The two run
+ * GenerateIcebergStorageType; this pass only supplies the per-mode leaf rule.  The two run
  * as independent passes on the same list and compose (each leaves untouched the
  * fields the other rewrote).
  *
@@ -267,8 +267,8 @@ ApplyIcebergTableTypeConversions(List *columnDefList,
 		Oid			convertedOid;
 		int32		convertedMod;
 
-		if (ConvertTypeTree(typeOid, typmod, 0, leafConv, NULL,
-							&convertedOid, &convertedMod))
+		if (GenerateIcebergStorageType(typeOid, typmod, 0, leafConv, NULL,
+									   &convertedOid, &convertedMod))
 		{
 			ErrorIfColumnRewriteUnsafe(columnDef);
 

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -52,6 +52,7 @@
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/iceberg/metadata_operations.h"
 #include "pg_lake/fdw/partition_transform.h"
 #include "pg_lake/parsetree/options.h"
@@ -219,6 +220,7 @@ static bool HasOnlyCatalogAlterTableOptions(AlterTableStmt *alterStmt);
 static void ErrorIfUnsupportedTableOptionChange(AlterTableStmt *alterStmt, List *allowedOptions);
 static void ErrorIfAnyRestCatalogTablesInSchema(const char *schemaName);
 static void MaybeConvertUnsupportedNumericColumnsToDoubleInAlterStmt(AlterTableStmt *alterStmt);
+static void ApplyIcebergCompatibilityModeInAlterStmt(AlterTableStmt *alterStmt, Oid relationId);
 
 /*
  * ProcessAlterTable is used in cases where we want to preempt the error
@@ -325,6 +327,7 @@ ProcessAlterTable(ProcessUtilityParams * processUtilityParams, void *arg)
 	}
 
 	MaybeConvertUnsupportedNumericColumnsToDoubleInAlterStmt(alterStmt);
+	ApplyIcebergCompatibilityModeInAlterStmt(alterStmt, relationId);
 	ErrorIfUnsupportedTypeAddedForIcebergTables(alterStmt);
 
 	/* check whether we are accepting writes for this table */
@@ -481,6 +484,37 @@ MaybeConvertUnsupportedNumericColumnsToDoubleInAlterStmt(AlterTableStmt *alterSt
 	}
 
 	MaybeConvertUnsupportedNumericColumnsToDouble(addColumnDefs);
+}
+
+
+/*
+ * ApplyIcebergCompatibilityModeInAlterStmt rewrites the types of any columns
+ * added by an ALTER TABLE ... ADD COLUMN according to the table's
+ * compatibility_mode option (e.g. nested uuid -> text for 'snowflake').
+ *
+ * Unlike the numeric->double conversion, which is gated by a global GUC, the
+ * compatibility mode is a per-table option read from the existing relation.
+ * Runs as a separate pass from the numeric one; the two compose.
+ */
+static void
+ApplyIcebergCompatibilityModeInAlterStmt(AlterTableStmt *alterStmt, Oid relationId)
+{
+	IcebergCompatibilityMode mode = IcebergCompatibilityModeFromRelation(relationId);
+	List	   *addColumnDefs = NIL;
+	ListCell   *cell;
+
+	if (mode != ICEBERG_COMPAT_SNOWFLAKE)
+		return;
+
+	foreach(cell, alterStmt->cmds)
+	{
+		AlterTableCmd *cmd = (AlterTableCmd *) lfirst(cell);
+
+		if (cmd->subtype == AT_AddColumn)
+			addColumnDefs = lappend(addColumnDefs, cmd->def);
+	}
+
+	ApplyIcebergTableCompatibilityModeForSchema(addColumnDefs, mode);
 }
 
 

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -514,7 +514,7 @@ ApplyIcebergCompatibilityModeInAlterStmt(AlterTableStmt *alterStmt, Oid relation
 			addColumnDefs = lappend(addColumnDefs, cmd->def);
 	}
 
-	ApplyIcebergTableCompatibilityModeForSchema(addColumnDefs, mode);
+	ApplyIcebergTableTypeConversions(addColumnDefs, mode);
 }
 
 

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -935,8 +935,8 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		else
 		{
 			MaybeConvertUnsupportedNumericColumnsToDouble(createStmt->base.tableElts);
-			ApplyIcebergTableCompatibilityModeForSchema(createStmt->base.tableElts,
-														IcebergCompatibilityModeFromCreateOptions(createStmt->options));
+			ApplyIcebergTableTypeConversions(createStmt->base.tableElts,
+											 IcebergCompatibilityModeFromCreateOptions(createStmt->options));
 			EnsureSupportedIcebergTableColumnDefinitions(createStmt->base.tableElts);
 
 			PgLakeCommonParentProcessUtility(params);
@@ -951,8 +951,8 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 	}
 
 	MaybeConvertUnsupportedNumericColumnsToDouble(createStmt->base.tableElts);
-	ApplyIcebergTableCompatibilityModeForSchema(createStmt->base.tableElts,
-												IcebergCompatibilityModeFromCreateOptions(createStmt->options));
+	ApplyIcebergTableTypeConversions(createStmt->base.tableElts,
+									 IcebergCompatibilityModeFromCreateOptions(createStmt->options));
 	EnsureSupportedIcebergTableColumnDefinitions(createStmt->base.tableElts);
 
 	Oid			namespaceId =

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -63,6 +63,7 @@
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/util/numeric.h"
 #include "pg_lake/util/rel_utils.h"
 #include "pg_lake/util/url_encode.h"
@@ -934,6 +935,8 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		else
 		{
 			MaybeConvertUnsupportedNumericColumnsToDouble(createStmt->base.tableElts);
+			ApplyIcebergTableCompatibilityModeForSchema(createStmt->base.tableElts,
+														IcebergCompatibilityModeFromCreateOptions(createStmt->options));
 			EnsureSupportedIcebergTableColumnDefinitions(createStmt->base.tableElts);
 
 			PgLakeCommonParentProcessUtility(params);
@@ -948,6 +951,8 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 	}
 
 	MaybeConvertUnsupportedNumericColumnsToDouble(createStmt->base.tableElts);
+	ApplyIcebergTableCompatibilityModeForSchema(createStmt->base.tableElts,
+												IcebergCompatibilityModeFromCreateOptions(createStmt->options));
 	EnsureSupportedIcebergTableColumnDefinitions(createStmt->base.tableElts);
 
 	Oid			namespaceId =

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -35,6 +35,7 @@
 #include "commands/extension.h"
 #include "foreign/foreign.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/partitioning/partition_by_parser.h"
 #include "pg_lake/permissions/roles.h"
 #include "pg_lake/copy/copy_format.h"
@@ -577,6 +578,11 @@ InitPgLakeIcebergOptions(void)
 		 */
 		{"out_of_range_values", ForeignTableRelationId},
 
+		/*
+		 * downstream-engine compatibility type rewrites: 'snowflake'
+		 */
+		{ICEBERG_COMPATIBILITY_MODE_OPTION, ForeignTableRelationId},
+
 		{NULL, InvalidOid}
 	};
 
@@ -879,6 +885,12 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 								outOfRangeValues),
 						 errhint("Valid values are \"error\" and \"clamp\".")));
 			}
+		}
+		else if (catalog == ForeignTableRelationId &&
+				 strcmp(def->defname, ICEBERG_COMPATIBILITY_MODE_OPTION) == 0)
+		{
+			/* errors on an unrecognized value; single source of truth */
+			(void) ParseIcebergCompatibilityMode(defGetString(def));
 		}
 	}
 

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -1,0 +1,664 @@
+"""
+Tests for the per-table iceberg option `compatibility_mode = 'snowflake'`.
+
+Snowflake cannot store a UUID inside a semi-structured or structured type, so
+when the option is set pg_lake rewrites any uuid that appears nested inside an
+array or composite to text.  A top-level uuid column is left native.
+
+This suite OWNS the exhaustive conversion matrix (snowflake_cdc only does a
+representative end-to-end check):
+  - option validation
+  - top-level uuid stays uuid; nested uuid -> text at every depth
+  - multiple converting columns in one table
+  - dropped-column lifecycle with data written on both sides of the drop
+  - CREATE and ALTER ADD COLUMN
+  - composition with numeric->double, timetz, and out_of_range clamping
+"""
+
+import json
+
+import pytest
+from utils_pytest import *
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _col_format_type(pg_conn, table, column):
+    """format_type() of a top-level column."""
+    return run_query(
+        "SELECT format_type(atttypid, atttypmod) FROM pg_attribute "
+        f"WHERE attrelid = '{table}'::regclass AND attname = '{column}'",
+        pg_conn,
+    )[0][0]
+
+
+def _composite_attrs_of_column(pg_conn, table, column):
+    """(attname, format_type) of the composite type backing a column."""
+    col_type_oid = run_query(
+        "SELECT atttypid FROM pg_attribute "
+        f"WHERE attrelid = '{table}'::regclass AND attname = '{column}'",
+        pg_conn,
+    )[0][0]
+    return run_query(
+        f"""
+        SELECT a.attname, format_type(a.atttypid, a.atttypmod)
+        FROM pg_attribute a
+        JOIN pg_type t ON t.typrelid = a.attrelid
+        WHERE t.oid = {col_type_oid} AND a.attnum > 0 AND NOT a.attisdropped
+        ORDER BY a.attnum
+        """,
+        pg_conn,
+    )
+
+
+def _iceberg_fields(s3, pg_conn, table):
+    """Parse the iceberg metadata and return the top-level schema fields."""
+    metadata_path = run_query(
+        "SELECT metadata_location FROM iceberg_tables " f"WHERE table_name = '{table}'",
+        pg_conn,
+    )[0][0]
+    data = read_s3_operations(s3, metadata_path)
+    return json.loads(data)["schemas"][0]["fields"]
+
+
+def _uuid_depths(itype, depth):
+    """
+    Collect the nesting depths at which a uuid logical type appears in an
+    iceberg field "type" (depth 0 == top-level column type).
+    """
+    if isinstance(itype, str):
+        return [depth] if itype == "uuid" else []
+
+    kind = itype["type"]
+    if kind == "list":
+        return _uuid_depths(itype["element"], depth + 1)
+    if kind == "map":
+        return _uuid_depths(itype["key"], depth + 1) + _uuid_depths(
+            itype["value"], depth + 1
+        )
+    if kind == "struct":
+        out = []
+        for f in itype["fields"]:
+            out += _uuid_depths(f["type"], depth + 1)
+        return out
+    return []
+
+
+def _assert_no_nested_uuid(s3, pg_conn, table):
+    """The decisive invariant: no uuid logical type at depth > 0 anywhere."""
+    fields = _iceberg_fields(s3, pg_conn, table)
+    for f in fields:
+        depths = _uuid_depths(f["type"], 0)
+        assert all(
+            d == 0 for d in depths
+        ), f"field {f['name']} has a nested uuid (depths {depths}) in {table}"
+
+
+# ---------------------------------------------------------------------------
+# option validation
+# ---------------------------------------------------------------------------
+
+
+def test_option_accepted_on_iceberg(s3, pg_conn, extension, with_default_location):
+    run_command(
+        "CREATE TABLE compat_ok (id int) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.rollback()
+
+
+def test_option_auto_is_default_noop(s3, pg_conn, extension, with_default_location):
+    """'auto' is accepted and, like the unset default, applies no rewrites."""
+    run_command(
+        "CREATE TABLE compat_auto (id int, us uuid[]) USING iceberg "
+        "WITH (compatibility_mode = 'auto');",
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_auto", "us") == "uuid[]"
+    pg_conn.rollback()
+
+
+def test_option_invalid_value_rejected(s3, pg_conn, extension, with_default_location):
+    error = run_command(
+        "CREATE TABLE compat_bad (id int) USING iceberg "
+        "WITH (compatibility_mode = 'redshift');",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "invalid compatibility_mode option" in error
+    pg_conn.rollback()
+
+
+def test_option_rejected_on_non_iceberg(s3, pg_conn, extension):
+    """compatibility_mode is an iceberg-only option."""
+    location = f"s3://{TEST_BUCKET}/compat_nope.csv"
+    error = run_command(
+        f"CREATE FOREIGN TABLE compat_csv (id int) SERVER pg_lake "
+        f"OPTIONS (format 'csv', path '{location}', compatibility_mode 'snowflake');",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "compatibility_mode" in error
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# top-level vs nested uuid
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_uuid_stays_uuid(s3, pg_conn, extension, with_default_location):
+    run_command(
+        "CREATE TABLE compat_top (id int, u uuid) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_top", "u") == "uuid"
+    pg_conn.rollback()
+
+
+def test_uuid_array_converted_to_text(s3, pg_conn, extension, with_default_location):
+    run_command(
+        "CREATE TABLE compat_arr (id int, us uuid[]) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_arr", "us") == "text[]"
+    pg_conn.rollback()
+
+
+def test_composite_uuid_field_converted(s3, pg_conn, extension, with_default_location):
+    run_command(
+        """
+        CREATE TYPE compat_c1 AS (cid uuid, note text);
+        CREATE TABLE compat_comp (id int, c compat_c1) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    # the composite is rebuilt (its oid differs from the user's type)
+    assert _col_format_type(pg_conn, "compat_comp", "c") != "compat_c1"
+    assert _composite_attrs_of_column(pg_conn, "compat_comp", "c") == [
+        ["cid", "text"],
+        ["note", "text"],
+    ]
+    pg_conn.rollback()
+
+
+def test_composite_uuid_array_field_converted(
+    s3, pg_conn, extension, with_default_location
+):
+    run_command(
+        """
+        CREATE TYPE compat_c2 AS (cids uuid[], note text);
+        CREATE TABLE compat_comp2 (id int, c compat_c2) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    assert _composite_attrs_of_column(pg_conn, "compat_comp2", "c") == [
+        ["cids", "text[]"],
+        ["note", "text"],
+    ]
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# maps (a map is a domain over an array of key/value structs, so a nested uuid
+# must stay a MAP with the uuid leaf rewritten, not collapse to array<struct>)
+# ---------------------------------------------------------------------------
+
+
+def _column_type_changed(pg_conn, table, column, original_type):
+    """True if the column's type oid differs from original_type (a rebuild)."""
+    return run_query(
+        f"SELECT atttypid <> '{original_type}'::regtype FROM pg_attribute "
+        f"WHERE attrelid = '{table}'::regclass AND attname = '{column}'",
+        pg_conn,
+    )[0][0]
+
+
+def test_map_uuid_value_converted(s3, pg_conn, extension, with_default_location):
+    """A nested uuid map value becomes text while the column stays a MAP."""
+    map_type = create_map_type("text", "uuid")
+    run_command(
+        f"CREATE TABLE compat_map_val (id int, m {map_type}) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        assert _column_type_changed(pg_conn, "compat_map_val", "m", map_type)
+        converted = _col_format_type(pg_conn, "compat_map_val", "m")
+
+        fields = _iceberg_fields(s3, pg_conn, "compat_map_val")
+        m_field = next(f for f in fields if f["name"] == "m")
+        assert m_field["type"]["type"] == "map"
+        assert m_field["type"]["key"] == "string"
+        assert m_field["type"]["value"] == "string"
+        _assert_no_nested_uuid(s3, pg_conn, "compat_map_val")
+
+        # data round-trips through the rewritten text value
+        u = "a0974028-d682-4796-b142-b96580b1c103"
+        run_command(
+            f"INSERT INTO compat_map_val VALUES (1, ARRAY[('k', '{u}')]::{converted});",
+            pg_conn,
+        )
+        pg_conn.commit()
+        rows = run_query("SELECT id, m FROM compat_map_val ORDER BY id", pg_conn)
+        assert rows[0][0] == 1
+        assert rows[0][1] is not None
+    finally:
+        run_command("DROP TABLE compat_map_val", pg_conn)
+        pg_conn.commit()
+
+
+def test_map_uuid_key_converted(s3, pg_conn, extension, with_default_location):
+    """A nested uuid map key becomes text while the column stays a MAP."""
+    map_type = create_map_type("uuid", "text")
+    run_command(
+        f"CREATE TABLE compat_map_key (id int, m {map_type}) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        assert _column_type_changed(pg_conn, "compat_map_key", "m", map_type)
+        fields = _iceberg_fields(s3, pg_conn, "compat_map_key")
+        m_field = next(f for f in fields if f["name"] == "m")
+        assert m_field["type"]["type"] == "map"
+        assert m_field["type"]["key"] == "string"
+        _assert_no_nested_uuid(s3, pg_conn, "compat_map_key")
+    finally:
+        run_command("DROP TABLE compat_map_key", pg_conn)
+        pg_conn.commit()
+
+
+def test_uuid_free_map_not_rebuilt(s3, pg_conn, extension, with_default_location):
+    """Regression guard: a map with no uuid must NOT be rebuilt."""
+    map_type = create_map_type("int", "text")
+    run_command(
+        f"CREATE TABLE compat_map_clean (id int, m {map_type}) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    assert not _column_type_changed(pg_conn, "compat_map_clean", "m", map_type)
+    pg_conn.rollback()
+
+
+def test_uuid_free_composite_not_rebuilt(s3, pg_conn, extension, with_default_location):
+    """Regression guard: a composite with no uuid must NOT be rebuilt."""
+    run_command(
+        """
+        CREATE TYPE compat_clean AS (a int, b text);
+        CREATE TABLE compat_clean_tbl (id int, c compat_clean) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_clean_tbl", "c") == "compat_clean"
+    pg_conn.rollback()
+
+
+def test_deeply_nested_uuid_all_converted(
+    s3, pg_conn, extension, with_default_location
+):
+    run_command(
+        """
+        CREATE TYPE leaf AS (k uuid, ks uuid[], label text);
+        CREATE TYPE mid  AS (one leaf, many leaf[], mid_id uuid);
+        CREATE TABLE compat_deep (
+            pk       bigint,
+            top_id   uuid,
+            flat_ids uuid[],
+            m        mid,
+            ms       mid[]
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        assert _col_format_type(pg_conn, "compat_deep", "top_id") == "uuid"
+        assert _col_format_type(pg_conn, "compat_deep", "flat_ids") == "text[]"
+        # the decisive invariant on the real iceberg schema
+        _assert_no_nested_uuid(s3, pg_conn, "compat_deep")
+    finally:
+        run_command("DROP TABLE compat_deep", pg_conn)
+        pg_conn.commit()
+
+
+def test_multiple_converting_columns(s3, pg_conn, extension, with_default_location):
+    """Don't assume one: many uuid[] and many composite columns all convert."""
+    run_command(
+        """
+        CREATE TYPE m_a AS (cid uuid, note text);
+        CREATE TYPE m_b AS (cids uuid[], n int);
+        CREATE TABLE compat_multi (
+            id      int,
+            u1      uuid[],
+            u2      uuid[],
+            ca      m_a,
+            cb      m_b,
+            ca2     m_a,        -- same composite reused
+            top_id  uuid
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        assert _col_format_type(pg_conn, "compat_multi", "u1") == "text[]"
+        assert _col_format_type(pg_conn, "compat_multi", "u2") == "text[]"
+        assert _col_format_type(pg_conn, "compat_multi", "top_id") == "uuid"
+        assert _composite_attrs_of_column(pg_conn, "compat_multi", "ca") == [
+            ["cid", "text"],
+            ["note", "text"],
+        ]
+        assert _composite_attrs_of_column(pg_conn, "compat_multi", "ca2") == [
+            ["cid", "text"],
+            ["note", "text"],
+        ]
+        assert _composite_attrs_of_column(pg_conn, "compat_multi", "cb") == [
+            ["cids", "text[]"],
+            ["n", "integer"],
+        ]
+        _assert_no_nested_uuid(s3, pg_conn, "compat_multi")
+    finally:
+        run_command("DROP TABLE compat_multi", pg_conn)
+        pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# ALTER TABLE ADD COLUMN
+# ---------------------------------------------------------------------------
+
+
+def test_alter_add_nested_uuid_converted(s3, pg_conn, extension, with_default_location):
+    run_command(
+        """
+        CREATE TABLE compat_alter (id int) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        ALTER TABLE compat_alter ADD COLUMN us uuid[];
+        ALTER TABLE compat_alter ADD COLUMN top_id uuid;
+        """,
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_alter", "us") == "text[]"
+    assert _col_format_type(pg_conn, "compat_alter", "top_id") == "uuid"
+    pg_conn.rollback()
+
+
+def test_alter_add_without_option_keeps_uuid(
+    s3, pg_conn, extension, with_default_location
+):
+    """A table created without the option does not convert on ALTER."""
+    run_command(
+        """
+        CREATE TABLE compat_noopt (id int) USING iceberg;
+        ALTER TABLE compat_noopt ADD COLUMN us uuid[];
+        """,
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_noopt", "us") == "uuid[]"
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# dropped-column lifecycle (data written on both sides of the drop)
+# ---------------------------------------------------------------------------
+
+
+def test_dropped_uuid_array_column_lifecycle(
+    s3, pg_conn, extension, with_default_location
+):
+    u1 = "11111111-1111-1111-1111-111111111111"
+    u2 = "22222222-2222-2222-2222-222222222222"
+
+    run_command(
+        """
+        CREATE TABLE compat_drop (pk int, top_id uuid, keep_ids uuid[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    # batch 1
+    run_command(
+        f"INSERT INTO compat_drop VALUES (1, '{u1}', ARRAY['{u1}','{u2}']::uuid[]);",
+        pg_conn,
+    )
+    # add a nested-uuid column, write batch 2 populating it
+    run_command("ALTER TABLE compat_drop ADD COLUMN extra uuid[];", pg_conn)
+    assert _col_format_type(pg_conn, "compat_drop", "extra") == "text[]"
+    run_command(
+        f"INSERT INTO compat_drop VALUES (2, '{u2}', ARRAY['{u2}']::uuid[], ARRAY['{u1}']::uuid[]);",
+        pg_conn,
+    )
+    # drop it, write batch 3
+    run_command("ALTER TABLE compat_drop DROP COLUMN extra;", pg_conn)
+    run_command(
+        f"INSERT INTO compat_drop VALUES (3, '{u1}', ARRAY['{u1}']::uuid[]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        # final query: all three batches survive, conversions intact
+        rows = run_query(
+            "SELECT pk, top_id, keep_ids FROM compat_drop ORDER BY pk", pg_conn
+        )
+        assert [r[0] for r in rows] == [1, 2, 3]
+        assert rows[0][1] == u1
+        assert rows[0][2] == [u1, u2]
+        assert rows[1][2] == [u2]
+        assert rows[2][2] == [u1]
+        # the dropped slot must not have re-appeared / left a uuid behind
+        _assert_no_nested_uuid(s3, pg_conn, "compat_drop")
+    finally:
+        run_command("DROP TABLE compat_drop", pg_conn)
+        pg_conn.commit()
+
+
+def test_dropped_composite_attribute(s3, pg_conn, extension, with_default_location):
+    """A composite whose uuid[] attribute was dropped must skip that attr."""
+    run_command(
+        """
+        CREATE TYPE drop_attr AS (ids uuid[], note text);
+        ALTER TYPE drop_attr DROP ATTRIBUTE ids;
+        CREATE TABLE compat_drop_attr (id int, c drop_attr) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    # only the remaining (uuid-free) attribute survives; nothing rebuilt to uuid
+    assert _composite_attrs_of_column(pg_conn, "compat_drop_attr", "c") == [
+        ["note", "text"]
+    ]
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# value round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_nested_uuid_value_roundtrip(s3, pg_conn, extension, with_default_location):
+    u1 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    u2 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    run_command(
+        """
+        CREATE TYPE rt_comp AS (cid uuid, note text);
+        CREATE TABLE compat_rt (id int, top_id uuid, us uuid[], c rt_comp) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        f"""
+        INSERT INTO compat_rt VALUES
+            (1, '{u1}', ARRAY['{u1}','{u2}']::uuid[], ROW('{u2}', 'hi'));
+        """,
+        pg_conn,
+    )
+    rows = run_query("SELECT top_id, us, (c).cid, (c).note FROM compat_rt", pg_conn)
+    assert rows[0][0] == u1
+    assert rows[0][1] == [u1, u2]  # text[] preserving the canonical strings
+    assert rows[0][2] == u2
+    assert rows[0][3] == "hi"
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# iceberg metadata logical types
+# ---------------------------------------------------------------------------
+
+
+def test_iceberg_metadata_logical_types(s3, pg_conn, extension, with_default_location):
+    location = f"s3://{TEST_BUCKET}/compat_meta"
+    run_command(
+        f"""
+        CREATE TYPE meta_comp AS (cid uuid, note text);
+        CREATE FOREIGN TABLE compat_meta (
+            top_id uuid,
+            us     uuid[],
+            c      meta_comp
+        ) SERVER pg_lake_iceberg
+          OPTIONS (location '{location}', compatibility_mode 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        fields = _iceberg_fields(s3, pg_conn, "compat_meta")
+        top = next(f for f in fields if f["name"] == "top_id")
+        us = next(f for f in fields if f["name"] == "us")
+        c = next(f for f in fields if f["name"] == "c")
+
+        assert top["type"] == "uuid"  # top-level stays uuid
+        assert us["type"]["type"] == "list"
+        assert us["type"]["element"] == "string"
+        assert c["type"]["type"] == "struct"
+        cid = next(f for f in c["type"]["fields"] if f["name"] == "cid")
+        assert cid["type"] == "string"
+
+        _assert_no_nested_uuid(s3, pg_conn, "compat_meta")
+    finally:
+        run_command("DROP FOREIGN TABLE compat_meta", pg_conn)
+        pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# composition: uuid + numeric + timetz + out_of_range clamp on one table
+# ---------------------------------------------------------------------------
+
+
+def test_combined_all_conversions(s3, pg_conn, extension, with_default_location):
+    """
+    A single composite carrying every conversion class at once proves the
+    passes compose: nested uuid -> text AND unsupported numeric -> double on
+    the same rebuilt composite, with timetz/clamping still applied at write.
+    """
+    run_command(
+        """
+        CREATE TYPE kitchen AS (
+            cid       uuid,
+            cids      uuid[],
+            c_unb     numeric,
+            c_large   numeric(50,2),
+            c_bounded numeric(10,2),
+            c_ttz     timetz,
+            c_ttz_arr timetz[],
+            c_label   text
+        );
+        CREATE TABLE compat_kitchen (
+            pk          bigint,
+            top_id      uuid,
+            top_unb     numeric,
+            top_bounded numeric(10,2),
+            top_ttz     timetz,
+            k           kitchen,
+            ks          kitchen[]
+        ) USING iceberg
+          WITH (compatibility_mode = 'snowflake', out_of_range_values = 'clamp');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        # top-level: uuid stays, unbounded numeric -> double, bounded numeric and
+        # timetz are kept as-is (not rebuilt, so the typmod survives intact)
+        assert _col_format_type(pg_conn, "compat_kitchen", "top_id") == "uuid"
+        assert (
+            _col_format_type(pg_conn, "compat_kitchen", "top_unb") == "double precision"
+        )
+        assert (
+            _col_format_type(pg_conn, "compat_kitchen", "top_bounded")
+            == "numeric(10,2)"
+        )
+        assert (
+            _col_format_type(pg_conn, "compat_kitchen", "top_ttz")
+            == "time with time zone"
+        )
+
+        # the rebuilt composite carries BOTH uuid->text AND numeric->double on the
+        # same struct, with the bounded numeric / timetz fields still present.
+        # (Bounded numeric typmod is dropped by the composite-rebuild round-trip;
+        # we only assert it stays a numeric, which is orthogonal to this feature.)
+        attrs = dict(
+            (name, ftype)
+            for name, ftype in _composite_attrs_of_column(
+                pg_conn, "compat_kitchen", "k"
+            )
+        )
+        assert attrs["cid"] == "text"
+        assert attrs["cids"] == "text[]"
+        assert attrs["c_unb"] == "double precision"
+        assert attrs["c_large"] == "double precision"
+        assert attrs["c_bounded"].startswith("numeric")
+        assert attrs["c_ttz"] == "time with time zone"
+        assert attrs["c_ttz_arr"] == "time with time zone[]"
+        assert attrs["c_label"] == "text"
+
+        # no uuid survives nested anywhere in the iceberg schema
+        _assert_no_nested_uuid(s3, pg_conn, "compat_kitchen")
+
+        # values: timetz normalized to UTC; uuid canonical text in the composite;
+        # out_of_range clamp applies at write on the top-level bounded numeric.
+        uid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        run_command(
+            f"""
+            INSERT INTO compat_kitchen (pk, top_id, top_unb, top_bounded, top_ttz, k) VALUES
+              (1, '{uid}', 1.5, 'NaN'::numeric(10,2), '12:30:00+04'::timetz,
+               ROW('{uid}', ARRAY['{uid}']::uuid[], 1.5, 2.5,
+                   3.25, '01:00:00+02'::timetz,
+                   ARRAY['00:00:00+00']::timetz[], 'lbl'));
+            """,
+            pg_conn,
+        )
+        row = run_query(
+            """
+            SELECT top_id, top_bounded, top_ttz, (k).cid, (k).cids
+            FROM compat_kitchen WHERE pk = 1
+            """,
+            pg_conn,
+        )[0]
+        assert row[0] == uid
+        assert row[1] is None  # NaN clamped to NULL on the bounded decimal
+        # timetz normalized to UTC: 12:30+04 -> 08:30+00
+        assert str(row[2]) == "08:30:00+00:00"
+        assert row[3] == uid  # composite uuid is text now, value preserved
+        assert row[4] == [uid]
+    finally:
+        run_command("DROP TABLE compat_kitchen", pg_conn)
+        pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -731,6 +731,30 @@ def test_alter_add_default_on_rewritten_column_rejected(
         pg_conn.commit()
 
 
+def test_alter_add_generated_on_rewritten_column_rejected(
+    s3, pg_conn, extension, with_default_location
+):
+    run_command(
+        "CREATE TABLE compat_alter_gen (u uuid) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+    try:
+        error = run_command(
+            "ALTER TABLE compat_alter_gen "
+            "ADD COLUMN g uuid[] GENERATED ALWAYS AS (ARRAY[u]) STORED;",
+            pg_conn,
+            raise_error=False,
+        )
+        assert "cannot rewrite column" in error
+        assert "g" in error
+        pg_conn.rollback()
+    finally:
+        run_command("DROP TABLE compat_alter_gen", pg_conn)
+        pg_conn.commit()
+
+
 def test_default_on_top_level_uuid_allowed(
     s3, pg_conn, extension, with_default_location
 ):

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -97,6 +97,29 @@ def _assert_no_nested_uuid(s3, pg_conn, table):
         ), f"field {f['name']} has a nested uuid (depths {depths}) in {table}"
 
 
+def _struct_field(itype, name):
+    """Return the named subfield "type" of an iceberg struct type node."""
+    assert itype["type"] == "struct", itype
+    return next(f["type"] for f in itype["fields"] if f["name"] == name)
+
+
+def _collect_kinds(itype, kinds=None):
+    """Collect every structural "type" tag (list/map/struct) in an iceberg type."""
+    kinds = kinds if kinds is not None else []
+    if isinstance(itype, str):
+        return kinds
+    kinds.append(itype["type"])
+    if itype["type"] == "list":
+        _collect_kinds(itype["element"], kinds)
+    elif itype["type"] == "map":
+        _collect_kinds(itype["key"], kinds)
+        _collect_kinds(itype["value"], kinds)
+    elif itype["type"] == "struct":
+        for f in itype["fields"]:
+            _collect_kinds(f["type"], kinds)
+    return kinds
+
+
 # ---------------------------------------------------------------------------
 # option validation
 # ---------------------------------------------------------------------------
@@ -374,6 +397,150 @@ def test_multiple_converting_columns(s3, pg_conn, extension, with_default_locati
         _assert_no_nested_uuid(s3, pg_conn, "compat_multi")
     finally:
         run_command("DROP TABLE compat_multi", pg_conn)
+        pg_conn.commit()
+
+
+def test_wide_deep_composite_with_maps_all_converted(
+    s3, pg_conn, extension, with_default_location
+):
+    """
+    A wide + deep composite carrying many uuids across arrays, maps, nested
+    composites and arrays-of-composites: every nested uuid must be rewritten,
+    while the structure (maps stay maps, lists stay lists) is preserved and
+    uuid-free maps/fields are left intact.
+    """
+    m_val = create_map_type("text", "uuid")  # uuid in the value
+    m_key = create_map_type("uuid", "text")  # uuid in the key
+    m_clean = create_map_type("int", "text")  # no uuid -> must survive as-is
+    run_command(
+        f"""
+        CREATE TYPE wd_leaf AS (
+            l1     uuid,
+            l2     uuid,
+            lids   uuid[],
+            lmv    {m_val},
+            llabel text
+        );
+        CREATE TYPE wd_top AS (
+            t1     uuid,
+            t2     uuid,
+            t3     uuid,
+            tids1  uuid[],
+            tids2  uuid[],
+            leaf   wd_leaf,
+            leaves wd_leaf[],
+            mv     {m_val},
+            mk     {m_key},
+            mc     {m_clean},
+            keep_i int,
+            keep_t text
+        );
+        CREATE TABLE compat_widedeep (id int, w wd_top, ws wd_top[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        # decisive invariant on the real iceberg schema: no uuid nested anywhere
+        _assert_no_nested_uuid(s3, pg_conn, "compat_widedeep")
+
+        # the rebuilt top composite keeps its width, with uuids -> text and the
+        # non-uuid scalar fields untouched
+        attrs = dict(_composite_attrs_of_column(pg_conn, "compat_widedeep", "w"))
+        for f in ("t1", "t2", "t3"):
+            assert attrs[f] == "text", attrs
+        assert attrs["tids1"] == "text[]"
+        assert attrs["tids2"] == "text[]"
+        assert attrs["keep_i"] == "integer"
+        assert attrs["keep_t"] == "text"
+
+        # structure survives: the w struct still has maps for mv/mk/mc, and the
+        # converted maps have string leaves while the clean map is untouched.
+        fields = _iceberg_fields(s3, pg_conn, "compat_widedeep")
+        w = next(f["type"] for f in fields if f["name"] == "w")
+        mv = _struct_field(w, "mv")
+        mk = _struct_field(w, "mk")
+        mc = _struct_field(w, "mc")
+        assert mv["type"] == "map" and mv["value"] == "string"
+        assert mk["type"] == "map" and mk["key"] == "string"
+        assert mc["type"] == "map"  # uuid-free map preserved
+
+        # the nested leaf composite (and the array-of-composites) also converted
+        leaf = _struct_field(w, "leaf")
+        assert _struct_field(leaf, "l1") == "string"
+        assert "uuid" not in _collect_kinds(_struct_field(w, "leaves"))
+        ws = next(f["type"] for f in fields if f["name"] == "ws")
+        assert "uuid" not in str(ws)
+    finally:
+        run_command(
+            "DROP TABLE compat_widedeep; " "DROP TYPE wd_top; DROP TYPE wd_leaf;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# CREATE TABLE ... LIKE ... USING iceberg
+# ---------------------------------------------------------------------------
+
+
+def test_create_table_like_converts(s3, pg_conn, extension, with_default_location):
+    """
+    CREATE TABLE (LIKE src) USING iceberg expands the LIKE into real columns
+    before the option hook runs, so nested uuids from the source are converted
+    just like an explicit column list.  Source here is a plain heap table.
+    """
+    run_command(
+        """
+        CREATE TYPE like_comp AS (cid uuid, tags uuid[], note text);
+        CREATE TABLE like_src (
+            id     int,
+            top_id uuid,
+            us     uuid[],
+            c      like_comp
+        );
+        CREATE TABLE like_ice (LIKE like_src) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    try:
+        assert _col_format_type(pg_conn, "like_ice", "top_id") == "uuid"
+        assert _col_format_type(pg_conn, "like_ice", "us") == "text[]"
+        assert _composite_attrs_of_column(pg_conn, "like_ice", "c") == [
+            ["cid", "text"],
+            ["tags", "text[]"],
+            ["note", "text"],
+        ]
+        _assert_no_nested_uuid(s3, pg_conn, "like_ice")
+    finally:
+        run_command(
+            "DROP TABLE like_ice; DROP TABLE like_src; DROP TYPE like_comp;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+
+def test_create_table_like_without_option_keeps_uuid(
+    s3, pg_conn, extension, with_default_location
+):
+    """LIKE without the option must not convert (the option is per-new-table)."""
+    run_command(
+        """
+        CREATE TABLE like_src_noopt (id int, us uuid[]);
+        CREATE TABLE like_ice_noopt (LIKE like_src_noopt) USING iceberg;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    try:
+        assert _col_format_type(pg_conn, "like_ice_noopt", "us") == "uuid[]"
+    finally:
+        run_command("DROP TABLE like_ice_noopt; DROP TABLE like_src_noopt;", pg_conn)
         pg_conn.commit()
 
 

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -1032,8 +1032,16 @@ def test_data_file_uuid_array_written_as_string(
         "WITH (compatibility_mode = 'snowflake');",
         pg_conn,
     )
+    # a populated row, a whole-array NULL, a NULL element, and an empty array:
+    # none may introduce a uuid leaf, and the NULLs must survive the round trip.
     run_command(
-        f"INSERT INTO compat_df_arr VALUES (1, ARRAY['{u1}','{u2}']::uuid[]);",
+        f"""
+        INSERT INTO compat_df_arr VALUES
+            (1, ARRAY['{u1}','{u2}']::uuid[]),
+            (2, NULL),
+            (3, ARRAY['{u1}', NULL]::uuid[]),
+            (4, ARRAY[]::uuid[]);
+        """,
         pg_conn,
     )
     pg_conn.commit()
@@ -1043,6 +1051,14 @@ def test_data_file_uuid_array_written_as_string(
         assert ("element", "BYTE_ARRAY") in _parquet_leaf_types(
             superuser_conn, "compat_df_arr"
         )
+        # the NULLs round-trip: whole-array NULL stays NULL, the NULL element is
+        # preserved inside the (now text) array, and uuids read back as text.
+        # Read on pg_conn (the owner) so the scan's lock doesn't block the DROP.
+        rows = run_query("SELECT id, us FROM compat_df_arr ORDER BY id", pg_conn)
+        assert rows[0][1] == [u1, u2]
+        assert rows[1][1] is None
+        assert rows[2][1] == [u1, None]
+        assert rows[3][1] == []
     finally:
         run_command("DROP TABLE compat_df_arr", pg_conn)
         pg_conn.commit()
@@ -1062,17 +1078,32 @@ def test_data_file_composite_and_map_written_as_string(
         pg_conn,
     )
     converted_map = _col_format_type(pg_conn, "compat_df_comp", "m")
+    # populated; whole composite + map NULL; composite with NULL uuid fields +
+    # empty map; composite with a NULL array element + NULL map value.
     run_command(
         f"""
         INSERT INTO compat_df_comp VALUES
             (1, ROW('{u}', ARRAY['{u}']::uuid[], 'hi'),
-             ARRAY[('k', '{u}')]::{converted_map});
+             ARRAY[('k', '{u}')]::{converted_map}),
+            (2, NULL, NULL),
+            (3, ROW(NULL, NULL, 'no-ids'), ARRAY[]::{converted_map}),
+            (4, ROW('{u}', ARRAY['{u}', NULL]::uuid[], NULL),
+             ARRAY[('k', NULL)]::{converted_map});
         """,
         pg_conn,
     )
     pg_conn.commit()
     try:
         _assert_data_files_uuid_free(superuser_conn, "compat_df_comp")
+        # NULLs survive: whole composite/map NULL, NULL fields, and the NULL
+        # array element inside the (now text) composite all round-trip.
+        rows = run_query(
+            "SELECT id, (c).cid, (c).cids, m FROM compat_df_comp ORDER BY id",
+            pg_conn,
+        )
+        assert rows[1][1] is None and rows[1][2] is None and rows[1][3] is None
+        assert rows[2][1] is None and rows[2][2] is None
+        assert rows[3][2] == [u, None]
     finally:
         run_command("DROP TABLE compat_df_comp", pg_conn)
         pg_conn.commit()
@@ -1105,13 +1136,15 @@ def test_data_file_deeply_nested_written_as_string(
     # array-of-composite structure at the schema level.
     leaf = f"ROW('{u}', ARRAY['{u}'], 'l')"
     mid = f"ROW({leaf}, NULL, '{u}')"
+    # a populated deep row; an all-NULL row; and a row with NULLs at every
+    # intermediate level (NULL leaf, NULL array element, NULL mid_id).
+    mid_nulls = f"ROW(NULL, NULL, NULL)"
     run_command(
         f"""
-        INSERT INTO compat_df_deep VALUES (
-            1, '{u}', ARRAY['{u}'],
-            {mid},
-            NULL
-        );
+        INSERT INTO compat_df_deep VALUES
+            (1, '{u}', ARRAY['{u}'], {mid}, NULL),
+            (2, NULL, NULL, NULL, NULL),
+            (3, '{u}', ARRAY['{u}', NULL], {mid_nulls}, NULL);
         """,
         pg_conn,
     )
@@ -1150,11 +1183,15 @@ def test_data_file_copy_from_uuid_parquet_written_as_string(
     src = f"s3://{TEST_BUCKET}/compat_df_src/u.parquet"
     duck = create_duckdb_conn()
     try:
+        # source rows: populated, whole-array NULL, NULL element, empty array
         duck.execute(
             f"""
-            COPY (SELECT 1 AS id,
-                         ['{u1}'::uuid, '{u2}'::uuid] AS us)
-            TO '{src}' (FORMAT parquet);
+            COPY (
+                          SELECT 1 AS id, ['{u1}'::uuid, '{u2}'::uuid] AS us
+                UNION ALL SELECT 2, NULL
+                UNION ALL SELECT 3, ['{u1}'::uuid, NULL]
+                UNION ALL SELECT 4, []::uuid[]
+            ) TO '{src}' (FORMAT parquet);
             """
         )
         # sanity: the source really is a uuid leaf (proves the test can detect it)
@@ -1174,6 +1211,69 @@ def test_data_file_copy_from_uuid_parquet_written_as_string(
         assert ("element", "BYTE_ARRAY") in _parquet_leaf_types(
             superuser_conn, "compat_df_copy"
         )
+        # NULLs from the source parquet round-trip through the cast
+        rows = run_query("SELECT id, us FROM compat_df_copy ORDER BY id", pg_conn)
+        assert rows[0][1] == [u1, u2]
+        assert rows[1][1] is None
+        assert rows[2][1] == [u1, None]
+        assert rows[3][1] == []
     finally:
         run_command("DROP TABLE compat_df_copy", pg_conn)
+        pg_conn.commit()
+
+
+def test_data_file_all_null_nested_column_still_string(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    """
+    The hardest case for a column-oriented writer: when EVERY row's nested value
+    is NULL the writer never observes a concrete uuid, so nothing but the column
+    type can force the leaf to string.  The data file must still serialize the
+    rewritten leaves as BYTE_ARRAY (never uuid), and the top-level uuid stays
+    uuid even when it too is all-NULL.
+    """
+    run_command(
+        """
+        CREATE TYPE df_null_comp AS (cid uuid, cids uuid[], note text);
+        CREATE TABLE compat_df_allnull (
+            id      int,
+            top_id  uuid,        -- top-level: stays uuid
+            us      uuid[],      -- nested: -> text[]
+            c       df_null_comp -- nested: cid / cids -> text
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        """
+        INSERT INTO compat_df_allnull VALUES
+            (1, NULL, NULL, NULL),
+            (2, NULL, NULL, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    try:
+        # no rewritten leaf may be a uuid, even with no concrete value to infer
+        paths = _data_file_paths(superuser_conn, "compat_df_allnull")
+        duck = create_duckdb_conn()
+        try:
+            for path in paths:
+                offenders = [
+                    (n, p, l)
+                    for (n, p, l) in _parquet_uuid_leaves(duck, path)
+                    if n != "top_id"  # the top-level uuid legitimately stays uuid
+                ]
+                assert (
+                    not offenders
+                ), f"all-NULL file serialized uuid leaves: {offenders}"
+        finally:
+            duck.close()
+        # positively: the rewritten array element is a string leaf
+        assert ("element", "BYTE_ARRAY") in _parquet_leaf_types(
+            superuser_conn, "compat_df_allnull"
+        )
+    finally:
+        run_command("DROP TABLE compat_df_allnull", pg_conn)
+        run_command("DROP TYPE df_null_comp", pg_conn)
         pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -120,6 +120,75 @@ def _collect_kinds(itype, kinds=None):
     return kinds
 
 
+def _data_file_paths(conn, table):
+    """The committed DATA files (parquet) backing an iceberg table."""
+    metadata_path = run_query(
+        f"SELECT metadata_location FROM iceberg_tables WHERE table_name = '{table}'",
+        conn,
+    )[0][0]
+    rows = run_query(
+        f"SELECT file_path FROM lake_iceberg.files('{metadata_path}') "
+        "WHERE content = 'DATA'",
+        conn,
+    )
+    return [r[0] for r in rows]
+
+
+def _parquet_schema(duck, file_path):
+    """(name, physical_type, logical_type) per parquet column, types as text."""
+    return duck.execute(
+        "SELECT name, type::varchar, logical_type::varchar "
+        f"FROM parquet_schema('{file_path}')"
+    ).fetchall()
+
+
+def _parquet_uuid_leaves(duck, file_path):
+    """
+    Parquet leaves serialized as a uuid.  A nested uuid that was rewritten to
+    text MUST be a BYTE_ARRAY (string); if it shows up here as a UUID logical
+    type / FIXED_LEN_BYTE_ARRAY the data file diverges from the iceberg schema.
+    """
+    return [
+        (name, ptype, ltype)
+        for (name, ptype, ltype) in _parquet_schema(duck, file_path)
+        if (ltype and "UUID" in ltype.upper()) or ptype == "FIXED_LEN_BYTE_ARRAY"
+    ]
+
+
+def _assert_data_files_uuid_free(conn, table):
+    """
+    The decisive companion to _assert_no_nested_uuid: not just the iceberg
+    metadata schema but the actual Parquet data files must carry string, never
+    uuid, for every rewritten leaf.
+    """
+    paths = _data_file_paths(conn, table)
+    assert paths, f"no data files written for {table}"
+    duck = create_duckdb_conn()
+    try:
+        for path in paths:
+            offenders = _parquet_uuid_leaves(duck, path)
+            assert (
+                not offenders
+            ), f"{table} data file {path} serialized uuid leaves: {offenders}"
+    finally:
+        duck.close()
+
+
+def _parquet_leaf_types(conn, table):
+    """Union of (name, physical_type) leaf tuples across all data files."""
+    paths = _data_file_paths(conn, table)
+    assert paths, f"no data files written for {table}"
+    duck = create_duckdb_conn()
+    out = set()
+    try:
+        for path in paths:
+            for name, ptype, _ in _parquet_schema(duck, path):
+                out.add((name, ptype))
+    finally:
+        duck.close()
+    return out
+
+
 # ---------------------------------------------------------------------------
 # option validation
 # ---------------------------------------------------------------------------
@@ -937,4 +1006,174 @@ def test_combined_all_conversions(s3, pg_conn, extension, with_default_location)
         assert row[4] == [uid]
     finally:
         run_command("DROP TABLE compat_kitchen", pg_conn)
+        pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# data-file physical types: the committed parquet must serialize string, not uuid
+#
+# Every assertion above checks the iceberg *metadata schema*.  These tests
+# check the decisive companion invariant on the actual Parquet *data files*: a
+# schema-faithful reader (Snowflake / Spark / PyIceberg / pyarrow) trusts the
+# file's physical type, so a rewritten nested uuid must be written as a string
+# (BYTE_ARRAY) and never as a UUID logical type (FIXED_LEN_BYTE_ARRAY).
+# pg_lake's SQL write paths (INSERT ... VALUES/SELECT, COPY ... FROM) cast to
+# the target column type, so they must always produce string leaves here.
+# ---------------------------------------------------------------------------
+
+
+def test_data_file_uuid_array_written_as_string(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    u1 = "11111111-1111-1111-1111-111111111111"
+    u2 = "22222222-2222-2222-2222-222222222222"
+    run_command(
+        "CREATE TABLE compat_df_arr (id int, us uuid[]) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    run_command(
+        f"INSERT INTO compat_df_arr VALUES (1, ARRAY['{u1}','{u2}']::uuid[]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+    try:
+        _assert_data_files_uuid_free(superuser_conn, "compat_df_arr")
+        # positively: the list element leaf is a string (BYTE_ARRAY)
+        assert ("element", "BYTE_ARRAY") in _parquet_leaf_types(
+            superuser_conn, "compat_df_arr"
+        )
+    finally:
+        run_command("DROP TABLE compat_df_arr", pg_conn)
+        pg_conn.commit()
+
+
+def test_data_file_composite_and_map_written_as_string(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    u = "a0974028-d682-4796-b142-b96580b1c103"
+    map_type = create_map_type("text", "uuid")
+    run_command(
+        f"""
+        CREATE TYPE df_comp AS (cid uuid, cids uuid[], note text);
+        CREATE TABLE compat_df_comp (id int, c df_comp, m {map_type}) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    converted_map = _col_format_type(pg_conn, "compat_df_comp", "m")
+    run_command(
+        f"""
+        INSERT INTO compat_df_comp VALUES
+            (1, ROW('{u}', ARRAY['{u}']::uuid[], 'hi'),
+             ARRAY[('k', '{u}')]::{converted_map});
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    try:
+        _assert_data_files_uuid_free(superuser_conn, "compat_df_comp")
+    finally:
+        run_command("DROP TABLE compat_df_comp", pg_conn)
+        pg_conn.commit()
+
+
+def test_data_file_deeply_nested_written_as_string(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    u = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    run_command(
+        """
+        CREATE TYPE df_leaf AS (k uuid, ks uuid[], label text);
+        CREATE TYPE df_mid  AS (one df_leaf, many df_leaf[], mid_id uuid);
+        CREATE TABLE compat_df_deep (
+            pk       bigint,
+            top_id   uuid,
+            flat_ids uuid[],
+            m        df_mid,
+            ms       df_mid[]
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    # bare string literals / ROW() / ARRAY[] (no ::uuid casts) so each value
+    # coerces straight into the rewritten text columns.  PG can coerce a nested
+    # ROW() into a composite field, but not an anonymous record[] into a
+    # composite[]; so the array-of-composite fields (many / ms) stay NULL here.
+    # The deep struct path (m.one.{k,ks,mid_id}) still lands rewritten leaves in
+    # the data file; test_deeply_nested_uuid_all_converted covers the full
+    # array-of-composite structure at the schema level.
+    leaf = f"ROW('{u}', ARRAY['{u}'], 'l')"
+    mid = f"ROW({leaf}, NULL, '{u}')"
+    run_command(
+        f"""
+        INSERT INTO compat_df_deep VALUES (
+            1, '{u}', ARRAY['{u}'],
+            {mid},
+            NULL
+        );
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    try:
+        # top-level uuid stays uuid; every nested uuid is a string in the file
+        offenders_outside_top = []
+        paths = _data_file_paths(superuser_conn, "compat_df_deep")
+        duck = create_duckdb_conn()
+        try:
+            for path in paths:
+                for name, ptype, ltype in _parquet_uuid_leaves(duck, path):
+                    if name != "top_id":
+                        offenders_outside_top.append((name, ptype, ltype))
+        finally:
+            duck.close()
+        assert (
+            not offenders_outside_top
+        ), f"nested uuid serialized in deep file: {offenders_outside_top}"
+    finally:
+        run_command("DROP TABLE compat_df_deep", pg_conn)
+        pg_conn.commit()
+
+
+def test_data_file_copy_from_uuid_parquet_written_as_string(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    """
+    COPY FROM a source parquet whose element is a real uuid: pg_lake casts to
+    the rewritten text[] column, so the committed data file is a string.
+    """
+    u1 = "11111111-1111-1111-1111-111111111111"
+    u2 = "22222222-2222-2222-2222-222222222222"
+
+    # a source parquet whose element is a genuine UUID logical type
+    src = f"s3://{TEST_BUCKET}/compat_df_src/u.parquet"
+    duck = create_duckdb_conn()
+    try:
+        duck.execute(
+            f"""
+            COPY (SELECT 1 AS id,
+                         ['{u1}'::uuid, '{u2}'::uuid] AS us)
+            TO '{src}' (FORMAT parquet);
+            """
+        )
+        # sanity: the source really is a uuid leaf (proves the test can detect it)
+        assert _parquet_uuid_leaves(duck, src), "source parquet should be uuid"
+    finally:
+        duck.close()
+
+    run_command(
+        "CREATE TABLE compat_df_copy (id int, us uuid[]) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    run_command(f"COPY compat_df_copy FROM '{src}';", pg_conn)
+    pg_conn.commit()
+    try:
+        _assert_data_files_uuid_free(superuser_conn, "compat_df_copy")
+        assert ("element", "BYTE_ARRAY") in _parquet_leaf_types(
+            superuser_conn, "compat_df_copy"
+        )
+    finally:
+        run_command("DROP TABLE compat_df_copy", pg_conn)
         pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -580,6 +580,115 @@ def test_alter_add_without_option_keeps_uuid(
 
 
 # ---------------------------------------------------------------------------
+# type-bound clauses on a rewritten column are refused
+#
+# Rewriting a column swaps only its type; there is no implicit uuid->text cast,
+# so a DEFAULT/GENERATED expression bound to the original (uuid) type cannot be
+# silently re-coerced.  We fail fast instead of producing a broken column.
+# This is reachable only from user-authored DDL (programmatic Iceberg table
+# creation builds columns from type/typmod/collation alone, never these
+# clauses).  A clause on a column we DON'T rewrite (top-level uuid, or a
+# uuid-free column) is fine.
+# ---------------------------------------------------------------------------
+
+
+def test_default_on_rewritten_column_rejected(
+    s3, pg_conn, extension, with_default_location
+):
+    error = run_command(
+        "CREATE TABLE compat_def (id int, us uuid[] DEFAULT '{}'::uuid[]) "
+        "USING iceberg WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "cannot rewrite column" in error
+    assert "us" in error
+    pg_conn.rollback()
+
+
+def test_generated_on_rewritten_column_rejected(
+    s3, pg_conn, extension, with_default_location
+):
+    error = run_command(
+        "CREATE TABLE compat_gen "
+        "(u uuid, g uuid[] GENERATED ALWAYS AS (ARRAY[u]) STORED) "
+        "USING iceberg WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "cannot rewrite column" in error
+    assert "g" in error
+    pg_conn.rollback()
+
+
+def test_default_on_nested_composite_column_rejected(
+    s3, pg_conn, extension, with_default_location
+):
+    """The clause is refused even when the uuid is buried inside a composite."""
+    error = run_command(
+        """
+        CREATE TYPE def_comp AS (cid uuid, note text);
+        CREATE TABLE compat_def_comp
+            (id int, c def_comp DEFAULT ROW(NULL, 'x')::def_comp)
+            USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+        raise_error=False,
+    )
+    assert "cannot rewrite column" in error
+    pg_conn.rollback()
+
+
+def test_alter_add_default_on_rewritten_column_rejected(
+    s3, pg_conn, extension, with_default_location
+):
+    run_command(
+        "CREATE TABLE compat_alter_def (id int) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+    try:
+        error = run_command(
+            "ALTER TABLE compat_alter_def ADD COLUMN us uuid[] DEFAULT '{}'::uuid[];",
+            pg_conn,
+            raise_error=False,
+        )
+        assert "cannot rewrite column" in error
+        assert "us" in error
+        pg_conn.rollback()
+    finally:
+        run_command("DROP TABLE compat_alter_def", pg_conn)
+        pg_conn.commit()
+
+
+def test_default_on_top_level_uuid_allowed(
+    s3, pg_conn, extension, with_default_location
+):
+    """A top-level uuid is never rewritten, so a DEFAULT on it is fine."""
+    run_command(
+        "CREATE TABLE compat_top_def (id int, u uuid DEFAULT gen_random_uuid()) "
+        "USING iceberg WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_top_def", "u") == "uuid"
+    pg_conn.rollback()
+
+
+def test_default_on_uuid_free_column_allowed(
+    s3, pg_conn, extension, with_default_location
+):
+    """A DEFAULT on a column we don't rewrite is untouched by the guard."""
+    run_command(
+        "CREATE TABLE compat_clean_def (id int DEFAULT 7, note text DEFAULT 'x') "
+        "USING iceberg WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_clean_def", "id") == "integer"
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
 # dropped-column lifecycle (data written on both sides of the drop)
 # ---------------------------------------------------------------------------
 

--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -4633,3 +4633,126 @@ def set_auto_vacuum_params(superuser_conn):
         ],
         superuser_conn,
     )
+
+
+def _rest_schema_fields(s3, schema, table, pg_conn):
+    """Top-level iceberg schema fields of a writable REST-catalog table."""
+    metadata = get_rest_table_metadata(schema, table, pg_conn)
+    data = read_s3_operations(s3, metadata["metadata-location"])
+    return json.loads(data)["schemas"][0]["fields"]
+
+
+def test_writable_rest_compatibility_mode(
+    pg_conn,
+    installcheck,
+    s3,
+    extension,
+    with_default_location,
+    polaris_session,
+    set_polaris_gucs,
+    create_http_helper_functions,
+):
+    """compatibility_mode='snowflake' must apply on the writable REST catalog
+    creation path: nested uuids become text both in the local catalog and in
+    the iceberg schema registered in the REST catalog, with data round-trip."""
+    if installcheck:
+        return
+
+    run_command("CREATE SCHEMA test_rest_compat;", pg_conn)
+    pg_conn.commit()
+    run_command(
+        """
+        CREATE TYPE test_rest_compat.c1 AS (cid uuid, tags uuid[], note text);
+        CREATE TABLE test_rest_compat.t (
+            id     int,
+            top_id uuid,
+            us     uuid[],
+            c      test_rest_compat.c1
+        ) USING iceberg WITH (catalog='rest', compatibility_mode='snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    def coltype(col):
+        return run_query(
+            "SELECT format_type(atttypid, atttypmod) FROM pg_attribute "
+            f"WHERE attrelid='test_rest_compat.t'::regclass AND attname='{col}'",
+            pg_conn,
+        )[0][0]
+
+    # local postgres column types reflect the conversion
+    assert coltype("top_id") == "uuid"
+    assert coltype("us") == "text[]"
+
+    # iceberg schema registered in the REST catalog has no nested uuid
+    fields = _rest_schema_fields(s3, "test_rest_compat", "t", pg_conn)
+    top = next(f for f in fields if f["name"] == "top_id")
+    us = next(f for f in fields if f["name"] == "us")
+    c = next(f for f in fields if f["name"] == "c")
+    assert top["type"] == "uuid"
+    assert us["type"]["type"] == "list" and us["type"]["element"] == "string"
+    assert c["type"]["type"] == "struct"
+    cid = next(x for x in c["type"]["fields"] if x["name"] == "cid")
+    tags = next(x for x in c["type"]["fields"] if x["name"] == "tags")
+    assert cid["type"] == "string"
+    assert tags["type"]["type"] == "list" and tags["type"]["element"] == "string"
+
+    # data round-trips through the rewritten text columns
+    u = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+    run_command(
+        f"INSERT INTO test_rest_compat.t VALUES "
+        f"(1, '{u}', ARRAY['{u}']::uuid[], ROW('{u}', ARRAY['{u}']::uuid[], 'n'));",
+        pg_conn,
+    )
+    pg_conn.commit()
+    row = run_query(
+        "SELECT top_id, us, (c).cid, (c).tags FROM test_rest_compat.t", pg_conn
+    )[0]
+    assert str(row[0]) == u
+    assert row[1] == [u]
+    assert row[2] == u
+    assert row[3] == [u]
+
+
+def test_writable_rest_create_table_like_compatibility_mode(
+    pg_conn,
+    installcheck,
+    s3,
+    extension,
+    with_default_location,
+    polaris_session,
+    set_polaris_gucs,
+    create_http_helper_functions,
+):
+    """CREATE TABLE (LIKE src) USING iceberg WITH (catalog='rest', ...) must
+    expand the LIKE and still apply compatibility_mode on the REST path."""
+    if installcheck:
+        return
+
+    run_command("CREATE SCHEMA test_rest_compat_like;", pg_conn)
+    pg_conn.commit()
+    run_command(
+        """
+        CREATE TABLE test_rest_compat_like.src (id int, top_id uuid, us uuid[]);
+        CREATE TABLE test_rest_compat_like.t
+            (LIKE test_rest_compat_like.src)
+            USING iceberg WITH (catalog='rest', compatibility_mode='snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    def coltype(col):
+        return run_query(
+            "SELECT format_type(atttypid, atttypmod) FROM pg_attribute "
+            f"WHERE attrelid='test_rest_compat_like.t'::regclass AND attname='{col}'",
+            pg_conn,
+        )[0][0]
+
+    assert coltype("top_id") == "uuid"
+    assert coltype("us") == "text[]"
+
+    fields = _rest_schema_fields(s3, "test_rest_compat_like", "t", pg_conn)
+    us = next(f for f in fields if f["name"] == "us")
+    assert us["type"]["type"] == "list" and us["type"]["element"] == "string"


### PR DESCRIPTION
## Summary
(#410, the `ConvertTypeTree` walker this builds on, is now merged; this PR targets `main`.)

- Adds an opt-in, per-table `pg_lake_iceberg.compatibility_mode` table option so the Iceberg schema can be kept consumable by a downstream engine with narrower type support.
- Default is `auto` (no rewrites today, leaving room for future auto-detection). The only active mode is `snowflake`: Snowflake cannot store a UUID inside a semi-structured or structured type, so a `uuid` nested inside an array / map / composite is rewritten to `text`, while a top-level `uuid` column stays a native Iceberg `uuid`.
- The conversion reuses the shared `ConvertTypeTree` walker, supplying only the nested-uuid → text leaf rule. It runs as an independent pass that composes with the numeric → double conversion, and is applied on `CREATE TABLE` and `ALTER TABLE ... ADD COLUMN`.
- The rewrite is **announced** with a `NOTICE` (old type → new type), mirroring the existing numeric → double notice, so the type change is never silent. A column we would rewrite that also carries a `DEFAULT` / `GENERATED` / `IDENTITY` is rejected (there is no implicit uuid → text cast for core to re-coerce it through); this is only reachable from user-authored DDL, never from programmatic Iceberg table creation.

## Examples

`uuid[]` becomes `text[]` (a structural type that is itself usable and castable):

```
CREATE TABLE t (id int, tags uuid[]) USING iceberg WITH (compatibility_mode='snowflake');
NOTICE:  column "tags" type uuid[] rewritten to text[] for compatibility_mode 'snowflake'
DETAIL:  Snowflake cannot store a uuid inside an array, map, or composite; a top-level uuid column is left unchanged.
```

A composite carrying nested uuids is rebuilt into a generated `lake_struct.*` type (same mechanism the merged numeric → double pass uses for composites):

```
CREATE TYPE acct AS (acct_id uuid, owner uuid, addr addr_t, note text);
CREATE TABLE t2 (id int, acct acct) USING iceberg WITH (compatibility_mode='snowflake');
NOTICE:  column "acct" type acct rewritten to lake_struct.acct_id_owner_addr_note_d2fcb086 for compatibility_mode 'snowflake'
DETAIL:  Snowflake cannot store a uuid inside an array, map, or composite; a top-level uuid column is left unchanged.
```

A top-level `uuid` column is left untouched (no rewrite, no notice):

```
CREATE TABLE t3 (id int, gid uuid) USING iceberg WITH (compatibility_mode='snowflake');
-- gid stays uuid; no NOTICE
```

## Test plan
- [x] \`pg_lake_table/tests/pytests/test_compatibility_mode.py\`: conversion matrix across arrays, maps, composites, deep nesting, multiple and dropped columns, value round-trips, Iceberg metadata logical types, physical Parquet data-file types (string, never a uuid logical type), NULL coverage, and composition with numeric / timetz / out-of-range handling.
- [x] CI green on branch \`okalaci/iceberg-compatibility-mode\`.

Made with [Cursor](https://cursor.com)