### PR TITLE
pg_lake_table: parameterize CheckIfTypeIsUsedInInternalIcebergTable

### DIFF
--- a/pg_lake_table/include/pg_lake/ddl/drop_table.h
+++ b/pg_lake_table/include/pg_lake/ddl/drop_table.h
@@ -22,6 +22,7 @@
 extern bool SkipDropAccessHook;
 
 extern void InitializeDropTableHandler(void);
-extern bool CheckIfTypeIsUsedInIcebergTable(Oid typeId);
+extern PGDLLEXPORT bool CheckIfTypeIsUsedInTables(Oid typeId, const char *tableSetSubquery);
+extern bool CheckIfTypeIsUsedInInternalIcebergTable(Oid typeId);
 extern bool ProcessDropPgLakeTable(ProcessUtilityParams * params, void *arg);
 extern void TryMarkAllReferencedFilesForDeletion(Oid relationId);

--- a/pg_lake_table/src/ddl/alter_table.c
+++ b/pg_lake_table/src/ddl/alter_table.c
@@ -546,7 +546,7 @@ ProcessAlterType(ProcessUtilityParams * processUtilityParams, void *arg)
 		TypeName   *typename = makeTypeNameFromNameList(nameList);
 		Oid			typeOid = typenameTypeId(NULL, typename);
 
-		if (CheckIfTypeIsUsedInIcebergTable(typeOid))
+		if (CheckIfTypeIsUsedInInternalIcebergTable(typeOid))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -574,7 +574,7 @@ ProcessEnumStatement(ProcessUtilityParams * processUtilityParams, void *arg)
 	TypeName   *typename = makeTypeNameFromNameList(stmt->typeName);
 	Oid			typeOid = typenameTypeId(NULL, typename);
 
-	if (CheckIfTypeIsUsedInIcebergTable(typeOid))
+	if (CheckIfTypeIsUsedInInternalIcebergTable(typeOid))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -610,7 +610,7 @@ ProcessAlterTypeAttributeRename(ProcessUtilityParams * processUtilityParams, voi
 	TypeName   *typename = makeTypeNameFromNameList(nameList);
 	Oid			typeOid = typenameTypeId(NULL, typename);
 
-	if (CheckIfTypeIsUsedInIcebergTable(typeOid))
+	if (CheckIfTypeIsUsedInInternalIcebergTable(typeOid))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/pg_lake_table/src/ddl/drop_table.c
+++ b/pg_lake_table/src/ddl/drop_table.c
@@ -63,6 +63,11 @@
 /* controlled via GUC */
 bool		SkipDropAccessHook = false;
 
+#define INTERNAL_ICEBERG_TABLES_SUBQUERY \
+	"SELECT c.oid AS relid " \
+	"FROM lake_iceberg.tables_internal tbl " \
+	"JOIN pg_class c ON c.oid = tbl.table_name"
+
 static bool IsDropPgLakeTable(DropStmt *dropStmt);
 static void PgLakeTableObjectsInDropStmt(DropStmt *dropStmt,
 										 List **pgLakeTableObjects,
@@ -316,7 +321,7 @@ DropTableAccessHook(ObjectAccessType access, Oid classId, Oid objectId,
 		 */
 		Oid			typeId = get_rel_type_id(objectId);
 
-		if (CheckIfTypeIsUsedInIcebergTable(typeId))
+		if (CheckIfTypeIsUsedInInternalIcebergTable(typeId))
 			ereport(ERROR,
 					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					 errmsg("cannot alter type \"%s\" because it is used in an iceberg table",
@@ -338,20 +343,30 @@ PreventCitusTableVisibility(void)
 }
 
 /*
-* CheckIfTypeIsUsedInIcebergTable checks if the given type is used in any
-* iceberg table.
-*
-* It recursively walks the type dependency graph upward: composites that
-* contain the type as an attribute, array types whose element is the type,
-* and domain types (including maps) whose base type is the type.
-*/
+ * CheckIfTypeIsUsedInTables checks if the given type is used as an attribute
+ * type of any relation in the table set defined by tableSetSubquery.
+ *
+ * It recursively walks the type dependency graph upward: composites that
+ * contain the type as an attribute, array types whose element is the type,
+ * and domain types (including maps) whose base type is the type.  Any of
+ * the resulting types appearing as a non-dropped attribute on a relation
+ * returned by tableSetSubquery makes the function return true.
+ *
+ * tableSetSubquery must be a SELECT statement that returns a single
+ * column of pg_class OIDs aliased as "relid", e.g.:
+ *
+ *     "SELECT c.oid AS relid
+ *        FROM lake_iceberg.tables_internal tbl
+ *        JOIN pg_class c ON c.oid = tbl.table_name"
+ *
+ * The subquery is embedded verbatim, so callers are responsible for any
+ * required quoting or filtering.  Callers must ensure their schema(s) are
+ * accessible to the pg_lake_iceberg extension owner, which is the role
+ * under which the SPI query runs.
+ */
 bool
-CheckIfTypeIsUsedInIcebergTable(Oid typeId)
+CheckIfTypeIsUsedInTables(Oid typeId, const char *tableSetSubquery)
 {
-
-	if (!IsExtensionCreated(PgLakeTable))
-		return false;
-
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
@@ -370,11 +385,11 @@ CheckIfTypeIsUsedInIcebergTable(Oid typeId)
 					 ") "
 					 "SELECT EXISTS ( "
 					 "    SELECT 1 "
-					 "    FROM lake_iceberg.tables_internal tbl "
-					 "    JOIN pg_class c ON c.oid = tbl.table_name "
-					 "    JOIN pg_attribute attr ON attr.attrelid = c.oid "
+					 "    FROM (%s) _ts "
+					 "    JOIN pg_attribute attr ON attr.attrelid = _ts.relid "
 					 "    WHERE NOT attr.attisdropped "
-					 "      AND attr.atttypid IN (SELECT type_oid FROM dependent_types));");
+					 "      AND attr.atttypid IN (SELECT type_oid FROM dependent_types));",
+					 tableSetSubquery);
 
 
 	/* set the user context */
@@ -404,6 +419,21 @@ CheckIfTypeIsUsedInIcebergTable(Oid typeId)
 	SPI_END();
 
 	return exists;
+}
+
+
+/*
+ * CheckIfTypeIsUsedInInternalIcebergTable checks if the given type is used in
+ * any iceberg table.  Thin wrapper around CheckIfTypeIsUsedInTables that
+ * supplies the iceberg-specific table set.
+ */
+bool
+CheckIfTypeIsUsedInInternalIcebergTable(Oid typeId)
+{
+	if (!IsExtensionCreated(PgLakeTable))
+		return false;
+
+	return CheckIfTypeIsUsedInTables(typeId, INTERNAL_ICEBERG_TABLES_SUBQUERY);
 }
 
 


### PR DESCRIPTION
Extract the recursive type-graph walk in `CheckIfTypeIsUsedInIcebergTable` into a generic `CheckIfTypeIsUsedInTables(typeId, tableSetSubquery)` helper. The caller now supplies the relation set as a `SELECT` subquery aliased to "relid" instead of hard-coding `lake_iceberg.tables_internal`.

Rename `CheckIfTypeIsUsedInIcebergTable` to `CheckIfTypeIsUsedInInternalIcebergTable` and turn it into a thin wrapper that passes the `INTERNAL_ICEBERG_TABLES_SUBQUERY` macro.