### PR TITLE
iceberg: add compatibility_mode table option (storage no-op)

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "postgres.h"
+
+#include "nodes/pg_list.h"
+
+/*
+ * Name of the per-table iceberg option that selects a compatibility mode.
+ * Defined here so option validation (pg_lake_table) and the conversion logic
+ * share a single source of truth.
+ */
+#define ICEBERG_COMPATIBILITY_MODE_OPTION "compatibility_mode"
+
+/*
+ * IcebergCompatibilityMode selects how a table's Iceberg STORAGE is shaped so
+ * the table is consumable by a downstream engine with narrower type support.
+ *
+ * Unlike a type-rewrite, these modes never change the PostgreSQL column type:
+ * the column stays exactly as declared (uuid stays uuid). The intent is that
+ * only the physical Iceberg/Parquet storage type and the I/O-boundary
+ * conversions differ, with that surface->storage divergence persisted per-leaf
+ * in lake_table.field_id_mappings (decided once, at registration).
+ *
+ * This option layer recognizes and validates the mode and enforces the DDL
+ * guards; on its own it records no divergence (a storage no-op). The actual
+ * per-leaf storage shaping is layered on top by the surface/storage mapping
+ * change.
+ *
+ *   ICEBERG_COMPAT_AUTO       default (option unset or 'auto'): no storage
+ *                             divergence. This is the hook where future
+ *                             auto-detection would live.
+ *   ICEBERG_COMPAT_SNOWFLAKE  selects the Snowflake-compatible storage shape
+ *                             (a uuid nested inside an array/composite is
+ *                             stored as Iceberg `string`, since Snowflake
+ *                             cannot hold a UUID inside a structured type; a
+ *                             top-level uuid column stays native `uuid`).
+ */
+typedef enum IcebergCompatibilityMode
+{
+	ICEBERG_COMPAT_AUTO = 0,
+	ICEBERG_COMPAT_SNOWFLAKE,
+}			IcebergCompatibilityMode;
+
+/*
+ * GUC pg_lake_iceberg.default_compatibility_mode: the compatibility_mode a new
+ * iceberg table adopts when CREATE does not specify one. Backed by an enum GUC
+ * (declared int, as Postgres requires for enum GUCs), so the accepted set is
+ * exactly {auto, snowflake}, matched case-insensitively. Defaults to AUTO.
+ */
+extern PGDLLEXPORT int IcebergDefaultCompatibilityMode;
+
+/* Canonical lowercase name ("auto"/"snowflake") for a mode. */
+extern PGDLLEXPORT const char *IcebergCompatibilityModeName(IcebergCompatibilityMode mode);
+
+/* Maps an option string ("auto"/"snowflake"/NULL) to the enum; errors otherwise. */
+extern PGDLLEXPORT IcebergCompatibilityMode ParseIcebergCompatibilityMode(const char *optionValue);
+
+/* Reads the option out of a CREATE statement's WITH (...) DefElem list. */
+extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromCreateOptions(List *options);
+
+/* Reads the option from an existing relation; AUTO for non-iceberg/unset. */
+extern PGDLLEXPORT IcebergCompatibilityMode IcebergCompatibilityModeFromRelation(Oid relationId);
+
+/*
+ * True iff typeOid is, or contains at any depth, a pg_map type. Used to reject
+ * map columns under compatibility_mode='snowflake' (Snowflake cannot represent
+ * them, mirroring snowflake_cdc's restriction).
+ */
+extern PGDLLEXPORT bool TypeContainsMap(Oid typeOid);

