### PR TITLE
pg_lake_copy: add GUC to control generated columns in COPY TO

### DIFF
--- a/docs/data-lake-import-export.md
+++ b/docs/data-lake-import-export.md
@@ -136,6 +136,26 @@ COPY (SELECT * FROM table_to_export JOIN other_table USING (id)) TO 's3://your_b
 You can also pass options to the COPY command based on the format of the file
 you want to write.
 
+### Generated columns
+
+By default, `COPY ... TO` includes generated columns in the exported file. This
+differs from core PostgreSQL, which excludes generated columns so that the
+output can be reloaded with `COPY ... FROM`.
+
+To get the core PostgreSQL behavior and exclude generated columns from the
+output, turn off the `pg_lake_copy.include_generated_columns` setting:
+
+```sql
+-- exclude generated columns from COPY TO output (default: on)
+SET pg_lake_copy.include_generated_columns TO off;
+
+COPY table_to_export TO 's3://your_bucket_name/your_file_name.parquet';
+```
+
+The setting only affects `COPY ... TO` when no explicit column list is given;
+an explicit column list (for example `COPY t (a, b) TO ...`) is exported as
+specified regardless of this setting.
+
 ### psql copy
 
 pg_lake also lets you import and export with the copy formats

--- a/pg_lake_copy/include/pg_lake/copy/copy.h
+++ b/pg_lake_copy/include/pg_lake/copy/copy.h
@@ -27,6 +27,7 @@
 /* settings */
 extern bool EnablePgLakeCopy;
 extern bool EnablePgLakeCopyJson;
+extern bool PgLakeCopyIncludeGeneratedColumns;
 
 bool		PgLakeCopyHandler(ProcessUtilityParams * params, void *arg);
 void		ProcessPgLakeCopy(ParseState *pstate, PlannedStmt *plannedStmt,

--- a/pg_lake_copy/src/copy/copy.c
+++ b/pg_lake_copy/src/copy/copy.c
@@ -139,6 +139,7 @@ PG_FUNCTION_INFO_V1(pg_lake_last_copy_pushed_down_test);
 /* settings */
 bool		EnablePgLakeCopy = true;
 bool		EnablePgLakeCopyJson = true;
+bool		PgLakeCopyIncludeGeneratedColumns = true;
 
 /*
  * For COPY .. FROM, we convert incoming tuples into CSV format via a callback.
@@ -1219,6 +1220,22 @@ ErrorIfCopyFromWithRowLevelSecurityEnabled(PlannedStmt *plannedStmt, Relation re
 
 
 /*
+ * MakeColumnResTarget builds a ResTarget wrapping a target-list expression.
+ */
+static ResTarget *
+MakeColumnResTarget(Node *val)
+{
+	ResTarget  *target = makeNode(ResTarget);
+
+	target->name = NULL;
+	target->indirection = NIL;
+	target->val = val;
+	target->location = -1;
+	return target;
+}
+
+
+/*
  * CreateQueryForCopyToCommand is based on a section of DoCopy in PostgreSQL
  * to build a query to use in place of a relation when a row-level security
  * policy is in effect.
@@ -1230,7 +1247,6 @@ CreateQueryForCopyToCommand(PlannedStmt *plannedStmt, Relation relation)
 
 	SelectStmt *select;
 	ColumnRef  *cr;
-	ResTarget  *target;
 	RangeVar   *from;
 	List	   *targetList = NIL;
 
@@ -1238,8 +1254,10 @@ CreateQueryForCopyToCommand(PlannedStmt *plannedStmt, Relation relation)
 	 * Build target list
 	 *
 	 * If no columns are specified in the attribute list of the COPY command,
-	 * then the target list is 'all' columns. Therefore, '*' should be used as
-	 * the target list for the resulting SELECT statement.
+	 * build the target list based on the pg_lake_copy.include_generated_columns
+	 * GUC. If true (default), use '*' to preserve existing pg_lake behavior.
+	 * If false, build an explicit list of non-dropped, non-generated columns
+	 * to match core PostgreSQL's COPY TO behavior (CopyGetAttnums).
 	 *
 	 * In the case that columns are specified in the attribute list, create a
 	 * ColumnRef and ResTarget for each column and add them to the target list
@@ -1247,17 +1265,36 @@ CreateQueryForCopyToCommand(PlannedStmt *plannedStmt, Relation relation)
 	 */
 	if (!copyStmt->attlist)
 	{
-		cr = makeNode(ColumnRef);
-		cr->fields = list_make1(makeNode(A_Star));
-		cr->location = -1;
+		if (!PgLakeCopyIncludeGeneratedColumns)
+		{
+			TupleDesc	tupDesc = RelationGetDescr(relation);
+			int			attr_count = tupDesc->natts;
 
-		target = makeNode(ResTarget);
-		target->name = NULL;
-		target->indirection = NIL;
-		target->val = (Node *) cr;
-		target->location = -1;
+			for (int i = 0; i < attr_count; i++)
+			{
+				Form_pg_attribute att = TupleDescAttr(tupDesc, i);
 
-		targetList = list_make1(target);
+				if (att->attisdropped)
+					continue;
+
+				if (att->attgenerated)
+					continue;
+
+				cr = makeNode(ColumnRef);
+				cr->fields = list_make1(makeString(pstrdup(NameStr(att->attname))));
+				cr->location = -1;
+
+				targetList = lappend(targetList, MakeColumnResTarget((Node *) cr));
+			}
+		}
+		else
+		{
+			cr = makeNode(ColumnRef);
+			cr->fields = list_make1(makeNode(A_Star));
+			cr->location = -1;
+
+			targetList = list_make1(MakeColumnResTarget((Node *) cr));
+		}
 	}
 	else
 	{
@@ -1274,15 +1311,7 @@ CreateQueryForCopyToCommand(PlannedStmt *plannedStmt, Relation relation)
 			cr->fields = list_make1(lfirst(lc));
 			cr->location = -1;
 
-			/* Build the ResTarget and add the ColumnRef to it. */
-			target = makeNode(ResTarget);
-			target->name = NULL;
-			target->indirection = NIL;
-			target->val = (Node *) cr;
-			target->location = -1;
-
-			/* Add each column to the SELECT statement's target list */
-			targetList = lappend(targetList, target);
+			targetList = lappend(targetList, MakeColumnResTarget((Node *) cr));
 		}
 	}
 

