### PR TITLE
pg_lake_iceberg: compatibility_mode='snowflake' storing nested uuid as string (alternative to #411)

### DIFF
--- a/pg_lake_copy/src/copy/copy.c
+++ b/pg_lake_copy/src/copy/copy.c
@@ -938,7 +938,8 @@ ProcessPgLakeCopyTo(CopyStmt *copyStmt, ParseState *pstate, Relation relation,
 	 */
 	ConvertCSVFileTo(tempCSVPath, tupleDesc, maximumLineLength,
 					 destinationPath, destinationFormat, destinationCompression,
-					 copyStmt->options, schema, NIL);
+					 copyStmt->options, schema, NIL,
+					 false /* convertNestedUuid: regular COPY TO export */ );
 
 	if (IsCopyToStdout(copyStmt))
 	{

--- a/pg_lake_engine/include/pg_lake/pgduck/compatibility_mode.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/compatibility_mode.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "postgres.h"
+
+#include "pg_lake/parquet/field.h"
+
+/*
+ * Name of the per-table iceberg option that selects a compatibility mode.
+ * Shared by option validation (pg_lake_table) and the conversion logic so the
+ * accepted set lives in one place.
+ */
+#define ICEBERG_COMPATIBILITY_MODE_OPTION "compatibility_mode"
+
+/*
+ * IcebergCompatibilityMode selects how a table's Iceberg STORAGE is shaped so
+ * the table is consumable by a downstream engine with narrower type support.
+ *
+ * Unlike a type-rewrite, these modes never change the Postgres column type: the
+ * column stays exactly as declared.  Only the physical Iceberg/Parquet
+ * representation and the I/O-boundary conversions differ.
+ *
+ *   ICEBERG_COMPAT_AUTO       default (unset or 'auto'): no storage divergence.
+ *   ICEBERG_COMPAT_SNOWFLAKE  a uuid nested inside an array/map/composite is
+ *                             stored as Iceberg `string` (Snowflake cannot hold
+ *                             a UUID inside a structured type).  A top-level
+ *                             uuid column stays native `uuid`.
+ */
+typedef enum IcebergCompatibilityMode
+{
+	ICEBERG_COMPAT_AUTO = 0,
+	ICEBERG_COMPAT_SNOWFLAKE,
+}			IcebergCompatibilityMode;
+
+/* Maps an option string ("auto"/"snowflake"/NULL) to the enum; errors otherwise. */
+extern PGDLLEXPORT IcebergCompatibilityMode ParseIcebergCompatibilityMode(const char *optionValue);
+
+/* Reads the compatibility_mode option for relationId; AUTO for non-iceberg/unset. */
+extern PGDLLEXPORT IcebergCompatibilityMode GetIcebergCompatibilityModeForTable(Oid relationId);
+
+/*
+ * True iff a uuid appears strictly nested (inside an array, map, or composite)
+ * within typeOid.  A bare top-level uuid returns false.  Used to decide whether
+ * a column participates in the snowflake storage divergence.
+ */
+extern PGDLLEXPORT bool TypeHasNestedUuid(Oid typeOid);
+
+/*
+ * Rewrites, in place, every nested (level > 0) scalar Iceberg field whose type
+ * is "uuid" to "string", leaving a top-level uuid untouched.  No-op unless mode
+ * is ICEBERG_COMPAT_SNOWFLAKE.
+ */
+extern PGDLLEXPORT void RewriteNestedUuidFieldsToString(Field * field, IcebergCompatibilityMode mode);

--- a/pg_lake_engine/include/pg_lake/pgduck/iceberg_query_validation.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/iceberg_query_validation.h
@@ -44,4 +44,6 @@ extern PGDLLEXPORT char *IcebergWrapQueryWithErrorOrClampChecks(char *query,
  */
 extern PGDLLEXPORT char *IcebergWrapQueryWithNativeTypeConversion(char *query,
 																  TupleDesc tupleDesc,
-																  bool queryHasRowId);
+																  bool queryHasRowId,
+																  bool convertTemporal,
+																  bool convertNestedUuid);

--- a/pg_lake_engine/include/pg_lake/pgduck/write_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/write_data.h
@@ -52,7 +52,8 @@ extern PGDLLEXPORT StatsCollector * ConvertCSVFileTo(char *csvFilePath,
 													 CopyDataCompression destinationCompression,
 													 List *formatOptions,
 													 DataFileSchema * schema,
-													 List *leafFields);
+													 List *leafFields,
+													 bool convertNestedUuid);
 extern PGDLLEXPORT StatsCollector * WriteQueryResultTo(char *query,
 													   char *destinationPath,
 													   CopyDataFormat destinationFormat,
@@ -64,6 +65,7 @@ extern PGDLLEXPORT StatsCollector * WriteQueryResultTo(char *query,
 													   List *leafFields,
 													   IcebergOutOfRangePolicy outOfRangePolicy,
 													   bool wrapNativeTypes,
+													   bool convertNestedUuid,
 													   List *partitionByExprs);
 extern PGDLLEXPORT void AppendFields(StringInfo map, DataFileSchema * schema);
 extern PGDLLEXPORT char *TupleDescToColumnMapForWrite(TupleDesc tupleDesc, CopyDataFormat destinationFormat);

--- a/pg_lake_engine/src/pgduck/compatibility_mode.c
+++ b/pg_lake_engine/src/pgduck/compatibility_mode.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * compatibility_mode.c
+ *  Per-table Iceberg "compatibility mode" STORAGE shaping.
+ *
+ * Some engines that read pg_lake's Iceberg tables have narrower type support
+ * than Iceberg itself.  The `compatibility_mode` table option opts a table into
+ * a storage shape consumable by such an engine WITHOUT changing the Postgres
+ * column type the user declared.
+ *
+ * The only mode today is 'snowflake'.  Snowflake cannot store a UUID inside a
+ * semi-structured/structured type, so a uuid nested inside an array, map, or
+ * composite is stored physically as Iceberg `string`; a top-level uuid column
+ * stays native `uuid`.  The Postgres column type is left as uuid in every case
+ * -- conversion happens at the I/O boundary (uuid->varchar on write,
+ * varchar->uuid on read), so `\d` and DEFAULT/GENERATED clauses are unaffected.
+ *
+ * This module supplies the type predicate (TypeHasNestedUuid), the per-table
+ * option accessor, and the Iceberg Field-tree rewrite
+ * (RewriteNestedUuidFieldsToString).  The write-side value cast lives in
+ * iceberg_query_validation.c and the read-side cast in read_data.c; both take a
+ * plain bool so they need no knowledge of the option machinery.
+ */
+
+#include "postgres.h"
+
+#include "catalog/pg_type.h"
+#include "foreign/foreign.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/typcache.h"
+
+#include "pg_lake/parquet/field.h"
+#include "pg_lake/parsetree/options.h"
+#include "pg_lake/pgduck/compatibility_mode.h"
+#include "pg_lake/pgduck/map.h"
+#include "pg_lake/util/table_type.h"
+
+
+static bool TypeContainsUuid(Oid typeOid);
+static bool AnyCompositeFieldContainsUuid(Oid typeOid);
+static void RewriteNestedUuidFieldsToStringInternal(Field * field, int level);
+
+
+IcebergCompatibilityMode
+ParseIcebergCompatibilityMode(const char *optionValue)
+{
+	if (optionValue == NULL || pg_strcasecmp(optionValue, "auto") == 0)
+		return ICEBERG_COMPAT_AUTO;
+
+	if (pg_strcasecmp(optionValue, "snowflake") == 0)
+		return ICEBERG_COMPAT_SNOWFLAKE;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("invalid compatibility_mode option: \"%s\"", optionValue),
+			 errhint("Valid values are 'auto' and 'snowflake'.")));
+}
+
+
+IcebergCompatibilityMode
+GetIcebergCompatibilityModeForTable(Oid relationId)
+{
+	if (!IsIcebergTable(relationId))
+		return ICEBERG_COMPAT_AUTO;
+
+	ForeignTable *foreignTable = GetForeignTable(relationId);
+	char	   *value = GetStringOption(foreignTable->options,
+										ICEBERG_COMPATIBILITY_MODE_OPTION, false);
+
+	return ParseIcebergCompatibilityMode(value);
+}
+
+
+/*
+ * AnyCompositeFieldContainsUuid returns true if any non-dropped attribute of
+ * the composite type contains a uuid at any depth.
+ */
+static bool
+AnyCompositeFieldContainsUuid(Oid typeOid)
+{
+	TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeOid, -1);
+	bool		found = false;
+
+	for (int i = 0; i < tupleDesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, i);
+
+		if (attr->attisdropped)
+			continue;
+
+		if (TypeContainsUuid(attr->atttypid))
+		{
+			found = true;
+			break;
+		}
+	}
+
+	ReleaseTupleDesc(tupleDesc);
+	return found;
+}
+
+
+/*
+ * TypeContainsUuid returns true if typeOid is a uuid or contains a uuid at any
+ * nesting depth (array element, composite field, or map key/value).
+ */
+static bool
+TypeContainsUuid(Oid typeOid)
+{
+	typeOid = ResolveDomainBaseType(typeOid);
+
+	if (typeOid == UUIDOID)
+		return true;
+
+	if (type_is_array(typeOid))
+		return TypeContainsUuid(get_element_type(typeOid));
+
+	if (IsMapTypeOid(typeOid))
+		return TypeContainsUuid(GetMapKeyType(typeOid).postgresTypeOid) ||
+			TypeContainsUuid(GetMapValueType(typeOid).postgresTypeOid);
+
+	if (get_typtype(typeOid) == TYPTYPE_COMPOSITE)
+		return AnyCompositeFieldContainsUuid(typeOid);
+
+	return false;
+}
+
+
+bool
+TypeHasNestedUuid(Oid typeOid)
+{
+	typeOid = ResolveDomainBaseType(typeOid);
+
+	if (type_is_array(typeOid))
+		return TypeContainsUuid(get_element_type(typeOid));
+
+	if (IsMapTypeOid(typeOid))
+		return TypeContainsUuid(GetMapKeyType(typeOid).postgresTypeOid) ||
+			TypeContainsUuid(GetMapValueType(typeOid).postgresTypeOid);
+
+	if (get_typtype(typeOid) == TYPTYPE_COMPOSITE)
+		return AnyCompositeFieldContainsUuid(typeOid);
+
+	/* bare scalar (including a top-level uuid) is not "nested" */
+	return false;
+}
+
+
+/*
+ * RewriteNestedUuidFieldsToStringInternal flips every nested (level > 0) scalar
+ * "uuid" field to "string".  level 0 is the column itself, so a top-level uuid
+ * is left as-is.
+ */
+static void
+RewriteNestedUuidFieldsToStringInternal(Field * field, int level)
+{
+	if (field == NULL)
+		return;
+
+	switch (field->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			if (level > 0 && field->field.scalar.typeName != NULL &&
+				strcmp(field->field.scalar.typeName, "uuid") == 0)
+				field->field.scalar.typeName = pstrdup("string");
+			break;
+
+		case FIELD_TYPE_LIST:
+			RewriteNestedUuidFieldsToStringInternal(field->field.list.element, level + 1);
+			break;
+
+		case FIELD_TYPE_MAP:
+			RewriteNestedUuidFieldsToStringInternal(field->field.map.key, level + 1);
+			RewriteNestedUuidFieldsToStringInternal(field->field.map.value, level + 1);
+			break;
+
+		case FIELD_TYPE_STRUCT:
+			for (size_t i = 0; i < field->field.structType.nfields; i++)
+				RewriteNestedUuidFieldsToStringInternal(field->field.structType.fields[i].type,
+														level + 1);
+			break;
+	}
+}
+
+
+void
+RewriteNestedUuidFieldsToString(Field * field, IcebergCompatibilityMode mode)
+{
+	if (mode != ICEBERG_COMPAT_SNOWFLAKE)
+		return;
+
+	RewriteNestedUuidFieldsToStringInternal(field, 0);
+}

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -71,13 +71,15 @@ static bool AppendIcebergValidationExpression(StringInfo buf, const char *expr,
 											  IcebergOutOfRangePolicy policy,
 											  int depth);
 
