### PR TITLE
pg_lake_table: reject partition_by on read_only table creation

### DIFF
--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -817,6 +817,14 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		 */
 		bool		hasExternalCatalogReadOnlyOption = HasReadOnlyOption(createStmt->options);
 
+		if (hasExternalCatalogReadOnlyOption &&
+			GetOption(createStmt->options, "partition_by") != NULL)
+			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							errmsg("read-only external catalog iceberg tables do not "
+								   "allow the partition_by option"),
+							errdetail("Partitioning of a read-only table is derived "
+									  "from the source table in the external catalog.")));
+
 		char	   *metadataLocation = NULL;
 		char	   *catalogNamespace = NULL;
 		char	   *catalogTableName = NULL;

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -131,6 +131,47 @@ def test_read_only_object_store_with_non_existing_options(
     pg_conn.commit()
 
 
+def test_read_only_object_store_partition_by_rejected(
+    pg_conn, s3, extension, with_default_location, adjust_object_store_settings
+):
+    run_command("CREATE SCHEMA test_read_only_partition_by", pg_conn)
+
+    run_command(
+        f"""CREATE TABLE test_read_only_partition_by.wrt_tbl(a INT, b INT) USING iceberg WITH (catalog='object_store')""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    wait_until_object_store_writable_table_pushed(
+        pg_conn, "test_read_only_partition_by", "wrt_tbl"
+    )
+
+    res = run_command(
+        f"""CREATE TABLE test_read_only_partition_by.read_tbl(a INT, b INT) USING iceberg WITH (catalog='object_store', read_only=True, catalog_table_name='wrt_tbl', partition_by='b')""",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "do not allow the partition_by option" in str(res)
+    pg_conn.rollback()
+
+    res = run_command(
+        f"""CREATE TABLE test_read_only_partition_by.read_tbl(a INT, b INT) USING iceberg WITH (catalog='object_store', read_only=True, catalog_table_name='wrt_tbl', partition_by='d')""",
+        pg_conn,
+        raise_error=False,
+    )
+    assert "do not allow the partition_by option" in str(res)
+    pg_conn.rollback()
+
+    run_command(
+        f"""CREATE TABLE test_read_only_partition_by.read_tbl(a INT, b INT) USING iceberg WITH (catalog='object_store', read_only=True, catalog_table_name='wrt_tbl')""",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("DROP SCHEMA test_read_only_partition_by CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 def test_object_store_read_only_alter_drop_required_options(
     pg_conn, s3, extension, with_default_location, adjust_object_store_settings
 ):


### PR DESCRIPTION
When you create a read-only external catalog table (`read_only=True` with `catalog='rest'` or `catalog='object_store'`), its partitioning comes from the source table's metadata in the external catalog, so a user-supplied `partition_by` has no meaning there. The create path still accepted one, though: the option was stored but never applied, and it wasn't validated either, so even a column that doesn't exist went through. ALTER already refuses to touch `partition_by` on these tables, so CREATE accepting it was inconsistent.

This adds a check in the create path that rejects `partition_by` when `read_only=True`. It sits right where the read-only flag is resolved, before any external catalog lookups, and mirrors the existing error for explicit catalog options on writable tables a few lines below. Tables that already have the option stored are unaffected, since the check only runs at CREATE.

Added a pytest covering three cases: `partition_by` on an existing column is rejected, `partition_by` on a non-existing column is rejected, and the same create without `partition_by` still works. The surrounding suites (`test_object_store_catalog.py`, `test_iceberg_read_only_table.py`, `test_iceberg_catalog_server.py`, 125 tests) pass.

Fixes #111 