### PR TITLE
pg_lake_copy: reject multidimensional arrays in COPY TO before CSV serialization

### DIFF
--- a/pg_lake_copy/tests/pytests/test_csv_copy.py
+++ b/pg_lake_copy/tests/pytests/test_csv_copy.py
@@ -1074,3 +1074,49 @@ def test_auto_detect(pg_conn, azure):
     # assert result_before == result_after
 
     pg_conn.rollback()
+
+
+def test_copy_to_multidim_array_csv(pg_conn, s3):
+    """
+    Regression test for https://github.com/Snowflake-Labs/pg_lake/issues/407.
+
+    Unlike Parquet/JSON, COPY TO in CSV format must still ACCEPT
+    multidimensional arrays.  For CSV, ShouldUseDuckSerialization is false and
+    ChooseDuckDBEngineTypeForWrite treats every column as VARCHAR, so the value
+    is written using the PostgreSQL text representation ("{{1,2},{3,4}}") and
+    copied through verbatim rather than cast to a DuckDB LIST(T).  The multidim
+    guard in CopyOneRowTo must therefore NOT fire for CSV, otherwise a value
+    that writes fine today would start erroring.
+
+    (Local-file / STDOUT CSV is handled by PostgreSQL directly and never
+    reaches pg_lake, so we exercise the pg_lake CSV path via an object-store
+    URL.)
+    """
+    csv_key = "test_copy_to_multidim_array_csv/data.csv"
+    csv_path = f"s3://{TEST_BUCKET}/{csv_key}"
+
+    # Must not raise: the guard is scoped to DuckDB-serialised formats.
+    run_command(
+        f"""
+        CREATE TABLE test_multidim_csv (id bigint, v int[]);
+        INSERT INTO test_multidim_csv VALUES
+            (1, ARRAY[[1,2],[3,4]]),
+            (2, ARRAY[10,20,30]),
+            (3, NULL);
+        COPY test_multidim_csv TO '{csv_path}' WITH (format 'csv');
+        """,
+        pg_conn,
+    )
+
+    # The multidimensional value is preserved verbatim as PostgreSQL array
+    # text (the field is quoted because it contains commas, but the literal is
+    # intact), and the 1-D array is written alongside it.
+    content = s3.get_object(Bucket=TEST_BUCKET, Key=csv_key)["Body"].read().decode()
+    assert (
+        "{{1,2},{3,4}}" in content
+    ), f"multidimensional array text missing from CSV output: {content!r}"
+    assert (
+        "{10,20,30}" in content
+    ), f"1-D array text missing from CSV output: {content!r}"
+
+    pg_conn.rollback()

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -1132,6 +1132,88 @@ def test_copy_to_1d_array_succeeds(pg_conn, duckdb_conn, tmp_path):
     pg_conn.rollback()
 
 