--- a/pg_lake_iceberg/src/iceberg/compatibility_mode.c
+++ b/pg_lake_iceberg/src/iceberg/compatibility_mode.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * compatibility_mode.c
+ *  Per-table Iceberg "compatibility mode" option recognition and DDL guards.
+ *
+ * Some engines that read pg_lake's Iceberg tables have narrower type support
+ * than Iceberg itself. The `compatibility_mode` table option opts a table into
+ * a storage shape consumable by such an engine WITHOUT changing the PostgreSQL
+ * column type the user declared.
+ *
+ * This module is the option layer: it parses/validates the option value
+ * ('auto' or 'snowflake'), exposes accessors that read the mode off a CREATE
+ * statement or an existing relation, and provides TypeContainsMap so the DDL
+ * paths can reject types a restrictive mode cannot represent (a pg_map under
+ * 'snowflake'). On its own this layer is a pure storage no-op: choosing
+ * 'snowflake' is accepted and validated, but no surface->storage divergence is
+ * yet recorded or applied.
+ *
+ * The actual storage shaping (e.g. storing a nested uuid as Iceberg `string`)
+ * and its persistence in lake_table.field_id_mappings are layered on top of
+ * this option by the surface/storage type-mapping change; the read/write
+ * codecs then recover the conversion from the persisted mapping, never from
+ * this option directly.
+ */
+
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "catalog/pg_type.h"
+#include "foreign/foreign.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "utils/typcache.h"
+
+#include "pg_lake/iceberg/compatibility_mode.h"
+#include "pg_lake/parsetree/options.h"
+#include "pg_lake/pgduck/map.h"
+#include "pg_lake/util/table_type.h"
+
+
+/*
+ * GUC pg_lake_iceberg.default_compatibility_mode (defined in init.c). The
+ * default a new table adopts when CREATE does not specify compatibility_mode.
+ */
+int			IcebergDefaultCompatibilityMode = ICEBERG_COMPAT_AUTO;
+
+
+static bool AnyCompositeFieldContainsMap(Oid typeOid);
+static Oid	DomainBaseTypeOneLevel(Oid domainOid);
+
+
+/*
+ * IcebergCompatibilityModeName returns the canonical lowercase option string
+ * for a mode. Used when seeding a new table's compatibility_mode option from
+ * the GUC default, so the stored value is exactly what ParseIcebergCompatibilityMode
+ * accepts.
+ */
+const char *
+IcebergCompatibilityModeName(IcebergCompatibilityMode mode)
+{
+	switch (mode)
+	{
+		case ICEBERG_COMPAT_AUTO:
+			return "auto";
+		case ICEBERG_COMPAT_SNOWFLAKE:
+			return "snowflake";
+	}
+
+	return "auto";
+}
+
+
+/*
+ * ParseIcebergCompatibilityMode maps an option string to the enum. NULL (the
+ * option being absent) and 'auto' both mean ICEBERG_COMPAT_AUTO, the default.
+ * An unrecognized value is a hard error so the accepted set lives in exactly
+ * one place; option validation in pg_lake_table calls straight into this.
+ */
+IcebergCompatibilityMode
+ParseIcebergCompatibilityMode(const char *optionValue)
+{
+	if (optionValue == NULL)
+		return ICEBERG_COMPAT_AUTO;
+
+	if (strcmp(optionValue, "auto") == 0)
+		return ICEBERG_COMPAT_AUTO;
+
+	if (strcmp(optionValue, "snowflake") == 0)
+		return ICEBERG_COMPAT_SNOWFLAKE;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("invalid %s option: \"%s\"",
+					ICEBERG_COMPATIBILITY_MODE_OPTION, optionValue),
+			 errhint("Valid values are \"auto\" and \"snowflake\".")));
+
+	return ICEBERG_COMPAT_AUTO; /* keep the compiler happy */
+}
+
+
+/*
+ * IcebergCompatibilityModeFromCreateOptions reads the option out of a CREATE
+ * statement's WITH (...) DefElem list.
+ */
+IcebergCompatibilityMode
+IcebergCompatibilityModeFromCreateOptions(List *options)
+{
+	return ParseIcebergCompatibilityMode(
+										 GetStringOption(options, ICEBERG_COMPATIBILITY_MODE_OPTION, false));
+}
+
+
+/*
+ * IcebergCompatibilityModeFromRelation reads the option from an existing
+ * relation's stored foreign-table options. Returns AUTO for non-iceberg
+ * relations (e.g. during ALTER on an unrelated table).
+ */
+IcebergCompatibilityMode
+IcebergCompatibilityModeFromRelation(Oid relationId)
+{
+	if (!IsIcebergTable(relationId))
+		return ICEBERG_COMPAT_AUTO;
+
+	ForeignTable *foreignTable = GetForeignTable(relationId);
+
+	return ParseIcebergCompatibilityMode(
+										 GetStringOption(foreignTable->options, ICEBERG_COMPATIBILITY_MODE_OPTION, false));
+}
+
+
+/*
+ * AnyCompositeFieldContainsMap returns true if any non-dropped attribute of the
+ * composite type contains a map at any depth.
+ */
+static bool
+AnyCompositeFieldContainsMap(Oid typeOid)
+{
+	TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeOid, -1);
+	bool		found = false;
+
+	for (int i = 0; i < tupleDesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, i);
+
+		if (attr->attisdropped)
+			continue;
+
+		if (TypeContainsMap(attr->atttypid))
+		{
+			found = true;
+			break;
+		}
+	}
+
+	ReleaseTupleDesc(tupleDesc);
+	return found;
+}
+
+
+/*
+ * TypeContainsMap returns true if typeOid is a pg_map or contains one at any
+ * nesting depth (array element or composite field). A map's own key/value are
+ * not descended: the presence of the map itself is already disqualifying.
+ *
+ * The map check runs BEFORE any domain resolution, and domains are resolved
+ * one level at a time, because pg_map types are themselves domains over
+ * arrays; getBaseType() would skip past the map OID and miss it.
+ */
+bool
+TypeContainsMap(Oid typeOid)
+{
+	if (IsMapTypeOid(typeOid))
+		return true;
+
+	if (type_is_array(typeOid))
+		return TypeContainsMap(get_element_type(typeOid));
+
+	char		typtype = get_typtype(typeOid);
+
+	if (typtype == TYPTYPE_COMPOSITE)
+		return AnyCompositeFieldContainsMap(typeOid);
+
+	if (typtype == TYPTYPE_DOMAIN)
+		return TypeContainsMap(DomainBaseTypeOneLevel(typeOid));
+
+	return false;
+}
+
+
+/*
+ * DomainBaseTypeOneLevel returns the immediate base type of a domain (one
+ * level of unwrapping). Unlike getBaseType(), it does not chase the whole
+ * domain chain, so a pg_map domain nested under a user domain is still seen as
+ * a map by the callers above.
+ */
+static Oid
+DomainBaseTypeOneLevel(Oid domainOid)
+{
+	HeapTuple	tp = SearchSysCache1(TYPEOID, ObjectIdGetDatum(domainOid));
+
+	if (!HeapTupleIsValid(tp))
+		return domainOid;
+
+	Form_pg_type typtup = (Form_pg_type) GETSTRUCT(tp);
+	Oid			baseType = typtup->typbasetype;
+
+	ReleaseSysCache(tp);
+
+	return OidIsValid(baseType) ? baseType : domainOid;
+}

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -31,6 +31,7 @@
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/iceberg/iceberg_field.h"
 #include "pg_lake/iceberg/operations/manifest_merge.h"
 #include "pg_lake/iceberg/operations/vacuum.h"
