### PR TITLE
iceberg: surface/storage type mapping for tables, with compatibility_mode on top

### DIFF
--- a/pg_lake_engine/include/pg_lake/parquet/field.h
+++ b/pg_lake_engine/include/pg_lake/parquet/field.h
@@ -157,3 +157,13 @@ typedef FieldStructElement DataFileSchemaField;
 extern PGDLLEXPORT DataFileSchema * DeepCopyDataFileSchema(const DataFileSchema * schema);
 extern PGDLLEXPORT Field * DeepCopyField(const Field * field);
 extern PGDLLEXPORT bool PGTypeRequiresConversionToIcebergString(Field * field, PGType pgType);
+extern PGDLLEXPORT char *PostgresBaseTypeIdToIcebergTypeName(PGType pgType);
+
+extern PGDLLEXPORT Field * StorageFieldForColumn(DataFileSchema * storageSchema,
+												 const char *name);
+extern PGDLLEXPORT Field * StorageStructFieldByName(Field * storageStruct,
+													const char *name);
+extern PGDLLEXPORT bool ScalarLeafStorageDiverges(Field * storageField,
+												  Oid surfaceOid, int32 surfaceTypmod);
+extern PGDLLEXPORT bool TypeHasStorageDivergentLeaf(Oid typeOid, int32 typmod,
+													Field * storageField);

--- a/pg_lake_engine/include/pg_lake/pgduck/iceberg_query_validation.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/iceberg_query_validation.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "access/tupdesc.h"
+#include "pg_lake/parquet/field.h"
 #include "pg_lake/pgduck/iceberg_validation.h"
 
 /*
@@ -38,10 +39,43 @@ extern PGDLLEXPORT char *IcebergWrapQueryWithErrorOrClampChecks(char *query,
 																bool queryHasRowId);
 
 /*
- * IcebergWrapQueryWithNativeTypeConversion wraps a query to rewrite
- * columns whose native DuckDB shape does not match Iceberg's.  See the
- * implementation for the set of rewrites and why each is required.
+ * IcebergRewriteKind is a bitmask of independent per-leaf rewrites the write
+ * query may need before the data matches Iceberg's on-disk shape.  They are
+ * applied in a single traversal (see IcebergWrapQueryWithRewrites); combine
+ * them with bitwise OR.  Each leaf needs at most one kind (the sets are
+ * disjoint), and a future rewrite is just another flag.
  */
-extern PGDLLEXPORT char *IcebergWrapQueryWithNativeTypeConversion(char *query,
-																  TupleDesc tupleDesc,
-																  bool queryHasRowId);
+typedef enum
+{
+	/*
+	 * Encode INTERVAL/TIMETZ into their Iceberg on-disk shape (interval ->
+	 * struct(months,days,microseconds), timetz -> UTC-normalized time).
+	 * Type-intrinsic: depends only on the DuckDB type, never on a per-table
+	 * storage mapping.  storageSchema unused.
+	 */
+	ICEBERG_REWRITE_NATIVE_ENCODE = 1 << 0,
+
+	/*
+	 * Surface -> persisted storage type wherever the two diverge (e.g. a
+	 * nested uuid stored as iceberg string under compatibility_mode).  Driven
+	 * entirely by storageSchema; type-agnostic.
+	 */
+	ICEBERG_REWRITE_STORAGE_CAST = 1 << 1,
+}			IcebergRewriteKind;
+
+/*
+ * IcebergWrapQueryWithRewrites wraps a query with an outer SELECT that applies
+ * every rewrite in rewriteKinds to each column in a single pass, aliasing
+ * rewritten columns back to their original names and passing untouched columns
+ * through.  storageSchema is the target table's persisted Iceberg storage
+ * schema (or NULL); it is only consulted when ICEBERG_REWRITE_STORAGE_CAST is
+ * set.
+ *
+ * Returns the original query unchanged if no column needs any of the requested
+ * rewrites.
+ */
+extern PGDLLEXPORT char *IcebergWrapQueryWithRewrites(char *query,
+													  TupleDesc tupleDesc,
+													  bool queryHasRowId,
+													  int rewriteKinds,
+													  DataFileSchema * storageSchema);

--- a/pg_lake_engine/include/pg_lake/pgduck/read_data.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/read_data.h
@@ -76,7 +76,8 @@ extern PGDLLEXPORT char *TupleDescToProjectionList(TupleDesc tupleDesc,
 												   List *formatOptions,
 												   ReadRowLocationMode readRowLocationMode,
 												   bool emitRowId,
-												   bool addCast);
+												   bool addCast,
+												   DataFileSchema * storageSchema);
 
 extern PGDLLEXPORT char *TupleDescToDuckDBColumnsMap(TupleDesc tupleDesc,
 													 CopyDataFormat sourceFormat,

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -19,10 +19,18 @@
 
 #include "common/int.h"
 
+#include "pg_lake/extensions/pg_lake_spatial.h"
 #include "pg_lake/extensions/postgis.h"
 #include "pg_lake/parquet/field.h"
 #include "pg_lake/parquet/leaf_field.h"
+#include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/string_utils.h"
+
+#include "access/htup_details.h"
+#include "catalog/pg_type.h"
+#include "utils/lsyscache.h"
+#include "utils/typcache.h"
 
 static FieldStructElement * DeepCopyFieldStructElement(FieldStructElement * structElementField);
 
@@ -207,4 +215,250 @@ PGTypeRequiresConversionToIcebergString(Field * field, PGType pgType)
 	}
 
 	return strcmp(field->field.scalar.typeName, "string") == 0 && pgType.postgresTypeOid != TEXTOID;
+}
+
+
+/*
+ * PostgresBaseTypeIdToIcebergTypeName returns the Iceberg scalar type name a
+ * PostgreSQL base (non-container) type maps to, e.g. uuid -> "uuid", bytea ->
+ * "binary", an oversized numeric or any unknown type -> "string".
+ *
+ * This is the single source of truth for the surface PostgreSQL -> Iceberg
+ * scalar name mapping. It lives in the engine so both the Iceberg field
+ * builder (which shapes the stored schema) and the read/write codecs (which
+ * decide whether a leaf's storage type diverges from its surface type) agree
+ * on the mapping without re-implementing it.
+ *
+ * Domains are unwrapped to their base type so a domain over e.g. bytea maps to
+ * "binary" rather than falling through to the "string" default. The field
+ * builder already resolves domains before reaching here, so this is a no-op for
+ * that caller, but the codecs hand us raw attribute type ids and rely on it.
+ */
+char *
+PostgresBaseTypeIdToIcebergTypeName(PGType pgType)
+{
+	pgType.postgresTypeOid = ResolveDomainBaseType(pgType.postgresTypeOid);
+
+	switch (pgType.postgresTypeOid)
+	{
+		case BOOLOID:
+			return "boolean";
+		case INT4OID:
+		case INT2OID:
+			return "int";
+		case INT8OID:
+			return "long";
+		case FLOAT4OID:
+			return "float";
+		case FLOAT8OID:
+			return "double";
+		case DATEOID:
+			return "date";
+		case TIMEOID:
+			return "time";
+		case TIMETZOID:
+			return "time";
+		case TIMESTAMPOID:
+			return "timestamp";
+		case TIMESTAMPTZOID:
+			return "timestamptz";
+		case TEXTOID:
+		case BPCHAROID:
+		case VARCHAROID:
+			return "string";
+		case UUIDOID:
+			return "uuid";
+		case BYTEAOID:
+			return "binary";
+		case NUMERICOID:
+			{
+				/*
+				 * Follow similar logic as in ChooseCompatibleDuckDBType
+				 */
+				int			precision = -1;
+				int			scale = -1;
+
+				GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(pgType.postgresTypeMod,
+																	 &precision, &scale);
+
+				if (CanPushdownNumericToDuckdb(precision, scale))
+				{
+					/*
+					 * happy case: we can map to DECIMAL(precision, scale)
+					 */
+					return psprintf("decimal(%d,%d)", precision, scale);
+				}
+				else
+				{
+					/* explicit precision which is too big for us */
+					return "string";
+				}
+			}
+		default:
+
+			/*
+			 * We need to handle the case where the type is a PostGIS type.
+			 */
+			if (IsGeometryTypeId(pgType.postgresTypeOid))
+			{
+				ErrorIfPgLakeSpatialNotEnabled();
+				return "binary";
+			}
+
+			/*
+			 * By default, we fallback to string type for any unknown type. In
+			 * majority of the cases, given the type is not known, we pull the
+			 * data as string from pgduck_server. Then, the fdw converts it to
+			 * the appropriate type.
+			 */
+			return "string";
+	}
+}
+
+
+/*
+ * StorageFieldForColumn returns the top-level storage field for a column of the
+ * given name within a DataFileSchema, or NULL.
+ */
+Field *
+StorageFieldForColumn(DataFileSchema * storageSchema, const char *name)
+{
+	if (storageSchema == NULL)
+		return NULL;
+
+	for (size_t i = 0; i < storageSchema->nfields; i++)
+	{
+		FieldStructElement *element = &storageSchema->fields[i];
+
+		if (element->name != NULL && strcmp(element->name, name) == 0)
+			return element->type;
+	}
+
+	return NULL;
+}
+
+
+/*
+ * StorageStructFieldByName returns the child storage field of a struct storage
+ * field whose name matches, or NULL. Navigation is by name so dropped
+ * attributes (absent from the storage struct) are skipped in lockstep.
+ */
+Field *
+StorageStructFieldByName(Field * storageStruct, const char *name)
+{
+	if (storageStruct == NULL || storageStruct->type != FIELD_TYPE_STRUCT)
+		return NULL;
+
+	for (size_t i = 0; i < storageStruct->field.structType.nfields; i++)
+	{
+		FieldStructElement *element = &storageStruct->field.structType.fields[i];
+
+		if (element->name != NULL && strcmp(element->name, name) == 0)
+			return element->type;
+	}
+
+	return NULL;
+}
+
+
+/*
+ * ScalarLeafStorageDiverges returns true when a scalar surface leaf is
+ * physically persisted as a different Iceberg type than the surface type would
+ * naturally map to (e.g. a uuid surface leaf stored as iceberg string under a
+ * compatibility mode). It compares the surface type's natural Iceberg name
+ * against the persisted storage name, so it is type-agnostic and matches the
+ * registration-time divergence decision exactly: intrinsic representation
+ * differences that keep the same Iceberg name (geometry/bytea -> "binary",
+ * oversized numeric -> "string") are NOT divergences, while a genuine
+ * compatibility remap (uuid -> "string") is.
+ */
+bool
+ScalarLeafStorageDiverges(Field * storageField, Oid surfaceOid, int32 surfaceTypmod)
+{
+	if (storageField == NULL ||
+		storageField->type != FIELD_TYPE_SCALAR ||
+		storageField->field.scalar.typeName == NULL)
+		return false;
+
+	char	   *surfaceName =
+		PostgresBaseTypeIdToIcebergTypeName(MakePGType(surfaceOid, surfaceTypmod));
+
+	return strcmp(surfaceName, storageField->field.scalar.typeName) != 0;
+}
+
+
+/*
+ * TypeHasStorageDivergentLeaf recursively checks whether a surface type has any
+ * scalar leaf whose persisted storage type diverges from the surface type
+ * (e.g. a nested uuid stored as iceberg string under compatibility_mode).
+ *
+ * It navigates the surface type tree and the storage field tree in parallel
+ * (by name for composites, by element for arrays, unwrapping domains) so each
+ * surface leaf is matched to its storage field. The check is fully
+ * type-agnostic; see ScalarLeafStorageDiverges.
+ *
+ * Both the read path (which must cast diverging leaves back to the surface type
+ * on read) and the write path (which casts them to the storage type on write)
+ * use this single predicate so the two directions can never disagree on what
+ * diverges.
+ */
+bool
+TypeHasStorageDivergentLeaf(Oid typeOid, int32 typmod, Field * storageField)
+{
+	if (storageField == NULL)
+		return false;
+
+	if (ScalarLeafStorageDiverges(storageField, typeOid, typmod))
+		return true;
+
+	Oid			elemType = get_element_type(typeOid);
+
+	if (OidIsValid(elemType))
+	{
+		Field	   *elemStorage =
+			(storageField->type == FIELD_TYPE_LIST) ?
+			storageField->field.list.element : NULL;
+
+		/* an array column's typmod applies to its element type */
+		return TypeHasStorageDivergentLeaf(elemType, typmod, elemStorage);
+	}
+
+	char		typtype = get_typtype(typeOid);
+
+	if (typtype == TYPTYPE_DOMAIN)
+	{
+		int32		baseTypmod = typmod;
+		Oid			baseType = getBaseTypeAndTypmod(typeOid, &baseTypmod);
+
+		return TypeHasStorageDivergentLeaf(baseType, baseTypmod, storageField);
+	}
+
+	if (typtype == TYPTYPE_COMPOSITE && storageField->type == FIELD_TYPE_STRUCT)
+	{
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
+		bool		found = false;
+
+		for (int i = 0; i < tupdesc->natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+			if (attr->attisdropped)
+				continue;
+
+			Field	   *childStorage =
+				StorageStructFieldByName(storageField, NameStr(attr->attname));
+
+			if (TypeHasStorageDivergentLeaf(attr->atttypid, attr->atttypmod,
+											childStorage))
+			{
+				found = true;
+				break;
+			}
+		}
+
+		ReleaseTupleDesc(tupdesc);
+		return found;
+	}
+
+	return false;
 }

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -18,17 +18,21 @@
 /*
  * Query-level Iceberg value clamp/error and type transformations.
  *
- * Two SELECT-wrapping entry points live here, both applied to the write
+ * Two SELECT-wrapping entry points live here, applied to the write
  * query sent to pgduck_server.  See the function-level comments for the
  * exact set of rewrites and why each is required:
  *
  *   - IcebergWrapQueryWithErrorOrClampChecks: clamp/error checks for
  *     out-of-range temporal values and nested-list flattening.
- *   - IcebergWrapQueryWithNativeTypeConversion: rewrites DuckDB columns
- *     whose native representation differs from the Iceberg target
- *     (INTERVAL, TIMETZ).
+ *   - IcebergWrapQueryWithRewrites: applies a bitmask of per-leaf rewrites
+ *     in a single traversal.  Today that is ICEBERG_REWRITE_NATIVE_ENCODE
+ *     (INTERVAL/TIMETZ -> Iceberg shape, type-intrinsic) and
+ *     ICEBERG_REWRITE_STORAGE_CAST (surface -> persisted storage type for
+ *     compatibility divergences such as a nested uuid stored as iceberg
+ *     string, driven by the storage schema).  A future rewrite is just
+ *     another flag handled in the same pass.
  *
- * Both recurse through arrays, composites, maps, and domains.
+ * All recurse through arrays, composites, maps, and domains.
  *
  * Common validation helpers (policy resolution, IsTemporalType, temporal
  * boundary constants) live in iceberg_validation.c.  Datum-level
@@ -45,6 +49,7 @@
 #include "pg_lake/pgduck/iceberg_query_validation.h"
 #include "pg_lake/pgduck/keywords.h"
 #include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/type.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
@@ -72,12 +77,13 @@ static bool AppendIcebergValidationExpression(StringInfo buf, const char *expr,
 											  int depth);
 
 static bool TypeNeedsNativeConversion(Oid typeOid);
-static bool TupleDescHasNativeConversionColumn(TupleDesc tupleDesc);
+static bool LeafSubtreeNeedsRewrite(Oid typeOid, int32 typmod, int rewriteKinds,
+									Field * storageField);
 static void AppendIntervalStructPack(StringInfo buf, const char *expr);
 static void AppendTimeTzUtcCast(StringInfo buf, const char *expr);
-static bool AppendNativeConversionExpression(StringInfo buf, const char *expr,
-											 Oid typeOid, int32 typmod,
-											 int depth);
+static bool AppendRewriteExpression(StringInfo buf, const char *expr,
+									Oid typeOid, int32 typmod, int depth,
+									int rewriteKinds, Field * storageField);
 
 
 /* ================================================================
@@ -475,10 +481,11 @@ IcebergWrapQueryWithErrorOrClampChecks(char *query, TupleDesc tupleDesc,
  * ================================================================ */
 
 /*
- * TypeNeedsNativeConversion recursively checks whether a type is, or
- * contains, one of the native DuckDB types that needs rewriting before
- * being written to Iceberg (currently INTERVAL and TIMETZ).  Recurses
- * through arrays, composites, maps, and domains.
+ * TypeNeedsNativeConversion recursively checks whether a type is, or contains,
+ * a native DuckDB type (INTERVAL, TIMETZ) whose representation differs from
+ * Iceberg's and so must be rewritten on write. This depends only on the type,
+ * never on a per-table storage mapping. Recurses through arrays, composites,
+ * maps, and domains.
  */
 static bool
 TypeNeedsNativeConversion(Oid typeOid)
@@ -532,24 +539,6 @@ TypeNeedsNativeConversion(Oid typeOid)
 }
 
 
-static bool
-TupleDescHasNativeConversionColumn(TupleDesc tupleDesc)
-{
-	for (int i = 0; i < tupleDesc->natts; i++)
-	{
-		Form_pg_attribute attr = TupleDescAttr(tupleDesc, i);
-
-		if (attr->attisdropped)
-			continue;
-
-		if (TypeNeedsNativeConversion(attr->atttypid))
-			return true;
-	}
-
-	return false;
-}
-
-
 /*
  * AppendIntervalStructPack appends a DuckDB struct_pack expression that
  * decomposes a DuckDB INTERVAL into {months, days, microseconds}.
@@ -575,8 +564,8 @@ AppendIntervalStructPack(StringInfo buf, const char *expr)
 
 /*
  * AppendTimeTzUtcCast emits the DuckDB expression that produces the
- * Iceberg-storable TIME for a TIMETZ leaf.  See
- * IcebergWrapQueryWithNativeTypeConversion for the why.
+ * Iceberg-storable TIME for a TIMETZ leaf.  See AppendRewriteExpression
+ * (ICEBERG_REWRITE_NATIVE_ENCODE) for the why.
  *
  * The inner "CAST(... AS TIMETZ)" is deliberately retained because the
  * leaf expression can arrive at this helper in either of two shapes:
@@ -602,53 +591,134 @@ AppendTimeTzUtcCast(StringInfo buf, const char *expr)
 
 
 /*
- * AppendNativeConversionExpression recursively generates DuckDB SQL
- * that converts native-only types to their Iceberg-compatible shape:
- *   - INTERVAL -> STRUCT(months, days, microseconds)
- *   - TIMETZ   -> CAST(CAST(<expr> AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)
+ * LeafSubtreeNeedsRewrite returns true when the type subtree rooted at
+ * (typeOid, typmod) contains at least one leaf that one of the enabled
+ * rewriteKinds must touch.  It is the OR of the per-kind predicates and gates
+ * container rebuilds: a struct/array is only repacked when something inside it
+ * actually changes, otherwise the whole branch passes through by reference.
+ */
+static bool
+LeafSubtreeNeedsRewrite(Oid typeOid, int32 typmod, int rewriteKinds,
+						Field * storageField)
+{
+	if ((rewriteKinds & ICEBERG_REWRITE_NATIVE_ENCODE) &&
+		TypeNeedsNativeConversion(typeOid))
+		return true;
+
+	if ((rewriteKinds & ICEBERG_REWRITE_STORAGE_CAST) &&
+		TypeHasStorageDivergentLeaf(typeOid, typmod, storageField))
+		return true;
+
+	return false;
+}
+
+
+/*
+ * AppendRewriteExpression recursively generates the DuckDB expression that
+ * applies every enabled rewrite in rewriteKinds to one (sub)value, returning
+ * true when it wrote a rewritten expression (false means "emit the value
+ * unchanged").  The two rewrite families touch disjoint leaves:
  *
- * Handles scalars, arrays (list_transform), composites (struct_pack),
- * maps (map_from_entries + list_transform), and domains.
+ *   - ICEBERG_REWRITE_NATIVE_ENCODE encodes INTERVAL/TIMETZ leaves into their
+ *     Iceberg shape (INTERVAL -> struct(months,days,microseconds), TIMETZ ->
+ *     UTC-normalized TIME).  Type-intrinsic, storageSchema unused.
+ *   - ICEBERG_REWRITE_STORAGE_CAST casts a surface leaf to the storage type
+ *     persisted for it (storageField), e.g. a nested uuid -> string under a
+ *     compatibility mode.
+ *
+ * Containers (array/struct/map/domain) are walked once and rebuilt structurally
+ * only where LeafSubtreeNeedsRewrite reports a changing descendant, so every
+ * untouched branch is reused by reference.  One traversal handles both
+ * families, so a struct mixing an encoded sibling and a storage-cast sibling is
+ * rebuilt by a single struct_pack, never two stacked ones.
  *
  * Returns true if a transformed expression was written to buf.
  */
 static bool