+# The multidimensional-array rejection must reach an array leaf no matter how
+# deeply it is nested -- inside a composite field, an array of composites, or a
+# domain over an array -- not just a top-level array column (review feedback on
+# PR #430).  This mirrors the recursive numeric-leaf validation above; the walk
+# lives in ErrorIfCopyToContainsMultidimArray (csv_writer.c).
+MULTIDIM_ARRAY_ERROR = "multidimensional arrays are not supported"
+
+NESTED_ARRAY_KINDS = ["composite", "array_of_composite", "domain_array"]
+
+
+def _create_nested_array_types(pg_conn):
+    run_command(
+        """
+        CREATE SCHEMA IF NOT EXISTS lake_arr;
+        CREATE TYPE lake_arr.tagged AS (label text, vals int[]);
+        CREATE DOMAIN int_matrix AS int[];
+        """,
+        pg_conn,
+    )
+
+
+def _nested_array_select(kind, arr_expr):
+    """Build a SELECT that places the int[] expression `arr_expr` inside the
+    given container shape.  "array_of_composite" is the deepest case: the array
+    leaf sits two container levels down (array -> composite -> int[])."""
+    return {
+        "composite": f"SELECT ('m', {arr_expr})::lake_arr.tagged AS v",
+        "array_of_composite": (
+            f"SELECT ARRAY[('base', ARRAY[1, 2])::lake_arr.tagged, "
+            f"('leaf', {arr_expr})::lake_arr.tagged]::lake_arr.tagged[] AS v"
+        ),
+        "domain_array": f"SELECT {arr_expr}::int_matrix AS v",
+    }[kind]
+
+
+@pytest.mark.parametrize("kind", NESTED_ARRAY_KINDS)
+def test_nested_multidim_array_errors(pg_conn, tmp_path, kind):
+    parquet_path = tmp_path / "test.parquet"
+
+    _create_nested_array_types(pg_conn)
+
+    # A multidimensional (2-D) array leaf is rejected wherever it sits in the
+    # nested structure, with the same clear error the top-level column gets.
+    error = run_command(
+        f"COPY ({_nested_array_select(kind, 'ARRAY[[1, 2], [3, 4]]')}) "
+        f"TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+    assert error is not None, f"{kind}: expected a multidimensional-array error"
+    assert MULTIDIM_ARRAY_ERROR in error.lower(), f"{kind}: {error}"
+
+    pg_conn.rollback()
+
+
+# domain_array is intentionally omitted here: a domain over an array does not
+# round-trip through COPY TO parquet even for a 1-D value (its DuckDB engine
+# type is inferred as a bare, untyped LIST), which is a separate pre-existing
+# limitation unrelated to the multidimensional-array guard.  The 2-D domain
+# case is still covered above -- the guard rejects it before that path is hit.
+NESTED_ARRAY_ROUNDTRIP_KINDS = ["composite", "array_of_composite"]
+
+
+@pytest.mark.parametrize("kind", NESTED_ARRAY_ROUNDTRIP_KINDS)
+def test_nested_1d_array_succeeds(pg_conn, tmp_path, kind):
+    # A 1-D array leaf nested in the same container shapes must NOT be rejected;
+    # guards against the recursive walk over-rejecting well-formed values.
+    parquet_path = tmp_path / "test.parquet"
+
+    _create_nested_array_types(pg_conn)
+
+    error = run_command(
+        f"COPY ({_nested_array_select(kind, 'ARRAY[1, 2, 3]')}) "
+        f"TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+    assert error is None, f"{kind}: unexpected error {error}"
+
+    pg_conn.rollback()
+
+
 def test_copy_to_multidim_array_json_errors(pg_conn, tmp_path):
     """
     Companion to the CSV case: JSON serialises arrays through DuckDB as a

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -1132,6 +1132,38 @@ def test_copy_to_1d_array_succeeds(pg_conn, duckdb_conn, tmp_path):
     pg_conn.rollback()
 
 
+def test_copy_to_multidim_array_json_errors(pg_conn, tmp_path):
+    """
+    Companion to the CSV case: JSON serialises arrays through DuckDB as a
+    typed LIST(T) (ShouldUseDuckSerialization is true), so a multidimensional
+    value must still be rejected by the guard in CopyOneRowTo.
+    """
+    json_path = tmp_path / "test_multidim.json"
+
+    run_command(
+        """
+        CREATE TABLE test_multidim_json (id bigint, v int[]);
+        INSERT INTO test_multidim_json VALUES (1, ARRAY[[1,2],[3,4]]);
+        """,
+        pg_conn,
+    )
+
+    error = run_command(
+        f"COPY test_multidim_json TO '{json_path}' WITH (format 'json')",
+        pg_conn,
+        raise_error=False,
+    )
+
+    assert (
+        error is not None
+    ), "Expected an error for multidimensional array in COPY TO json"
+    assert (
+        "multidimensional arrays are not supported" in error.lower()
+    ), f"Unexpected error message: {error}"
+
+    pg_conn.rollback()
+
+
 def test_copy_virtual_column(pg_conn, tmp_path):
     # virtual columns were introduced in PostgreSQL 18
     if get_pg_version_num(pg_conn) < 180000:

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -1062,6 +1062,76 @@ def test_copy_to_array_with_nulls(pg_conn, duckdb_conn, tmp_path):
     pg_conn.rollback()
 
 
+def test_copy_to_multidim_array_errors(pg_conn, tmp_path):
+    """
+    Regression test for https://github.com/Snowflake-Labs/pg_lake/issues/407.
+
+    COPY <table> TO <lake-file> must raise a clear pg_lake error when a column
+    contains a multidimensional array value.  Previously the value was
+    serialised into the intermediate temp CSV and handed to DuckDB, which
+    either returned a cryptic Conversion Error or crashed the shared
+    pgduck_server process (issue #408).
+
+    The check lives in CopyOneRowTo (csv_writer.c) and fires before the CSV
+    is written, so the engine is never involved.
+    """
+    parquet_path = tmp_path / "test_multidim_err.parquet"
+
+    run_command(
+        """
+        CREATE TABLE test_multidim_err (id bigint, v int[]);
+        INSERT INTO test_multidim_err VALUES (1, ARRAY[[1,2],[3,4]]);
+    """,
+        pg_conn,
+    )
+
+    error = run_command(
+        f"COPY test_multidim_err TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+
+    assert error is not None, "Expected an error for multidimensional array in COPY TO"
+    assert (
+        "multidimensional arrays are not supported" in error.lower()
+    ), f"Unexpected error message: {error}"
+
+    pg_conn.rollback()
+
+
+def test_copy_to_1d_array_succeeds(pg_conn, duckdb_conn, tmp_path):
+    """
+    Regression guard: 1-D array columns must still round-trip correctly through
+    COPY TO after the multidim check is added.  A 1-D value has ARR_NDIM == 1
+    and must not be rejected.
+    """
+    parquet_path = tmp_path / "test_1d_array.parquet"
+
+    run_command(
+        f"""
+        CREATE TABLE test_1d_array (id bigint, tags text[]);
+        INSERT INTO test_1d_array VALUES
+            (1, ARRAY['a', 'b', 'c']),
+            (2, NULL),
+            (3, ARRAY['x']);
+        COPY test_1d_array TO '{parquet_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+
+    duckdb_conn.execute(
+        "SELECT id, tags FROM read_parquet($1) ORDER BY id", [str(parquet_path)]
+    )
+    rows = duckdb_conn.fetchall()
+
+    assert len(rows) == 3
+    assert rows[0] == (1, ["a", "b", "c"])
+    assert rows[1] == (2, None)
+    assert rows[2] == (3, ["x"])
+
+    pg_conn.rollback()
+
+
 def test_copy_virtual_column(pg_conn, tmp_path):
     # virtual columns were introduced in PostgreSQL 18
     if get_pg_version_num(pg_conn) < 180000:

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -1279,6 +1279,39 @@ def test_copy_to_multidim_array_json_errors(pg_conn, tmp_path):
     pg_conn.rollback()
 
 
+def test_copy_to_nested_multidim_array_json_errors(pg_conn, tmp_path):
+    """
+    The recursive guard is format-independent: a multidimensional array nested
+    inside a composite must be rejected for JSON too, not only Parquet.
+    """
+    json_path = tmp_path / "test_nested_multidim.json"
+
+    run_command(
+        """
+        CREATE TYPE lake_arr_jc AS (id int, vals int[]);
+        CREATE TABLE test_nested_multidim_json (id bigint, c lake_arr_jc);
+        INSERT INTO test_nested_multidim_json
+            VALUES (1, ROW(1, ARRAY[[1, 2], [3, 4]])::lake_arr_jc);
+        """,
+        pg_conn,
+    )
+
+    error = run_command(
+        f"COPY test_nested_multidim_json TO '{json_path}' WITH (format 'json')",
+        pg_conn,
+        raise_error=False,
+    )
+
+    assert (
+        error is not None
+    ), "Expected an error for nested multidim array in COPY TO json"
+    assert (
+        "multidimensional arrays are not supported" in error.lower()
+    ), f"Unexpected error message: {error}"
+
+    pg_conn.rollback()
+
+
 def test_copy_virtual_column(pg_conn, tmp_path):
     # virtual columns were introduced in PostgreSQL 18
     if get_pg_version_num(pg_conn) < 180000:

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -1214,6 +1214,39 @@ def test_nested_1d_array_succeeds(pg_conn, tmp_path, kind):
     pg_conn.rollback()
 
 
+def test_nested_multidim_bigint_array_errors(pg_conn, tmp_path):
+    """
+    A multidimensional bigint[] nested inside a composite field is rejected by
+    the recursive guard.  bigint (a fixed-width element) is called out
+    separately because it is one of the element types whose unguarded nested
+    multidim value crashed the shared pgduck_server in issue #408; the walk
+    must reach it wherever it is nested, not only when it is the column type.
+    """
+    parquet_path = tmp_path / "test.parquet"
+
+    run_command(
+        """
+        CREATE TYPE lake_arr_bc AS (id int, vals bigint[]);
+        CREATE TABLE test_multidim_bigint (id bigint, c lake_arr_bc);
+        INSERT INTO test_multidim_bigint
+            VALUES (1, ROW(1, ARRAY[[1, 2], [3, 4]]::bigint[])::lake_arr_bc);
+        """,
+        pg_conn,
+    )
+
+    error = run_command(
+        f"COPY test_multidim_bigint TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+    assert error is not None, "expected a multidimensional-array error"
+    assert (
+        "multidimensional arrays are not supported" in error.lower()
+    ), f"Unexpected error message: {error}"
+
+    pg_conn.rollback()
+
+
 def test_copy_to_multidim_array_json_errors(pg_conn, tmp_path):
     """
     Companion to the CSV case: JSON serialises arrays through DuckDB as a

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -942,6 +942,36 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 				 */
 				Form_pg_attribute attr = TupleDescAttr(slot->tts_tupleDescriptor, attnum - 1);
 
+				/*
+				 * Reject multidimensional arrays before serialization.
+				 * PostgreSQL cannot distinguish int[] from int[][] at the
+				 * type level, so a value with ndim > 1 would be serialised as
+				 * "[[1,2],[3,4]]" and DuckDB cannot cast that string back to
+				 * a flat LIST(T).  For Iceberg tables this is handled
+				 * upstream by IcebergErrorOrClampDatum; for plain COPY TO
+				 * there is no such guard, so we raise here.  Check before
+				 * serialisation so we do not pay the cost of PGDuckSerialize
+				 * on a value we will reject.
+				 */
+				if (get_element_type(attr->atttypid) != InvalidOid &&
+					cstate->targetFormat != DATA_FORMAT_ICEBERG)
+				{
+					ArrayType  *arr = DatumGetArrayTypeP(value);
+
+					if (ARR_NDIM(arr) > 1)
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("multidimensional arrays are not supported"
+										" in COPY TO"),
+								 errdetail("Column \"%s\" contains a"
+										   " %d-dimensional array value.",
+										   NameStr(attr->attname),
+										   ARR_NDIM(arr)),
+								 errhint("Flatten the array to one dimension before"
+										 " exporting, or write to an Iceberg table"
+										 " with out_of_range_values = 'clamp'.")));
+				}
+
 				if (cstate->useDuckSerialization[attnum - 1])
 				{
 					/*

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -943,23 +943,31 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 				Form_pg_attribute attr = TupleDescAttr(slot->tts_tupleDescriptor, attnum - 1);
 
 				/*
-				 * Reject multidimensional arrays before serialization.
+				 * Reject multidimensional arrays before DuckDB serialization.
 				 * PostgreSQL cannot distinguish int[] from int[][] at the
 				 * type level, so a value with ndim > 1 would be serialised as
 				 * "[[1,2],[3,4]]" and DuckDB cannot cast that string back to
 				 * a flat LIST(T).  Check before serialisation so we do not
 				 * pay the cost of PGDuckSerialize on a value we will reject.
 				 *
-				 * This runs for every target format as a backstop.  For the
-				 * Iceberg write path (INSERT into an Iceberg table) a
+				 * This only fires for formats that hand the value to DuckDB
+				 * as a typed LIST(T) (Parquet/Iceberg/JSON), i.e. exactly the
+				 * formats for which ShouldUseDuckSerialization returns true
+				 * for an array.  CSV is deliberately exempt: it preserves the
+				 * PostgreSQL text representation ("{{1,2},{3,4}}") and reads
+				 * every column back as VARCHAR, so a multidimensional value
+				 * round-trips faithfully and must not be rejected (#407).
+				 *
+				 * For the Iceberg write path (INSERT into an Iceberg table) a
 				 * multidimensional value is already rejected (error policy)
 				 * or set to NULL (clamp policy) upstream by
 				 * IcebergErrorOrClampDatum, so it never reaches here with
 				 * ndim > 1.  COPY TO in Iceberg format is rejected earlier in
 				 * EnsureFormatSupported.  In practice this only fires on
-				 * plain COPY TO to a file.
+				 * plain COPY TO to a Parquet or JSON file.
 				 */
-				if (get_element_type(attr->atttypid) != InvalidOid)
+				if (cstate->useDuckSerialization[attnum - 1] &&
+					get_element_type(attr->atttypid) != InvalidOid)
 				{
 					ArrayType  *arr = DatumGetArrayTypeP(value);
 
@@ -973,8 +981,9 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 										   NameStr(attr->attname),
 										   ARR_NDIM(arr)),
 								 errhint("Flatten the array to one dimension before"
-										 " exporting, or write to an Iceberg table"
-										 " with out_of_range_values = 'clamp'.")));
+										 " exporting, write to CSV format, or write"
+										 " to an Iceberg table with"
+										 " out_of_range_values = 'clamp'.")));
 				}
 
 				if (cstate->useDuckSerialization[attnum - 1])

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -947,14 +947,19 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 				 * PostgreSQL cannot distinguish int[] from int[][] at the
 				 * type level, so a value with ndim > 1 would be serialised as
 				 * "[[1,2],[3,4]]" and DuckDB cannot cast that string back to
-				 * a flat LIST(T).  For Iceberg tables this is handled
-				 * upstream by IcebergErrorOrClampDatum; for plain COPY TO
-				 * there is no such guard, so we raise here.  Check before
-				 * serialisation so we do not pay the cost of PGDuckSerialize
-				 * on a value we will reject.
+				 * a flat LIST(T).  Check before serialisation so we do not
+				 * pay the cost of PGDuckSerialize on a value we will reject.
+				 *
+				 * This runs for every target format as a backstop.  For the
+				 * Iceberg write path (INSERT into an Iceberg table) a
+				 * multidimensional value is already rejected (error policy)
+				 * or set to NULL (clamp policy) upstream by
+				 * IcebergErrorOrClampDatum, so it never reaches here with
+				 * ndim > 1.  COPY TO in Iceberg format is rejected earlier in
+				 * EnsureFormatSupported.  In practice this only fires on
+				 * plain COPY TO to a file.
 				 */
-				if (get_element_type(attr->atttypid) != InvalidOid &&
-					cstate->targetFormat != DATA_FORMAT_ICEBERG)
+				if (get_element_type(attr->atttypid) != InvalidOid)
 				{
 					ArrayType  *arr = DatumGetArrayTypeP(value);
 

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -119,6 +119,14 @@ typedef struct CopyToStateData
 	 * and looking it up per value costs several syscache probes.
 	 */
 	bool	   *useDuckSerialization;
+
+	/*
+	 * Per-column flag: the column's type reaches an array (directly, or
+	 * nested inside a composite/map/domain).  Precomputed once so the per-row
+	 * multidimensional-array validation only walks columns that can carry
+	 * one.
+	 */
+	bool	   *needsMultidimArrayCheck;
 	MemoryContext rowcontext;	/* per-row evaluation context */
 	uint64		bytes_processed;	/* number of bytes processed so far */
 
@@ -164,6 +172,9 @@ static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(Numeric num);
 static bool TypeContainsNumeric(Oid typeOid);
 static void ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid,
 													 int32 typmod);
+static bool TypeContainsArray(Oid typeOid);
+static void ErrorIfCopyToContainsMultidimArray(Datum value, Oid typeOid,
+											   const char *colname);
 
 
 /*----------
@@ -475,6 +486,7 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 	cstate->out_functions = (FmgrInfo *) palloc(num_phys_attrs * sizeof(FmgrInfo));
 	cstate->needsNumericLeafCheck = (bool *) palloc0(num_phys_attrs * sizeof(bool));
 	cstate->useDuckSerialization = (bool *) palloc0(num_phys_attrs * sizeof(bool));
+	cstate->needsMultidimArrayCheck = (bool *) palloc0(num_phys_attrs * sizeof(bool));
 	foreach(cur, cstate->attnumlist)
 	{
 		int			attnum = lfirst_int(cur);
@@ -499,6 +511,9 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 			ShouldUseDuckSerialization(cstate->targetFormat,
 									   MakePGType(attr->atttypid,
 												  attr->atttypmod));
+
+		cstate->needsMultidimArrayCheck[attnum - 1] =
+			TypeContainsArray(attr->atttypid);
 	}
 
 	/*
@@ -760,6 +775,55 @@ TypeContainsNumeric(Oid typeOid)
 
 
 /*
+ * TypeContainsArray returns true if `typeOid` reaches an array at any nesting
+ * depth: as the type itself, a composite field, or through a domain over
+ * either.  Mirror of TypeContainsNumeric; called once per column at COPY
+ * setup (see needsMultidimArrayCheck) so the per-row multidimensional-array
+ * walk only visits columns that can actually carry an array.
+ */
+static bool
+TypeContainsArray(Oid typeOid)
+{
+	if (OidIsValid(get_element_type(typeOid)))
+		return true;
+
+	char		typtype = get_typtype(typeOid);
+
+	/*
+	 * Domains (including pg_map) unwrap to their base type, which feeds back
+	 * into the array and composite checks above.
+	 */
+	if (typtype == TYPTYPE_DOMAIN)
+		return TypeContainsArray(getBaseType(typeOid));
+
+	if (typtype == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
+		bool		found = false;
+
+		for (int i = 0; i < tupdesc->natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+			if (attr->attisdropped)
+				continue;
+
+			if (TypeContainsArray(attr->atttypid))
+			{
+				found = true;
+				break;
+			}
+		}
+
+		ReleaseTupleDesc(tupdesc);
+		return found;
+	}
+
+	return false;
+}
+
+
+/*
  * ErrorIfCopyToExceedsNumericLimitsInDatum applies the COPY TO numeric limits
  * to every numeric leaf reachable from `value`, recursing through arrays,
  * composites, maps, and domains.  Each numeric leaf is subject to the same
@@ -889,6 +953,127 @@ ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid, int32 typmod)
 
 
 /*
+ * ErrorIfCopyToContainsMultidimArray raises if any array reachable from
+ * `value` -- the value itself, an array element, a composite field, or one
+ * reached through a domain -- has more than one dimension.
+ *
+ * PostgreSQL does not encode dimensionality in the type system (int[] and
+ * int[][] share one OID), so a multidimensional value would be serialised as
+ * "{{1,2},{3,4}}" and DuckDB cannot cast that back to a flat LIST(T) (see the
+ * top-level rationale in CopyOneRowTo).  The reviewer on #430 asked that the
+ * top-level column check also reach arrays nested inside composites, maps, and
+ * domains; this recurses like ErrorIfCopyToExceedsNumericLimitsInDatum does
+ * for numeric leaves.
+ *
+ * Callers gate on the column type actually containing an array (see
+ * needsMultidimArrayCheck), and the inner TypeContainsArray guard prunes
+ * subtrees with no array so we never deconstruct or deform needlessly.
+ * `colname` is the top-level column name, carried through the recursion only
+ * so the error can point back at it.
+ */
+static void
+ErrorIfCopyToContainsMultidimArray(Datum value, Oid typeOid, const char *colname)
+{
+	Oid			elemType = get_element_type(typeOid);
+
+	if (OidIsValid(elemType))
+	{
+		ArrayType  *array = DatumGetArrayTypeP(value);
+
+		if (ARR_NDIM(array) > 1)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("multidimensional arrays are not supported"
+							" in COPY TO"),
+					 errdetail("Column \"%s\" contains a"
+							   " %d-dimensional array value.",
+							   colname,
+							   ARR_NDIM(array)),
+					 errhint("Flatten the array to one dimension before"
+							 " exporting, write to CSV format, or write"
+							 " to an Iceberg table with"
+							 " out_of_range_values = 'clamp'.")));
+
+		/*
+		 * A 1-D array can still carry arrays deeper down (e.g. an array of a
+		 * composite that has an array field), so recurse into the elements
+		 * when the element type can reach one.
+		 */
+		if (!TypeContainsArray(elemType))
+			return;
+
+		int16		elmlen;
+		bool		elmbyval;
+		char		elmalign;
+		Datum	   *elems;
+		bool	   *nulls;
+		int			nelems;
+
+		get_typlenbyvalalign(elemType, &elmlen, &elmbyval, &elmalign);
+		deconstruct_array(array, elemType, elmlen, elmbyval, elmalign,
+						  &elems, &nulls, &nelems);
+
+		for (int i = 0; i < nelems; i++)
+		{
+			if (nulls[i])
+				continue;
+
+			ErrorIfCopyToContainsMultidimArray(elems[i], elemType, colname);
+		}
+
+		return;
+	}
+
+	char		typtype = get_typtype(typeOid);
+
+	/* domains (including maps): unwrap to the base type and recurse */
+	if (typtype == TYPTYPE_DOMAIN)
+	{
+		ErrorIfCopyToContainsMultidimArray(value, getBaseType(typeOid), colname);
+		return;
+	}
+
+	/* composite: deform the tuple and recurse into each field */
+	if (typtype == TYPTYPE_COMPOSITE)
+	{
+		HeapTupleHeader tup = DatumGetHeapTupleHeader(value);
+		Oid			tupType = HeapTupleHeaderGetTypeId(tup);
+		int32		tupTypmod = HeapTupleHeaderGetTypMod(tup);
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
+		int			natts = tupdesc->natts;
+		HeapTupleData tmptup;
+		Datum	   *values = (Datum *) palloc(natts * sizeof(Datum));
+		bool	   *attrNulls = (bool *) palloc(natts * sizeof(bool));
+
+		tmptup.t_len = HeapTupleHeaderGetDatumLength(tup);
+		ItemPointerSetInvalid(&(tmptup.t_self));
+		tmptup.t_tableOid = InvalidOid;
+		tmptup.t_data = tup;
+
+		heap_deform_tuple(&tmptup, tupdesc, values, attrNulls);
+
+		for (int i = 0; i < natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+			if (attr->attisdropped || attrNulls[i])
+				continue;
+
+			if (!TypeContainsArray(attr->atttypid))
+				continue;
+
+			ErrorIfCopyToContainsMultidimArray(values[i], attr->atttypid, colname);
+		}
+
+		pfree(values);
+		pfree(attrNulls);
+		ReleaseTupleDesc(tupdesc);
+		return;
+	}
+}
+
+
+/*
  * Emit one row
  */
 static void
@@ -946,9 +1131,11 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 				 * Reject multidimensional arrays before DuckDB serialization.
 				 * PostgreSQL cannot distinguish int[] from int[][] at the
 				 * type level, so a value with ndim > 1 would be serialised as
-				 * "[[1,2],[3,4]]" and DuckDB cannot cast that string back to
+				 * "{{1,2},{3,4}}" and DuckDB cannot cast that string back to
 				 * a flat LIST(T).  Check before serialisation so we do not
 				 * pay the cost of PGDuckSerialize on a value we will reject.
+				 * The walk reaches arrays nested inside composites, maps, and
+				 * domains, not just a top-level array column.
 				 *
 				 * This only fires for formats that hand the value to DuckDB
 				 * as a typed LIST(T) (Parquet/Iceberg/JSON), i.e. exactly the
@@ -967,24 +1154,9 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 				 * plain COPY TO to a Parquet or JSON file.
 				 */
 				if (cstate->useDuckSerialization[attnum - 1] &&
-					get_element_type(attr->atttypid) != InvalidOid)
-				{
-					ArrayType  *arr = DatumGetArrayTypeP(value);
-
-					if (ARR_NDIM(arr) > 1)
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("multidimensional arrays are not supported"
-										" in COPY TO"),
-								 errdetail("Column \"%s\" contains a"
-										   " %d-dimensional array value.",
-										   NameStr(attr->attname),
-										   ARR_NDIM(arr)),
-								 errhint("Flatten the array to one dimension before"
-										 " exporting, write to CSV format, or write"
-										 " to an Iceberg table with"
-										 " out_of_range_values = 'clamp'.")));
-				}
+					cstate->needsMultidimArrayCheck[attnum - 1])
+					ErrorIfCopyToContainsMultidimArray(value, attr->atttypid,
+													   NameStr(attr->attname));
 
 				if (cstate->useDuckSerialization[attnum - 1])
 				{

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -96,8 +96,12 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 	 * When reached from the Iceberg FDW INSERT path, the CSV data has already
 	 * been clamped by WriteInsertRecord (via ClampAndCheckConstraints →
 	 * IcebergErrorOrClampSlotInPlace).  When reached from the plain COPY TO
-	 * path (ProcessPgLakeCopyTo), multidimensional array values are rejected
-	 * earlier in CopyOneRowTo, so they never appear in the CSV.
+	 * path (ProcessPgLakeCopyTo) with a DuckDB-serialised destination
+	 * (Parquet/JSON), multidimensional array values are rejected earlier in
+	 * CopyOneRowTo, so they never appear in the CSV.  For a CSV destination
+	 * such values may appear, but every column is read back as VARCHAR (see
+	 * ChooseDuckDBEngineTypeForWrite), so the PostgreSQL array text is copied
+	 * through verbatim rather than cast to a LIST(T).
 	 */
 	return WriteQueryResultTo(command.data,
 							  destinationPath,

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -93,8 +93,11 @@ ConvertCSVFileTo(char *csvFilePath, TupleDesc csvTupleDesc, int maxLineSize,
 	bool		queryHasRowIds = false;
 
 	/*
-	 * CSV data is already clamped by WriteInsertRecord and converted to
-	 * struct for Iceberg
+	 * When reached from the Iceberg FDW INSERT path, the CSV data has already
+	 * been clamped by WriteInsertRecord (via ClampAndCheckConstraints →
+	 * IcebergErrorOrClampSlotInPlace).  When reached from the plain COPY TO
+	 * path (ProcessPgLakeCopyTo), multidimensional array values are rejected
+	 * earlier in CopyOneRowTo, so they never appear in the CSV.
 	 */
 	return WriteQueryResultTo(command.data,
 							  destinationPath,


### PR DESCRIPTION
Rebased version of #428 (by @sfc-gh-rbachala) with the C indentation corrected, opened to run CI.

The original change is unmodified in substance. The only fix here is running `pgindent` over the two edited C files: the added block in `CopyOneRowTo` and the rewritten comment in `ConvertCSVFileTo` used space indentation, which fails the `check-indent` CI step. Reindenting restores the project's tab style, so the diff against main is now just the logical change (106 insertions, 2 deletions).

Authorship is preserved: the commit is still authored by Richie Bachala with their `Signed-off-by`, with my own sign-off added as committer.

## What the change does

COPY `<table>` TO a lake file serializes rows through an intermediate CSV before handing them to DuckDB. That path had no guard against multidimensional array values, so a column declared `int[]` holding `ARRAY[[1,2],[3,4]]` would serialize to `[[1,2],[3,4]]`, which DuckDB cannot cast back to a flat `LIST(T)` — returning a cryptic Conversion Error or, for some element types, crashing the shared pgduck_server process (#408). The fix rejects `ARR_NDIM > 1` in `CopyOneRowTo` before serialization, matching the guard the Iceberg write path already has.

Fixes #407. Mitigates #408.

## Test plan

- `test_copy_to_multidim_array_errors` — a multidim `int[]` value raises a clear pg_lake error with no engine involvement
- `test_copy_to_1d_array_succeeds` — 1-D arrays still round-trip correctly

CI on this branch exercises the full build, indentation check, and pytest suite.