@@ -65,6 +66,13 @@ static const struct config_enum_entry RestCatalogAuthTypeOptions[] = {
 	{"oauth2", REST_CATALOG_AUTH_TYPE_OAUTH2, false},
 	{"default", REST_CATALOG_AUTH_TYPE_OAUTH2, false},
 	{"horizon", REST_CATALOG_AUTH_TYPE_HORIZON, false},
+	{NULL, 0, false},
+};
+
+/* pg_lake_iceberg.default_compatibility_mode */
+static const struct config_enum_entry CompatibilityModeOptions[] = {
+	{"auto", ICEBERG_COMPAT_AUTO, false},
+	{"snowflake", ICEBERG_COMPAT_SNOWFLAKE, false},
 	{NULL, 0, false},
 };
 
@@ -274,6 +282,21 @@ _PG_init(void)
 							 RestCatalogAuthTypeOptions,
 							 PGC_SUSET,
 							 GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
+
+	DefineCustomEnumVariable("pg_lake_iceberg.default_compatibility_mode",
+							 gettext_noop("Downstream-engine storage compatibility mode that new "
+										  "iceberg tables adopt when CREATE does not specify "
+										  "compatibility_mode."),
+							 gettext_noop("'auto' (the default) applies no storage divergence. "
+										  "'snowflake' shapes nested storage for Snowflake. The "
+										  "value is fixed into each table at creation, so changing "
+										  "this GUC only affects tables created afterwards."),
+							 &IcebergDefaultCompatibilityMode,
+							 ICEBERG_COMPAT_AUTO,
+							 CompatibilityModeOptions,
+							 PGC_USERSET,
+							 0,
 							 NULL, NULL, NULL);
 
 	DefineCustomStringVariable("pg_lake_iceberg.rest_catalog_host",

--- a/pg_lake_table/include/pg_lake/fdw/schema_operations/register_field_ids.h
+++ b/pg_lake_table/include/pg_lake/fdw/schema_operations/register_field_ids.h
@@ -41,6 +41,7 @@ typedef struct PostgresColumnMapping
 }			PostgresColumnMapping;
 
 extern PGDLLEXPORT void RegisterPostgresColumnMappings(List *pgColumnMappingList);
+extern PGDLLEXPORT void ErrorIfColumnsUnsupportedForCompatibilityMode(Oid relationId, List *columnDefList);
 extern PGDLLEXPORT List *CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, bool forAddColumn);
 extern PGDLLEXPORT List *CreatePostgresColumnMappingsForIcebergTableFromExternalMetadata(Oid relationId);
 extern PGDLLEXPORT DataFileSchema * GetDataFileSchemaForTable(Oid relationId);

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -52,6 +52,7 @@
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/iceberg/metadata_operations.h"
 #include "pg_lake/fdw/partition_transform.h"
 #include "pg_lake/parsetree/options.h"
@@ -1407,6 +1408,22 @@ HandleIcebergOptionsChanges(Oid relationId, AlterTableStmt *alterStmt)
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("Changing option \"%s\" is not supported",
 								newOption->defname)));