-AppendNativeConversionExpression(StringInfo buf, const char *expr,
-								 Oid typeOid, int32 typmod,
-								 int depth)
+AppendRewriteExpression(StringInfo buf, const char *expr,
+						Oid typeOid, int32 typmod, int depth,
+						int rewriteKinds, Field * storageField)
 {
-	if (typeOid == INTERVALOID)
+	/*
+	 * A single scalar leaf is claimed by at most one rewrite family.  The
+	 * native leaves (INTERVAL/TIMETZ) are bespoke shapes Iceberg has no type
+	 * for, so they are never recorded with a storage divergence in
+	 * field_id_mappings, and a storage cast never lands on them.  Handling a
+	 * leaf that needs both at once would force us to order the two casts,
+	 * which we deliberately do not support today; assert the invariant here
+	 * instead of silently applying only one of them.  (On container nodes the
+	 * first condition is false, so this is a no-op until we reach an actual
+	 * leaf.)
+	 */
+	Assert(!((typeOid == INTERVALOID || typeOid == TIMETZOID) &&
+			 ScalarLeafStorageDiverges(storageField, typeOid, typmod)));
+
+	/* scalar leaf: native encode (INTERVAL/TIMETZ) */
+	if (rewriteKinds & ICEBERG_REWRITE_NATIVE_ENCODE)
 	{
-		AppendIntervalStructPack(buf, expr);
+		if (typeOid == INTERVALOID)
+		{
+			AppendIntervalStructPack(buf, expr);
+			return true;
+		}
+
+		if (typeOid == TIMETZOID)
+		{
+			AppendTimeTzUtcCast(buf, expr);
+			return true;
+		}
+	}
+
+	/* scalar leaf: surface -> storage cast */
+	if ((rewriteKinds & ICEBERG_REWRITE_STORAGE_CAST) &&
+		ScalarLeafStorageDiverges(storageField, typeOid, typmod))
+	{
+		DuckDBType	storageDuck =
+			GetDuckDBTypeByName(storageField->field.scalar.typeName);
+
+		appendStringInfo(buf, "CAST(%s AS %s)", expr,
+						 GetDuckDBTypeName(storageDuck));
 		return true;
 	}
 
-	if (typeOid == TIMETZOID)
-	{
-		AppendTimeTzUtcCast(buf, expr);
-		return true;
-	}
-
-	/* array types: wrap elements via list_transform */
+	/* array types: rewrite elements via list_transform */
 	Oid			elemType = get_element_type(typeOid);
 
 	if (OidIsValid(elemType))
 	{
-		if (!TypeNeedsNativeConversion(elemType))
+		Field	   *elemStorage =
+			(storageField != NULL && storageField->type == FIELD_TYPE_LIST) ?
+			storageField->field.list.element : NULL;
+
+		/* an array's typmod applies to its element type */
+		if (!LeafSubtreeNeedsRewrite(elemType, typmod, rewriteKinds, elemStorage))
 			return false;
 
 		char	   *lambdaVar = psprintf("_x%d", depth);
 
 		appendStringInfo(buf, "list_transform(%s, %s -> ", expr, lambdaVar);
-		AppendNativeConversionExpression(buf, lambdaVar, elemType, -1,
-										 depth + 1);
+		AppendRewriteExpression(buf, lambdaVar, elemType, typmod, depth + 1,
+								rewriteKinds, elemStorage);
 		appendStringInfoChar(buf, ')');
 		return true;
 	}
 
-	/* map check must precede the generic domain unwrap (maps are domains) */
+	/*
+	 * Map check must precede the generic domain unwrap (maps are domains). A
+	 * map only ever carries native encodes: the registration-time DDL rules
+	 * forbid the storage-diverging leaves (uuid and friends) inside a map, so
+	 * ICEBERG_REWRITE_STORAGE_CAST has nothing to do here.  Gate the whole
+	 * branch on the native flag exactly like the scalar native branch above
+	 * -- this is the flag check, not a type check: a storage-only pass (the
+	 * change-log CSV path, which hands us values already in Iceberg shape)
+	 * must leave the map untouched rather than encode an already-encoded
+	 * value.
+	 */
 	if (IsMapTypeOid(typeOid))
 	{
+		if (!(rewriteKinds & ICEBERG_REWRITE_NATIVE_ENCODE))
+			return false;
+
 		PGType		keyType = GetMapKeyType(typeOid);
 		PGType		valType = GetMapValueType(typeOid);
 		bool		keyNeedsConversion = TypeNeedsNativeConversion(keyType.postgresTypeOid);
@@ -666,10 +736,9 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 		char	   *keyExpr = psprintf("%s.key", lambdaVar);
 
 		if (keyNeedsConversion)
-			AppendNativeConversionExpression(buf, keyExpr,
-											 keyType.postgresTypeOid,
-											 keyType.postgresTypeMod,
-											 depth + 1);
+			AppendRewriteExpression(buf, keyExpr, keyType.postgresTypeOid,
+									keyType.postgresTypeMod, depth + 1,
+									ICEBERG_REWRITE_NATIVE_ENCODE, NULL);
 		else
 			appendStringInfoString(buf, keyExpr);
 
@@ -678,10 +747,9 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 		char	   *valExpr = psprintf("%s.value", lambdaVar);
 
 		if (valNeedsConversion)
-			AppendNativeConversionExpression(buf, valExpr,
-											 valType.postgresTypeOid,
-											 valType.postgresTypeMod,
-											 depth + 1);
+			AppendRewriteExpression(buf, valExpr, valType.postgresTypeOid,
+									valType.postgresTypeMod, depth + 1,
+									ICEBERG_REWRITE_NATIVE_ENCODE, NULL);
 		else
 			appendStringInfoString(buf, valExpr);
 
@@ -696,35 +764,39 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 	{
 		Oid			baseType = getBaseTypeAndTypmod(typeOid, &typmod);
 
-		return AppendNativeConversionExpression(buf, expr, baseType, typmod,
-												depth);
+		return AppendRewriteExpression(buf, expr, baseType, typmod, depth,
+									   rewriteKinds, storageField);
 	}
 
-	/* composite types: transform fields via struct_pack */
+	/*
+	 * Composite types: rebuild the struct with struct_pack rather than a
+	 * direct whole-struct CAST.  struct_pack(field := ...) lets us rewrite
+	 * only the fields that change (an encoded INTERVAL/TIMETZ leaf and/or a
+	 * storage-cast uuid leaf) while reusing every other field by name and
+	 * recursing into nested lists/structs.  Because one traversal handles
+	 * both rewrite families, a struct whose fields mix an encoded sibling and
+	 * a storage-cast sibling is rebuilt by a single struct_pack here, never
+	 * two stacked ones.
+	 *
+	 * This is a genuine rebuild, not an in-place edit: DuckDB cannot mutate a
+	 * struct, so struct_pack produces a brand-new struct (new validity mask +
+	 * field set).  Three consequences we rely on: 1. We only reach the
+	 * rebuild when the struct actually contains a changing leaf (gated by
+	 * LeafSubtreeNeedsRewrite), so unchanged structs are emitted by plain
+	 * reference and never repacked.  2. The new struct's validity is reset,
+	 * so the surrounding "CASE WHEN <expr> IS NOT NULL THEN struct_pack(...)
+	 * ELSE NULL END" restores the parent's NULL-ness (DuckDB's struct IS NOT
+	 * NULL is value-level, not the SQL per-field row rule).  3. On write,
+	 * Iceberg field ids are reattached to the rebuilt struct's fields by NAME
+	 * (see AppendFields in write_data.c), so the new vectors carry the
+	 * correct ids regardless of identity or field order.
+	 */
 	if (typtype == TYPTYPE_COMPOSITE)
 	{
-		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
-		bool		anyFieldNeedsTransform = false;
-
-		for (int i = 0; i < tupdesc->natts; i++)
-		{
-			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
-
-			if (attr->attisdropped)
-				continue;
-
-			if (TypeNeedsNativeConversion(attr->atttypid))
-			{
-				anyFieldNeedsTransform = true;
-				break;
-			}
-		}
-
-		if (!anyFieldNeedsTransform)
-		{
-			ReleaseTupleDesc(tupdesc);
+		if (!LeafSubtreeNeedsRewrite(typeOid, typmod, rewriteKinds, storageField))
 			return false;
-		}
+
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
 
 		appendStringInfo(buf, "CASE WHEN %s IS NOT NULL THEN struct_pack(", expr);
 
@@ -743,13 +815,14 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 			const char *fieldName = NameStr(attr->attname);
 			const char *quotedField = duckdb_quote_identifier(fieldName);
 			char	   *fieldExpr = psprintf("%s.%s", expr, quotedField);
+			Field	   *childStorage =
+				StorageStructFieldByName(storageField, fieldName);
 
 			appendStringInfo(buf, "%s := ", quotedField);
 
-			if (!AppendNativeConversionExpression(buf, fieldExpr,
-												  attr->atttypid,
-												  attr->atttypmod,
-												  depth))
+			if (!AppendRewriteExpression(buf, fieldExpr, attr->atttypid,
+										 attr->atttypmod, depth, rewriteKinds,
+										 childStorage))
 				appendStringInfoString(buf, fieldExpr);
 
 			firstField = false;
@@ -765,30 +838,23 @@ AppendNativeConversionExpression(StringInfo buf, const char *expr,
 
 
 /*
- * IcebergWrapQueryWithNativeTypeConversion wraps a query string with an
- * outer SELECT that rewrites columns whose native DuckDB shape does not
- * match Iceberg's:
+ * IcebergWrapQueryWithRewrites wraps query in an outer SELECT that applies every
+ * rewrite in rewriteKinds to each column in a single pass, aliasing every
+ * rewritten column back to its original name and passing untouched columns
+ * straight through.  AppendRewriteExpression returns whether it actually
+ * rewrote a column, which doubles as the "is there any work to do?" check: if no
+ * column changes we return the original query untouched (no redundant SELECT
+ * nesting).
  *
- *   - INTERVAL columns are decomposed into
- *     STRUCT(months BIGINT, days BIGINT, microseconds BIGINT).
- *   - TIMETZ columns are UTC-normalized and cast to TIME
- *     (CAST(CAST(<expr> AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)),
- *     because Iceberg has no time-with-timezone type and DuckDB's
- *     direct CAST(TIMETZ AS TIME) drops the offset without shifting
- *     the time digits.  The inner cast to TIMETZ keeps the outer
- *     AT TIME ZONE 'UTC' well-typed when the source is already plain
- *     TIME (e.g. a TIMETZ field read back from an Iceberg composite
- *     column, where the Parquet-level type is TIME).
- *
- * Rewrites recurse through arrays, composites, maps, and domains.
- *
- * Returns the original query unchanged if no column needs conversion.
+ * storageSchema is the target table's persisted Iceberg storage schema (or
+ * NULL) and is only consulted for the ICEBERG_REWRITE_STORAGE_CAST kind.
  */
 char *
-IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
-										 bool queryHasRowId)
+IcebergWrapQueryWithRewrites(char *query, TupleDesc tupleDesc,
+							 bool queryHasRowId, int rewriteKinds,
+							 DataFileSchema * storageSchema)
 {
-	if (tupleDesc == NULL || !TupleDescHasNativeConversionColumn(tupleDesc))
+	if (tupleDesc == NULL || rewriteKinds == 0)
 		return query;
 
 	StringInfoData wrapped;
@@ -798,6 +864,7 @@ IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
 	appendStringInfoString(&wrapped, "SELECT ");
 
 	bool		firstColumn = true;
+	bool		anyRewritten = false;
 
 	for (int i = 0; i < tupleDesc->natts; i++)
 	{
@@ -810,16 +877,24 @@ IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
 			appendStringInfoString(&wrapped, ", ");
 
 		const char *quotedName = duckdb_quote_identifier(NameStr(attr->attname));
+		Field	   *colStorage =
+			(rewriteKinds & ICEBERG_REWRITE_STORAGE_CAST) ?
+			StorageFieldForColumn(storageSchema, NameStr(attr->attname)) : NULL;
 
 		StringInfoData exprBuf;
 
 		initStringInfo(&exprBuf);
 
-		if (AppendNativeConversionExpression(&exprBuf, quotedName,
-											 attr->atttypid,
-											 attr->atttypmod, 0))
+		bool		rewritten = AppendRewriteExpression(&exprBuf, quotedName,
+														attr->atttypid,
+														attr->atttypmod, 0,
+														rewriteKinds,
+														colStorage);
+
+		if (rewritten)
 		{
 			appendStringInfo(&wrapped, "%s AS %s", exprBuf.data, quotedName);
+			anyRewritten = true;
 		}
 		else
 		{
@@ -831,6 +906,13 @@ IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
 		firstColumn = false;
 	}
 
+	/* no column needed rewriting: leave the query (and any nesting) untouched */
+	if (!anyRewritten)
+	{
+		pfree(wrapped.data);
+		return query;
+	}
+
 	if (queryHasRowId)
 	{
 		if (!firstColumn)
@@ -838,7 +920,7 @@ IcebergWrapQueryWithNativeTypeConversion(char *query, TupleDesc tupleDesc,
 		appendStringInfoString(&wrapped, "_row_id");
 	}
 
-	appendStringInfo(&wrapped, " FROM (%s) AS __iceberg_native_conv", query);
+	appendStringInfo(&wrapped, " FROM (%s) AS __iceberg_rewrite", query);
 
 	return wrapped.data;
 }

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -73,6 +73,10 @@ static char *BuildColumnProjection(char *expression,
 								   List *formatOptions,
 								   bool addAlias);
 static char *BuildMapWithIntervalProjection(char *columnName, Oid mapTypeId);
+static char *BuildStorageToSurfaceProjection(const char *columnName,
+											 Oid columnTypeId, int32 columnTypeMod,
+											 DuckDBTypeInfo duckdbType,
+											 DataFileSchema * storageSchema);
 static char *GetLogFormatRegex(List *options);
 static char *GetLogTimestampFormat(List *options);
 
@@ -150,7 +154,8 @@ ReadDataSourceQuery(List *sourcePaths,
 														   formatOptions,
 														   readRowLocationMode,
 														   emitRowId,
-														   addCast);
+														   addCast,
+														   schema);
 
 		appendStringInfo(&command, "%s ", projection);
 	}
@@ -1023,17 +1028,89 @@ BuildStructWithIntervalProjection(char *columnName, Oid compositeTypeId)
 
 
 /*
+ * BuildStorageToSurfaceProjection is the read-side inverse of the write-side
+ * IcebergWrapQueryWithRewrites: where the write path casts a surface leaf down
+ * to its persisted storage type (e.g. a nested uuid -> iceberg string under
+ * compatibility_mode), this brings the leaf back up to the surface type on
+ * read.  The read schema makes DuckDB return the leaf in its storage form, but
+ * PostgreSQL expects the surface type, so a recursive CAST to the surface duck
+ * type lifts every diverging leaf back.
+ *
+ * Returns the full "CAST(...) AS column" projection for a storage-diverging
+ * column, or NULL when the column has no divergence (the caller then emits the
+ * column through its normal projection).
+ */
+static char *
+BuildStorageToSurfaceProjection(const char *columnName, Oid columnTypeId,
+								int32 columnTypeMod, DuckDBTypeInfo duckdbType,
+								DataFileSchema * storageSchema)
+{
+	Field	   *storageField = StorageFieldForColumn(storageSchema, columnName);
+
+	if (!TypeHasStorageDivergentLeaf(columnTypeId, columnTypeMod, storageField))
+		return NULL;
+
+	const char *reconstruction = NULL;
+	const char *castTargetType = duckdbType.typeName;
+
+	/*
+	 * Interval fields living alongside a diverging leaf inside a composite
+	 * are first reconstructed into a DuckDB INTERVAL (which then casts to
+	 * itself as a no-op), since a struct cannot be cast directly to INTERVAL.
+	 */
+	if (duckdbType.typeId == DUCKDB_TYPE_STRUCT)
+		reconstruction = BuildStructWithIntervalProjection((char *) columnName,
+														   columnTypeId);
+
+	if (reconstruction == NULL)
+		reconstruction = duckdb_quote_identifier((char *) columnName);
+	else
+	{
+		/*
+		 * BuildStructWithIntervalProjection already rebuilt the interval
+		 * leaves into DuckDB INTERVAL values, so the surface cast must
+		 * describe those leaves as INTERVAL too. duckdbType.typeName is built
+		 * with DATA_FORMAT_ICEBERG, which renders interval as
+		 * STRUCT(months,days,microseconds) (its on-disk shape) -- casting
+		 * against that would attempt INTERVAL -> STRUCT and fail. Re-deriving
+		 * the type name with a non-Iceberg format flips only the interval
+		 * rendering to INTERVAL; every other leaf (including the
+		 * storage-diverging uuid->string) is format-independent, so the cast
+		 * stays "interval -> interval" (a no-op) for the reconstructed fields
+		 * while still bringing the diverging leaves back to their surface
+		 * type.
+		 */
+		castTargetType =
+			GetFullDuckDBTypeNameForPGType(MakePGType(columnTypeId,
+													  columnTypeMod),
+										   DATA_FORMAT_PARQUET);
+	}
+
+	return psprintf("CAST(%s AS %s) AS %s",
+					reconstruction,
+					castTargetType,
+					duckdb_quote_identifier((char *) columnName));
+}
+
+
+/*
  * TupleDescToProjectionList converts a PostgreSQL tuple descriptor to
  * projection list in string form.
  *
  * We add explicit casts for types that do not have an equivalent in
  * the source format.
+ *
+ * storageSchema is the table's persisted Iceberg storage schema (or NULL). It
+ * is used to detect columns whose physical storage diverges from the surface
+ * type (e.g. a nested uuid stored as string under compatibility_mode), which
+ * require an unconditional cast back to the surface type.
  */
 char *
 TupleDescToProjectionList(TupleDesc tupleDesc, CopyDataFormat sourceFormat,
 						  List *formatOptions,
 						  ReadRowLocationMode readRowLocationMode,
-						  bool emitRowId, bool addCast)
+						  bool emitRowId, bool addCast,
+						  DataFileSchema * storageSchema)
 {
 	StringInfoData projection;
 
@@ -1058,6 +1135,32 @@ TupleDescToProjectionList(TupleDesc tupleDesc, CopyDataFormat sourceFormat,
 															   columnTypeMod,
 															   sourceFormat,
 															   preferVarchar);
+
+		/*
+		 * Columns whose physical storage diverges from the surface type (e.g.
+		 * a nested uuid stored as iceberg string under compatibility_mode)
+		 * are cast back to the surface type by
+		 * BuildStorageToSurfaceProjection, the read-side inverse of the write
+		 * path's IcebergWrapQueryWithRewrites.
+		 */
+		if (sourceFormat == DATA_FORMAT_ICEBERG)
+		{
+			char	   *divergentProjection =
+				BuildStorageToSurfaceProjection(columnName, columnTypeId,
+												columnTypeMod, duckdbType,
+												storageSchema);
+
+			if (divergentProjection != NULL)
+			{
+				if (hasColumns)
+					appendStringInfoString(&projection, ", ");
+
+				appendStringInfoString(&projection, divergentProjection);
+
+				hasColumns = true;
+				continue;
+			}
+		}
 
 		/*
 		 * For composite types containing interval fields, we need to

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -137,10 +137,24 @@ WriteQueryResultTo(char *query,
 													   queryHasRowId);
 	}
 
-	if (wrapNativeTypes && destinationFormat == DATA_FORMAT_ICEBERG)
+	if (destinationFormat == DATA_FORMAT_ICEBERG)
 	{
-		query = IcebergWrapQueryWithNativeTypeConversion(query, queryTupleDesc,
-														 queryHasRowId);
+		/*
+		 * Storage->surface divergence casts are always applied: they reflect
+		 * the destination's persisted storage types and are a no-op unless
+		 * the schema actually diverges for some leaf.  Native temporal encode
+		 * (INTERVAL/TIMETZ) is additionally gated by wrapNativeTypes: some
+		 * callers (the change-log CSV path) hand us a query whose temporal
+		 * columns were already normalized to their Iceberg struct shape
+		 * upstream.  Both kinds run in a single traversal.
+		 */
+		int			rewriteKinds = ICEBERG_REWRITE_STORAGE_CAST;
+
+		if (wrapNativeTypes)
+			rewriteKinds |= ICEBERG_REWRITE_NATIVE_ENCODE;
+
+		query = IcebergWrapQueryWithRewrites(query, queryTupleDesc,
+											 queryHasRowId, rewriteKinds, schema);
 	}
 
 	/*

--- a/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
@@ -21,6 +21,8 @@
 
 #include "nodes/pg_list.h"
 
+#include "pg_lake/parquet/field.h"
+
 /*
  * Name of the per-table iceberg option that selects a compatibility mode.
  * Defined here so option validation (pg_lake_table) and the conversion logic
@@ -33,24 +35,18 @@
  * the table is consumable by a downstream engine with narrower type support.
  *
  * Unlike a type-rewrite, these modes never change the PostgreSQL column type:
- * the column stays exactly as declared (uuid stays uuid). The intent is that
- * only the physical Iceberg/Parquet storage type and the I/O-boundary
- * conversions differ, with that surface->storage divergence persisted per-leaf
- * in lake_table.field_id_mappings (decided once, at registration).
- *
- * This option layer recognizes and validates the mode and enforces the DDL
- * guards; on its own it records no divergence (a storage no-op). The actual
- * per-leaf storage shaping is layered on top by the surface/storage mapping
- * change.
+ * the column stays exactly as declared (uuid stays uuid). Only the physical
+ * Iceberg/Parquet storage type and the I/O-boundary conversions differ, and
+ * that surface->storage divergence is persisted per-leaf in
+ * lake_table.field_id_mappings (decided once, at registration).
  *
  *   ICEBERG_COMPAT_AUTO       default (option unset or 'auto'): no storage
  *                             divergence. This is the hook where future
  *                             auto-detection would live.
- *   ICEBERG_COMPAT_SNOWFLAKE  selects the Snowflake-compatible storage shape
- *                             (a uuid nested inside an array/composite is
- *                             stored as Iceberg `string`, since Snowflake
- *                             cannot hold a UUID inside a structured type; a
- *                             top-level uuid column stays native `uuid`).
+ *   ICEBERG_COMPAT_SNOWFLAKE  a uuid nested inside an array/composite is
+ *                             stored as Iceberg `string` (Snowflake cannot
+ *                             hold a UUID inside a structured type). A
+ *                             top-level uuid column stays native `uuid`.
  */
 typedef enum IcebergCompatibilityMode
 {
@@ -77,6 +73,16 @@ extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromCreateOp
 
 /* Reads the option from an existing relation; AUTO for non-iceberg/unset. */
 extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromRelation(Oid relationId);
+
+/*
+ * Rewrites, in place, the storage type of every nested (level > 0) scalar
+ * Iceberg field for which the mode's per-leaf policy diverges from the surface
+ * type (e.g. snowflake stores a nested "uuid" as "string"), leaving top-level
+ * fields untouched. No-op for ICEBERG_COMPAT_AUTO. Maps are NOT descended: a
+ * column containing a map is rejected at DDL time under a restrictive mode.
+ */
+extern PGDLLEXPORT void ApplyCompatibilityStorageMapping(Field * field,
+														 IcebergCompatibilityMode mode);
 
 /*
  * True iff typeOid is, or contains at any depth, a pg_map type. Used to reject

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -17,26 +17,32 @@
 
 /*
  * compatibility_mode.c
- *  Per-table Iceberg "compatibility mode" option recognition and DDL guards.
+ *  Per-table Iceberg "compatibility mode" STORAGE shaping.
  *
  * Some engines that read pg_lake's Iceberg tables have narrower type support
  * than Iceberg itself. The `compatibility_mode` table option opts a table into
  * a storage shape consumable by such an engine WITHOUT changing the PostgreSQL
  * column type the user declared.
  *
- * This module is the option layer: it parses/validates the option value
- * ('auto' or 'snowflake'), exposes accessors that read the mode off a CREATE
- * statement or an existing relation, and provides TypeContainsMap so the DDL
- * paths can reject types a restrictive mode cannot represent (a pg_map under
- * 'snowflake'). On its own this layer is a pure storage no-op: choosing
- * 'snowflake' is accepted and validated, but no surface->storage divergence is
- * yet recorded or applied.
+ * The only mode today is 'snowflake'. Snowflake cannot store a UUID inside a
+ * semi-structured/structured type, so a uuid nested inside an array or
+ * composite is stored physically as Iceberg `string`; a top-level uuid column
+ * stays native `uuid`. The PostgreSQL column type is left as uuid in every
+ * case -- conversion happens at the I/O boundary (uuid->varchar on write,
+ * varchar->uuid on read) driven by the persisted storage mapping in
+ * lake_table.field_id_mappings, so `\d` and DEFAULT/GENERATED clauses are
+ * unaffected.
  *
- * The actual storage shaping (e.g. storing a nested uuid as Iceberg `string`)
- * and its persistence in lake_table.field_id_mappings are layered on top of
- * this option by the surface/storage type-mapping change; the read/write
- * codecs then recover the conversion from the persisted mapping, never from
- * this option directly.
+ * This module supplies the option accessors and the registration-time Iceberg
+ * Field-tree walker (ApplyCompatibilityStorageMapping). It deliberately does
+ * NOT rewrite the PostgreSQL column type: the read/write codecs recover the
+ * conversion from the persisted storage mapping, never from this option.
+ *
+ * The walker is type-agnostic: it applies a per-leaf POLICY
+ * (CompatStorageScalarType) to every nested scalar field. All knowledge of
+ * which surface types diverge from their storage type for a given mode lives
+ * in that one small policy function, so a new rule (or a new mode) is a single
+ * edit there rather than a new walker.
  */
 
 #include "postgres.h"
@@ -61,6 +67,10 @@
 int			IcebergDefaultCompatibilityMode = ICEBERG_COMPAT_AUTO;
 
 
+static const char *CompatStorageScalarType(const char *surfaceTypeName,
+										   IcebergCompatibilityMode mode);
+static void ApplyCompatibilityStorageMappingInternal(Field * field, int level,
+													 IcebergCompatibilityMode mode);
 static bool AnyCompositeFieldContainsMap(Oid typeOid);
 static Oid	DomainBaseTypeOneLevel(Oid domainOid);
 
@@ -141,6 +151,104 @@ IcebergCompatibilityModeFromRelation(Oid relationId)
 
 	return ParseIcebergCompatibilityMode(
 										 GetStringOption(foreignTable->options, ICEBERG_COMPATIBILITY_MODE_OPTION, false));
+}
+
+
+/*
+ * CompatStorageScalarType is the ONE place that knows which surface scalar
+ * types diverge from their storage type under a compatibility mode. Given the
+ * iceberg type name of a nested scalar leaf, it returns the iceberg type name
+ * it must be STORED as, or NULL when the leaf is stored as-is (the common
+ * case). Adding a rule (or a mode) is an edit here, not a new walker.
+ *
+ * snowflake: Snowflake cannot hold a uuid inside a structured type, so a
+ * nested uuid is stored as `string`.
+ */
+static const char *
+CompatStorageScalarType(const char *surfaceTypeName, IcebergCompatibilityMode mode)
+{
+	if (surfaceTypeName == NULL)
+		return NULL;
+
+	switch (mode)
+	{
+		case ICEBERG_COMPAT_SNOWFLAKE:
+			if (strcmp(surfaceTypeName, "uuid") == 0)
+				return "string";
+			break;
+
+		case ICEBERG_COMPAT_AUTO:
+			break;
+	}
+
+	return NULL;
+}
+
+
+/*
+ * ApplyCompatibilityStorageMappingInternal rewrites, in place, the storage type
+ * of every nested (level > 0) scalar leaf for which the mode's policy returns a
+ * divergent storage type. level 0 is the column itself, so a top-level leaf is
+ * left as-is. Maps are not descended: a column containing a map is rejected at
+ * DDL time under a restrictive mode, so a divergent leaf can never reach here
+ * through a map, and not descending keeps the read/write codecs free of
+ * map-key/value conversion handling.
+ */
+static void
+ApplyCompatibilityStorageMappingInternal(Field * field, int level,
+										 IcebergCompatibilityMode mode)
+{
+	if (field == NULL)
+		return;
+
+	switch (field->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			{
+				const char *storageTypeName = (level > 0)
+					? CompatStorageScalarType(field->field.scalar.typeName, mode)
+					: NULL;
+
+				if (storageTypeName != NULL)
+					field->field.scalar.typeName = pstrdup(storageTypeName);
+				break;
+			}
+
+		case FIELD_TYPE_LIST:
+			ApplyCompatibilityStorageMappingInternal(field->field.list.element,
+													 level + 1, mode);
+			break;
+
+		case FIELD_TYPE_STRUCT:
+			for (size_t i = 0; i < field->field.structType.nfields; i++)
+				ApplyCompatibilityStorageMappingInternal(field->field.structType.fields[i].type,
+														 level + 1, mode);
+			break;
+
+		case FIELD_TYPE_MAP:
+
+			/*
+			 * Unreachable: this walker only runs for non-auto modes (see
+			 * ApplyCompatibilityStorageMapping), and every such mode rejects
+			 * map columns at DDL time
+			 * (ErrorIfColumnsUnsupportedForCompatibilityMode), so a divergent
+			 * leaf can never reach here through a map. The Assert documents
+			 * and enforces that invariant; the break keeps production builds
+			 * safe if a future mode ever relaxes the DDL rejection.
+			 */
+			Assert(false);
+			break;
+	}
+}
+
+
+void
+ApplyCompatibilityStorageMapping(Field * field, IcebergCompatibilityMode mode)
+{
+	if (mode == ICEBERG_COMPAT_AUTO)
+		return;
+
+	ApplyCompatibilityStorageMappingInternal(field, 0, mode);
 }
 
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -154,7 +154,6 @@ static IcebergToDuckDBType IcebergToDuckDBTypes[] =
 };
 
 static DuckDBType GetDuckDBTypeFromIcebergType(IcebergType icebergType);
-static char *PostgresBaseTypeIdToIcebergTypeName(PGType pgType);
 static IcebergTypeInfo * GetIcebergTypeInfoFromTypeName(const char *typeName);
 static const char *GetIcebergJsonSerializedConstDefaultIfExists(const char *attrName, Field * field, Node *defaultExpr);
 
@@ -591,92 +590,6 @@ GetIcebergTypeInfoFromTypeName(const char *typeName)
 	}
 
 	return icebergTypeInfo;