--- a/pg_lake_copy/src/init.c
+++ b/pg_lake_copy/src/init.c
@@ -68,6 +68,16 @@ _PG_init(void)
 							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+							 "pg_lake_copy.include_generated_columns",
+							 gettext_noop("Include generated columns in COPY TO output"),
+							 gettext_noop("When off, generated columns are excluded from COPY TO output so the result can be reloaded with COPY FROM, matching core PostgreSQL behavior"),
+							 &PgLakeCopyIncludeGeneratedColumns,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
 	RegisterUtilityStatementHandler(CreateTableFromFileHandler, NULL);
 	RegisterUtilityStatementHandler(PgLakeCopyHandler, NULL);
 }

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -866,3 +866,88 @@ def test_copy_virtual_column(pg_conn, tmp_path):
     ]
 
     pg_conn.rollback()
+
+
+def test_copy_to_generated_columns(pg_conn, tmp_path):
+    on_path = tmp_path / "gencol_on.parquet"
+    off_path = tmp_path / "gencol_off.parquet"
+    attlist_path = tmp_path / "gencol_attlist.parquet"
+
+    # Emit a table with a generated column under each GUC setting and as a subset
+    run_command(
+        f"""
+        CREATE TABLE test_gencol (a int, b int, c int GENERATED ALWAYS AS (a + b) STORED);
+        INSERT INTO test_gencol VALUES (1, 2), (3, 4);
+        COPY test_gencol TO '{on_path}' WITH (format 'parquet');
+        COPY test_gencol (a, b) TO '{attlist_path}' WITH (format 'parquet');
+        SET pg_lake_copy.include_generated_columns = off;
+        COPY test_gencol TO '{off_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+
+    # By default the generated column c is included
+    run_command(
+        f"""
+        CREATE TABLE test_gencol_on (a int, b int, c int);
+        COPY test_gencol_on FROM '{on_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+    assert run_query("SELECT a, b, c FROM test_gencol_on ORDER BY a", pg_conn) == [
+        [1, 2, 3],
+        [3, 4, 7],
+    ]
+
+    # With the GUC off the generated column is excluded
+    run_command(
+        f"""
+        CREATE TABLE test_gencol_off (a int, b int);
+        COPY test_gencol_off FROM '{off_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+    assert run_query("SELECT a, b FROM test_gencol_off ORDER BY a", pg_conn) == [
+        [1, 2],
+        [3, 4],
+    ]
+
+    # An explicit column list is unaffected by the GUC
+    run_command(
+        f"""
+        CREATE TABLE test_gencol_attlist (a int, b int);
+        COPY test_gencol_attlist FROM '{attlist_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+    assert run_query("SELECT a, b FROM test_gencol_attlist ORDER BY a", pg_conn) == [
+        [1, 2],
+        [3, 4],
+    ]
+
+    pg_conn.rollback()
+
+
+def test_copy_to_all_generated_columns(pg_conn, tmp_path):
+    # A table whose only live column is generated. Core PostgreSQL's COPY TO
+    # emits zero data columns without error, so excluding generated columns
+    # must not produce an invalid (empty target list) query.
+    out_path = tmp_path / "all_gen.parquet"
+
+    run_command(
+        """
+        CREATE TABLE test_all_gen (g int GENERATED ALWAYS AS (42) STORED);
+        INSERT INTO test_all_gen DEFAULT VALUES;
+        INSERT INTO test_all_gen DEFAULT VALUES;
+        SET pg_lake_copy.include_generated_columns = off;
+        """,
+        pg_conn,
+    )
+
+    # Must not raise (empty target list / "SELECT FROM t" would be invalid)
+    run_command(
+        f"COPY test_all_gen TO '{out_path}' WITH (format 'parquet');",
+        pg_conn,
+    )
+
+    pg_conn.rollback()


