### PR TITLE
pg_lake_copy: pass auto_detect=false on internal CSV read-back

### DIFF
--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -834,6 +834,55 @@ def test_md_array(pg_conn, duckdb_conn, tmp_path):
     assert result[0]["val"] == 2
 
 
+def test_copy_to_array_with_nulls(pg_conn, duckdb_conn, tmp_path):
+    """
+    Regression test for https://github.com/Snowflake-Labs/pg_lake/issues/408.
+
+    DuckDB's CSV string-to-LIST cast can segfault (SIGSEGV) when a row with an
+    array value is followed by NULL rows and auto_detect is left enabled.
+    AppendReadCSVClause now passes auto_detect=false when a typed columns= map
+    is present, which causes DuckDB to return a clean conversion error instead
+    of crashing.  This test exercises the internal temp-CSV read-back path
+    (COPY TO parquet via ConvertCSVFileTo) with a 1-D integer array column and
+    several trailing NULL rows.
+    """
+    parquet_path = tmp_path / "test_array_nulls.parquet"
+
+    run_command(
+        f"""
+        CREATE TABLE test_array_nulls (id bigint, arr int[]);
+        INSERT INTO test_array_nulls VALUES
+            (1, ARRAY[1, 2, 3]),
+            (2, NULL),
+            (3, NULL),
+            (4, NULL),
+            (5, ARRAY[4, 5]),
+            (6, NULL),
+            (7, NULL),
+            (8, NULL),
+            (9, NULL),
+            (10, NULL);
+        COPY test_array_nulls TO '{parquet_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+
+    # Verify the parquet file contains the correct rows (not a partial/corrupt
+    # write from a crashed engine process)
+    duckdb_conn.execute(
+        f"SELECT id, arr FROM read_parquet($1) ORDER BY id", [str(parquet_path)]
+    )
+    rows = duckdb_conn.fetchall()
+
+    assert len(rows) == 10
+    assert rows[0] == (1, [1, 2, 3])
+    assert rows[1] == (2, None)
+    assert rows[4] == (5, [4, 5])
+    assert rows[9] == (10, None)
+
+    pg_conn.rollback()
+
+
 def test_copy_virtual_column(pg_conn, tmp_path):
     # virtual columns were introduced in PostgreSQL 18
     if get_pg_version_num(pg_conn) < 180000:

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -1651,15 +1651,28 @@ AppendReadCSVClause(StringInfo buf, const char *filePath,
 		appendStringInfoString(buf, ", parallel=false");
 	}
 
-	if (columnsMap != NULL)
-	{
-		appendStringInfo(buf, ", columns=%s", columnsMap);
-	}
-	else
-	{
-		/* infer columns and their types automatically */
-		appendStringInfoString(buf, ", auto_detect=true");
-	}
+  if (columnsMap != NULL)
+  {
+    appendStringInfo(buf, ", columns=%s", columnsMap);
+
+    /*
+     * Disable DuckDB's CSV sniffer when column types are fully specified.
+     * With auto_detect on (the default), DuckDB activates a
+     * string-to-LIST cast path that can segfault when a
+     * multidimensional-array value is followed by NULL rows
+     * (uninitialized offset/length in nullify_parent). The types are
+     * already explicit in columnsMap, so the sniffer adds no value and
+     * must not run.  header= is always explicit via the caller's
+     * csvOptions, so header detection is unaffected. See:
+     * https://github.com/duckdb/duckdb/issues/23373
+     */
+    appendStringInfoString(buf, ", auto_detect=false");
+  }
+  else
+  {
+    /* infer columns and their types automatically */
+    appendStringInfoString(buf, ", auto_detect=true");
+  }
 
 	appendStringInfoString(buf, CopyOptionsToReadCSVParams(csvOptions));
 


### PR DESCRIPTION
## Summary

- Fixes the `pgduck_server` segfault (SIGSEGV) triggered by `COPY <table> TO '<file>'` when the table has an array column and the intermediate temp CSV contains a multidimensional-array string value followed by NULL rows.
- Because `pgduck_server` is a shared process, this crash disconnects **all** concurrent sessions from the query engine.
- Root cause: `AppendReadCSVClause` never set `auto_detect=false` when a typed `columns=` map was present. DuckDB's sniffer then activates a string-to-LIST cast path with an uninitialized `offset`/`length` in its `nullify_parent` loop, causing an out-of-bounds validity-mask read. Upstream DuckDB bug: https://github.com/duckdb/duckdb/issues/23373
- Fix is a single `appendStringInfoString(buf, ", auto_detect=false")` in the `columnsMap != NULL` branch of `AppendReadCSVClause` (`read_data.c`). The column types are already fully specified; the sniffer adds nothing. `header=` is always explicit via `InternalCSVOptions`, so header detection is unaffected.
- With `auto_detect=false` DuckDB returns a clean `Conversion Error` on invalid values instead of crashing.

## Scope

`AppendReadCSVClause` has exactly one caller: `ConvertCSVFileTo` in `write_data.c`. No user-facing CSV COPY FROM paths are touched.

## Test

New `test_copy_to_array_with_nulls` in `test_parquet_copy.py`: creates a table with a 1-D `int[]` column and 10 rows (array values interleaved with NULLs), COPYs to Parquet, and verifies the output round-trips correctly via DuckDB `read_parquet`.

## Notes

`pgindent` is not available locally; the C change adds one `appendStringInfoString` call and a comment block. CI should confirm formatting.

Fixes #408.