-}
-
-
-/*
- * PostgresTypeIdToIcebergTypeName converts a PostgreSQL type ID and typemod
- * to an Iceberg type name.
- *
- * Based on https://iceberg.apache.org/spec/#schemas
- */
-static char *
-PostgresBaseTypeIdToIcebergTypeName(PGType pgType)
-{
-	switch (pgType.postgresTypeOid)
-	{
-		case BOOLOID:
-			return "boolean";
-		case INT4OID:
-		case INT2OID:
-			return "int";
-		case INT8OID:
-			return "long";
-		case FLOAT4OID:
-			return "float";
-		case FLOAT8OID:
-			return "double";
-		case DATEOID:
-			return "date";
-		case TIMEOID:
-			return "time";
-		case TIMETZOID:
-			return "time";
-		case TIMESTAMPOID:
-			return "timestamp";
-		case TIMESTAMPTZOID:
-			return "timestamptz";
-		case TEXTOID:
-		case BPCHAROID:
-		case VARCHAROID:
-			return "string";
-		case UUIDOID:
-			return "uuid";
-		case BYTEAOID:
-			return "binary";
-		case NUMERICOID:
-			{
-				/*
-				 * Follow similar logic as in ChooseCompatibleDuckDBType
-				 */
-				int			precision = -1;
-				int			scale = -1;
-
-				GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(pgType.postgresTypeMod,
-																	 &precision, &scale);
-
-				if (CanPushdownNumericToDuckdb(precision, scale))
-				{
-					/*
-					 * happy case: we can map to DECIMAL(precision, scale)
-					 */
-					return psprintf("decimal(%d,%d)", precision, scale);
-				}
-				else
-				{
-					/* explicit precision which is too big for us */
-					return "string";
-				}
-			}
-		default:
-
-			/*
-			 * We need to handle the case where the type is a PostGIS type.
-			 */
-			if (IsGeometryTypeId(pgType.postgresTypeOid))
-			{
-				ErrorIfPgLakeSpatialNotEnabled();
-				return "binary";
-			}
-
-			/*
-			 * By default, we fallback to string type for any unknown type. In
-			 * majority of the cases, given the type is not known, we pull the
-			 * data as string from pgduck_server. Then, the fdw converts it to
-			 * the appropriate type.
-			 */
-			return "string";
-	}
 }
 
 

--- a/pg_lake_table/include/pg_lake/fdw/schema_operations/field_id_mapping_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/schema_operations/field_id_mapping_catalog.h
@@ -27,6 +27,19 @@
 
 #define INVALID_FIELD_ID 0
 
+/*
+ * StorageOverride records a per-leaf storage type that diverges from the
+ * surface type, keyed by the leaf's iceberg field_id. The compatibility-mode
+ * policy decides these at registration time; reads and writes recover them
+ * from the persisted mapping. An empty list means storage equals surface
+ * everywhere (the common case).
+ */
+typedef struct StorageOverride
+{
+	int			fieldId;
+	PGType		storagePgType;
+}			StorageOverride;
+
 extern PGDLLEXPORT DataFileSchema * GetDataFileSchemaForInternalIcebergTable(Oid relationId);
 extern PGDLLEXPORT List *GetLeafFieldsForInternalIcebergTable(Oid relationId);
 extern PGDLLEXPORT List *GetRegisteredFieldForAttributes(Oid relationId, List *attrNos);
@@ -34,6 +47,19 @@ extern PGDLLEXPORT DataFileSchemaField * GetRegisteredFieldForAttribute(Oid rela
 extern PGDLLEXPORT AttrNumber GetAttributeForFieldId(Oid relationId, int fieldId);
 extern PGDLLEXPORT void UpdateRegisteredFieldWriteDefaultForAttribute(Oid relationId, AttrNumber attNum, const char *writeDefault);
 extern PGDLLEXPORT int GetLargestRegisteredFieldId(Oid relationId);
+
+/*
+ * CollectStorageDivergences walks a surface iceberg field tree and the matching
+ * storage tree (same shape, differing only in scalar type names) in parallel
+ * and returns the list of per-leaf StorageOverrides where the two diverge (NIL
+ * when identical). fieldId is the iceberg id of the root node of both trees.
+ * This is where the surface->storage decision is turned into persistable rows;
+ * RegisterIcebergColumnMapping merely records the result.
+ */
+extern PGDLLEXPORT List *CollectStorageDivergences(Field * surfaceField,
+												   Field * storageField, int fieldId);
+
 extern PGDLLEXPORT void RegisterIcebergColumnMapping(Oid relationId, Field * field,
 													 AttrNumber attNo, int parentFieldId, PGType pgType,
-													 int fieldId, const char *writeDefault, const char *initialDefault);
+													 int fieldId, const char *writeDefault, const char *initialDefault,
+													 List *storageOverrides);

--- a/pg_lake_table/include/pg_lake/fdw/schema_operations/register_field_ids.h
+++ b/pg_lake_table/include/pg_lake/fdw/schema_operations/register_field_ids.h
@@ -36,8 +36,17 @@ typedef struct PostgresColumnMapping
 	bool		attHasDef;
 	PGType		pgType;
 
-	/* field that is mapped to postgres column */
+	/* field that is mapped to postgres column (storage-shaped) */
 	DataFileSchemaField *field;
+
+	/*
+	 * Per-leaf surface->storage divergences for this column (a list of
+	 * StorageOverride), decided when the column mapping was created. NIL when
+	 * storage equals surface (the common case).
+	 * RegisterPostgresColumnMappings hands these to the catalog so they are
+	 * persisted alongside the field.
+	 */
+	List	   *storageOverrides;
 }			PostgresColumnMapping;
 
 extern PGDLLEXPORT void RegisterPostgresColumnMappings(List *pgColumnMappingList);

--- a/pg_lake_table/pg_lake_table--3.3--3.4.sql
+++ b/pg_lake_table/pg_lake_table--3.3--3.4.sql
@@ -1,5 +1,14 @@
 -- Upgrade script for pg_lake_table from 3.3 to 3.4
 
+-- Per-leaf surface->storage type divergence for compatibility_mode (e.g.
+-- 'snowflake'): field_pg_type stays the PostgreSQL surface type (e.g. uuid),
+-- while field_storage_pg_type records the Iceberg/Parquet storage type (e.g.
+-- text/string) when it differs. NULL means storage == surface (the common
+-- case), so existing rows keep identical behavior after upgrade.
+ALTER TABLE lake_table.field_id_mappings
+    ADD COLUMN field_storage_pg_type regtype,
+    ADD COLUMN field_storage_pg_typemod int;
+
 -- Tighten autovacuum_analyze on the commit-time diff catalogs so the planner's
 -- reltuples stays close enough to reality to keep the diff query off the
 -- nested-loop cliff. Complements pg_lake_table.commit_time_analyze_threshold.

--- a/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
+++ b/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
@@ -55,7 +55,10 @@ static DataFileSchemaField * CreateRegisteredFieldForAttribute(Oid relationId, i
 static void InsertFieldMapping(Oid relationId, int attrIcebergFieldId,
 							   AttrNumber pg_attnum, PGType pgType,
 							   const char *writeDefault, const char *initialDefault,
-							   int parentFieldId);
+							   int parentFieldId, Oid storagePgType,
+							   int32 storagePgTypemod);
+static void ApplyPersistedStorageOverridesToFields(Oid relationId, List *fields);
+static void ApplyStorageOverrideToField(Field * field, int fieldId, List *overrides);
 static AttrNumber GetAttributeForFieldIdForInternalIcebergTable(Oid relationId, int fieldId);
 static AttrNumber GetAttributeForFieldIdForExternalIcebergTable(char *metadataPath, Oid relationId, int fieldId);
 
@@ -133,8 +136,208 @@ GetRegisteredFieldForAttributes(Oid relationId, List *attrNos)
 
 	SPI_END();
 
+	/*
+	 * The tree above is re-derived purely from the surface pg types, so apply
+	 * any persisted surface->storage overrides (e.g. nested uuid stored as
+	 * string) onto the rebuilt field trees. Done as a post-pass with its own
+	 * SPI session to avoid nesting inside the loop above.
+	 */
+	ApplyPersistedStorageOverridesToFields(relationId, fields);
+
 	return fields;
 