-static bool TypeNeedsNativeConversion(Oid typeOid);
-static bool TupleDescHasNativeConversionColumn(TupleDesc tupleDesc);
+static bool TypeNeedsNativeConversion(Oid typeOid, bool convertTemporal, bool convertNestedUuid);
+static bool TupleDescHasNativeConversionColumn(TupleDesc tupleDesc, bool convertTemporal, bool convertNestedUuid);
 static void AppendIntervalStructPack(StringInfo buf, const char *expr);
 static void AppendTimeTzUtcCast(StringInfo buf, const char *expr);
 static bool AppendNativeConversionExpression(StringInfo buf, const char *expr,
 											 Oid typeOid, int32 typmod,
-											 int depth);
+											 int depth, bool nested,
+											 bool convertTemporal,
+											 bool convertNestedUuid);
 
 
 /* ================================================================
@@ -481,29 +483,38 @@ IcebergWrapQueryWithErrorOrClampChecks(char *query, TupleDesc tupleDesc,
  * through arrays, composites, maps, and domains.
  */
 static bool
-TypeNeedsNativeConversion(Oid typeOid)
+TypeNeedsNativeConversion(Oid typeOid, bool convertTemporal, bool convertNestedUuid)
 {
-	if (typeOid == INTERVALOID || typeOid == TIMETZOID)
+	if (convertTemporal && (typeOid == INTERVALOID || typeOid == TIMETZOID))
+		return true;
+
+	/*
+	 * Under compatibility_mode='snowflake' a uuid is stored as string. We
+	 * treat uuid as "needs conversion" so containers descend into it; the
+	 * actual cast is gated on `nested` in AppendNativeConversionExpression so
+	 * a bare top-level uuid is left as native uuid.
+	 */
+	if (convertNestedUuid && typeOid == UUIDOID)
 		return true;
 
 	Oid			elemType = get_element_type(typeOid);
 
 	if (OidIsValid(elemType))
-		return TypeNeedsNativeConversion(elemType);
+		return TypeNeedsNativeConversion(elemType, convertTemporal, convertNestedUuid);
 
 	if (IsMapTypeOid(typeOid))
 	{
 		PGType		keyType = GetMapKeyType(typeOid);
 		PGType		valType = GetMapValueType(typeOid);
 
-		return TypeNeedsNativeConversion(keyType.postgresTypeOid) ||
-			TypeNeedsNativeConversion(valType.postgresTypeOid);
+		return TypeNeedsNativeConversion(keyType.postgresTypeOid, convertTemporal, convertNestedUuid) ||
+			TypeNeedsNativeConversion(valType.postgresTypeOid, convertTemporal, convertNestedUuid);
 	}
 
 	char		typtype = get_typtype(typeOid);
 
 	if (typtype == TYPTYPE_DOMAIN)
-		return TypeNeedsNativeConversion(getBaseType(typeOid));
+		return TypeNeedsNativeConversion(getBaseType(typeOid), convertTemporal, convertNestedUuid);
 
 	if (typtype == TYPTYPE_COMPOSITE)
 	{
@@ -517,7 +528,7 @@ TypeNeedsNativeConversion(Oid typeOid)
 			if (attr->attisdropped)
 				continue;
 
-			if (TypeNeedsNativeConversion(attr->atttypid))
+			if (TypeNeedsNativeConversion(attr->atttypid, convertTemporal, convertNestedUuid))
 			{
 				found = true;
 				break;
@@ -533,7 +544,7 @@ TypeNeedsNativeConversion(Oid typeOid)
 
 
 static bool
-TupleDescHasNativeConversionColumn(TupleDesc tupleDesc)
+TupleDescHasNativeConversionColumn(TupleDesc tupleDesc, bool convertTemporal, bool convertNestedUuid)
 {
 	for (int i = 0; i < tupleDesc->natts; i++)
 	{
@@ -542,7 +553,7 @@ TupleDescHasNativeConversionColumn(TupleDesc tupleDesc)
 		if (attr->attisdropped)
 			continue;
 
-		if (TypeNeedsNativeConversion(attr->atttypid))
+		if (TypeNeedsNativeConversion(attr->atttypid, convertTemporal, convertNestedUuid))
 			return true;
 	}
 
@@ -615,17 +626,29 @@ AppendTimeTzUtcCast(StringInfo buf, const char *expr)
 static bool
 AppendNativeConversionExpression(StringInfo buf, const char *expr,
 								 Oid typeOid, int32 typmod,
-								 int depth)
+								 int depth, bool nested,
+								 bool convertTemporal, bool convertNestedUuid)
 {
-	if (typeOid == INTERVALOID)
+	if (convertTemporal && typeOid == INTERVALOID)
 	{
 		AppendIntervalStructPack(buf, expr);
 		return true;
 	}
 
-	if (typeOid == TIMETZOID)
+	if (convertTemporal && typeOid == TIMETZOID)
 	{
 		AppendTimeTzUtcCast(buf, expr);
+		return true;
+	}
+
+	/*
+	 * compatibility_mode='snowflake': a uuid nested inside a container is
+	 * stored as string, so cast it to varchar on write. `nested` is false
+	 * only for a bare top-level uuid column, which stays native uuid.
+	 */
+	if (convertNestedUuid && nested && typeOid == UUIDOID)
+	{
+		appendStringInfo(buf, "CAST(%s AS VARCHAR)", expr);
 		return true;
 	}
 
@@ -634,14 +657,14 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 
 	if (OidIsValid(elemType))
 	{
-		if (!TypeNeedsNativeConversion(elemType))
+		if (!TypeNeedsNativeConversion(elemType, convertTemporal, convertNestedUuid))
 			return false;
 
 		char	   *lambdaVar = psprintf("_x%d", depth);
 
 		appendStringInfo(buf, "list_transform(%s, %s -> ", expr, lambdaVar);
 		AppendNativeConversionExpression(buf, lambdaVar, elemType, -1,
-										 depth + 1);
+										 depth + 1, true, convertTemporal, convertNestedUuid);
 		appendStringInfoChar(buf, ')');
 		return true;
 	}
@@ -651,8 +674,8 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 	{
 		PGType		keyType = GetMapKeyType(typeOid);
 		PGType		valType = GetMapValueType(typeOid);
-		bool		keyNeedsConversion = TypeNeedsNativeConversion(keyType.postgresTypeOid);
-		bool		valNeedsConversion = TypeNeedsNativeConversion(valType.postgresTypeOid);
+		bool		keyNeedsConversion = TypeNeedsNativeConversion(keyType.postgresTypeOid, convertTemporal, convertNestedUuid);
+		bool		valNeedsConversion = TypeNeedsNativeConversion(valType.postgresTypeOid, convertTemporal, convertNestedUuid);
 
 		if (!keyNeedsConversion && !valNeedsConversion)
 			return false;
@@ -669,7 +692,7 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 			AppendNativeConversionExpression(buf, keyExpr,
 											 keyType.postgresTypeOid,
 											 keyType.postgresTypeMod,
-											 depth + 1);
+											 depth + 1, true, convertTemporal, convertNestedUuid);
 		else
 			appendStringInfoString(buf, keyExpr);
 
@@ -681,7 +704,7 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 			AppendNativeConversionExpression(buf, valExpr,
 											 valType.postgresTypeOid,
 											 valType.postgresTypeMod,
-											 depth + 1);
+											 depth + 1, true, convertTemporal, convertNestedUuid);
 		else
 			appendStringInfoString(buf, valExpr);
 
@@ -697,7 +720,7 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 		Oid			baseType = getBaseTypeAndTypmod(typeOid, &typmod);
 
 		return AppendNativeConversionExpression(buf, expr, baseType, typmod,
-												depth);
+												depth, nested, convertTemporal, convertNestedUuid);
 	}
 
 	/* composite types: transform fields via struct_pack */