### PR DESCRIPTION
Fixes #403

## Problem

pg_lake's `COPY <table> TO <url>` includes generated columns in the output for CSV-to-URL, JSON, and Parquet formats, diverging from core PostgreSQL which excludes them so the result can be round-tripped via `COPY FROM`.

Root cause: `CreateQueryForCopyToCommand` rewrites relation-form `COPY TO` into `SELECT * FROM <table>`, and `SELECT *` expands to include generated columns. Core PostgreSQL avoids this by building an explicit column list in `CopyGetAttnums` that skips generated columns — pg_lake's own `CopyGetAttnumsFixed` in `csv_writer.c` does the same, but the query rewrite path bypasses it.

## Solution

Add `pg_lake_copy.include_generated_columns` GUC (default: `on`).

When `off`, `CreateQueryForCopyToCommand` builds an explicit column list skipping generated and dropped columns instead of `SELECT *`, matching core's `CopyGetAttnums` and pg_lake's own `CopyGetAttnumsFixed`.

## Design decisions

**GUC instead of a straight fix:** per @sfc-gh-okalaci 's suggestion, pg_lake's behavior of including generated columns is arguably saner for data lake export use cases where you want the materialized value in your Parquet/JSON/CSV output. Changing the default would be a breaking change for existing users. The GUC lets users opt into core-compatible behavior without forcing it on everyone.

**Default: on (include generated columns):** preserves existing pg_lake behavior, no breaking change.

**PGC_USERSET instead of PGC_SUSET:** output round-trippability is a per-session user preference, not an admin/security concern. A regular user should be able to control how their own `COPY TO` behaves without
needing superuser access. The existing `enable` and `enable_json` GUCs are `SUSET` because they gate experimental/internal features — this one is a deliberate user-facing behavioral toggle, so I saw that `USERSET` is appropriate.

**flags = 0 instead of `GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE`:** there are existing GUCs that use those flags because they are internal/experimental toggles that shouldn't be advertised. This GUC is intentionally user-facing and documented, so it should appear in `SHOW ALL` and pg_settings.

**Test in test_parquet_copy.py only:** all three affected formats (CSV-to-URL, JSON, Parquet) hit the same `CreateQueryForCopyToCommand` code path, so one test covering the GUC logic is sufficient from a
correctness standpoint. Parquet was chosen because it always routes through pg_lake's interception regardless of target (local file or URL), meaning the test runs without needing a live S3/MinIO setup in CI.

**Test covers three cases:**
- GUC on (default): generated column present in output
- GUC off: generated column excluded, output loads cleanly into a two-column table
- Explicit attlist: unaffected by GUC — user explicitly named columns are always respected

## Testing

- Manually reproduced the bug across CSV, JSON, and Parquet before patching
- Verified fix across all three formats after patching
- Verified default behavior (GUC on) is unchanged
- Added regression test in test_parquet_copy.py
- Documented the new GUC in docs/data-lake-import-export.md