### PR TITLE
Set default Parquet row group size to 128 MB

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/write_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/write_data.h
@@ -32,7 +32,7 @@
 #define PARTITION_COLUMN_PREFIX "__pglake_part_"
 
 /* pg_lake_table.target_row_group_size_mb */
-#define DEFAULT_TARGET_ROW_GROUP_SIZE_MB 512
+#define DEFAULT_TARGET_ROW_GROUP_SIZE_MB 128
 extern PGDLLEXPORT int TargetRowGroupSizeMB;
 
 typedef enum ParquetVersion

--- a/pg_lake_table/src/init.c
+++ b/pg_lake_table/src/init.c
@@ -235,7 +235,7 @@ _PG_init(void)
 
 	DefineCustomIntVariable("pg_lake_table.target_row_group_size_mb",
 							"Determines the target size of row groups in writable tables, in MB. "
-							"The default is 512; set to 0 to disable. ",
+							"The default is 128; set to 0 to disable. ",
 							NULL,
 							&TargetRowGroupSizeMB,
 							DEFAULT_TARGET_ROW_GROUP_SIZE_MB,


### PR DESCRIPTION
## Problem

`pg_lake_table.target_row_group_size_mb` defaults to 512. The comment
above the place we apply it in `WriteQueryResultTo` already explains
that a single row group per writer thread has to fit in memory
uncompressed and points at duckdb/duckdb#16078, where the upstream
recommendation is 128 MB. The default we ship is four times that, so
out of the box pg_lake writes much larger row groups than the source
itself says is sensible, and parallel writers can use a lot more memory
than the comment leads a reader to expect.

## Solution

Lower `DEFAULT_TARGET_ROW_GROUP_SIZE_MB` to 128 and update the GUC help
text in `pg_lake_table` to match. The setting is still `PGC_SUSET` and
still accepts 0 to disable, so anyone who wants the old behavior can
set the GUC explicitly.

## Test plan

- [x] precommit (pgindent, typos)
- [x] full CI on the PR