@@ -713,7 +736,7 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 			if (attr->attisdropped)
 				continue;
 
-			if (TypeNeedsNativeConversion(attr->atttypid))
+			if (TypeNeedsNativeConversion(attr->atttypid, convertTemporal, convertNestedUuid))
 			{
 				anyFieldNeedsTransform = true;
 				break;
@@ -749,7 +772,7 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 			if (!AppendNativeConversionExpression(buf, fieldExpr,
 												  attr->atttypid,
 												  attr->atttypmod,
-												  depth))
+												  depth, true, convertTemporal, convertNestedUuid))
 				appendStringInfoString(buf, fieldExpr);
 
 			firstField = false;
@@ -786,9 +809,11 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
  */
 char *
 IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
-										 bool queryHasRowId)
+										 bool queryHasRowId, bool convertTemporal,
+										 bool convertNestedUuid)
 {
-	if (tupleDesc == NULL || !TupleDescHasNativeConversionColumn(tupleDesc))
+	if (tupleDesc == NULL ||
+		!TupleDescHasNativeConversionColumn(tupleDesc, convertTemporal, convertNestedUuid))
 		return query;
 
 	StringInfoData wrapped;
@@ -817,7 +842,8 @@ IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
 
 		if (AppendNativeConversionExpression(&exprBuf, quotedName,
 											 attr->atttypid,
-											 attr->atttypmod, 0))
+											 attr->atttypmod, 0, false,
+											 convertTemporal, convertNestedUuid))
 		{
 			appendStringInfo(&wrapped, "%s AS %s", exprBuf.data, quotedName);
 		}

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -69,7 +69,8 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 				 CopyDataCompression destinationCompression,
 				 List *formatOptions,
 				 DataFileSchema * schema,