+
+			/*
+			 * compatibility_mode decides the per-leaf storage mapping once,
+			 * at registration. Changing it on an existing table would desync
+			 * the persisted mapping (field_storage_pg_type) from the data
+			 * files and Iceberg metadata already written, so forbid it
+			 * outright.
+			 */
+			if (strcmp(newOption->defname, ICEBERG_COMPATIBILITY_MODE_OPTION) == 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("Changing option \"%s\" is not supported",
+								newOption->defname),
+						 errdetail("The storage layout was fixed when the table "
+								   "was created; altering it would not match the "
+								   "existing data files.")));
 
 			/* we currently only care about row_ids */
 			if (strcmp(newOption->defname, "row_ids") != 0)

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -63,6 +63,7 @@
 #include "pg_lake/fdw/schema_operations/register_field_ids.h"
 #include "pg_lake/iceberg/api.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/util/numeric.h"
 #include "pg_lake/util/rel_utils.h"
 #include "pg_lake/util/url_encode.h"
@@ -753,6 +754,27 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 							 REST_CATALOG_NAME,
 							 POSTGRES_CATALOG_NAME,
 							 OBJECT_STORE_CATALOG_NAME)));
+	}
+
+	/*
+	 * Seed compatibility_mode from pg_lake_iceberg.default_compatibility_mode
+	 * when the table does not specify it explicitly. We persist only a
+	 * non-default ('snowflake') value: 'auto' is the natural default, so an
+	 * absent option already means auto. Persisting the resolved value makes
+	 * the table self-describing -- its storage layout is fixed at creation
+	 * and is unaffected by later changes to the GUC (the option itself is
+	 * immutable).
+	 */
+	if (GetOption(createStmt->options, ICEBERG_COMPATIBILITY_MODE_OPTION) == NULL &&
+		IcebergDefaultCompatibilityMode != ICEBERG_COMPAT_AUTO)
+	{
+		const char *modeName =
+			IcebergCompatibilityModeName(IcebergDefaultCompatibilityMode);
+
+		createStmt->options =
+			lappend(createStmt->options,
+					makeDefElem(ICEBERG_COMPATIBILITY_MODE_OPTION,
+								(Node *) makeString(pstrdup(modeName)), -1));
 	}
 
 	bool		hasRestCatalogOption = HasRestCatalogTableOption(createStmt->options);

--- a/pg_lake_table/src/ddl/ddl_changes.c
+++ b/pg_lake_table/src/ddl/ddl_changes.c
@@ -118,6 +118,10 @@ ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 			*metadataLocation = catalogType == REST_CATALOG_READ_WRITE ? NULL : GenerateInitialIcebergTableMetadataPath(relationId);
 			InsertInternalIcebergCatalogTable(relationId, *metadataLocation, ddlOperation->hasCustomLocation);
 
+			/* reject column types the table's compatibility mode cannot store */
+			ErrorIfColumnsUnsupportedForCompatibilityMode(relationId,
+														  ddlOperation->columnDefs);
+
 			/* register mappings for new columns */
 			bool		forAddColumn = false;
 			List	   *columnMappings = CreatePostgresColumnMappingsForColumnDefs(relationId,
@@ -188,6 +192,10 @@ ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 		}
 		else if (ddlOperation->type == DDL_COLUMN_ADD)
 		{
+			/* reject column types the table's compatibility mode cannot store */
+			ErrorIfColumnsUnsupportedForCompatibilityMode(relationId,
+														  ddlOperation->columnDefs);
+
 			/* register mapping for new column */
 			bool		forAddColumn = true;
 			List	   *columnMappings = CreatePostgresColumnMappingsForColumnDefs(relationId,

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -35,6 +35,7 @@
 #include "commands/extension.h"
 #include "foreign/foreign.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/partitioning/partition_by_parser.h"
 #include "pg_lake/permissions/roles.h"
 #include "pg_lake/copy/copy_format.h"
@@ -577,6 +578,12 @@ InitPgLakeIcebergOptions(void)
 		 */
 		{"out_of_range_values", ForeignTableRelationId},
 
+		/*
+		 * downstream-engine storage compatibility: 'auto' (default) or
+		 * 'snowflake' (store nested uuid physically as string)
+		 */
+		{ICEBERG_COMPATIBILITY_MODE_OPTION, ForeignTableRelationId},
+
 		{NULL, InvalidOid}
 	};
 
@@ -879,6 +886,12 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 								outOfRangeValues),
 						 errhint("Valid values are \"error\" and \"clamp\".")));
 			}
+		}
+		else if (catalog == ForeignTableRelationId &&
+				 strcmp(def->defname, ICEBERG_COMPATIBILITY_MODE_OPTION) == 0)
+		{
+			/* errors on an unrecognized value; single source of truth */
+			(void) ParseIcebergCompatibilityMode(defGetString(def));
 		}
 	}
 