+}
+
+
+/*
+ * ApplyPersistedStorageOverridesToFields rewrites the (surface-derived) iceberg
+ * field trees so each leaf with a persisted field_storage_pg_type reflects the
+ * storage type. This keeps the tree path (read_parquet schema + .metadata.json)
+ * consistent with the leaf path (GetLeafFieldsForInternalIcebergTable), which
+ * already prefers storage over surface via COALESCE.
+ */
+static void
+ApplyPersistedStorageOverridesToFields(Oid relationId, List *fields)
+{
+	MemoryContext currentContext = CurrentMemoryContext;
+	List	   *overrides = NIL;
+
+	DECLARE_SPI_ARGS(1);
+
+	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+
+	SPI_START_EXTENSION_OWNER(PgLakeIceberg);
+
+	bool		readOnly = false;
+
+	SPI_EXECUTE("SELECT field_id, field_storage_pg_type, field_storage_pg_typemod FROM "
+				MAPPING_TABLE_NAME
+				" WHERE table_name OPERATOR(pg_catalog.=) $1 "
+				"AND field_storage_pg_type IS NOT NULL", readOnly);
+
+	for (int rowIndex = 0; rowIndex < SPI_processed; rowIndex++)
+	{
+		MemoryContext spiContext = MemoryContextSwitchTo(currentContext);
+
+		bool		isNull = false;
+		int			fieldId = GET_SPI_VALUE(INT4OID, rowIndex, 1, &isNull);
+		Oid			storageTypeOid = GET_SPI_VALUE(OIDOID, rowIndex, 2, &isNull);
+		int32		storageTypmod = GET_SPI_VALUE(INT4OID, rowIndex, 3, &isNull);
+
+		StorageOverride *override = palloc0(sizeof(StorageOverride));
+
+		override->fieldId = fieldId;
+		override->storagePgType = MakePGType(storageTypeOid, storageTypmod);
+
+		overrides = lappend(overrides, override);
+
+		MemoryContextSwitchTo(spiContext);
+	}
+
+	SPI_END();
+
+	/* common (and fast) case: no divergence, nothing to rewrite */
+	if (overrides == NIL)
+		return;
+
+	ListCell   *fieldCell = NULL;
+
+	foreach(fieldCell, fields)
+	{
+		DataFileSchemaField *field = lfirst(fieldCell);
+
+		ApplyStorageOverrideToField(field->type, field->id, overrides);
+	}
+}
+
+
+/*
+ * ApplyStorageOverrideToField recursively walks an iceberg field tree (mirroring
+ * RegisterIcebergColumnMapping's descent) and, at each scalar leaf whose
+ * field_id has a persisted storage override, rewrites the scalar type name to
+ * the storage type's iceberg type (e.g. "uuid" -> "string").
+ */
+static void
+ApplyStorageOverrideToField(Field * field, int fieldId, List *overrides)
+{
+	if (field == NULL)
+		return;
+
+	switch (field->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			{
+				ListCell   *overrideCell = NULL;
+
+				foreach(overrideCell, overrides)
+				{
+					StorageOverride *override = lfirst(overrideCell);
+
+					if (override->fieldId == fieldId)
+					{
+						int			dummy = fieldId;
+						Field	   *storageField =
+							PostgresTypeToIcebergField(override->storagePgType,
+													   false, &dummy);
+
+						field->field.scalar.typeName =
+							pstrdup(storageField->field.scalar.typeName);
+						break;
+					}
+				}
+				break;
+			}
+
+		case FIELD_TYPE_LIST:
+			ApplyStorageOverrideToField(field->field.list.element,
+										field->field.list.elementId, overrides);
+			break;
+
+		case FIELD_TYPE_MAP:
+			ApplyStorageOverrideToField(field->field.map.key,
+										field->field.map.keyId, overrides);
+			ApplyStorageOverrideToField(field->field.map.value,
+										field->field.map.valueId, overrides);
+			break;
+
+		case FIELD_TYPE_STRUCT:
+			for (size_t i = 0; i < field->field.structType.nfields; i++)
+				ApplyStorageOverrideToField(field->field.structType.fields[i].type,
+											field->field.structType.fields[i].id,
+											overrides);
+			break;
+	}
+}
+
+
+/*
+ * CollectStorageDivergences walks the surface and storage field trees in
+ * parallel (they share a shape; only scalar type names can differ) and records
+ * one StorageOverride per scalar leaf whose storage iceberg type differs from
+ * its surface iceberg type. The storage PostgreSQL type is recovered from the
+ * storage leaf via IcebergFieldToPostgresType. This is the single place the
+ * surface->storage divergence is turned into persistable rows; the caller
+ * (which shaped the storage tree via the compatibility policy) owns the
+ * decision, and RegisterIcebergColumnMapping merely records the rows.
+ */
+List *
+CollectStorageDivergences(Field * surfaceField, Field * storageField, int fieldId)
+{
+	List	   *overrides = NIL;
+
+	if (surfaceField == NULL || storageField == NULL ||
+		surfaceField->type != storageField->type)
+		return NIL;
+
+	switch (storageField->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			{
+				const char *surfaceName = surfaceField->field.scalar.typeName;
+				const char *storageName = storageField->field.scalar.typeName;
+
+				if (surfaceName != NULL && storageName != NULL &&
+					strcmp(surfaceName, storageName) != 0)
+				{
+					StorageOverride *override = palloc0(sizeof(StorageOverride));
+
+					override->fieldId = fieldId;
+					override->storagePgType = IcebergFieldToPostgresType(storageField);
+					overrides = lappend(overrides, override);
+				}
+				break;
+			}
+
+		case FIELD_TYPE_LIST:
+			overrides = CollectStorageDivergences(surfaceField->field.list.element,
+												  storageField->field.list.element,
+												  storageField->field.list.elementId);
+			break;
+
+		case FIELD_TYPE_MAP:
+			overrides = list_concat(
+									CollectStorageDivergences(surfaceField->field.map.key,
+															  storageField->field.map.key,
+															  storageField->field.map.keyId),
+									CollectStorageDivergences(surfaceField->field.map.value,
+															  storageField->field.map.value,
+															  storageField->field.map.valueId));
+			break;
+
+		case FIELD_TYPE_STRUCT:
+			if (surfaceField->field.structType.nfields ==
+				storageField->field.structType.nfields)
+			{
+				for (size_t i = 0; i < storageField->field.structType.nfields; i++)
+					overrides = list_concat(overrides,
+											CollectStorageDivergences(surfaceField->field.structType.fields[i].type,
+																	  storageField->field.structType.fields[i].type,
+																	  storageField->field.structType.fields[i].id));
+			}
+			break;
+	}
+
+	return overrides;
 }
 
 
@@ -447,6 +650,8 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 					 "		field_id,"
 					 "		field_pg_type,"
 					 "		field_pg_typemod,"
+					 "		field_storage_pg_type,"
+					 "		field_storage_pg_typemod,"
 					 "		parent_field_id,"
 					 "		pg_attnum AS top_level_pg_attnum,"
 					 "		1 AS level"
@@ -464,6 +669,8 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 					 "		f.field_id,"
 					 "		f.field_pg_type,"
 					 "		f.field_pg_typemod,"
+					 "		f.field_storage_pg_type,"
+					 "		f.field_storage_pg_typemod,"
 					 "		f.parent_field_id,"
 					 "		fh.top_level_pg_attnum,"
 					 "		fh.level + 1 as level"
@@ -471,8 +678,15 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 					 "	  ON f.parent_field_id OPERATOR(pg_catalog.=) fh.field_id AND f.table_name OPERATOR(pg_catalog.=) fh.table_name"
 					 ") "
 
-	/* base query */
-					 "SELECT field_id, field_pg_type, field_pg_typemod, level "
+	/*
+	 * base query: build the leaf field from the STORAGE type (falling back to
+	 * the surface type when storage == surface), but keep the surface type
+	 * separate so leafField->pgType stays the PostgreSQL type (e.g. uuid).
+	 */
+					 "SELECT field_id, "
+					 "COALESCE(field_storage_pg_type, field_pg_type), "
+					 "COALESCE(field_storage_pg_typemod, field_pg_typemod), "
+					 "field_pg_type, field_pg_typemod, level "
 					 "FROM field_hierarchy fh "
 					 "WHERE NOT EXISTS ("
 	/* If a field never appears as a parent, it's a leaf */
@@ -509,15 +723,21 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 		bool		isNull = false;
 
 		int			fieldId = GET_SPI_VALUE(INT4OID, rowIndex, 1, &isNull);
-		Oid			typeOid = GET_SPI_VALUE(OIDOID, rowIndex, 2, &isNull);
-		int32		typmod = GET_SPI_VALUE(INT4OID, rowIndex, 3, &isNull);
-		int32		level = GET_SPI_VALUE(INT4OID, rowIndex, 4, &isNull);
+		Oid			storageTypeOid = GET_SPI_VALUE(OIDOID, rowIndex, 2, &isNull);
+		int32		storageTypmod = GET_SPI_VALUE(INT4OID, rowIndex, 3, &isNull);
+		Oid			surfaceTypeOid = GET_SPI_VALUE(OIDOID, rowIndex, 4, &isNull);
+		int32		surfaceTypmod = GET_SPI_VALUE(INT4OID, rowIndex, 5, &isNull);
+		int32		level = GET_SPI_VALUE(INT4OID, rowIndex, 6, &isNull);
 
-		PGType		pgType = MakePGType(typeOid, typmod);
+		/* the iceberg leaf field reflects the storage type (e.g. string) */
+		PGType		storagePgType = MakePGType(storageTypeOid, storageTypmod);
+
+		/* but the leaf's pgType stays the surface type (e.g. uuid) */
+		PGType		surfacePgType = MakePGType(surfaceTypeOid, surfaceTypmod);
 
 		bool		forAddColumn = false;
 		int			subFieldIndex = fieldId;
-		Field	   *field = PostgresTypeToIcebergField(pgType, forAddColumn, &subFieldIndex);
+		Field	   *field = PostgresTypeToIcebergField(storagePgType, forAddColumn, &subFieldIndex);
 
 		Assert(field != NULL && field->type == FIELD_TYPE_SCALAR);
 
@@ -525,7 +745,7 @@ GetLeafFieldsForInternalIcebergTable(Oid relationId)
 
 		leafField->fieldId = fieldId;
 		leafField->field = field;
-		leafField->pgType = pgType;
+		leafField->pgType = surfacePgType;
 		leafField->duckTypeName = IcebergTypeNameToDuckdbTypeName(field->field.scalar.typeName);
 		leafField->level = level;
 
@@ -638,9 +858,34 @@ GetLargestRegisteredFieldId(Oid relationId)
 void
 RegisterIcebergColumnMapping(Oid relationId, Field * field,
 							 AttrNumber attNo, int parentFieldId, PGType pgType,
-							 int fieldId, const char *writeDefault, const char *initialDefault)
+							 int fieldId, const char *writeDefault, const char *initialDefault,
+							 List *storageOverrides)
 {
 	EnsureIcebergField(field);
+
+	/*
+	 * Record the surface->storage divergence for this leaf, if any. The
+	 * caller decided the divergence (by shaping the storage field tree via
+	 * the compatibility policy) and handed us the precomputed StorageOverride
+	 * rows; here we only look this leaf's id up and persist what we are told.
+	 * A container's id never appears in the list, so the lookup is a no-op
+	 * for non-leaf nodes.
+	 */
+	Oid			storagePgType = InvalidOid;
+	int32		storagePgTypemod = -1;
+	ListCell   *overrideCell = NULL;
+
+	foreach(overrideCell, storageOverrides)
+	{
+		StorageOverride *override = lfirst(overrideCell);
+
+		if (override->fieldId == fieldId)
+		{
+			storagePgType = override->storagePgType.postgresTypeOid;
+			storagePgTypemod = override->storagePgType.postgresTypeMod;
+			break;
+		}
+	}
 
 	/*
 	 * we always insert given field mapping before recursing into its
@@ -648,7 +893,7 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 	 */
 	InsertFieldMapping(relationId, fieldId, attNo, pgType,
 					   writeDefault, initialDefault,
-					   parentFieldId);
+					   parentFieldId, storagePgType, storagePgTypemod);
 
 	/* update parent field id before recursing into subfields */
 	parentFieldId = fieldId;
@@ -679,7 +924,7 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 				RegisterIcebergColumnMapping(relationId, elementField,
 											 attNo, parentFieldId, elementPGType,
 											 elementFieldId, elementWriteDefault,
-											 elementInitialDefault);
+											 elementInitialDefault, storageOverrides);
 
 				break;
 			}
@@ -700,7 +945,8 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 
 				RegisterIcebergColumnMapping(relationId, keyField, attNo,
 											 parentFieldId, keyPGType, keyFieldId,
-											 keyWriteDefault, keyInitialDefault);
+											 keyWriteDefault, keyInitialDefault,
+											 storageOverrides);
 
 				PGType		valuePGType = GetMapValueType(pgType.postgresTypeOid);
 
@@ -714,7 +960,8 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 
 				RegisterIcebergColumnMapping(relationId, valueField, attNo,
 											 parentFieldId, valuePGType, valueFieldId,
-											 valueWriteDefault, valueInitialDefault);
+											 valueWriteDefault, valueInitialDefault,
+											 storageOverrides);
 
 				break;
 
@@ -761,7 +1008,8 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 
 					RegisterIcebergColumnMapping(relationId, subField, attNo,
 												 parentFieldId, subFieldPGType, subFieldId,
-												 subFieldWriteDefault, subFieldInitialDefault);
+												 subFieldWriteDefault, subFieldInitialDefault,
+												 storageOverrides);
 				}
 
 				if (isComposite)
@@ -786,7 +1034,8 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 */
 static void
 InsertFieldMapping(Oid relationId, int fieldId, AttrNumber attrNo, PGType pgType,
-				   const char *writeDefault, const char *initialDefault, int parentFieldId)
+				   const char *writeDefault, const char *initialDefault, int parentFieldId,
+				   Oid storagePgType, int32 storagePgTypemod)
 {
 	/*
 	 * Now, with SPI select from field_id_mappings (relation_id, pg_attnum)
@@ -797,10 +1046,11 @@ InsertFieldMapping(Oid relationId, int fieldId, AttrNumber attrNo, PGType pgType
 					 "(table_name, field_id, pg_attnum, "
 					 "parent_field_id, field_pg_type, "
 					 "field_pg_typemod, initial_default, "
-					 "write_default) VALUES "
-					 "($1, $2, $3, $4, $5, $6, $7, $8)");
+					 "write_default, field_storage_pg_type, "
+					 "field_storage_pg_typemod) VALUES "
+					 "($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)");
 
-	DECLARE_SPI_ARGS(8);
+	DECLARE_SPI_ARGS(10);
 
 	SPI_ARG_VALUE(1, OIDOID, relationId, false);
 	SPI_ARG_VALUE(2, INT4OID, fieldId, false);
@@ -810,6 +1060,15 @@ InsertFieldMapping(Oid relationId, int fieldId, AttrNumber attrNo, PGType pgType
 	SPI_ARG_VALUE(6, INT4OID, pgType.postgresTypeMod, false);
 	SPI_ARG_VALUE(7, TEXTOID, initialDefault, initialDefault == NULL);
 	SPI_ARG_VALUE(8, TEXTOID, writeDefault, writeDefault == NULL);
+
+	/*
+	 * field_storage_pg_type/typemod record the Iceberg/Parquet storage type
+	 * when it diverges from the surface field_pg_type (e.g. a nested uuid
+	 * stored as string under compatibility_mode='snowflake'); NULL means
+	 * storage == surface, the common case.
+	 */
+	SPI_ARG_VALUE(9, OIDOID, storagePgType, !OidIsValid(storagePgType));
+	SPI_ARG_VALUE(10, INT4OID, storagePgTypemod, !OidIsValid(storagePgType));
 
 	/* switch to schema owner */
 	SPI_START_EXTENSION_OWNER(PgLakeIceberg);

--- a/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
+++ b/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
@@ -84,7 +84,8 @@ RegisterPostgresColumnMappings(List *pgColumnMappingList)
 									 attrNo, parentFieldId, pgColumnMapping->pgType,
 									 field->id,
 									 field->writeDefault,
-									 field->initialDefault);
+									 field->initialDefault,
+									 pgColumnMapping->storageOverrides);
 	}
 }
 
@@ -190,6 +191,14 @@ CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, b
 
 	TupleDesc	tupleDesc = RelationGetDescr(rel);
 
+	/*
+	 * compatibility_mode is consulted ONLY here, at registration. It decides
+	 * the per-leaf storage mapping once; reads and writes recover the
+	 * surface->storage divergence from the persisted mapping, never from this
+	 * option again.
+	 */
+	IcebergCompatibilityMode compatMode = IcebergCompatibilityModeFromRelation(relationId);
+
 	foreach(columnDefCell, columnDefList)
 	{
 		ColumnDef  *columnDef = (ColumnDef *) lfirst(columnDefCell);
@@ -219,8 +228,30 @@ CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, b
 
 		PGType		pgType = MakePGType(typeOid, typmod);
 
-		field->type =
+		/*
+		 * Columns unsupported under the table's compatibility mode (e.g. a
+		 * map under 'snowflake') are rejected at the DDL layer
+		 * (ErrorIfColumnsUnsupportedForCompatibilityMode), so by the time we
+		 * shape the storage tree they can only be supported types.
+		 */
+		Assert(!(compatMode == ICEBERG_COMPAT_SNOWFLAKE && TypeContainsMap(typeOid)));
+
+		/*
+		 * Build the surface field tree, then a storage tree that the
+		 * compatibility policy may remap (e.g. snowflake stores a nested uuid
+		 * as string). field->type carries the storage shape (used for
+		 * metadata and writes); the per-leaf surface->storage divergence is
+		 * collected here and persisted by RegisterPostgresColumnMappings. The
+		 * PostgreSQL column type is never touched.
+		 */
+		Field	   *surfaceFieldTree =
 			PostgresTypeToIcebergField(pgType, forAddColumn, &subFieldIndex);
+
+		field->type = DeepCopyField(surfaceFieldTree);
+		ApplyCompatibilityStorageMapping(field->type, compatMode);
+
+		List	   *storageOverrides =
+			CollectStorageDivergences(surfaceFieldTree, field->type, fieldId);
 
 		field->required = columnDef->is_not_null;
 
@@ -253,6 +284,7 @@ CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, b
 		columnMapping->attname = pstrdup(columnName);
 		columnMapping->pgType = MakePGType(typeOid, typmod);
 		columnMapping->attrNum = attrNo;
+		columnMapping->storageOverrides = storageOverrides;
 
 		pgColumnMappingList = lappend(pgColumnMappingList, columnMapping);
 
@@ -320,6 +352,19 @@ CreatePostgresColumnMappingsForIcebergTableFromExternalMetadata(Oid relationId)
 		columnMapping->pgType = MakePGType(attr->atttypid, attr->atttypmod);
 		columnMapping->attNotNull = attr->attnotnull;
 		columnMapping->attHasDef = attr->atthasdef;
+
+		/*
+		 * The external metadata is the storage shape; the PostgreSQL
+		 * attribute is the surface. Persist any per-leaf divergence between
+		 * them (e.g. a nested uuid column stored as string) so a
+		 * re-registered table keeps its storage mapping.
+		 */
+		int			subFieldIndex = field->id;
+		Field	   *surfaceFieldTree =
+			PostgresTypeToIcebergField(columnMapping->pgType, false, &subFieldIndex);
+
+		columnMapping->storageOverrides =
+			CollectStorageDivergences(surfaceFieldTree, field->type, field->id);
 
 		pgColumnMappingList = lappend(pgColumnMappingList, columnMapping);
 	}

--- a/pg_lake_table/src/planner/query_pushdown.c
+++ b/pg_lake_table/src/planner/query_pushdown.c
@@ -34,6 +34,7 @@
 #include "pg_lake/fdw/pg_lake_table.h"
 #include "pg_lake/fdw/deparse_ruleutils.h"
 #include "pg_lake/fdw/shippable.h"