-				 List *leafFields)
+				 List *leafFields,
+				 bool convertNestedUuid)
 {
 	StringInfoData command;
 
@@ -107,6 +108,7 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 							  leafFields,
 							  ICEBERG_OOR_NONE,
 							  false /* wrapNativeTypes */ ,
+							  convertNestedUuid,
 							  NIL /* partitionByExprs */ );
 }
 
@@ -128,6 +130,7 @@ WriteQueryResultTo(char *query,
 				   List *leafFields,
 				   IcebergOutOfRangePolicy outOfRangePolicy,
 				   bool wrapNativeTypes,
+				   bool convertNestedUuid,
 				   List *partitionByExprs)
 {
 	if (outOfRangePolicy != ICEBERG_OOR_NONE)
@@ -137,10 +140,21 @@ WriteQueryResultTo(char *query,
 													   queryHasRowId);
 	}
 
-	if (wrapNativeTypes && destinationFormat == DATA_FORMAT_ICEBERG)
+	/*
+	 * Apply the native-type wrap when temporal types need rewriting
+	 * (wrapNativeTypes, e.g. INSERT..SELECT / COPY FROM) or when nested uuid
+	 * must be stored as string under compatibility_mode='snowflake'. The CSV
+	 * ingest path passes wrapNativeTypes=false (temporal already normalized
+	 * during Postgres-side serialization) but still needs the uuid pass, so
+	 * convertTemporal tracks wrapNativeTypes while convertNestedUuid is
+	 * applied in both cases.
+	 */
+	if ((wrapNativeTypes || convertNestedUuid) && destinationFormat == DATA_FORMAT_ICEBERG)
 	{
 		query = IcebergWrapQueryWithNativeTypeConversion(query, queryTupleDesc,
-														 queryHasRowId);
+														 queryHasRowId,
+														 wrapNativeTypes,
+														 convertNestedUuid);
 	}
 
 	/*

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -577,6 +577,13 @@ InitPgLakeIcebergOptions(void)
 		 */
 		{"out_of_range_values", ForeignTableRelationId},
 
+		/*
+		 * compatibility-mode storage shaping: 'auto' (default) or 'snowflake'
+		 * (store nested uuid physically as string). Never changes the
+		 * Postgres column type.
+		 */
+		{"compatibility_mode", ForeignTableRelationId},
+
 		{NULL, InvalidOid}
 	};
 
@@ -878,6 +885,20 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 						 errmsg("invalid out_of_range_values option: \"%s\"",
 								outOfRangeValues),
 						 errhint("Valid values are \"error\" and \"clamp\".")));
+			}
+		}
+		else if (catalog == ForeignTableRelationId && strcmp(def->defname, "compatibility_mode") == 0)
+		{
+			const char *compatibilityMode = defGetString(def);
+
+			if (strcmp(compatibilityMode, "auto") != 0 &&
+				strcmp(compatibilityMode, "snowflake") != 0)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("invalid compatibility_mode option: \"%s\"",
+								compatibilityMode),
+						 errhint("Valid values are \"auto\" and \"snowflake\".")));
 			}
 		}
 	}

--- a/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
+++ b/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
@@ -45,6 +45,7 @@
 #include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/iceberg/iceberg_field.h"
 #include "pg_lake/parquet/leaf_field.h"
+#include "pg_lake/pgduck/compatibility_mode.h"
 #include "pg_lake/pgduck/map.h"
 #include "pg_lake/pgduck/serialize.h"
 #include "pg_lake/util/array_utils.h"
@@ -204,6 +205,16 @@ CreateRegisteredFieldForAttribute(Oid relationId, int spiIndex)
 	PGType		pgType = MakePGType(fieldType, fieldTypeMod);
 
 	field->type = PostgresTypeToIcebergField(pgType, forAddColumn, &subFieldIndex);
+
+	/*
+	 * The stored field_pg_type is the (unchanged) Postgres type, e.g. uuid.
+	 * Under compatibility_mode='snowflake' the physical Iceberg/Parquet
+	 * storage is string for nested uuid, so rewrite the rebuilt field tree to
+	 * match what read_parquet will be handed. This is the read-side mirror of
+	 * the rewrite applied when the schema was written.
+	 */
+	RewriteNestedUuidFieldsToString(field->type,
+									GetIcebergCompatibilityModeForTable(relationId));
 
 	field->duckSerializedInitialDefault =
 		!initialDefaultValueIsNull ?