--- a/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
+++ b/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
@@ -32,6 +32,7 @@
 #include "commands/defrem.h"
 #include "commands/comment.h"
 #include "foreign/foreign.h"
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "parser/parse_type.h"
@@ -42,6 +43,7 @@
 #include "pg_lake/iceberg/api/table_metadata.h"
 #include "pg_lake/iceberg/api/table_schema.h"
 #include "pg_lake/iceberg/catalog.h"
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/iceberg/iceberg_field.h"
 #include "pg_lake/iceberg/iceberg_type_json_serde.h"
 #include "pg_lake/parsetree/options.h"
@@ -132,6 +134,44 @@ GetDataFileSchemaForTableWithExclusion(Oid relationId, List *excludedColumns)
 	table_close(rel, NoLock);
 
 	return schema;
+}
+
+
+/*
+ * ErrorIfColumnsUnsupportedForCompatibilityMode rejects, at the DDL layer,
+ * column types a table's compatibility_mode cannot represent. Today: a map
+ * (pg_map) under 'snowflake', which Snowflake cannot store (this also keeps a
+ * uuid from ever living inside a map under snowflake compat, so the read/write
+ * codecs never need map-key/value conversion). Called from the CREATE / ALTER
+ * ADD COLUMN paths before any field mapping is built; the registration code
+ * then only asserts the invariant.
+ */
+void
+ErrorIfColumnsUnsupportedForCompatibilityMode(Oid relationId, List *columnDefList)
+{
+	IcebergCompatibilityMode compatMode = IcebergCompatibilityModeFromRelation(relationId);
+
+	if (compatMode != ICEBERG_COMPAT_SNOWFLAKE)
+		return;
+
+	ListCell   *columnDefCell = NULL;
+
+	foreach(columnDefCell, columnDefList)
+	{
+		ColumnDef  *columnDef = (ColumnDef *) lfirst(columnDefCell);
+		int32		typmod = 0;
+		Oid			typeOid = InvalidOid;
+
+		typenameTypeIdAndMod(NULL, columnDef->typeName, &typeOid, &typmod);
+
+		if (TypeContainsMap(typeOid))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("column \"%s\" of type %s is not supported with "
+							"compatibility_mode 'snowflake'",
+							columnDef->colname, format_type_be(typeOid)),
+					 errdetail("Snowflake cannot represent map types.")));
+	}
 }
 
 