+#include "pg_lake/fdw/schema_operations/register_field_ids.h"
 #include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/planner/dbt.h"
 #include "pg_lake/planner/explain.h"
@@ -1738,10 +1739,15 @@ QueryPushdownExplainScan(CustomScanState *node, List *ancestors,
 														   false);
 
 			if (IsWritableIcebergTable(scanState->insertIntoRelid))
+			{
 				queryString =
-					IcebergWrapQueryWithNativeTypeConversion(queryString,
-															 scanState->insertTargetTupleDesc,
-															 false);
+					IcebergWrapQueryWithRewrites(queryString,
+												 scanState->insertTargetTupleDesc,
+												 false,
+												 ICEBERG_REWRITE_NATIVE_ENCODE |
+												 ICEBERG_REWRITE_STORAGE_CAST,
+												 GetDataFileSchemaForTable(scanState->insertIntoRelid));
+			}
 		}
 
 		ExplainPropertyText("Vectorized SQL", queryString, es);

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -322,7 +322,7 @@ def test_map_rejected_under_snowflake_compat_on_add_column(
 
 
 # ---------------------------------------------------------------------------
-# Storage no-op: this layer alone does NOT shape storage
+# Top-level uuid stays native under snowflake
 # ---------------------------------------------------------------------------
 
 
@@ -352,55 +352,6 @@ def test_top_level_uuid_stays_native_under_snowflake(
     pg_conn.commit()
 
 
-def test_nested_uuid_is_storage_noop_under_snowflake(
-    pg_conn, s3, with_default_location
-):
-    """
-    Option layer only: a nested uuid under 'snowflake' is STILL stored as
-    Iceberg uuid (no surface->storage divergence yet) and the surface type is
-    unchanged. The storage-mapping layer changes this to 'string'; this test
-    pins down that the option alone is a storage no-op.
-    """
-    run_command(
-        """
-        CREATE SCHEMA test_compat_nested;
-        SET search_path TO test_compat_nested;
-        CREATE TYPE acct AS (name text, uid uuid);
-        CREATE TABLE t (id int, a acct, us uuid[]) USING iceberg
-            WITH (compatibility_mode = 'snowflake');
-        """,
-        pg_conn,
-    )
-    pg_conn.commit()
-
-    fields = _metadata_fields(s3, pg_conn, "test_compat_nested", "t")
-    # The composite's uuid field (uid) stays Iceberg uuid; the text field
-    # (name) is naturally Iceberg string, so we only assert the uuid leaf is
-    # still uuid here (the storage-mapping layer would turn it into string).
-    comp_leaves = _collect_leaf_types(_field_by_name(fields, "a")["type"])
-    arr_leaves = _collect_leaf_types(_field_by_name(fields, "us")["type"])
-    assert "uuid" in comp_leaves, comp_leaves
-    # uuid[] is the clean discriminator: no-op keeps it list<uuid> (the
-    # storage-mapping layer would make it list<string>).
-    assert arr_leaves == ["uuid"], arr_leaves
-
-    run_command(
-        f"""
-        INSERT INTO test_compat_nested.t VALUES
-            (1, ROW('alice', '{U1}')::acct, ARRAY['{U1}','{U2}']::uuid[]),
-            (2, ROW('bob', NULL)::acct, NULL);
-        """,
-        pg_conn,
-    )
-    pg_conn.commit()
-    result = run_query(
-        "SELECT id, (a).name, (a).uid, us FROM test_compat_nested.t ORDER BY id",
-        pg_conn,
-    )
-    assert [[r[0], r[1], _u(r[2]), _ulist(r[3])] for r in result] == [
-        [1, "alice", U1, [U1, U2]],
-        [2, "bob", None, None],
-    ]
-
-    run_command("DROP SCHEMA test_compat_nested CASCADE;", pg_conn)
-    pg_conn.commit()
+# Nested surface->storage divergence (nested uuid stored as Iceberg string under
+# 'snowflake') is exercised in test_iceberg_uuid_compat.py, which owns the
+# storage-mapping behavior. This file stays focused on the option/GUC/DDL layer.

--- a/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
@@ -878,8 +878,8 @@ def test_insert_select_timetz_with_oor_clamp_and_aggregate_pushdown(
 
     IcebergWrapQueryWithErrorOrClampChecks (driven by
     ``out_of_range_values = 'clamp'`` on the target) wraps the timestamp
-    column.  IcebergWrapQueryWithNativeTypeConversion (this PR) wraps the
-    timetz column.  Both must coexist on the same query without aliasing
+    column.  IcebergWrapQueryWithRewrites (this PR) wraps the timetz
+    column.  Both must coexist on the same query without aliasing
     collision, and both must still rewrite the column expression when it
     is the output of an aggregate rather than a bare column reference.
 
@@ -887,7 +887,7 @@ def test_insert_select_timetz_with_oor_clamp_and_aggregate_pushdown(
     file, this pins:
 
       * Both subquery aliases (``__iceberg_oor`` and
-        ``__iceberg_native_conv``) appear in the Vectorized SQL.
+        ``__iceberg_rewrite``) appear in the Vectorized SQL.
       * The TIMETZ UTC-normalizing cast still fires when the column
         expression is ``max(at_time)``.
       * The aggregated end-to-end result matches what PostgreSQL would
@@ -948,12 +948,12 @@ def test_insert_select_timetz_with_oor_clamp_and_aggregate_pushdown(
         # Both wrappers must have fired on the same query.  The subquery
         # aliases are the canonical signature of each wrap: __iceberg_oor
         # for the clamp/error wrap on the timestamp column, and
-        # __iceberg_native_conv for the TIMETZ rewrite.
+        # __iceberg_rewrite for the TIMETZ rewrite.
         assert "__iceberg_oor" in explain, (
             "Expected OOR clamp wrapper to fire on the timestamp column:\n" + explain
         )
-        assert "__iceberg_native_conv" in explain, (
-            "Expected native-type-conversion wrapper to fire on timetz:\n" + explain
+        assert "__iceberg_rewrite" in explain, (
+            "Expected the rewrite wrapper to fire on timetz:\n" + explain
         )
         assert "AT TIME ZONE 'UTC' AS TIME" in explain, (
             "Expected TIMETZ UTC-normalizing cast in the wrapped SQL:\n" + explain

--- a/pg_lake_table/tests/pytests/test_iceberg_uuid_compat.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_uuid_compat.py
@@ -1,0 +1,1652 @@
+"""
+Tests for compatibility_mode='snowflake' UUID surface/storage mapping.
+
+Background
+----------
+Snowflake cannot store a uuid inside a structured/semi-structured type.
+``compatibility_mode='snowflake'`` makes pg_lake keep the PostgreSQL column
+type as ``uuid`` (the *surface* type) while physically storing any *nested*
+uuid as an Iceberg ``string`` (the *storage* type).  A top-level uuid column
+is unaffected (Iceberg/Snowflake both represent it natively).
+
+The surface->storage divergence is persisted per leaf in
+``lake_table.field_id_mappings`` (``field_storage_pg_type``), so:
+
+  * the external Iceberg metadata.json shows ``string`` for nested uuids,
+  * the *physical Parquet* leaf is written as ``VARCHAR`` (verified by reading
+    the data file directly, because the Iceberg metadata claiming ``string`` is
+    not proof of what was actually written to disk),
+  * the PostgreSQL-visible column type stays ``uuid``,
+  * the write path casts ``uuid -> VARCHAR`` before writing,
+  * the read path casts the stored string back to ``uuid``.
+
+psycopg2 returns uuid values as plain strings here (no UUID adapter is
+registered), so uuid round-trips are compared via ``_u`` after normalizing
+to a lowercase string.
+"""
+
+from utils_pytest import *
+import json
+import pytest
+
+
+# A handful of stable uuid literals used across the tests.
+U1 = "11111111-1111-1111-1111-111111111111"
+U2 = "22222222-2222-2222-2222-222222222222"
+U3 = "33333333-3333-3333-3333-333333333333"
+
+# Distinct uuid literals for the deeply nested "pyramid" fixture below.  Named
+# after their position so the round-trip assertions read unambiguously.
+NODE1 = "a0000000-0000-0000-0000-00000000000a"
+NODE2 = "b0000000-0000-0000-0000-00000000000b"
+PRIM1 = "c1111111-1111-1111-1111-11111111111c"
+SEC1 = "d2222222-2222-2222-2222-22222222222d"  # stored in a DOMAIN-over-uuid leaf
+PRIM2 = "e3333333-3333-3333-3333-33333333333e"
+DEV1 = "f4444444-4444-4444-4444-44444444444f"
+BAK1 = "05555555-5555-5555-5555-555555555550"
+DEV2 = "16666666-6666-6666-6666-666666666661"
+TAG1 = "27777777-7777-7777-7777-777777777772"
+TAG2 = "38888888-8888-8888-8888-888888888883"
+
+
+def _u(value):
+    """Normalize a uuid value (psycopg may return str or uuid.UUID)."""
+    return None if value is None else str(value).lower()
+
+
+def _ulist(value):
+    """
+    Normalize a uuid array, preserving NULL for the whole array.
+
+    psycopg2 returns uuid[] as the raw PostgreSQL array text ``{u1,u2}`` here
+    (uuid elements are unquoted and have no array-special characters), so parse
+    that form as well as an already-decoded python list.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        inner = value.strip("{}")
+        return [] if inner == "" else [_u(v) for v in inner.split(",")]
+    return [_u(v) for v in value]
+
+
+def _metadata_fields(s3, pg_conn, schema_name, table_name):
+    """Return the top-level Iceberg schema fields list from metadata.json."""
+    results = run_query(
+        f"SELECT metadata_location FROM lake_iceberg.tables "
+        f"WHERE table_name = '{table_name}' AND table_namespace = '{schema_name}'",
+        pg_conn,
+    )
+    assert len(results) == 1, f"expected one iceberg table {schema_name}.{table_name}"
+    data = read_s3_operations(s3, results[0][0])
+    return json.loads(data)["schemas"][0]["fields"]
+
+
+def _catalog_storage_divergences(superuser_conn, qualified_table):
+    """
+    Return the per-leaf surface->storage overrides pg_lake recorded in
+    ``lake_table.field_id_mappings`` for a table, as a sorted list of
+    ``(field_pg_type, field_storage_pg_type)`` tuples for every leaf whose
+    storage type diverges (``field_storage_pg_type IS NOT NULL``).
+
+    The catalog is the source of truth that both the write and read paths
+    consult to decide which leaves get cast.  The storage-mapping tests already
+    assert the Iceberg ``metadata.json`` and the physical Parquet; asserting the
+    catalog too proves all three agree on what diverges.
+    """
+    rows = run_query(
+        "SELECT field_pg_type::text, field_storage_pg_type::text "
+        "FROM lake_table.field_id_mappings "
+        f"WHERE table_name = '{qualified_table}'::regclass "
+        "  AND field_storage_pg_type IS NOT NULL "
+        "ORDER BY 1, 2",
+        superuser_conn,
+    )
+    return sorted((r[0], r[1]) for r in rows)
+
+
+def _assert_uuid_to_text_divergences(superuser_conn, qualified_table, count):
+    """
+    Assert the table records exactly ``count`` storage overrides in the catalog
+    and that every one is the ``uuid -> text`` mapping, the only divergence the
+    'snowflake' compatibility mode produces today.  ``count=None`` only requires
+    that at least one override exists and that all of them are ``uuid -> text``
+    (handy for deep type pyramids where the exact leaf count is not the point).
+    """
+    divergences = _catalog_storage_divergences(superuser_conn, qualified_table)
+    if count is None:
+        assert (
+            divergences
+        ), f"expected at least one storage override for {qualified_table}"
+        assert set(divergences) == {("uuid", "text")}, divergences
+    else:
+        assert divergences == [("uuid", "text")] * count, divergences
+
+
+def _collect_leaf_types(field_type):
+    """
+    Recursively collect every scalar (leaf) Iceberg type string reachable
+    from an Iceberg field ``type`` node (which may be a plain string for a
+    scalar, or a dict for struct/list/map).
+    """
+    if isinstance(field_type, str):
+        return [field_type]
+
+    kind = field_type.get("type")
+    if kind == "struct":
+        leaves = []
+        for f in field_type["fields"]:
+            leaves.extend(_collect_leaf_types(f["type"]))
+        return leaves
+    if kind == "list":
+        return _collect_leaf_types(field_type["element"])
+    if kind == "map":
+        return _collect_leaf_types(field_type["key"]) + _collect_leaf_types(
+            field_type["value"]
+        )
+    return []
+
+
+def _field_by_name(fields, name):
+    return next(f for f in fields if f["name"] == name)
+
+
+def _parquet_column_types(superuser_conn, pgduck_conn, qualified_table):
+    """
+    Return ``{column_name: physical_parquet_type}`` for the table's actual data
+    file(s), as resolved by DuckDB reading the bytes on disk.
+
+    This deliberately inspects the Parquet files themselves rather than the
+    Iceberg ``metadata.json``.  The metadata.json advertising ``string`` is not
+    proof that the value was physically written as a Parquet string -- the
+    write path could disagree with the declared schema.  Reading the file is
+    the only check that catches that divergence, so every storage-mapping test
+    asserts on this, not on the Iceberg type alone.
+
+    DuckDB resolves a Parquet UUID logical leaf to ``UUID`` and a Parquet string
+    leaf to ``VARCHAR``, including inside ``STRUCT(...)`` / ``...[]`` types, so a
+    leaked native uuid shows up as the substring ``UUID`` and a uuid stored as
+    string shows up as ``VARCHAR``.
+    """
+    files = run_query(
+        f"SELECT path FROM lake_table.files "
+        f"WHERE table_name = '{qualified_table}'::regclass",
+        superuser_conn,
+    )
+    assert files, f"expected at least one data file for {qualified_table}"
+
+    per_file = []
+    for (path,) in files:
+        described = run_query(
+            f"DESCRIBE SELECT * FROM read_parquet('{path}')", pgduck_conn
+        )
+        per_file.append({row[0]: row[1] for row in described})
+
+    # All data files for a table must share the same physical schema.
+    for types in per_file[1:]:
+        assert types == per_file[0], (per_file[0], types)
+    return per_file[0]
+
+
+def _parquet_leaf_fields(superuser_conn, pgduck_conn, qualified_table):
+    """
+    Return ``{field_id: (name, parquet_type, converted_type)}`` for every *leaf*
+    column physically present in the table's data file(s), read straight from
+    the Parquet footer.
+
+    Keyed by the Parquet ``field_id`` that DuckDB stamped into the file.  This is
+    the crux of the struct_pack correctness check: even though struct_pack
+    rebuilds the struct into brand-new vectors, the write path reattaches Iceberg
+    field ids to the new fields *by name*, so the physical leaf must still carry
+    the exact Iceberg id pg_lake assigned -- otherwise readers map it wrongly.
+    """
+    files = run_query(
+        f"SELECT path FROM lake_table.files "
+        f"WHERE table_name = '{qualified_table}'::regclass",
+        superuser_conn,
+    )
+    assert files, f"expected at least one data file for {qualified_table}"
+
+    per_file = []
+    for (path,) in files:
+        rows = run_query(
+            "SELECT field_id, name, type, converted_type "
+            f"FROM parquet_schema('{path}') WHERE num_children IS NULL",
+            pgduck_conn,
+        )
+        per_file.append(
+            {int(r[0]): (r[1], r[2], r[3]) for r in rows if r[0] is not None}
+        )
+
+    for leaves in per_file[1:]:
+        assert leaves == per_file[0], (per_file[0], leaves)
+    return per_file[0]
+
+
+def _metadata_leaf_ids(fields):
+    """
+    Walk the Iceberg metadata schema ``fields`` and return ``{name: (id, type)}``
+    for every named scalar leaf (descending through struct/list/map), where
+    ``type`` is the Iceberg type string the metadata advertises for that leaf.
+    """
+    out = {}
+
+    def walk(field_type, name):
+        if isinstance(field_type, str):
+            if name is not None:
+                out[name] = (None, field_type)
+            return
+        kind = field_type.get("type")
+        if kind == "struct":
+            for f in field_type["fields"]:
+                t = f["type"]
+                if isinstance(t, str):
+                    out[f["name"]] = (f["id"], t)
+                else:
+                    walk(t, f["name"])
+        elif kind == "list":
+            walk(field_type["element"], name)
+        elif kind == "map":
+            walk(field_type["key"], name)
+            walk(field_type["value"], name)
+
+    for f in fields:
+        t = f["type"]
+        if isinstance(t, str):
+            out[f["name"]] = (f["id"], t)
+        else:
+            walk(t, f["name"])
+    return out
+
+
+def _create_deep_uuid_types(conn, schema):
+    """
+    Build a deliberately deep, mixed type pyramid in ``schema`` and leave that
+    schema on the session search_path::
+
+        node[]                              -- array of structs
+          node    (node_id uuid,
+                   owners  owner_info,      -- sub-struct #1 (uuids + domain leaf)
+                   devices device_info,     -- sub-struct #2 (uuids + non-uuid struct)
+                   tags    uuid[])          -- uuid array nested in a struct
+          owner_info  (primary_owner uuid,
+                       secondary_owner account_id,   -- DOMAIN over uuid
+                       label text)                   -- non-uuid leaf
+          device_info (device_id uuid,
+                       backup_id uuid,
+                       location geo)
+          geo (lat double precision, lon double precision)  -- non-uuid leaves
+
+    Under ``compatibility_mode='snowflake'`` every uuid leaf at any depth -- the
+    plain uuids, the uuid[] element, and the domain-over-uuid -- must store as
+    string, while ``geo``'s doubles and the text label must pass through
+    unchanged.  Tables are created per test (they differ in compat mode).
+    """
+    run_command(
+        f"""
+        CREATE SCHEMA {schema};
+        SET search_path TO {schema};
+        CREATE DOMAIN account_id AS uuid;
+        CREATE TYPE geo AS (lat double precision, lon double precision);
+        CREATE TYPE owner_info AS (
+            primary_owner   uuid,
+            secondary_owner account_id,
+            label           text
+        );
+        CREATE TYPE device_info AS (
+            device_id uuid,
+            backup_id uuid,
+            location  geo
+        );
+        CREATE TYPE node AS (
+            node_id uuid,
+            owners  owner_info,
+            devices device_info,
+            tags    uuid[]
+        );
+        """,
+        conn,
+    )
+
+
+# One fully-populated node, one sparsely-populated node (NULL domain leaf, NULL
+# nested backup uuid, NULL tags array), exercised by every deep test.  Assumes
+# the deep types are on the search_path.
+_DEEP_TWO_NODES = f"""
+    ARRAY[
+        ROW(
+            '{NODE1}',
+            ROW('{PRIM1}', '{SEC1}', 'main')::owner_info,
+            ROW('{DEV1}', '{BAK1}', ROW(1.5, 2.5)::geo)::device_info,
+            ARRAY['{TAG1}', '{TAG2}']::uuid[]
+        )::node,
+        ROW(
+            '{NODE2}',
+            ROW('{PRIM2}', NULL, 'sec')::owner_info,
+            ROW('{DEV2}', NULL, NULL)::device_info,
+            NULL
+        )::node
+    ]::node[]
+"""
+
+
+# ---------------------------------------------------------------------------
+# Storage mapping: nested uuid becomes string (top-level stays native)
+#
+# Option validation, immutability, top-level-uuid-stays-native, and map
+# rejection live in test_compatibility_mode.py, which owns the option/GUC/DDL
+# layer. This file focuses on the nested surface->storage divergence.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_uuid_stored_as_string_in_composite(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """uuid inside a composite is stored as Iceberg string, surface stays uuid."""
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_comp;
+        SET search_path TO test_uuid_comp;
+        CREATE TYPE acct AS (name text, uid uuid);
+        CREATE TABLE t (id int, a acct) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # External Iceberg metadata: the nested uid leaf must be 'string'.
+    fields = _metadata_fields(s3, pg_conn, "test_uuid_comp", "t")
+    leaf_types = _collect_leaf_types(_field_by_name(fields, "a")["type"])
+    assert "uuid" not in leaf_types, f"nested uuid leaked as uuid: {leaf_types}"
+    assert "string" in leaf_types, f"nested uuid not stored as string: {leaf_types}"
+
+    # Surface type in the catalog stays uuid, with storage override recorded.
+    rows = run_query(
+        """
+        SELECT field_pg_type::text, field_storage_pg_type::text
+        FROM lake_table.field_id_mappings
+        WHERE table_name = 'test_uuid_comp.t'::regclass
+          AND field_pg_type = 'uuid'::regtype
+        """,
+        superuser_conn,
+    )
+    assert rows == [["uuid", "text"]], rows
+
+    # Round-trip: insert as uuid, read back as uuid.
+    run_command(
+        f"""
+        INSERT INTO test_uuid_comp.t VALUES
+            (1, ROW('alice', '{U1}')::acct),
+            (2, ROW('bob', NULL)::acct),
+            (3, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Physical Parquet: the nested uid leaf must be written as VARCHAR, never a
+    # native UUID, regardless of what the Iceberg metadata claims.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_comp.t")
+    assert "UUID" not in col_types["a"], col_types
+    assert "VARCHAR" in col_types["a"], col_types
+
+    result = run_query(
+        "SELECT id, (a).name, (a).uid FROM test_uuid_comp.t ORDER BY id", pg_conn
+    )
+    assert [[r[0], r[1], _u(r[2])] for r in result] == [
+        [1, "alice", U1],
+        [2, "bob", None],
+        [3, None, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_comp CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_nested_uuid_array_stored_as_string(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """uuid[] is stored as Iceberg list<string>, round-tripping as uuid[]."""
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_arr;
+        CREATE TABLE test_uuid_arr.t (id int, us uuid[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    fields = _metadata_fields(s3, pg_conn, "test_uuid_arr", "t")
+    us_type = _field_by_name(fields, "us")["type"]
+    assert us_type["type"] == "list"
+    assert _collect_leaf_types(us_type) == ["string"]
+
+    run_command(
+        f"""
+        INSERT INTO test_uuid_arr.t VALUES
+            (1, ARRAY['{U1}', '{U2}']::uuid[]),
+            (2, ARRAY[]::uuid[]),
+            (3, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Physical Parquet: the uuid array element must be written as VARCHAR.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_arr.t")
+    assert "UUID" not in col_types["us"], col_types
+    assert "VARCHAR" in col_types["us"], col_types
+
+    result = run_query("SELECT id, us FROM test_uuid_arr.t ORDER BY id", pg_conn)
+    assert [[r[0], _ulist(r[1])] for r in result] == [
+        [1, [U1, U2]],
+        [2, []],
+        [3, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_arr CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_nested_uuid_default_auto_stays_native(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """Without snowflake compat, nested uuid stays native Iceberg uuid (control)."""
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_auto;
+        SET search_path TO test_uuid_auto;
+        CREATE TYPE acct2 AS (name text, uid uuid);
+        CREATE TABLE t (id int, a acct2) USING iceberg;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    fields = _metadata_fields(s3, pg_conn, "test_uuid_auto", "t")
+    leaf_types = _collect_leaf_types(_field_by_name(fields, "a")["type"])
+    assert (
+        "uuid" in leaf_types
+    ), f"expected native nested uuid in auto mode: {leaf_types}"
+
+    # No storage override should be recorded.
+    rows = run_query(
+        """
+        SELECT count(*) FROM lake_table.field_id_mappings
+        WHERE table_name = 'test_uuid_auto.t'::regclass
+          AND field_storage_pg_type IS NOT NULL
+        """,
+        superuser_conn,
+    )
+    assert rows == [[0]]
+
+    # Physical Parquet: without snowflake compat the nested uuid is written as a
+    # native UUID, confirming the divergence is opt-in and not always applied.
+    run_command(
+        f"INSERT INTO test_uuid_auto.t VALUES (1, ROW('alice', '{U1}')::acct2);",
+        pg_conn,
+    )
+    pg_conn.commit()
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_auto.t")
+    assert "UUID" in col_types["a"], col_types
+
+    run_command("DROP SCHEMA test_uuid_auto CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Write-path codegen (INSERT..SELECT pushdown emits the uuid->varchar cast)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_uuid_insert_select_pushdown_casts_to_varchar(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    INSERT..SELECT into a snowflake-compat table whose column has a nested
+    uuid is pushed down and the Vectorized SQL casts the uuid leaf to VARCHAR
+    via struct_pack/list_transform, then the data reads back as uuid.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_pd;
+        SET search_path TO test_uuid_pd;
+        CREATE TYPE acct3 AS (name text, uid uuid);
+        CREATE TABLE src (id int, a acct3, us uuid[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        CREATE TABLE tgt (id int, a acct3, us uuid[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        f"""
+        INSERT INTO test_uuid_pd.src VALUES
+            (1, ROW('alice', '{U1}')::test_uuid_pd.acct3, ARRAY['{U2}','{U3}']::uuid[]),
+            (2, ROW('bob', NULL)::test_uuid_pd.acct3, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    explain = "\n".join(
+        line[0]
+        for line in run_query(
+            "EXPLAIN (VERBOSE) INSERT INTO test_uuid_pd.tgt "
+            "SELECT * FROM test_uuid_pd.src",
+            pg_conn,
+        )
+    )
+    assert "Custom Scan (Query Pushdown)" in explain, explain
+    assert "AS VARCHAR" in explain, (
+        "Expected uuid->VARCHAR cast in Vectorized SQL:\n" + explain
+    )
+    assert "struct_pack" in explain, explain
+    assert "list_transform" in explain, explain
+
+    run_command("INSERT INTO test_uuid_pd.tgt SELECT * FROM test_uuid_pd.src", pg_conn)
+    pg_conn.commit()
+
+    # Physical Parquet on the pushed-down target: both the nested composite uuid
+    # and the uuid array element land as VARCHAR on disk.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_pd.tgt")
+    assert "UUID" not in col_types["a"], col_types
+    assert "UUID" not in col_types["us"], col_types
+    assert "VARCHAR" in col_types["a"] and "VARCHAR" in col_types["us"], col_types
+
+    # Catalog agrees: the nested composite uuid and the uuid array element are
+    # the two leaves recorded as uuid -> text overrides.
+    _assert_uuid_to_text_divergences(superuser_conn, "test_uuid_pd.tgt", 2)
+
+    result = run_query(
+        "SELECT id, (a).name, (a).uid, us FROM test_uuid_pd.tgt ORDER BY id", pg_conn
+    )
+    assert [[r[0], r[1], _u(r[2]), _ulist(r[3])] for r in result] == [
+        [1, "alice", U1, [U2, U3]],
+        [2, "bob", None, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_pd CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_nested_uuid_field_id_fidelity_after_struct_pack(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    The crux of Marco's struct_pack concern: rebuilding a struct produces
+    brand-new vectors, so the *only* thing keeping readers correct is that the
+    rebuilt field still carries the right Iceberg field id.  Prove the id is
+    identical across all three sources of truth, for a weird-quoted leaf name,
+    with NULLs present:
+
+        field_id_mappings (catalog)  ==  metadata.json (Iceberg)  ==  Parquet footer
+
+    and that the physical leaf is a string (UTF8), not a native uuid, while the
+    non-diverging sibling int leaf keeps its own id and physical type.
+    """
+    # The diverging leaf has a deliberately nasty quoted name.
+    weird = 'uid;"weird'
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_fid;
+        SET search_path TO test_uuid_fid;
+        CREATE TYPE rec AS ("plain k" int, "uid;""weird" uuid);
+        CREATE TABLE t (id int, a rec) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        f"""
+        INSERT INTO test_uuid_fid.t VALUES
+            (1, ROW(7, '{U1}')::rec),
+            (2, ROW(8, NULL)::rec),
+            (3, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # 1. Catalog: exactly one diverging leaf, uuid surface stored as text.
+    catalog = run_query(
+        """
+        SELECT field_id, field_pg_type::text, field_storage_pg_type::text
+        FROM lake_table.field_id_mappings
+        WHERE table_name = 'test_uuid_fid.t'::regclass
+          AND field_storage_pg_type IS NOT NULL
+        """,
+        superuser_conn,
+    )
+    assert len(catalog) == 1, catalog
+    catalog_fid, surface_type, storage_type = catalog[0]
+    assert (surface_type, storage_type) == ("uuid", "text"), catalog
+    catalog_fid = int(catalog_fid)
+
+    # 2. Iceberg metadata: the weird-quoted leaf is advertised as string and has
+    #    the *same* field id the catalog recorded.
+    meta_leaves = _metadata_leaf_ids(
+        _metadata_fields(s3, pg_conn, "test_uuid_fid", "t")
+    )
+    assert weird in meta_leaves, meta_leaves
+    meta_fid, meta_type = meta_leaves[weird]
+    assert meta_type == "string", meta_leaves
+    assert meta_fid == catalog_fid, (meta_fid, catalog_fid)
+
+    # 3. Physical Parquet footer: the leaf with that exact field id is a string
+    #    (UTF8), carries the raw (unquoted) field name, and is not a uuid.
+    leaves = _parquet_leaf_fields(superuser_conn, pgduck_conn, "test_uuid_fid.t")
+    assert catalog_fid in leaves, (catalog_fid, leaves)
+    name, ptype, converted = leaves[catalog_fid]
+    assert name == weird, leaves
+    assert converted == "UTF8" and ptype == "BYTE_ARRAY", leaves
+
+    # The non-diverging sibling int leaf keeps its own distinct id + physical type.
+    int_leaves = [(fid, n, pt) for fid, (n, pt, _c) in leaves.items() if n == "plain k"]
+    assert len(int_leaves) == 1, leaves
+    int_fid, _, int_ptype = int_leaves[0]
+    assert int_fid != catalog_fid, leaves
+    assert int_ptype == "INT32", leaves
+
+    # Round-trip survives the rebuild + NULLs.
+    result = run_query(
+        'SELECT id, (a)."plain k", (a)."uid;""weird" FROM test_uuid_fid.t ORDER BY id',
+        pg_conn,
+    )
+    assert [[r[0], r[1], _u(r[2])] for r in result] == [
+        [1, 7, U1],
+        [2, 8, None],
+        [3, None, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_fid CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_non_diverging_struct_is_not_repacked(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Even under snowflake compat, a composite with *no* diverging leaf must be
+    passed through verbatim -- never rebuilt with struct_pack.  This guards the
+    gating in AppendStorageCastExpression and keeps writes cheap for the common
+    case.  We assert the pushed-down SQL contains no struct_pack at all.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_nopack;
+        SET search_path TO test_uuid_nopack;
+        CREATE TYPE plainrec AS (x int, y text);
+        CREATE TABLE src (id int, p plainrec) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        CREATE TABLE tgt (id int, p plainrec) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        """
+        INSERT INTO test_uuid_nopack.src VALUES
+            (1, ROW(7, 'a')::test_uuid_nopack.plainrec),
+            (2, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    explain = "\n".join(
+        line[0]
+        for line in run_query(
+            "EXPLAIN (VERBOSE) INSERT INTO test_uuid_nopack.tgt "
+            "SELECT * FROM test_uuid_nopack.src",
+            pg_conn,
+        )
+    )
+    assert "Custom Scan (Query Pushdown)" in explain, explain
+    assert "struct_pack" not in explain, (
+        "non-diverging struct must not be rebuilt with struct_pack:\n" + explain
+    )
+
+    run_command(
+        "INSERT INTO test_uuid_nopack.tgt SELECT * FROM test_uuid_nopack.src", pg_conn
+    )
+    pg_conn.commit()
+    result = run_query(
+        "SELECT id, (p).x, (p).y FROM test_uuid_nopack.tgt ORDER BY id", pg_conn
+    )
+    assert result == [[1, 7, "a"], [2, None, None]], result
+
+    run_command("DROP SCHEMA test_uuid_nopack CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_combined_native_encode_and_storage_cast_same_column(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    The nastiest interaction: one composite column whose leaves require *both*
+    rewrite passes at once --
+
+      * uid uuid    -> storage cast    (uuid -> iceberg string, struct_pack)
+      * span interval -> native encode (-> struct(months,days,microseconds))
+      * tz timetz     -> native encode (UTC-normalized TIME)
+      * label text    -> passthrough
+
+    Native encode and storage cast run in a single traversal
+    (IcebergWrapQueryWithRewrites), so this column is rebuilt by ONE struct_pack
+    that carries every transform at once, not by two stacked rebuilds.  We
+    assert the pushed-down SQL carries every transform, that the composite is
+    repacked exactly once, then that data (incl. all-NULL and NULL-row cases)
+    round-trips.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_mix;
+        SET search_path TO test_uuid_mix;
+        CREATE TYPE mixrec AS (uid uuid, span interval, tz timetz, label text);
+        CREATE TABLE src (id int, m mixrec) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        CREATE TABLE tgt (id int, m mixrec) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        f"""
+        INSERT INTO test_uuid_mix.src VALUES
+            (1, ROW('{U1}', interval '1 year 2 mons 3 days 04:05:06.789',
+                    timetz '08:00:00+04', 'x')::test_uuid_mix.mixrec),
+            (2, ROW(NULL, NULL, NULL, NULL)::test_uuid_mix.mixrec),
+            (3, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    explain = "\n".join(
+        line[0]
+        for line in run_query(
+            "EXPLAIN (VERBOSE) INSERT INTO test_uuid_mix.tgt "
+            "SELECT * FROM test_uuid_mix.src",
+            pg_conn,
+        )
+    )
+    assert "Custom Scan (Query Pushdown)" in explain, explain
+    # storage cast (uuid -> string) ...
+    assert "AS VARCHAR" in explain, explain
+    assert "struct_pack" in explain, explain
+    # ... composed with both native encodes on the same column.
+    assert "months :=" in explain, "interval encode missing:\n" + explain
+    assert "AT TIME ZONE 'UTC'" in explain, "timetz encode missing:\n" + explain
+    # Single-pass merge: exactly two struct_pack calls -- one rebuilding the
+    # mixrec composite, one for the interval leaf.  The old two-pass code
+    # rebuilt the composite twice (storage cast wrapping native encode), which
+    # would show three.
+    assert explain.count("struct_pack") == 2, (
+        "expected one composite rebuild + one interval struct_pack:\n" + explain
+    )
+
+    run_command(
+        "INSERT INTO test_uuid_mix.tgt SELECT * FROM test_uuid_mix.src", pg_conn
+    )
+    pg_conn.commit()
+
+    # Physical Parquet: the nested uuid is a string; interval/timetz are encoded
+    # away from any native type; no UUID leaks.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_mix.tgt")
+    assert "UUID" not in col_types["m"], col_types
+    assert "VARCHAR" in col_types["m"], col_types
+
+    # Only the uuid leaf is a storage divergence; the interval/timetz leaves are
+    # native encodes and carry no field_storage_pg_type override.
+    _assert_uuid_to_text_divergences(superuser_conn, "test_uuid_mix.tgt", 1)
+
+    result = run_query(
+        "SELECT id, (m).uid, (m).span::text, (m).tz::text, (m).label "
+        "FROM test_uuid_mix.tgt ORDER BY id",
+        pg_conn,
+    )
+    assert [[r[0], _u(r[1]), r[2], r[3], r[4]] for r in result] == [
+        [1, U1, "1 year 2 months 3 days 04:05:06.789", "04:00:00+00", "x"],
+        [2, None, None, None, None],
+        [3, None, None, None, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_mix CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_combined_native_storage_array_leaves_same_column(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Same native+storage composition, but every leaf is an *array* so the
+    list_transform reconstruction/cast paths compose too:
+
+      * uids  uuid[]     -> storage cast on the element (uuid -> string)
+      * spans interval[] -> native encode on the element (struct(...))
+      * tzs   timetz[]   -> native encode on the element (UTC TIME)
+
+    A uuid[] element living next to an interval[] element is exactly the read
+    path that previously broke (interval reconstructed to INTERVAL but cast
+    against the on-disk struct shape).  Covers empty arrays and NULLs.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_arrmix;
+        SET search_path TO test_uuid_arrmix;
+        CREATE TYPE arrrec AS (uids uuid[], spans interval[], tzs timetz[], label text);
+        CREATE TABLE t (id int, m arrrec) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        f"""
+        INSERT INTO test_uuid_arrmix.t VALUES
+            (1, ROW(ARRAY['{U1}','{U2}']::uuid[],
+                    ARRAY['1 day'::interval,'2 hours'::interval],
+                    ARRAY['08:00:00+04'::timetz,'00:00:00+00'::timetz],
+                    'x')::test_uuid_arrmix.arrrec),
+            (2, ROW(ARRAY[]::uuid[], ARRAY[]::interval[], ARRAY[]::timetz[],
+                    'empty')::test_uuid_arrmix.arrrec),
+            (3, ROW(NULL, NULL, NULL, NULL)::test_uuid_arrmix.arrrec),
+            (4, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Physical Parquet: uuid array element stored as string, no native uuid leak.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_arrmix.t")
+    assert "UUID" not in col_types["m"], col_types
+    assert "VARCHAR" in col_types["m"], col_types
+
+    # Only the uuid[] element leaf diverges; the interval[]/timetz[] leaves are
+    # native encodes with no storage override.
+    _assert_uuid_to_text_divergences(superuser_conn, "test_uuid_arrmix.t", 1)
+
+    result = run_query(
+        "SELECT id, (m).uids, (m).spans[1]::text, (m).spans[2]::text, "
+        "(m).tzs[1]::text, (m).tzs[2]::text, (m).label "
+        "FROM test_uuid_arrmix.t ORDER BY id",
+        pg_conn,
+    )
+    assert [[r[0], _ulist(r[1]), r[2], r[3], r[4], r[5], r[6]] for r in result] == [
+        [1, [U1, U2], "1 day", "02:00:00", "04:00:00+00", "00:00:00+00", "x"],
+        [2, [], None, None, None, None, "empty"],
+        [3, None, None, None, None, None, None],
+        [4, None, None, None, None, None, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_arrmix CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_nested_uuid_null_struct_vs_null_fields_distinct(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    NULL fidelity through the struct_pack rebuild (Marco's concern, at the SQL
+    level): a non-null row whose fields are all NULL (ROW(NULL,NULL)) must stay
+    distinct from a NULL row.  The "CASE WHEN m IS NOT NULL THEN struct_pack(...)
+    ELSE NULL END" guard must preserve that, and identically to auto mode (which
+    never repacks), so the storage rewrite introduces no NULL drift.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_null;
+        SET search_path TO test_uuid_null;
+        CREATE TYPE acctn AS (name text, uid uuid);
+        CREATE TABLE sf (id int, a acctn) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        CREATE TABLE au (id int, a acctn) USING iceberg;
+        """,
+        pg_conn,
+    )
+    for tbl in ("sf", "au"):
+        run_command(
+            f"""
+            INSERT INTO test_uuid_null.{tbl} VALUES
+                (1, ROW('bob', '{U1}')::test_uuid_null.acctn),
+                (2, ROW(NULL, NULL)::test_uuid_null.acctn),
+                (3, NULL);
+            """,
+            pg_conn,
+        )
+    pg_conn.commit()
+
+    expected = [
+        [1, False, "bob", U1],
+        [2, False, None, None],  # non-null row, null fields
+        [3, True, None, None],  # null row
+    ]
+    for tbl in ("sf", "au"):
+        result = run_query(
+            f"SELECT id, a IS NULL, (a).name, (a).uid "
+            f"FROM test_uuid_null.{tbl} ORDER BY id",
+            pg_conn,
+        )
+        assert [[r[0], r[1], r[2], _u(r[3])] for r in result] == expected, tbl
+
+    # The snowflake table physically stored the nested uuid as string.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_null.sf")
+    assert "UUID" not in col_types["a"] and "VARCHAR" in col_types["a"], col_types
+
+    run_command("DROP SCHEMA test_uuid_null CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_drop_column_divergent_parity_and_readd(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Dropping a column whose nested uuid is a *registered* storage-divergent leaf
+    must behave exactly like dropping a plain column, and leave the remaining
+    columns resolving correctly (matching is by name).  Uses adversarial quoted
+    names throughout.
+
+    Per the agreed parity_only behavior, the dropped column's field_id_mappings
+    rows are retained (orphaned), not cleaned up -- and this is identical for a
+    plain column, so a registered attribute is "not different".  Re-adding a
+    divergent column re-registers a fresh mapping and stores as string again.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_drop;
+        SET search_path TO test_uuid_drop;
+        CREATE TYPE acct AS (name text, uid uuid);
+        CREATE TABLE t (
+            id int,
+            "weird;""col" acct,
+            keep int,
+            a2 acct
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        f"""
+        INSERT INTO test_uuid_drop.t VALUES
+            (1, ROW('a', '{U1}')::acct, 7, ROW('b', '{U2}')::acct),
+            (2, NULL, NULL, ROW(NULL, NULL)::acct);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    def total_mappings():
+        return run_query(
+            "SELECT count(*) FROM lake_table.field_id_mappings "
+            "WHERE table_name = 'test_uuid_drop.t'::regclass",
+            superuser_conn,
+        )[0][0]
+
+    def divergent_mappings():
+        return run_query(
+            "SELECT count(*) FROM lake_table.field_id_mappings "
+            "WHERE table_name = 'test_uuid_drop.t'::regclass "
+            "AND field_storage_pg_type IS NOT NULL",
+            superuser_conn,
+        )[0][0]
+
+    before_total = total_mappings()
+    # two divergent leaves: the uid inside "weird;col" and inside a2.
+    assert divergent_mappings() == 2, divergent_mappings()
+
+    # Drop the *registered* (divergent) quoted column.
+    run_command('ALTER TABLE test_uuid_drop.t DROP COLUMN "weird;""col";', pg_conn)
+    pg_conn.commit()
+    # Orphan rows are retained (parity_only): nothing is removed.
+    assert total_mappings() == before_total, (before_total, total_mappings())
+    assert divergent_mappings() == 2, divergent_mappings()
+
+    # Dropping a plain column behaves identically (rows retained too).
+    run_command("ALTER TABLE test_uuid_drop.t DROP COLUMN keep;", pg_conn)
+    pg_conn.commit()
+    assert total_mappings() == before_total, (before_total, total_mappings())
+
+    # The surviving divergent column still resolves by name and stays string.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_drop.t")
+    assert "UUID" not in col_types["a2"] and "VARCHAR" in col_types["a2"], col_types
+    result = run_query(
+        "SELECT id, (a2).name, (a2).uid FROM test_uuid_drop.t ORDER BY id", pg_conn
+    )
+    assert [[r[0], r[1], _u(r[2])] for r in result] == [
+        [1, "b", U2],
+        [2, None, None],
+    ]
+
+    # Re-add a divergent column with another nasty quoted name: registers fresh.
+    run_command(
+        'ALTER TABLE test_uuid_drop.t ADD COLUMN "re ""added"";" acct;', pg_conn
+    )
+    pg_conn.commit()
+    assert divergent_mappings() == 3, divergent_mappings()
+    run_command(
+        f"""UPDATE test_uuid_drop.t SET "re ""added"";" = ROW('c', '{U3}')::acct WHERE id = 1;""",
+        pg_conn,
+    )
+    pg_conn.commit()
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_drop.t")
+    assert "UUID" not in col_types['re "added";'], col_types
+    assert "VARCHAR" in col_types['re "added";'], col_types
+    result = run_query(
+        'SELECT id, ("re ""added"";").uid FROM test_uuid_drop.t ORDER BY id', pg_conn
+    )
+    assert [[r[0], _u(r[1])] for r in result] == [[1, U3], [2, None]]
+
+    run_command("DROP SCHEMA test_uuid_drop CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_storage_cast_copy_and_nonpushdown_paths(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Exercise the write/read paths other than INSERT..SELECT pushdown (which is
+    covered above), all on a nested-uuid composite under snowflake compat, all
+    with NULLs:
+
+      * INSERT..SELECT from a *heap* source  -> non-pushdown (row-by-row) write
+      * COPY ... TO   (export / read path)
+      * COPY ... FROM (import / write path)  -> records pushdown status
+      * SELECT through a non-shippable barrier (no pushdown) read
+
+    Each must still store the nested uuid as Parquet string and round-trip.
+    """
+    export_url = f"s3://{TEST_BUCKET}/test_uuid_paths/export.parquet"
+    run_command(
+        f"""
+        CREATE SCHEMA test_uuid_paths;
+        SET search_path TO test_uuid_paths;
+        CREATE TYPE acct AS (name text, uid uuid);
+        CREATE TABLE heap_src (id int, a acct) USING heap;
+        CREATE TABLE ins_sel (id int, a acct) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        CREATE TABLE copy_tgt (id int, a acct) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        INSERT INTO heap_src VALUES
+            (1, ROW('alice', '{U1}')::acct),
+            (2, ROW('bob', NULL)::acct),
+            (3, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # --- INSERT..SELECT from heap: non-pushdown write path ---
+    explain = "\n".join(
+        line[0]
+        for line in run_query(
+            "EXPLAIN (VERBOSE) INSERT INTO test_uuid_paths.ins_sel "
+            "SELECT * FROM test_uuid_paths.heap_src",
+            pg_conn,
+        )
+    )
+    assert "Custom Scan (Query Pushdown)" not in explain, (
+        "heap source must NOT push down:\n" + explain
+    )
+    run_command(
+        "INSERT INTO test_uuid_paths.ins_sel SELECT * FROM test_uuid_paths.heap_src",
+        pg_conn,
+    )
+    pg_conn.commit()
+    col_types = _parquet_column_types(
+        superuser_conn, pgduck_conn, "test_uuid_paths.ins_sel"
+    )
+    assert "UUID" not in col_types["a"] and "VARCHAR" in col_types["a"], col_types
+    _assert_uuid_to_text_divergences(superuser_conn, "test_uuid_paths.ins_sel", 1)
+    assert [
+        [r[0], r[1], _u(r[2])]
+        for r in run_query(
+            "SELECT id, (a).name, (a).uid FROM test_uuid_paths.ins_sel ORDER BY id",
+            pg_conn,
+        )
+    ] == [[1, "alice", U1], [2, "bob", None], [3, None, None]]
+
+    # --- COPY TO (export / read path) then COPY FROM (import / write path) ---
+    run_command(
+        f"COPY (SELECT * FROM test_uuid_paths.ins_sel) TO '{export_url}'", pg_conn
+    )
+    pg_conn.commit()
+
+    run_command(f"COPY test_uuid_paths.copy_tgt FROM '{export_url}'", pg_conn)
+    pg_conn.commit()
+    assert (
+        run_query("SELECT count(*) FROM test_uuid_paths.copy_tgt", pg_conn)[0][0] == 3
+    )
+    col_types = _parquet_column_types(
+        superuser_conn, pgduck_conn, "test_uuid_paths.copy_tgt"
+    )
+    assert "UUID" not in col_types["a"] and "VARCHAR" in col_types["a"], col_types
+    _assert_uuid_to_text_divergences(superuser_conn, "test_uuid_paths.copy_tgt", 1)
+    assert [
+        [r[0], r[1], _u(r[2])]
+        for r in run_query(
+            "SELECT id, (a).name, (a).uid FROM test_uuid_paths.copy_tgt ORDER BY id",
+            pg_conn,
+        )
+    ] == [[1, "alice", U1], [2, "bob", None], [3, None, None]]
+
+    # --- SELECT through a non-shippable barrier (OFFSET in a CTE w/ volatile) ---
+    # random() is volatile + the materialized CTE prevents full pushdown; the
+    # nested uuid must still reconstruct from the stored string.
+    rows = run_query(
+        """
+        WITH x AS MATERIALIZED (
+            SELECT id, (a).uid AS uid, random() AS r
+            FROM test_uuid_paths.copy_tgt
+        )
+        SELECT id, uid FROM x ORDER BY id
+        """,
+        pg_conn,
+    )
+    assert [[r[0], _u(r[1])] for r in rows] == [[1, U1], [2, None], [3, None]]
+
+    run_command("DROP SCHEMA test_uuid_paths CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# ALTER TABLE ADD COLUMN goes through the same registration path
+# ---------------------------------------------------------------------------
+
+
+def test_alter_add_column_nested_uuid_stored_as_string(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """ALTER ... ADD COLUMN applies the same surface/storage mapping."""
+    run_command(
+        """
+        CREATE SCHEMA test_uuid_alter;
+        SET search_path TO test_uuid_alter;
+        CREATE TYPE acct4 AS (name text, uid uuid);
+        CREATE TABLE t (id int) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        ALTER TABLE t ADD COLUMN a acct4;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    fields = _metadata_fields(s3, pg_conn, "test_uuid_alter", "t")
+    leaf_types = _collect_leaf_types(_field_by_name(fields, "a")["type"])
+    assert "uuid" not in leaf_types and "string" in leaf_types, leaf_types
+
+    run_command(
+        f"INSERT INTO test_uuid_alter.t VALUES (1, ROW('alice', '{U1}')::test_uuid_alter.acct4);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Physical Parquet: the column added via ALTER also writes the nested uuid
+    # as VARCHAR, so the mapping is not specific to the CREATE TABLE path.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_alter.t")
+    assert "UUID" not in col_types["a"], col_types
+    assert "VARCHAR" in col_types["a"], col_types
+
+    result = run_query("SELECT id, (a).uid FROM test_uuid_alter.t ORDER BY id", pg_conn)
+    assert [[r[0], _u(r[1])] for r in result] == [[1, U1]]
+
+    run_command("DROP SCHEMA test_uuid_alter CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT / GENERATED on uuid columns
+# ---------------------------------------------------------------------------
+
+
+def test_uuid_default_and_generated_columns(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    DEFAULT and GENERATED values must go through the storage rewrite when they
+    are *composites with a nested uuid* -- a top-level uuid never enters the
+    struct_pack path, so the interesting case is a DEFAULT/GENERATED value whose
+    nested uuid has to be cast to string on write.
+
+    Covers, under snowflake compat:
+      * a top-level uuid DEFAULT/GENERATED (stays native UUID -- control),
+      * a composite DEFAULT with a nested uuid (rewritten to string),
+      * a STORED GENERATED composite derived from sibling columns, whose nested
+        uuid is rewritten -- including a row where the source uuid is NULL,
+      * the same generated table populated via INSERT..SELECT (which the STORED
+        generated column forces onto the non-pushdown path).
+    """
+    run_command(
+        f"""
+        CREATE SCHEMA test_uuid_default;
+        SET search_path TO test_uuid_default;
+        CREATE TYPE acct AS (name text, uid uuid);
+        CREATE TABLE t (
+            id int,
+            top_u uuid DEFAULT '{U1}'::uuid,
+            gen_u uuid GENERATED ALWAYS AS ('{U2}'::uuid) STORED,
+            -- composite DEFAULT: the nested uuid must be storage-cast to string
+            def_acct acct DEFAULT ROW('def', '{U1}'::uuid)::acct,
+            raw_name text,
+            raw_uid uuid,
+            -- STORED generated composite built from siblings; nested uuid -> string
+            gen_acct acct GENERATED ALWAYS AS (ROW(raw_name, raw_uid)::acct) STORED
+        ) USING iceberg WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        INSERT INTO test_uuid_default.t (id, raw_name, raw_uid) VALUES
+            (1, 'alice', '{U3}'),
+            (2, NULL, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Physical Parquet: top-level uuids stay native UUID; the nested uuids inside
+    # the DEFAULT and GENERATED composites diverge to string.
+    col_types = _parquet_column_types(
+        superuser_conn, pgduck_conn, "test_uuid_default.t"
+    )
+    assert col_types["top_u"] == "UUID", col_types
+    assert col_types["gen_u"] == "UUID", col_types
+    assert "UUID" not in col_types["def_acct"], col_types
+    assert "VARCHAR" in col_types["def_acct"], col_types
+    assert "UUID" not in col_types["gen_acct"], col_types
+    assert "VARCHAR" in col_types["gen_acct"], col_types
+
+    result = run_query(
+        "SELECT id, top_u, gen_u, (def_acct).name, (def_acct).uid, "
+        "(gen_acct).name, (gen_acct).uid FROM test_uuid_default.t ORDER BY id",
+        pg_conn,
+    )
+    assert [
+        [r[0], _u(r[1]), _u(r[2]), r[3], _u(r[4]), r[5], _u(r[6])] for r in result
+    ] == [
+        [1, U1, U2, "def", U1, "alice", U3],
+        [2, U1, U2, "def", U1, None, None],
+    ]
+
+    # INSERT..SELECT into the generated table: the STORED generated composite is
+    # recomputed by Postgres (not pushed down), then its nested uuid is rewritten.
+    explain = "\n".join(
+        row[0]
+        for row in run_query(
+            "EXPLAIN (VERBOSE) INSERT INTO test_uuid_default.t (id, raw_name, raw_uid) "
+            "SELECT id + 10, raw_name, raw_uid FROM test_uuid_default.t",
+            pg_conn,
+        )
+    )
+    assert "Custom Scan (Query Pushdown)" not in explain, (
+        "STORED generated column should force the non-pushdown path:\n" + explain
+    )
+    run_command(
+        "INSERT INTO test_uuid_default.t (id, raw_name, raw_uid) "
+        "SELECT id + 10, raw_name, raw_uid FROM test_uuid_default.t WHERE id <= 2",
+        pg_conn,
+    )
+    pg_conn.commit()
+    gen_rows = run_query(
+        "SELECT id, (gen_acct).name, (gen_acct).uid FROM test_uuid_default.t "
+        "WHERE id > 10 ORDER BY id",
+        pg_conn,
+    )
+    assert [[r[0], r[1], _u(r[2])] for r in gen_rows] == [
+        [11, "alice", U3],
+        [12, None, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_default CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Deeply nested pyramid: array<struct> with two sub-structs, many uuids at
+# several depths, a uuid[] inside a struct, a domain-over-uuid leaf, and a
+# non-uuid (geo) sub-struct that must survive untouched.
+# ---------------------------------------------------------------------------
+
+
+def test_deeply_nested_uuid_pyramid_storage_and_roundtrip(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Every uuid leaf at every depth diverges to string under snowflake compat,
+    domains-over-uuid included, while geo doubles / text labels are untouched
+    and the surface schema (including the domain) is preserved.  Verified end to
+    end: Iceberg metadata, persisted per-leaf mappings, physical Parquet, an
+    auto-mode control, and a deep round-trip with NULLs and an empty array.
+    """
+    _create_deep_uuid_types(pg_conn, "test_uuid_deep")
+    run_command(
+        """
+        CREATE TABLE test_uuid_deep.t (id int, nodes node[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        -- control: identical types, default (auto) compat
+        CREATE TABLE test_uuid_deep.t_auto (id int, nodes node[]) USING iceberg;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # --- Iceberg metadata: count every leaf, not just "is there a string". ----
+    nodes_type = _field_by_name(
+        _metadata_fields(s3, pg_conn, "test_uuid_deep", "t"), "nodes"
+    )["type"]
+    leaves = _collect_leaf_types(nodes_type)
+    # 6 uuid leaves -> string (node_id, primary, secondary-domain, device, backup,
+    # tag element) + 1 text label -> string = 7 strings; geo lat/lon = 2 doubles.
+    assert leaves.count("uuid") == 0, leaves
+    assert leaves.count("string") == 7, leaves
+    assert leaves.count("double") == 2, leaves
+
+    # --- Persisted mapping: exactly the 6 uuid leaves get a storage override. -
+    overrides = run_query(
+        """
+        SELECT field_storage_pg_type::text, count(*)
+        FROM lake_table.field_id_mappings
+        WHERE table_name = 'test_uuid_deep.t'::regclass
+          AND field_storage_pg_type IS NOT NULL
+        GROUP BY 1
+        """,
+        superuser_conn,
+    )
+    assert overrides == [["text", 6]], overrides
+    # The domain-over-uuid leaf in particular must be one of them.
+    domain_override = run_query(
+        """
+        SELECT count(*)
+        FROM lake_table.field_id_mappings
+        WHERE table_name = 'test_uuid_deep.t'::regclass
+          AND field_pg_type = 'test_uuid_deep.account_id'::regtype
+          AND field_storage_pg_type = 'text'::regtype
+        """,
+        superuser_conn,
+    )
+    assert domain_override == [[1]], domain_override
+
+    # --- Surface schema unchanged: column type and the domain both preserved. -
+    surface = run_query(
+        """
+        SELECT
+            (SELECT atttypid::regtype::text FROM pg_attribute
+              WHERE attrelid = 'test_uuid_deep.t'::regclass AND attname = 'nodes'),
+            (SELECT atttypid::regtype::text FROM pg_attribute
+              WHERE attrelid = 'test_uuid_deep.owner_info'::regclass
+                AND attname = 'secondary_owner')
+        """,
+        superuser_conn,
+    )
+    assert surface == [["test_uuid_deep.node[]", "test_uuid_deep.account_id"]], surface
+
+    run_command(
+        f"""
+        SET search_path TO test_uuid_deep;
+        INSERT INTO test_uuid_deep.t VALUES
+            (1, {_DEEP_TWO_NODES}),
+            (2, NULL),
+            (3, ARRAY[]::node[]);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # --- Physical Parquet: no UUID anywhere, doubles survive, it's array<struct>.
+    col_types = _parquet_column_types(superuser_conn, pgduck_conn, "test_uuid_deep.t")
+    nodes_phys = col_types["nodes"]
+    assert "UUID" not in nodes_phys, nodes_phys
+    assert "DOUBLE" in nodes_phys, nodes_phys
+    assert "STRUCT" in nodes_phys and nodes_phys.endswith("[]"), nodes_phys
+
+    # --- Deep round-trip, including the sparse node and the NULL/empty rows. ---
+    deep = run_query(
+        """
+        SELECT
+            (nodes[1]).node_id,
+            ((nodes[1]).owners).primary_owner,
+            ((nodes[1]).owners).secondary_owner,
+            ((nodes[1]).owners).label,
+            ((nodes[1]).devices).device_id,
+            ((nodes[1]).devices).backup_id,
+            (((nodes[1]).devices).location).lat,
+            (((nodes[1]).devices).location).lon,
+            (nodes[1]).tags,
+            (nodes[2]).node_id,
+            ((nodes[2]).owners).secondary_owner,
+            ((nodes[2]).devices).backup_id,
+            (nodes[2]).tags
+        FROM test_uuid_deep.t WHERE id = 1
+        """,
+        pg_conn,
+    )[0]
+    assert [
+        _u(deep[0]),
+        _u(deep[1]),
+        _u(deep[2]),
+        deep[3],
+        _u(deep[4]),
+        _u(deep[5]),
+        deep[6],
+        deep[7],
+        _ulist(deep[8]),
+        _u(deep[9]),
+        deep[10],
+        deep[11],
+        _ulist(deep[12]),
+    ] == [
+        NODE1,
+        PRIM1,
+        SEC1,
+        "main",
+        DEV1,
+        BAK1,
+        1.5,
+        2.5,
+        [TAG1, TAG2],
+        NODE2,
+        None,
+        None,
+        None,
+    ], deep
+
+    shape = run_query(
+        "SELECT id, nodes IS NULL, cardinality(nodes) "
+        "FROM test_uuid_deep.t ORDER BY id",
+        pg_conn,
+    )
+    assert shape == [[1, False, 2], [2, True, None], [3, False, 0]], shape
+
+    # --- Auto-mode control: same types, uuids stay native, no overrides. ------
+    run_command(
+        f"""
+        SET search_path TO test_uuid_deep;
+        INSERT INTO test_uuid_deep.t_auto VALUES (1, {_DEEP_TWO_NODES});
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    auto_phys = _parquet_column_types(
+        superuser_conn, pgduck_conn, "test_uuid_deep.t_auto"
+    )["nodes"]
+    assert "UUID" in auto_phys, auto_phys
+    assert "DOUBLE" in auto_phys, auto_phys
+    auto_overrides = run_query(
+        """
+        SELECT count(*) FROM lake_table.field_id_mappings
+        WHERE table_name = 'test_uuid_deep.t_auto'::regclass
+          AND field_storage_pg_type IS NOT NULL
+        """,
+        superuser_conn,
+    )
+    assert auto_overrides == [[0]], auto_overrides
+
+    run_command("DROP SCHEMA test_uuid_deep CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_deeply_nested_uuid_pyramid_insert_select_writepath(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Deep pyramid copied via INSERT..SELECT from an auto (native-uuid) source
+    into a snowflake target.  The scan is offloaded to DuckDB while the write
+    path must cast every nested uuid leaf -- at every depth, through both
+    sub-structs, the uuid[], and the domain-over-uuid -- to its storage type,
+    leaving geo doubles untouched.  Validated by the physical Parquet of the
+    target plus a deep round-trip, rather than brittle generated-SQL matching
+    (a top-level array<struct> isn't a single-node INSERT..SELECT pushdown, so
+    the casts run in the foreign-modify path, not the Vectorized SQL).
+    """
+    _create_deep_uuid_types(pg_conn, "test_uuid_deep_pd")
+    # src is auto (stores native uuid), tgt is snowflake.  This guarantees the
+    # pushed-down statement must actually cast surface uuid -> storage string on
+    # the way in -- a snowflake->snowflake copy would be a storage-identity move
+    # and emit no casts at all.
+    run_command(
+        """
+        CREATE TABLE test_uuid_deep_pd.src (id int, nodes node[]) USING iceberg;
+        CREATE TABLE test_uuid_deep_pd.tgt (id int, nodes node[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    run_command(
+        f"""
+        SET search_path TO test_uuid_deep_pd;
+        INSERT INTO test_uuid_deep_pd.src VALUES (1, {_DEEP_TWO_NODES});
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    explain = "\n".join(
+        line[0]
+        for line in run_query(
+            "EXPLAIN (VERBOSE) INSERT INTO test_uuid_deep_pd.tgt "
+            "SELECT * FROM test_uuid_deep_pd.src",
+            pg_conn,
+        )
+    )
+    # The source scan is offloaded to DuckDB (the native-uuid source is read via
+    # the vectorized engine); the surface->storage casts then run on write.
+    assert "Engine: DuckDB" in explain, explain
+
+    run_command(
+        "INSERT INTO test_uuid_deep_pd.tgt SELECT * FROM test_uuid_deep_pd.src",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # The source physically stored native UUID; the target must end up VARCHAR
+    # at every uuid leaf, proving the deep write-path cast actually fired.
+    src_phys = _parquet_column_types(
+        superuser_conn, pgduck_conn, "test_uuid_deep_pd.src"
+    )["nodes"]
+    assert "UUID" in src_phys, src_phys
+    tgt_phys = _parquet_column_types(
+        superuser_conn, pgduck_conn, "test_uuid_deep_pd.tgt"
+    )["nodes"]
+    assert "UUID" not in tgt_phys, tgt_phys
+    assert "DOUBLE" in tgt_phys, tgt_phys
+
+    roundtrip = run_query(
+        """
+        SELECT
+            ((nodes[1]).owners).secondary_owner,
+            (((nodes[1]).devices).location).lat,
+            (nodes[1]).tags,
+            ((nodes[2]).devices).backup_id
+        FROM test_uuid_deep_pd.tgt WHERE id = 1
+        """,
+        pg_conn,
+    )[0]
+    assert [_u(roundtrip[0]), roundtrip[1], _ulist(roundtrip[2]), roundtrip[3]] == [
+        SEC1,
+        1.5,
+        [TAG1, TAG2],
+        None,
+    ], roundtrip
+
+    run_command("DROP SCHEMA test_uuid_deep_pd CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Cross-engine read-back (object_store catalog): an external Iceberg reader
+# (DuckDB's iceberg_scan) must see the nested uuid as a *string*, which is the
+# whole point of snowflake compat -- engines that cannot store a nested uuid
+# still read a value.  pg_lake itself reads the surface uuid back.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_engine_duckdb_iceberg_scan_sees_string(
+    pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Write a snowflake-compat table via pg_lake (object_store catalog), then read
+    it back through DuckDB's Iceberg reader straight from the catalog metadata.
+    DuckDB has no pg_lake surface-type knowledge, so it must observe exactly the
+    on-disk Iceberg schema: nested uuid -> string, uuid[] -> list<string>.  NULLs
+    (null field, null struct, null array) must survive cross-engine.
+    """
+    run_command(
+        f"""
+        CREATE SCHEMA test_uuid_xeng;
+        SET search_path TO test_uuid_xeng;
+        CREATE TYPE acct AS (name text, uid uuid);
+        CREATE TABLE t (id int, a acct, us uuid[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        INSERT INTO t VALUES
+            (1, ROW('alice', '{U1}')::acct, ARRAY['{U2}','{U3}']::uuid[]),
+            (2, ROW('bob', NULL)::acct, NULL),
+            (3, NULL, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    metadata_location = run_query(
+        "SELECT metadata_location FROM iceberg_tables "
+        "WHERE table_name = 't' AND table_namespace = 'test_uuid_xeng'",
+        pg_conn,
+    )[0][0]
+
+    # External engine's view of the schema: nested uuid is string, never uuid.
+    described = {
+        row[0]: row[1]
+        for row in run_query(
+            f"DESCRIBE SELECT * FROM iceberg_scan('{metadata_location}')", pgduck_conn
+        )
+    }
+    assert "UUID" not in described["a"], described
+    assert "VARCHAR" in described["a"], described
+    assert described["us"] == "VARCHAR[]", described
+
+    # External engine reads the uuid text out of the string leaves, NULLs intact.
+    duck_rows = run_query(
+        f"SELECT id, a.uid, us FROM iceberg_scan('{metadata_location}') ORDER BY id",
+        pgduck_conn,
+    )
+    assert [[r[0], _u(r[1]), _ulist(r[2])] for r in duck_rows] == [
+        [1, U1, [U2, U3]],
+        [2, None, None],
+        [3, None, None],
+    ]
+
+    # pg_lake itself still presents the surface uuid type.
+    pg_rows = run_query(
+        "SELECT id, (a).uid, us FROM test_uuid_xeng.t ORDER BY id", pg_conn
+    )
+    assert [[r[0], _u(r[1]), _ulist(r[2])] for r in pg_rows] == [
+        [1, U1, [U2, U3]],
+        [2, None, None],
+        [3, None, None],
+    ]
+
+    run_command("DROP SCHEMA test_uuid_xeng CASCADE;", pg_conn)
+    pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -2669,6 +2669,199 @@ def test_rest_iceberg_types_converted_to_string(
     pg_conn.commit()
 
 
+def _rest_collect_leaf_types(field_type):
+    """Collect every scalar Iceberg leaf type reachable from a metadata.json
+    field ``type`` node (string, or struct/list/map dict)."""
+    if isinstance(field_type, str):
+        return [field_type]
+    kind = field_type.get("type")
+    if kind == "struct":
+        leaves = []
+        for f in field_type["fields"]:
+            leaves.extend(_rest_collect_leaf_types(f["type"]))
+        return leaves
+    if kind == "list":
+        return _rest_collect_leaf_types(field_type["element"])
+    if kind == "map":
+        return _rest_collect_leaf_types(field_type["key"]) + _rest_collect_leaf_types(
+            field_type["value"]
+        )
+    return []
+
+
+def test_rest_iceberg_nested_uuid_snowflake_compat(
+    pg_conn,
+    pgduck_conn,
+    installcheck,
+    s3,
+    extension,
+    create_types_helper_functions,
+    with_default_location,
+    polaris_session,
+    set_polaris_gucs,
+    create_http_helper_functions,
+):
+    """
+    Writable REST (Polaris) table with compatibility_mode='snowflake': a nested
+    uuid (inside a composite and inside an array) is persisted as Iceberg string
+    in the REST catalog metadata, round-trips as uuid through pg_lake, and is
+    read back cross-engine via DuckDB's iceberg_scan as a plain string -- with
+    NULLs (null field, null struct, null array) preserved everywhere.
+    """
+    if installcheck:
+        return
+
+    U1 = "11111111-1111-1111-1111-111111111111"
+    U2 = "22222222-2222-2222-2222-222222222222"
+    U3 = "33333333-3333-3333-3333-333333333333"
+
+    run_command("CREATE SCHEMA test_rest_uuid;", pg_conn)
+    run_command(
+        """
+        CREATE TYPE test_rest_uuid.acct AS (name text, uid uuid);
+        CREATE TABLE test_rest_uuid.t (
+            id int,
+            a test_rest_uuid.acct,
+            us uuid[],
+            top_u uuid
+        ) USING iceberg WITH (catalog='rest', compatibility_mode='snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    metadata = get_rest_table_metadata("test_rest_uuid", "t", pg_conn)
+    metadata_path = metadata["metadata-location"]
+
+    parsed = json.loads(read_s3_operations(s3, metadata_path))
+    fields = parsed["schemas"][0]["fields"]
+    by_name = {f["name"]: f for f in fields}
+
+    # Nested uuid leaves diverge to string; top-level uuid stays native uuid.
+    assert "uuid" not in _rest_collect_leaf_types(by_name["a"]["type"]), fields
+    assert "string" in _rest_collect_leaf_types(by_name["a"]["type"]), fields
+    assert _rest_collect_leaf_types(by_name["us"]["type"]) == ["string"], fields
+    assert by_name["top_u"]["type"] == "uuid", fields
+
+    run_command(
+        f"""
+        INSERT INTO test_rest_uuid.t VALUES
+            (1, ROW('alice', '{U1}')::test_rest_uuid.acct,
+                ARRAY['{U2}','{U3}']::uuid[], '{U1}'),
+            (2, ROW('bob', NULL)::test_rest_uuid.acct, NULL, NULL),
+            (3, NULL, NULL, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # pg_lake reads the surface uuid back.  Use array element access (not
+    # us::text) so the assertion is independent of array text rendering, which
+    # differs between the PG ({...}) and pushed-down DuckDB ([...]) paths.
+    result = run_query(
+        "SELECT id, (a).name, (a).uid::text, us[1]::text, us[2]::text, top_u::text "
+        "FROM test_rest_uuid.t ORDER BY id",
+        pg_conn,
+    )
+    assert result == [
+        [1, "alice", U1, U2, U3, U1],
+        [2, "bob", None, None, None, None],
+        [3, None, None, None, None, None],
+    ], result
+
+    # Cross-engine: DuckDB's Iceberg reader sees the nested uuid as string.
+    refreshed = get_rest_table_metadata("test_rest_uuid", "t", pg_conn)
+    described = {
+        row[0]: row[1]
+        for row in run_query(
+            f"DESCRIBE SELECT * FROM iceberg_scan('{refreshed['metadata-location']}')",
+            pgduck_conn,
+        )
+    }
+    assert "UUID" not in described["a"] and "VARCHAR" in described["a"], described
+    assert described["us"] == "VARCHAR[]", described
+    assert described["top_u"] == "UUID", described
+
+    # Use list element access (DuckDB 1-based) rather than selecting the whole
+    # array, so the assertion doesn't depend on how the VARCHAR[] is rendered
+    # back over the wire (it comes through as a raw '{...}' string, not a list).
+    duck_rows = run_query(
+        "SELECT id, a.uid, us[1], us[2], top_u::text "
+        f"FROM iceberg_scan('{refreshed['metadata-location']}') ORDER BY id",
+        pgduck_conn,
+    )
+    assert [[r[0], r[1], r[2], r[3], r[4]] for r in duck_rows] == [
+        [1, U1, U2, U3, U1],
+        [2, None, None, None, None],
+        [3, None, None, None, None],
+    ], duck_rows
+
+    # Read the same table back through a *separate* read-only REST handle.  That
+    # handle has no field_id_mappings of its own, so it derives the surface
+    # types purely from the Iceberg metadata, which records the diverged leaves
+    # as string.  An external/read-only consumer therefore sees the nested uuid
+    # and the uuid array element as text/text[]; only the non-diverging
+    # top-level uuid stays uuid.
+    run_command(
+        """
+        CREATE TABLE test_rest_uuid.readback ()
+        USING iceberg
+        WITH (catalog='rest', read_only=True, catalog_table_name='t');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    top_level = {
+        row[0]: row[1]
+        for row in run_query(
+            "SELECT attname, format_type(atttypid, atttypmod) "
+            "FROM pg_attribute "
+            "WHERE attrelid = 'test_rest_uuid.readback'::regclass "
+            "  AND attnum > 0 AND NOT attisdropped",
+            pg_conn,
+        )
+    }
+    assert top_level["us"] == "text[]", top_level
+    assert top_level["top_u"] == "uuid", top_level
+
+    composite_leaves = {
+        row[0]: row[1]
+        for row in run_query(
+            """
+            SELECT atts.attname, format_type(atts.atttypid, atts.atttypmod)
+            FROM pg_attribute col
+            JOIN pg_type t ON t.oid = col.atttypid
+            JOIN pg_class c ON c.oid = t.typrelid
+            JOIN pg_attribute atts
+              ON atts.attrelid = c.oid AND atts.attnum > 0
+                 AND NOT atts.attisdropped
+            WHERE col.attrelid = 'test_rest_uuid.readback'::regclass
+              AND col.attname = 'a'
+            ORDER BY atts.attnum
+            """,
+            pg_conn,
+        )
+    }
+    assert composite_leaves["uid"] == "text", composite_leaves
+
+    # The values still read back correctly through the read-only handle, now as
+    # the surface text type rather than uuid.
+    readback_rows = run_query(
+        "SELECT id, (a).uid, us[1], top_u::text "
+        "FROM test_rest_uuid.readback ORDER BY id",
+        pg_conn,
+    )
+    assert readback_rows == [
+        [1, U1, U2, U1],
+        [2, None, None, None],
+        [3, None, None, None],
+    ], readback_rows
+
+    run_command("DROP SCHEMA test_rest_uuid CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 def test_rest_iceberg_map_type(
     pg_conn,
     installcheck,


### PR DESCRIPTION
> **Stacked on #420** (the `compatibility_mode` option layer). This PR adds the surface/storage mapping on top; review #420 first. The diff shown here is the storage-mapping delta only.

## Overview

This PR introduces a general **surface/storage type-mapping layer** for pg_lake
Iceberg tables, and builds the first **Iceberg compatibility mode** on top of it.

The core idea is to decouple two things that pg_lake previously treated as one:

- the **surface type** — the PostgreSQL type the user declared and sees (`\d`,
  `DEFAULT`, `GENERATED`, query results), and
- the **storage type** — the physical Iceberg/Parquet type the value is actually
  written as.

For every leaf of every column we now allow these to differ, and we **persist
that divergence per-leaf** in `lake_table.field_id_mappings`
(`field_storage_pg_type` / `field_storage_pg_typemod`, `NULL` ⇒ they're the
same, which is the common case). The mapping is decided **once, at table
registration**, and is thereafter the single source of truth that every read
and write path consults. Nothing about the surface schema changes: the column
type stays exactly as declared.

On top of this layer we add a per-table option:

```sql
CREATE TABLE t (
    id    uuid DEFAULT gen_random_uuid(),   -- top-level uuid: stored as uuid
    tags  uuid[],                           -- nested uuid: stored as string
    meta  account                           -- composite w/ uuid field: nested uuid stored as string
) USING iceberg WITH (compatibility_mode = 'snowflake');
```

`compatibility_mode` defaults to `'auto'` (no divergence — a pure no-op, and the
hook where future auto-detection can live). `'snowflake'` stores a UUID nested
inside an array/composite as Iceberg `string`, because Snowflake cannot hold a
UUID inside a structured type, while leaving a top-level `uuid` column native.

## Relationship to #417

> This overlaps in goal with @sfc-gh-mslot's #417, which is a focused, surgical
> fix for exactly the nested-UUID-under-`snowflake` case. That PR is smaller and
> easier to land, and if the immediate need is just nested UUID it's a perfectly
> reasonable choice.
>
> This PR deliberately takes the longer road: instead of special-casing UUID in
> the type walkers, it introduces the surface/storage mapping as a first-class,
> persisted concept and expresses "nested uuid → string under snowflake" as
> *one policy* over that mechanism. It is undeniably more code and harder to
> review/merge — but it's type-agnostic and future-proof: any later
> surface≠storage need (other narrowing engines, other types, other modes) is a
> new policy, not new plumbing in the read/write paths. We're happy to fold in
> the parts of #417 that reviewers prefer.

The two approaches reach the same observable behavior for nested UUID; the
difference is entirely in the generality and placement of the machinery.

## What's in here

**Persistence (the mapping itself)**
- `field_id_mappings` gains `field_storage_pg_type` / `field_storage_pg_typemod`
  (additive migration `pg_lake_table--3.3--3.4.sql`; existing rows get `NULL`
  and keep identical behavior).
- At registration we build the surface field tree *and* the storage field tree,
  diff them (`CollectStorageDivergences`), and persist only the per-leaf
  divergences. `RegisterIcebergColumnMapping` stays a pure recorder — the caller
  computes the divergence; registration just writes it down.

**Policy (compatibility_mode)**
- The `compatibility_mode` table option and its parsing/validation live behind a
  small, extensible policy surface (`ApplyCompatibilityStorageMapping` +
  `compatibility_mode.h`). Adding a mode is a policy function, not a change to
  the codecs.

**Write path (surface → storage)**
- A generic, schema-driven wrapper `IcebergWrapQueryWithStorageCasts` casts each
  diverging leaf to its persisted storage type on the way into Iceberg. It is
  driven entirely by the destination table's stored schema and knows nothing
  about UUID specifically.
- This is kept orthogonal to the pre-existing temporal reshaping
  (`IcebergWrapQueryWithNativeTypeConversion`, INTERVAL/TIMETZ), and the two now
  share a single column-wise traversal (`WrapQueryColumnwise`).

**Read path (storage → surface)**
- `TupleDescToProjectionList` detects any column whose stored leaf type diverges
  from the surface type and casts it back, generically — no UUID-specific code.

**Shared, type-agnostic core**
- One divergence predicate (`TypeHasStorageDivergentLeaf` /
  `ScalarLeafStorageDiverges`) is shared by both read and write so the two
  directions can never disagree, and `PostgresBaseTypeIdToIcebergTypeName` is
  the single surface→Iceberg-name source of truth (moved into the engine).

## Compatibility / upgrade

- `'auto'` (the default, and every existing table) is a strict no-op: no
  divergence is recorded and all code paths short-circuit.
- The migration is additive; tables created before this change read and write
  exactly as before.
- Surface schema is untouched under any mode — `\d`, `DEFAULT`, `GENERATED`, and
  query result types are all unchanged.

## Test plan

`pg_lake_table/tests/pytests/test_iceberg_uuid_compat.py` covers option
validation (`auto`/`snowflake`/invalid/non-iceberg), surface types unchanged
(including named composites preserved), nested uuid stored as `string` in both
the Iceberg metadata and the physical Parquet (arrays, composites,
array-in-composite, arrays of numerics), top-level uuid kept native, both write
paths (`INSERT … VALUES` and pushed-down `INSERT … SELECT` / `COPY`), the
read-back round-trip, `ALTER TABLE ADD COLUMN`, `DEFAULT` accepted, domains over
diverging types, and the non-compat regression.

```bash
cd pg_lake_table && PYTHONPATH=../test_common pipenv run pytest tests/pytests/test_iceberg_uuid_compat.py
```

Also exercised against the interval/timetz, insert/select pushdown, copy-from
pushdown, domain, and spatial suites to confirm the generalized read/write paths
are behavior-preserving for existing types.