@@ -435,6 +446,14 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 {
 	List	   *leafFields = NIL;
 
+	/*
+	 * Under compatibility_mode='snowflake' a nested uuid leaf is stored as
+	 * string. The stored field_pg_type is still uuid, so rewrite the rebuilt
+	 * leaf to keep these leaf fields consistent with the physical data files
+	 * (and with the schema reported to read_parquet).
+	 */
+	IcebergCompatibilityMode compatMode = GetIcebergCompatibilityModeForTable(relationId);
+
 	MemoryContext currentContext = CurrentMemoryContext;
 
 	StringInfo	query = makeStringInfo();
@@ -520,6 +539,15 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 		Field	   *field = PostgresTypeToIcebergField(pgType, forAddColumn, &subFieldIndex);
 
 		Assert(field != NULL && field->type == FIELD_TYPE_SCALAR);
+
+		/*
+		 * level is 1-based here (top-level column == 1), so a uuid at level >
+		 * 1 is nested and is stored physically as string under compat mode.
+		 */
+		if (compatMode == ICEBERG_COMPAT_SNOWFLAKE && level > 1 &&
+			field->field.scalar.typeName != NULL &&
+			strcmp(field->field.scalar.typeName, "uuid") == 0)
+			field->field.scalar.typeName = pstrdup("string");
 
 		LeafField  *leafField = palloc0(sizeof(LeafField));
 

--- a/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
+++ b/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
@@ -46,6 +46,7 @@
 #include "pg_lake/iceberg/iceberg_type_json_serde.h"
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
+#include "pg_lake/pgduck/compatibility_mode.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
 #include "pg_lake/pgduck/remote_storage.h"
 #include "pg_lake/pgduck/serialize.h"
@@ -150,6 +151,14 @@ CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, b
 
 	TupleDesc	tupleDesc = RelationGetDescr(rel);
 
+	/*
+	 * Under compatibility_mode='snowflake' a nested uuid is stored physically
+	 * as Iceberg string; rewrite the built field tree's nested uuid leaves so
+	 * the written metadata advertises string. The Postgres column type is
+	 * left untouched.
+	 */
+	IcebergCompatibilityMode compatMode = GetIcebergCompatibilityModeForTable(relationId);
+
 	foreach(columnDefCell, columnDefList)
 	{
 		ColumnDef  *columnDef = (ColumnDef *) lfirst(columnDefCell);
@@ -181,6 +190,8 @@ CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, b
 
 		field->type =
 			PostgresTypeToIcebergField(pgType, forAddColumn, &subFieldIndex);
+
+		RewriteNestedUuidFieldsToString(field->type, compatMode);
 
 		field->required = columnDef->is_not_null;
 

--- a/pg_lake_table/src/fdw/writable_table.c
+++ b/pg_lake_table/src/fdw/writable_table.c
@@ -53,6 +53,7 @@
 #include "pg_lake/pgduck/read_data.h"
 #include "pg_lake/pgduck/remote_storage.h"
 #include "pg_lake/pgduck/write_data.h"
+#include "pg_lake/pgduck/compatibility_mode.h"
 #include "pg_lake/pgduck/iceberg_validation.h"
 #include "pg_lake/transaction/track_iceberg_metadata_changes.h"
 #include "pg_lake/util/rel_utils.h"
@@ -273,6 +274,8 @@ PrepareCSVInsertion(Oid relationId, char *insertCSV, int64 rowCount,
 	InsertInProgressFileRecordExtended(dataFilePrefix, isPrefix, autoDeleteRecord);
 
 	List	   *leafFields = GetLeafFieldsForTable(relationId);
+	bool		convertNestedUuid =
+		(GetIcebergCompatibilityModeForTable(relationId) == ICEBERG_COMPAT_SNOWFLAKE);
 
 	/* convert insert file to a new file in table format */
 	StatsCollector *statsCollector =
@@ -284,7 +287,8 @@ PrepareCSVInsertion(Oid relationId, char *insertCSV, int64 rowCount,
 						 compression,
 						 options,
 						 schema,
-						 leafFields);
+						 leafFields,
+						 convertNestedUuid);
 
 	ApplyColumnStatsModeForAllFileStats(relationId, statsCollector->dataFileStats);
 
@@ -602,7 +606,9 @@ ApplyDeleteFile(Relation rel, char *sourcePath, int64 sourceRowCount, int64 live
 			/* write the deletion file (no temporal validation needed) */
 			StatsCollector *statsCollector =
 				ConvertCSVFileTo(deleteFile, deleteTupleDesc, -1, deletionFilePath,
-								 DATA_FORMAT_PARQUET, compression, copyOptions, schema, leafFields);
+								 DATA_FORMAT_PARQUET, compression, copyOptions, schema, leafFields,
+								 false	/* convertNestedUuid: deletion files
+								   * have no uuid */ );
 
 			ereport(WriteLogLevel, (errmsg("adding deletion file %s with " INT64_FORMAT " rows ",
 										   deletionFilePath, deletedRowCount)));
@@ -1072,6 +1078,8 @@ PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryT
 
 	/* perform compaction */
 	List	   *leafFields = GetLeafFieldsForTable(relationId);
+	bool		convertNestedUuid =
+		(GetIcebergCompatibilityModeForTable(relationId) == ICEBERG_COMPAT_SNOWFLAKE);
 	StatsCollector *statsCollector =
 		WriteQueryResultTo(readQuery,
 						   newDataFilePath,
@@ -1084,6 +1092,7 @@ PrepareToAddQueryResultToTable(Oid relationId, char *readQuery, TupleDesc queryT
 						   leafFields,
 						   outOfRangePolicy,
 						   wrapNativeTypes,
+						   convertNestedUuid,
 						   partitionByExprs);
 
 	if (statsCollector->totalRowCount == 0)

--- a/pg_lake_table/src/planner/query_pushdown.c
+++ b/pg_lake_table/src/planner/query_pushdown.c
@@ -40,6 +40,7 @@
 #include "pg_lake/planner/pushdown_utils.h"
 #include "pg_lake/fdw/writable_table.h"
 #include "pg_lake/pgduck/iceberg_query_validation.h"
+#include "pg_lake/pgduck/compatibility_mode.h"
 #include "pg_lake/planner/insert_select.h"
 #include "pg_lake/planner/query_pushdown.h"
 #include "pg_lake/planner/restriction_collector.h"
@@ -1741,7 +1742,9 @@ QueryPushdownExplainScan(CustomScanState *node, List *ancestors,
 				queryString =
 					IcebergWrapQueryWithNativeTypeConversion(queryString,
 															 scanState->insertTargetTupleDesc,
-															 false);
+															 false,
+															 true /* convertTemporal */ ,
+															 GetIcebergCompatibilityModeForTable(scanState->insertIntoRelid) == ICEBERG_COMPAT_SNOWFLAKE);
 		}
 
 		ExplainPropertyText("Vectorized SQL", queryString, es);

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -1,0 +1,476 @@
+"""
+Tests for the per-table iceberg option ``compatibility_mode = 'snowflake'``.
+
+Snowflake cannot store a UUID inside a structured / semi-structured type. This
+option makes a nested uuid (inside an array, map, or composite) be stored
+PHYSICALLY as Iceberg ``string`` while leaving the Postgres column type exactly
+as declared.  A top-level uuid column stays a native Iceberg ``uuid``.
+
+Unlike the type-rewrite approach, the user-facing schema never changes, so the
+decisive invariants this suite checks are:
+
+  - the Postgres column type is UNCHANGED (still uuid / uuid[] / the named
+    composite) -- nothing the user sees is rewritten;
+  - the Iceberg metadata schema AND the physical Parquet data files carry no
+    uuid at any nested depth (only a top-level uuid column stays uuid);
+  - values round-trip exactly through the string storage;
+  - DEFAULT / GENERATED columns are accepted (they have no analogue restriction
+    here because the column type is not rewritten);
+  - both write paths convert: row-by-row INSERT .. VALUES (CSV ingest) and
+    pushed-down INSERT .. SELECT;
+  - a table without the option still stores native uuid (no regression).
+"""
+
+import json
+
+import pytest
+from utils_pytest import *
+
+
+# ---------------------------------------------------------------------------
+# introspection helpers
+# ---------------------------------------------------------------------------
+
+
+def _col_format_type(pg_conn, table, column):
+    """format_type() of a top-level column."""
+    return run_query(
+        "SELECT format_type(atttypid, atttypmod) FROM pg_attribute "
+        f"WHERE attrelid = '{table}'::regclass AND attname = '{column}'",
+        pg_conn,
+    )[0][0]
+
+
+def _composite_attrs_of_column(pg_conn, table, column):
+    """(attname, format_type) of the composite type backing a column."""
+    col_type_oid = run_query(
+        "SELECT atttypid FROM pg_attribute "
+        f"WHERE attrelid = '{table}'::regclass AND attname = '{column}'",
+        pg_conn,
+    )[0][0]
+    return run_query(
+        f"""
+        SELECT a.attname, format_type(a.atttypid, a.atttypmod)
+        FROM pg_attribute a
+        JOIN pg_type t ON t.typrelid = a.attrelid
+        WHERE t.oid = {col_type_oid} AND a.attnum > 0 AND NOT a.attisdropped
+        ORDER BY a.attnum
+        """,
+        pg_conn,
+    )
+
+
+def _iceberg_fields(s3, pg_conn, table):
+    """Parse the iceberg metadata and return the top-level schema fields."""
+    metadata_path = run_query(
+        f"SELECT metadata_location FROM iceberg_tables WHERE table_name = '{table}'",
+        pg_conn,
+    )[0][0]
+    data = read_s3_operations(s3, metadata_path)
+    return json.loads(data)["schemas"][0]["fields"]
+
+
+def _iceberg_field_type(s3, pg_conn, table, column):
+    """The iceberg "type" node of a named top-level column."""
+    return next(
+        f["type"] for f in _iceberg_fields(s3, pg_conn, table) if f["name"] == column
+    )
+
+
+def _uuid_depths(itype, depth):
+    """Nesting depths at which a uuid logical type appears (0 == top-level)."""
+    if isinstance(itype, str):
+        return [depth] if itype == "uuid" else []
+    kind = itype["type"]
+    if kind == "list":
+        return _uuid_depths(itype["element"], depth + 1)
+    if kind == "map":
+        return _uuid_depths(itype["key"], depth + 1) + _uuid_depths(
+            itype["value"], depth + 1
+        )
+    if kind == "struct":
+        out = []
+        for f in itype["fields"]:
+            out += _uuid_depths(f["type"], depth + 1)
+        return out
+    return []
+
+
+def _assert_no_nested_uuid(s3, pg_conn, table):
+    """No uuid logical type at depth > 0 anywhere in the iceberg schema."""
+    for f in _iceberg_fields(s3, pg_conn, table):
+        depths = _uuid_depths(f["type"], 0)
+        assert all(
+            d == 0 for d in depths
+        ), f"field {f['name']} has a nested uuid (depths {depths}) in {table}"
+
+
+def _data_file_paths(conn, table):
+    """The committed DATA files (parquet) backing an iceberg table."""
+    metadata_path = run_query(
+        f"SELECT metadata_location FROM iceberg_tables WHERE table_name = '{table}'",
+        conn,
+    )[0][0]
+    rows = run_query(
+        f"SELECT file_path FROM lake_iceberg.files('{metadata_path}') "
+        "WHERE content = 'DATA'",
+        conn,
+    )
+    return [r[0] for r in rows]
+
+
+def _parquet_uuid_leaves(duck, file_path):
+    """
+    Parquet leaves serialized as a uuid.  A nested uuid stored as string MUST be
+    a BYTE_ARRAY; if it shows up here as a UUID logical type / FIXED_LEN_BYTE_ARRAY
+    the data file diverges from the iceberg schema.
+    """
+    rows = duck.execute(
+        "SELECT name, type::varchar, logical_type::varchar "
+        f"FROM parquet_schema('{file_path}')"
+    ).fetchall()
+    return [
+        (name, ptype, ltype)
+        for (name, ptype, ltype) in rows
+        if (ltype and "UUID" in ltype.upper()) or ptype == "FIXED_LEN_BYTE_ARRAY"
+    ]
+
+
+def _assert_data_files_uuid_free(conn, table, allowed_top_level=()):
+    """The physical Parquet data files must carry string, never uuid, for every
+    nested leaf. A top-level uuid column legitimately stays uuid; pass its
+    parquet leaf name(s) in allowed_top_level to exempt it."""
+    paths = _data_file_paths(conn, table)
+    assert paths, f"no data files written for {table}"
+    duck = create_duckdb_conn()
+    try:
+        for path in paths:
+            offenders = [
+                o
+                for o in _parquet_uuid_leaves(duck, path)
+                if o[0] not in allowed_top_level
+            ]
+            assert (
+                not offenders
+            ), f"{table} data file {path} serialized uuid leaves: {offenders}"
+    finally:
+        duck.close()
+
+
+# ---------------------------------------------------------------------------
+# option validation
+# ---------------------------------------------------------------------------
+
+
+def test_option_accepted_and_auto_is_noop(
+    s3, pg_conn, extension, with_default_location
+):
+    run_command(
+        "CREATE TABLE compat_ok (id int) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    run_command(
+        "CREATE TABLE compat_auto (id int, us uuid[]) USING iceberg "
+        "WITH (compatibility_mode = 'auto');",
+        pg_conn,
+    )
+    # 'auto' applies no divergence; the column type is unchanged either way.
+    assert _col_format_type(pg_conn, "compat_auto", "us") == "uuid[]"
+    pg_conn.rollback()
+
+
+def test_option_invalid_value_rejected(s3, pg_conn, extension, with_default_location):
+    error = run_command(
+        "CREATE TABLE compat_bad (id int) USING iceberg "
+        "WITH (compatibility_mode = 'redshift');",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "invalid compatibility_mode option" in error
+    pg_conn.rollback()
+
+
+def test_option_rejected_on_non_iceberg(s3, pg_conn, extension):
+    location = f"s3://{TEST_BUCKET}/compat_nope.csv"
+    error = run_command(
+        f"CREATE FOREIGN TABLE compat_csv (id int) SERVER pg_lake "
+        f"OPTIONS (format 'csv', path '{location}', compatibility_mode 'snowflake');",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "compatibility_mode" in error
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Postgres column type is never rewritten
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_types_unchanged(s3, pg_conn, extension, with_default_location):
+    """The user-facing schema is identical to a plain table: top-level uuid,
+    uuid[], and the named composite are all preserved (the whole point vs a
+    type rewrite)."""
+    run_command(
+        """
+        CREATE TYPE compat_acct AS (acct_id uuid, note text);
+        CREATE TABLE compat_types (
+            id   uuid DEFAULT gen_random_uuid(),
+            tags uuid[],
+            meta compat_acct
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    assert _col_format_type(pg_conn, "compat_types", "id") == "uuid"
+    assert _col_format_type(pg_conn, "compat_types", "tags") == "uuid[]"
+    # the named composite is preserved (not rebuilt into a generated type)
+    assert _col_format_type(pg_conn, "compat_types", "meta") == "compat_acct"
+    assert _composite_attrs_of_column(pg_conn, "compat_types", "meta") == [
+        ["acct_id", "uuid"],
+        ["note", "text"],
+    ]
+    pg_conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# storage divergence + round-trip (INSERT .. VALUES / CSV ingest path)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_uuid_array_stored_as_string(
+    s3, pg_conn, extension, with_default_location
+):
+    run_command(
+        "CREATE TABLE compat_arr (id int, tags uuid[]) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    run_command(
+        """
+        INSERT INTO compat_arr VALUES
+          (1, ARRAY['11111111-1111-1111-1111-111111111111'::uuid,
+                    '22222222-2222-2222-2222-222222222222'::uuid]),
+          (2, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # storage: no nested uuid in iceberg metadata nor in the parquet data files
+    _assert_no_nested_uuid(s3, pg_conn, "compat_arr")
+    _assert_data_files_uuid_free(pg_conn, "compat_arr")
+
+    # column type unchanged and values round-trip exactly
+    assert _col_format_type(pg_conn, "compat_arr", "tags") == "uuid[]"
+    assert run_query(
+        "SELECT tags[1]::text, tags[2]::text FROM compat_arr WHERE id = 1", pg_conn
+    ) == [
+        [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ]
+    ]
+    assert run_query("SELECT tags FROM compat_arr WHERE id = 2", pg_conn) == [[None]]
+
+    run_command("DROP TABLE compat_arr;", pg_conn)
+    pg_conn.commit()
+
+
+def test_nested_uuid_composite_stored_as_string(
+    s3, pg_conn, extension, with_default_location
+):
+    run_command(
+        """
+        CREATE TYPE compat_c1 AS (cid uuid, note text);
+        CREATE TABLE compat_comp (id int, c compat_c1) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        INSERT INTO compat_comp VALUES
+          (1, ROW('33333333-3333-3333-3333-333333333333'::uuid, 'hi')::compat_c1);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    _assert_no_nested_uuid(s3, pg_conn, "compat_comp")
+    _assert_data_files_uuid_free(pg_conn, "compat_comp")
+
+    # the named composite is preserved and its uuid field still reads as uuid
+    assert _col_format_type(pg_conn, "compat_comp", "c") == "compat_c1"
+    assert run_query(
+        "SELECT (c).cid::text, (c).note FROM compat_comp WHERE id = 1", pg_conn
+    ) == [["33333333-3333-3333-3333-333333333333", "hi"]]
+
+    run_command("DROP TABLE compat_comp; DROP TYPE compat_c1;", pg_conn)
+    pg_conn.commit()
+
+
+def test_deep_nesting_uuid_array_in_composite(
+    s3, pg_conn, extension, with_default_location
+):
+    """uuid[] inside a composite (array-in-struct) is still uuid-free in storage."""
+    run_command(
+        """
+        CREATE TYPE compat_c2 AS (cids uuid[], note text);
+        CREATE TABLE compat_deep (id int, c compat_c2) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        INSERT INTO compat_deep VALUES
+          (1, ROW(ARRAY['44444444-4444-4444-4444-444444444444'::uuid], 'x')::compat_c2);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    _assert_no_nested_uuid(s3, pg_conn, "compat_deep")
+    _assert_data_files_uuid_free(pg_conn, "compat_deep")
+    assert _col_format_type(pg_conn, "compat_deep", "c") == "compat_c2"
+    assert run_query(
+        "SELECT (c).cids[1]::text FROM compat_deep WHERE id = 1", pg_conn
+    ) == [["44444444-4444-4444-4444-444444444444"]]
+
+    run_command("DROP TABLE compat_deep; DROP TYPE compat_c2;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# top-level uuid is NOT diverged (stays native iceberg uuid)
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_uuid_stays_native(s3, pg_conn, extension, with_default_location):
+    run_command(
+        "CREATE TABLE compat_top (id int, u uuid) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    run_command(
+        "INSERT INTO compat_top VALUES "
+        "(1, '55555555-5555-5555-5555-555555555555'::uuid);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # the top-level uuid column is left as a native iceberg uuid
+    assert _iceberg_field_type(s3, pg_conn, "compat_top", "u") == "uuid"
+    assert _col_format_type(pg_conn, "compat_top", "u") == "uuid"
+    assert run_query("SELECT u::text FROM compat_top", pg_conn) == [
+        ["55555555-5555-5555-5555-555555555555"]
+    ]
+
+    run_command("DROP TABLE compat_top;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# pushed-down INSERT .. SELECT write path
+# ---------------------------------------------------------------------------
+
+
+def test_insert_select_pushdown_path(s3, pg_conn, extension, with_default_location):
+    """A pushed-down INSERT .. SELECT (all-iceberg) takes the native-type walker
+    path; it must also store nested uuid as string."""
+    run_command(
+        """
+        CREATE TABLE compat_src (tags uuid[]) USING iceberg;
+        INSERT INTO compat_src VALUES
+          (ARRAY['66666666-6666-6666-6666-666666666666'::uuid]);
+        CREATE TABLE compat_dst (tags uuid[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    run_command("INSERT INTO compat_dst SELECT tags FROM compat_src;", pg_conn)
+    pg_conn.commit()
+
+    _assert_no_nested_uuid(s3, pg_conn, "compat_dst")
+    _assert_data_files_uuid_free(pg_conn, "compat_dst")
+    assert run_query("SELECT tags[1]::text FROM compat_dst", pg_conn) == [
+        ["66666666-6666-6666-6666-666666666666"]
+    ]
+
+    run_command("DROP TABLE compat_dst; DROP TABLE compat_src;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# ALTER ADD COLUMN + DEFAULT clause
+# ---------------------------------------------------------------------------
+
+
+def test_alter_add_nested_uuid_column(s3, pg_conn, extension, with_default_location):
+    run_command(
+        "CREATE TABLE compat_alter (id int) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    run_command("ALTER TABLE compat_alter ADD COLUMN tags uuid[];", pg_conn)
+    run_command(
+        "INSERT INTO compat_alter VALUES "
+        "(1, ARRAY['77777777-7777-7777-7777-777777777777'::uuid]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    _assert_no_nested_uuid(s3, pg_conn, "compat_alter")
+    _assert_data_files_uuid_free(pg_conn, "compat_alter")
+    assert _col_format_type(pg_conn, "compat_alter", "tags") == "uuid[]"
+
+    run_command("DROP TABLE compat_alter;", pg_conn)
+    pg_conn.commit()
+
+
+def test_default_clause_accepted_with_nested_uuid(
+    s3, pg_conn, extension, with_default_location
+):
+    """A column carrying DEFAULT is accepted even alongside a nested-uuid column
+    (a type rewrite would have to reject it; this approach does not)."""
+    run_command(
+        """
+        CREATE TABLE compat_def (
+            id   uuid DEFAULT gen_random_uuid(),
+            tags uuid[]
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        INSERT INTO compat_def (tags) VALUES
+          (ARRAY['88888888-8888-8888-8888-888888888888'::uuid]);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    assert run_query(
+        "SELECT count(*) FROM compat_def WHERE id IS NOT NULL", pg_conn
+    ) == [[1]]
+    # tags is stored as string; the top-level id uuid is legitimately native
+    _assert_data_files_uuid_free(pg_conn, "compat_def", allowed_top_level={"id"})
+    # top-level uuid id is still native uuid
+    assert _iceberg_field_type(s3, pg_conn, "compat_def", "id") == "uuid"
+
+    run_command("DROP TABLE compat_def;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# regression: without the option, nested uuid is stored natively
+# ---------------------------------------------------------------------------
+
+
+def test_non_compat_keeps_native_uuid(s3, pg_conn, extension, with_default_location):
+    run_command(
+        "CREATE TABLE compat_none (id int, tags uuid[]) USING iceberg;",
+        pg_conn,
+    )
+    run_command(
+        "INSERT INTO compat_none VALUES "
+        "(1, ARRAY['99999999-9999-9999-9999-999999999999'::uuid]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # the element IS a uuid at depth 1 in the iceberg metadata
+    tags_type = _iceberg_field_type(s3, pg_conn, "compat_none", "tags")
+    assert _uuid_depths(tags_type, 0) == [1]
+
+    run_command("DROP TABLE compat_none;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
> Draft / RFC. Alternative to #411 for the same goal (Snowflake cannot read a UUID nested in a structured type). Opening for design feedback.

## Problem

Snowflake cannot store a UUID inside a structured/semi-structured type, so a Postgres `uuid` nested in an array, map, or composite cannot be read from a pg_lake Iceberg table by Snowflake.

#411 solves this by rewriting the Postgres column type at DDL time (`uuid[]` becomes `text[]`, composites become generated `lake_struct.*`). That is effective but invasive: the user's declared schema changes, `\d` shows generated types, and columns carrying `DEFAULT` / `GENERATED` / `IDENTITY` are rejected.

## Solution

Keep the Postgres column type exactly as declared and only change the physical Iceberg/Parquet storage type: a nested `uuid` is stored as Iceberg `string`, a top-level `uuid` column stays native `uuid` (Snowflake handles that). Conversion happens only at the I/O boundary, so the user-facing schema, `\d`, and `DEFAULT`/`GENERATED` are all unaffected.

Opt in per table with the same option value as #411:

```sql
-- column types are unchanged; only the physical storage diverges
CREATE TABLE t (
  id    uuid DEFAULT gen_random_uuid(),  -- top-level: stored as uuid
  tags  uuid[],                          -- nested: stored as string
  meta  acct                             -- composite w/ uuid field: stored as string
) USING iceberg WITH (compatibility_mode = 'snowflake');
```

How it works (all gated on the option, no-op otherwise):
- Schema: `RewriteNestedUuidFieldsToString` flips nested `uuid` leaves to `string` in the Iceberg `Field` tree, applied at every site that rebuilds the schema from `field_id_mappings` (create-time registration, the read-time schema rebuild, and the leaf-field list used by consistency checks) so metadata, the schema handed to `read_parquet`, and the physical files all agree.
- Write: the existing depth-unbounded native-type walker (`IcebergWrapQueryWithNativeTypeConversion`) gains a `uuid` -> `varchar` leaf. A new `convertTemporal` flag lets the CSV-ingest path reuse it uuid-only (temporal types are already normalized during Postgres-side serialization there), so both the pushed-down `INSERT .. SELECT` / `COPY FROM` path and the row-by-row `INSERT .. VALUES` path store string.
- Read: no new code. The existing "read as string, convert via the type input function" path round-trips nested string back to `uuid` because the read-side schema rebuild reports string.

## Test plan

`pg_lake_table/tests/pytests/test_compatibility_mode.py` (12 tests, all passing locally) covers:
- option validation (accepted / `auto` no-op / invalid value rejected / rejected on non-iceberg);
- Postgres column types unchanged, including the named composite preserved (not rebuilt);
- nested uuid stored as `string` in BOTH the Iceberg metadata schema AND the physical Parquet data files (arrays, composites, array-in-composite);
- top-level uuid kept native;
- both write paths (`INSERT .. VALUES` CSV ingest and pushed-down `INSERT .. SELECT`);
- `ALTER TABLE ADD COLUMN`, `DEFAULT` accepted, exact value round-trip;
- regression: a table without the option still stores native uuid.

```
cd pg_lake_table && PYTHONPATH=../test_common pipenv run pytest tests/pytests/test_compatibility_mode.py
# 12 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