--- a/pg_lake_table/tests/pytests/test_compatibility_mode.py
+++ b/pg_lake_table/tests/pytests/test_compatibility_mode.py
@@ -1,0 +1,406 @@
+"""
+Tests for the ``compatibility_mode`` table option (option layer only).
+
+This is the option/DDL layer: ``compatibility_mode`` is recognized and
+validated ('auto' or 'snowflake'), it cannot be changed after creation, and a
+type a restrictive mode cannot represent (a pg_map under 'snowflake') is
+rejected up front at CREATE / ALTER ADD COLUMN.
+
+On its own this layer performs NO storage shaping -- it is a pure storage
+no-op: choosing 'snowflake' is accepted, but a nested uuid is still stored as
+Iceberg ``uuid`` and the PostgreSQL column type is unchanged. The actual
+surface->storage mapping (nested uuid stored as ``string``, persisted in
+``lake_table.field_id_mappings``) is layered on top by the storage-mapping
+change and is covered by its own test suite. The no-op tests below lock in that
+this layer does not, by itself, change physical storage.
+
+psycopg2 returns uuid values as plain strings here (no UUID adapter is
+registered), so uuid values are normalized via ``_u`` before comparison.
+"""
+
+from utils_pytest import *
+import json
+import pytest
+
+U1 = "11111111-1111-1111-1111-111111111111"
+U2 = "22222222-2222-2222-2222-222222222222"
+
+
+def _u(value):
+    """Normalize a uuid value (psycopg may return str or uuid.UUID)."""
+    return None if value is None else str(value).lower()
+
+
+def _ulist(value):
+    """Normalize a uuid array, preserving NULL for the whole array."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        inner = value.strip("{}")
+        return [] if inner == "" else [_u(v) for v in inner.split(",")]
+    return [_u(v) for v in value]
+
+
+def _metadata_fields(s3, pg_conn, schema_name, table_name):
+    """Return the top-level Iceberg schema fields list from metadata.json."""
+    results = run_query(
+        f"SELECT metadata_location FROM lake_iceberg.tables "
+        f"WHERE table_name = '{table_name}' AND table_namespace = '{schema_name}'",
+        pg_conn,
+    )
+    assert len(results) == 1, f"expected one iceberg table {schema_name}.{table_name}"
+    data = read_s3_operations(s3, results[0][0])
+    return json.loads(data)["schemas"][0]["fields"]
+
+
+def _collect_leaf_types(field_type):
+    """Recursively collect every scalar (leaf) Iceberg type reachable from a node."""
+    if isinstance(field_type, str):
+        return [field_type]
+
+    kind = field_type.get("type")
+    if kind == "struct":
+        leaves = []
+        for f in field_type["fields"]:
+            leaves.extend(_collect_leaf_types(f["type"]))
+        return leaves
+    if kind == "list":
+        return _collect_leaf_types(field_type["element"])
+    if kind == "map":
+        return _collect_leaf_types(field_type["key"]) + _collect_leaf_types(
+            field_type["value"]
+        )
+    return []
+
+
+def _field_by_name(fields, name):
+    return next(f for f in fields if f["name"] == name)
+
+
+def _persisted_compat_option(pg_conn, qualified_table):
+    """Return the stored compatibility_mode foreign-table option, or None."""
+    rows = run_query(
+        f"""
+        SELECT option_value
+        FROM pg_options_to_table(
+            (SELECT ftoptions FROM pg_foreign_table
+             WHERE ftrelid = '{qualified_table}'::regclass)
+        )
+        WHERE option_name = 'compatibility_mode'
+        """,
+        pg_conn,
+    )
+    return rows[0][0] if rows else None
+
+
+# ---------------------------------------------------------------------------
+# Option validation
+# ---------------------------------------------------------------------------
+
+
+def test_compatibility_mode_option_validation(pg_conn, s3, with_default_location):
+    """'auto' and 'snowflake' are accepted; anything else is rejected."""
+    run_command("CREATE SCHEMA test_compat_opt;", pg_conn)
+    pg_conn.commit()
+
+    run_command(
+        "CREATE TABLE test_compat_opt.a (id int) USING iceberg "
+        "WITH (compatibility_mode = 'auto');",
+        pg_conn,
+    )
+    run_command(
+        "CREATE TABLE test_compat_opt.b (id int) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    with pytest.raises(Exception) as exc:
+        run_command(
+            "CREATE TABLE test_compat_opt.bad (id int) USING iceberg "
+            "WITH (compatibility_mode = 'redshift');",
+            pg_conn,
+        )
+    pg_conn.rollback()
+    assert "compatibility_mode" in str(exc.value).lower()
+
+    run_command("DROP SCHEMA test_compat_opt CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_compatibility_mode_is_immutable(pg_conn, s3, with_default_location):
+    """compatibility_mode cannot be changed after the table is created."""
+    run_command("CREATE SCHEMA test_compat_immut;", pg_conn)
+    run_command(
+        "CREATE TABLE test_compat_immut.t (id int) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    with pytest.raises(Exception) as exc:
+        run_command(
+            "ALTER TABLE test_compat_immut.t "
+            "OPTIONS (SET compatibility_mode 'auto');",
+            pg_conn,
+        )
+    pg_conn.rollback()
+    assert "compatibility_mode" in str(exc.value).lower()
+
+    run_command(
+        "CREATE TABLE test_compat_immut.t2 (id int) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+    with pytest.raises(Exception):
+        run_command(
+            "ALTER TABLE test_compat_immut.t2 "
+            "OPTIONS (ADD compatibility_mode 'snowflake');",
+            pg_conn,
+        )
+    pg_conn.rollback()
+
+    run_command("DROP SCHEMA test_compat_immut CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# default_compatibility_mode GUC
+# ---------------------------------------------------------------------------
+
+
+def test_default_compatibility_mode_guc_metadata(pg_conn, s3, with_default_location):
+    """The GUC is a regular user-settable enum over exactly {auto, snowflake}."""
+    rows = run_query(
+        "SELECT context, vartype, enumvals, boot_val "
+        "FROM pg_settings "
+        "WHERE name = 'pg_lake_iceberg.default_compatibility_mode'",
+        pg_conn,
+    )
+    assert len(rows) == 1, "GUC not registered"
+    context, vartype, enumvals, boot_val = rows[0]
+    assert context == "user", context
+    assert vartype == "enum", vartype
+    assert set(enumvals) == {"auto", "snowflake"}, enumvals
+    assert boot_val == "auto", boot_val
+
+
+def test_default_compatibility_mode_guc_value_validation(
+    pg_conn, s3, with_default_location
+):
+    """Only auto/snowflake accepted; matching is case-insensitive; else rejected."""
+    # Case-insensitive: Postgres normalizes enum GUC values to the canonical name.
+    run_command(
+        "SET pg_lake_iceberg.default_compatibility_mode = 'SNOWFLAKE';", pg_conn
+    )
+    assert (
+        run_query("SHOW pg_lake_iceberg.default_compatibility_mode", pg_conn)[0][0]
+        == "snowflake"
+    )
+    run_command("SET pg_lake_iceberg.default_compatibility_mode = 'Auto';", pg_conn)
+    assert (
+        run_query("SHOW pg_lake_iceberg.default_compatibility_mode", pg_conn)[0][0]
+        == "auto"
+    )
+
+    with pytest.raises(Exception):
+        run_command(
+            "SET pg_lake_iceberg.default_compatibility_mode = 'redshift';", pg_conn
+        )
+    pg_conn.rollback()
+    run_command("RESET pg_lake_iceberg.default_compatibility_mode;", pg_conn)
+    pg_conn.commit()
+
+
+def test_default_compatibility_mode_guc_seeds_new_tables(
+    pg_conn, s3, with_default_location
+):
+    """
+    With the GUC set to 'snowflake', a new table that does not specify
+    compatibility_mode adopts (and persists) it; an explicit option still wins;
+    and the GUC default 'auto' leaves the option absent.
+    """
+    map_typename = create_map_type("text", "int")
+    run_command("CREATE SCHEMA test_compat_guc;", pg_conn)
+    pg_conn.commit()
+
+    # Default (auto): option not persisted, map column allowed.
+    run_command("CREATE TABLE test_compat_guc.auto_t (id int) USING iceberg;", pg_conn)
+    pg_conn.commit()
+    assert _persisted_compat_option(pg_conn, "test_compat_guc.auto_t") is None
+
+    # GUC = snowflake: new table persists compatibility_mode=snowflake...
+    run_command(
+        "SET pg_lake_iceberg.default_compatibility_mode = 'snowflake';", pg_conn
+    )
+    run_command("CREATE TABLE test_compat_guc.sf_t (id int) USING iceberg;", pg_conn)
+    pg_conn.commit()
+    assert (
+        _persisted_compat_option(pg_conn, "test_compat_guc.sf_t") == "snowflake"
+    ), "GUC default not seeded into new table"
+
+    # ...so the snowflake DDL guard applies even without an explicit option.
+    with pytest.raises(Exception) as exc:
+        run_command(
+            f"CREATE TABLE test_compat_guc.sf_map (id int, m {map_typename}) "
+            f"USING iceberg;",
+            pg_conn,
+        )
+    pg_conn.rollback()
+    assert "snowflake" in str(exc.value).lower()
+
+    # An explicit option overrides the GUC.
+    run_command(
+        "CREATE TABLE test_compat_guc.explicit_auto (id int) USING iceberg "
+        "WITH (compatibility_mode = 'auto');",
+        pg_conn,
+    )
+    pg_conn.commit()
+    assert _persisted_compat_option(pg_conn, "test_compat_guc.explicit_auto") == "auto"
+
+    run_command("RESET pg_lake_iceberg.default_compatibility_mode;", pg_conn)
+    run_command("DROP SCHEMA test_compat_guc CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Map rejection under snowflake compat (DDL guard)
+# ---------------------------------------------------------------------------
+
+
+def test_map_rejected_under_snowflake_compat_on_create(
+    pg_conn, s3, with_default_location
+):
+    """Map columns are rejected at CREATE under compatibility_mode='snowflake'."""
+    map_typename = create_map_type("text", "int")
+    run_command("CREATE SCHEMA test_compat_map;", pg_conn)
+    pg_conn.commit()
+
+    with pytest.raises(Exception) as exc:
+        run_command(
+            f"CREATE TABLE test_compat_map.t (id int, m {map_typename}) USING iceberg "
+            f"WITH (compatibility_mode = 'snowflake');",
+            pg_conn,
+        )
+    pg_conn.rollback()
+    assert "snowflake" in str(exc.value).lower()
+
+    # The same map is fine without snowflake compat.
+    run_command(
+        f"CREATE TABLE test_compat_map.ok (id int, m {map_typename}) USING iceberg;",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("DROP SCHEMA test_compat_map CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_map_rejected_under_snowflake_compat_on_add_column(
+    pg_conn, s3, with_default_location
+):
+    """ALTER ... ADD COLUMN of a map is rejected under 'snowflake'."""
+    map_typename = create_map_type("text", "int")
+    run_command(
+        "CREATE SCHEMA test_compat_map_add;"
+        "CREATE TABLE test_compat_map_add.t (id int) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    with pytest.raises(Exception) as exc:
+        run_command(
+            f"ALTER TABLE test_compat_map_add.t ADD COLUMN m {map_typename};",
+            pg_conn,
+        )
+    pg_conn.rollback()
+    assert "snowflake" in str(exc.value).lower()
+
+    run_command("DROP SCHEMA test_compat_map_add CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Storage no-op: this layer alone does NOT shape storage
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_uuid_stays_native_under_snowflake(
+    pg_conn, s3, with_default_location
+):
+    """A top-level uuid column is stored as Iceberg uuid and round-trips."""
+    run_command("CREATE SCHEMA test_compat_top;", pg_conn)
+    run_command(
+        "CREATE TABLE test_compat_top.t (id int, u uuid) USING iceberg "
+        "WITH (compatibility_mode = 'snowflake');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    fields = _metadata_fields(s3, pg_conn, "test_compat_top", "t")
+    assert _field_by_name(fields, "u")["type"] == "uuid"
+
+    run_command(
+        f"INSERT INTO test_compat_top.t VALUES (1, '{U1}'), (2, NULL);", pg_conn
+    )
+    pg_conn.commit()
+    result = run_query("SELECT id, u FROM test_compat_top.t ORDER BY id", pg_conn)
+    assert [[r[0], _u(r[1])] for r in result] == [[1, U1], [2, None]]
+
+    run_command("DROP SCHEMA test_compat_top CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_nested_uuid_is_storage_noop_under_snowflake(
+    pg_conn, s3, with_default_location
+):
+    """
+    Option layer only: a nested uuid under 'snowflake' is STILL stored as
+    Iceberg uuid (no surface->storage divergence yet) and the surface type is
+    unchanged. The storage-mapping layer changes this to 'string'; this test
+    pins down that the option alone is a storage no-op.
+    """
+    run_command(
+        """
+        CREATE SCHEMA test_compat_nested;
+        SET search_path TO test_compat_nested;
+        CREATE TYPE acct AS (name text, uid uuid);
+        CREATE TABLE t (id int, a acct, us uuid[]) USING iceberg
+            WITH (compatibility_mode = 'snowflake');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    fields = _metadata_fields(s3, pg_conn, "test_compat_nested", "t")
+    # The composite's uuid field (uid) stays Iceberg uuid; the text field
+    # (name) is naturally Iceberg string, so we only assert the uuid leaf is
+    # still uuid here (the storage-mapping layer would turn it into string).
+    comp_leaves = _collect_leaf_types(_field_by_name(fields, "a")["type"])
+    arr_leaves = _collect_leaf_types(_field_by_name(fields, "us")["type"])
+    assert "uuid" in comp_leaves, comp_leaves
+    # uuid[] is the clean discriminator: no-op keeps it list<uuid> (the
+    # storage-mapping layer would make it list<string>).
+    assert arr_leaves == ["uuid"], arr_leaves
+
+    run_command(
+        f"""
+        INSERT INTO test_compat_nested.t VALUES
+            (1, ROW('alice', '{U1}')::acct, ARRAY['{U1}','{U2}']::uuid[]),
+            (2, ROW('bob', NULL)::acct, NULL);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+    result = run_query(
+        "SELECT id, (a).name, (a).uid, us FROM test_compat_nested.t ORDER BY id",
+        pg_conn,
+    )
+    assert [[r[0], r[1], _u(r[2]), _ulist(r[3])] for r in result] == [
+        [1, "alice", U1, [U1, U2]],
+        [2, "bob", None, None],
+    ]
+
+    run_command("DROP SCHEMA test_compat_nested CASCADE;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
## Overview

Introduces the `compatibility_mode` per-table option for Iceberg tables plus the DDL guards around it, **without changing any physical storage**. This is the base layer that a following surface/storage type-mapping PR stacks on top of.

On its own it is a pure **storage no-op**: selecting `compatibility_mode = 'snowflake'` is accepted and validated, but no surface→storage divergence is recorded or applied. A nested `uuid` is still stored as Iceberg `uuid`, and every column's PostgreSQL type is unchanged.

## What's here

- **`compatibility_mode.{c,h}`** — the `IcebergCompatibilityMode` enum, the option name, and accessors that parse/validate the value (`'auto'`/`'snowflake'`) off a CREATE statement or an existing relation; plus `TypeContainsMap` for the DDL guard.
- **`option.c`** — register and validate the `compatibility_mode` foreign-table option (an unrecognized value errors, via the single parser).
- **`alter_table.c`** — forbid changing `compatibility_mode` after creation (the storage layout is fixed at registration).
- **`ddl_changes.c` + `register_field_ids.{c,h}`** — reject, at CREATE and ALTER ADD COLUMN, column types a restrictive mode cannot represent (a `pg_map` under `'snowflake'`, which Snowflake cannot store), via the new `ErrorIfColumnsUnsupportedForCompatibilityMode`.

## Why split this out

The storage mapping itself (persisting per-leaf surface→storage divergence in `lake_table.field_id_mappings`, the read/write casts) is a larger change. Landing the option + DDL surface first lets the mapping PR — and other work — stack cleanly on a stable option layer.

## Test plan

`pg_lake_table/tests/pytests/test_compatibility_mode.py` covers option validation, immutability, map rejection at CREATE / ADD COLUMN, and the storage no-op (top-level and nested `uuid` both stay native Iceberg `uuid` under `'snowflake'`, round-tripping unchanged).

```bash
cd pg_lake_table && PYTHONPATH=../test_common pipenv run pytest tests/pytests/test_compatibility_mode.py
```

Made with [Cursor](https://cursor.com)