### PR TITLE
Fix wrong Iceberg bounds for multi-row-group DECIMAL(38,0)

### DIFF
--- a/duckdb_pglake/patches/duckdb/return_stats.patch
+++ b/duckdb_pglake/patches/duckdb/return_stats.patch
@@ -1,5 +1,5 @@
 diff --git a/extension/parquet/parquet_writer.cpp b/extension/parquet/parquet_writer.cpp
-index 3c6d11d9ad..d1a7b54ad5 100644
+index 3c6d11d9ad..9e16d1b768 100644
 --- a/extension/parquet/parquet_writer.cpp
 +++ b/extension/parquet/parquet_writer.cpp
 @@ -3,6 +3,7 @@
@@ -10,7 +10,7 @@ index 3c6d11d9ad..d1a7b54ad5 100644
  #include "parquet_timestamp.hpp"
  #include "resizable_buffer.hpp"
  #include "duckdb/common/file_system.hpp"
-@@ -656,8 +657,20 @@ struct DecimalStatsUnifier : public NumericStatsUnifier<T> {
+@@ -656,8 +657,50 @@ struct DecimalStatsUnifier : public NumericStatsUnifier<T> {
  		if (stats.empty()) {
  			return string();
  		}
@@ -30,10 +30,40 @@ index 3c6d11d9ad..d1a7b54ad5 100644
 +			auto numeric_val = Load<T>(stats_data);
 +			return Value::DECIMAL(numeric_val, width, scale).ToString();
 +		}
++	}
++
++	void UnifyMinMax(const string &new_min, const string &new_max) override {
++		if (sizeof(T) != sizeof(hugeint_t))
++		{
++			// INT16/32/64-backed decimals are little-endian; the base comparison is correct.
++			BaseNumericStatsUnifier<T>::UnifyMinMax(new_min, new_max);
++			return;
++		}
++
++		// 128-bit decimals are stored big-endian two's complement, so decode before comparing.
++		auto decode = [](const string &stats) {
++			auto _schema = ParquetColumnSchema();
++			return ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(const_data_ptr_cast(stats.data()), stats.size(),
++			                                                        _schema);
++		};
++
++		if (!this->min_is_set) {
++			this->global_min = new_min;
++			this->min_is_set = true;
++		} else if (LessThan::Operation(decode(new_min), decode(this->global_min))) {
++			this->global_min = new_min;
++		}
++
++		if (!this->max_is_set) {
++			this->global_max = new_max;
++			this->max_is_set = true;
++		} else if (GreaterThan::Operation(decode(new_max), decode(this->global_max))) {
++			this->global_max = new_max;
++		}
  	}
  };
  
-@@ -781,7 +794,7 @@ struct NullStatsUnifier : public ColumnStatsUnifier {
+@@ -781,7 +824,7 @@ struct NullStatsUnifier : public ColumnStatsUnifier {
  static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &type) {
  	switch (type.id()) {
  	case LogicalTypeId::BOOLEAN:
@@ -42,7 +72,7 @@ index 3c6d11d9ad..d1a7b54ad5 100644
  	case LogicalTypeId::TINYINT:
  	case LogicalTypeId::SMALLINT:
  	case LogicalTypeId::INTEGER:
-@@ -826,6 +839,8 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
+@@ -826,6 +869,8 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
  			return make_uniq<DecimalStatsUnifier<int32_t>>(width, scale);
  		case PhysicalType::INT64:
  			return make_uniq<DecimalStatsUnifier<int64_t>>(width, scale);

--- a/duckdb_pglake/patches/duckdb/return_stats.patch
+++ b/duckdb_pglake/patches/duckdb/return_stats.patch
@@ -1,5 +1,5 @@
 diff --git a/extension/parquet/parquet_writer.cpp b/extension/parquet/parquet_writer.cpp
-index 3c6d11d9ad..c3165c12af 100644
+index 3c6d11d9ad..c43ec6e234 100644
 --- a/extension/parquet/parquet_writer.cpp
 +++ b/extension/parquet/parquet_writer.cpp
 @@ -3,6 +3,7 @@
@@ -10,64 +10,54 @@ index 3c6d11d9ad..c3165c12af 100644
  #include "parquet_timestamp.hpp"
  #include "resizable_buffer.hpp"
  #include "duckdb/common/file_system.hpp"
-@@ -656,8 +657,54 @@ struct DecimalStatsUnifier : public NumericStatsUnifier<T> {
+@@ -656,8 +657,44 @@ struct DecimalStatsUnifier : public NumericStatsUnifier<T> {
  		if (stats.empty()) {
  			return string();
  		}
 -		auto numeric_val = Load<T>(const_data_ptr_cast(stats.data()));
 -		return Value::DECIMAL(numeric_val, width, scale).ToString();
-+
 +		auto stats_data = const_data_ptr_cast(stats.data());
-+
-+		if (sizeof(T) == sizeof(hugeint_t))
-+		{
-+			auto _schema = ParquetColumnSchema();
-+			auto numeric_val = ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(stats_data, stats.size(), _schema);
++		if constexpr (sizeof(T) == sizeof(hugeint_t)) {
++			auto schema = ParquetColumnSchema(); // schema unused for FLBA/hugeint_t
++			auto numeric_val = ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(stats_data, stats.size(), schema);
 +			return Value::DECIMAL(numeric_val, width, scale).ToString();
-+		}
-+		else
-+		{
-+			auto numeric_val = Load<T>(stats_data);
-+			return Value::DECIMAL(numeric_val, width, scale).ToString();
++		} else {
++			return Value::DECIMAL(Load<T>(stats_data), width, scale).ToString();
 +		}
 +	}
 +
 +	void UnifyMinMax(const string &new_min, const string &new_max) override {
-+		if (sizeof(T) != sizeof(hugeint_t))
-+		{
-+			// Decimals up to 18 digits use an INT32/INT64 physical type whose min/max
-+			// stats are little-endian, matching the native Load<T> in the base unifier.
++		if constexpr (sizeof(T) != sizeof(hugeint_t)) {
++			// INT32/INT64-backed decimals are little-endian; the base compare is correct.
 +			BaseNumericStatsUnifier<T>::UnifyMinMax(new_min, new_max);
-+			return;
-+		}
++		} else {
++			// FLBA decimal stats are big-endian two's complement (most significant byte
++			// first), so a native little-endian Load would compare the wrong value; decode
++			// the bytes into a hugeint_t before comparing.
++			auto decode = [](const string &stats) {
++				auto schema = ParquetColumnSchema(); // schema unused for FLBA/hugeint_t
++				return ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(const_data_ptr_cast(stats.data()),
++				                                                        stats.size(), schema);
++			};
 +
-+		// Wider decimals use FIXED_LEN_BYTE_ARRAY, whose min/max stats are the value as a
-+		// signed integer with the most significant byte first (big-endian). The base
-+		// unifier's native Load<hugeint_t> would read those bytes little-endian and compare
-+		// the wrong value, so decode them into a hugeint_t before comparing.
-+		auto decode = [](const string &stats) {
-+			auto _schema = ParquetColumnSchema();
-+			return ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(const_data_ptr_cast(stats.data()), stats.size(),
-+			                                                        _schema);
-+		};
++			if (!this->min_is_set) {
++				this->global_min = new_min;
++				this->min_is_set = true;
++			} else if (LessThan::Operation(decode(new_min), decode(this->global_min))) {
++				this->global_min = new_min;
++			}
 +
-+		if (!this->min_is_set) {
-+			this->global_min = new_min;
-+			this->min_is_set = true;
-+		} else if (LessThan::Operation(decode(new_min), decode(this->global_min))) {
-+			this->global_min = new_min;
-+		}
-+
-+		if (!this->max_is_set) {
-+			this->global_max = new_max;
-+			this->max_is_set = true;
-+		} else if (GreaterThan::Operation(decode(new_max), decode(this->global_max))) {
-+			this->global_max = new_max;
++			if (!this->max_is_set) {
++				this->global_max = new_max;
++				this->max_is_set = true;
++			} else if (GreaterThan::Operation(decode(new_max), decode(this->global_max))) {
++				this->global_max = new_max;
++			}
 +		}
  	}
  };
  
-@@ -781,7 +828,7 @@ struct NullStatsUnifier : public ColumnStatsUnifier {
+@@ -781,7 +818,7 @@ struct NullStatsUnifier : public ColumnStatsUnifier {
  static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &type) {
  	switch (type.id()) {
  	case LogicalTypeId::BOOLEAN:
@@ -76,7 +66,7 @@ index 3c6d11d9ad..c3165c12af 100644
  	case LogicalTypeId::TINYINT:
  	case LogicalTypeId::SMALLINT:
  	case LogicalTypeId::INTEGER:
-@@ -826,6 +873,8 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
+@@ -826,6 +863,8 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
  			return make_uniq<DecimalStatsUnifier<int32_t>>(width, scale);
  		case PhysicalType::INT64:
  			return make_uniq<DecimalStatsUnifier<int64_t>>(width, scale);

--- a/duckdb_pglake/patches/duckdb/return_stats.patch
+++ b/duckdb_pglake/patches/duckdb/return_stats.patch
@@ -1,5 +1,5 @@
 diff --git a/extension/parquet/parquet_writer.cpp b/extension/parquet/parquet_writer.cpp
-index 3c6d11d9ad..9e16d1b768 100644
+index 3c6d11d9ad..c3165c12af 100644
 --- a/extension/parquet/parquet_writer.cpp
 +++ b/extension/parquet/parquet_writer.cpp
 @@ -3,6 +3,7 @@
@@ -10,7 +10,7 @@ index 3c6d11d9ad..9e16d1b768 100644
  #include "parquet_timestamp.hpp"
  #include "resizable_buffer.hpp"
  #include "duckdb/common/file_system.hpp"
-@@ -656,8 +657,50 @@ struct DecimalStatsUnifier : public NumericStatsUnifier<T> {
+@@ -656,8 +657,54 @@ struct DecimalStatsUnifier : public NumericStatsUnifier<T> {
  		if (stats.empty()) {
  			return string();
  		}
@@ -35,12 +35,16 @@ index 3c6d11d9ad..9e16d1b768 100644
 +	void UnifyMinMax(const string &new_min, const string &new_max) override {
 +		if (sizeof(T) != sizeof(hugeint_t))
 +		{
-+			// INT16/32/64-backed decimals are little-endian; the base comparison is correct.
++			// Decimals up to 18 digits use an INT32/INT64 physical type whose min/max
++			// stats are little-endian, matching the native Load<T> in the base unifier.
 +			BaseNumericStatsUnifier<T>::UnifyMinMax(new_min, new_max);
 +			return;
 +		}
 +
-+		// 128-bit decimals are stored big-endian two's complement, so decode before comparing.
++		// Wider decimals use FIXED_LEN_BYTE_ARRAY, whose min/max stats are the value as a
++		// signed integer with the most significant byte first (big-endian). The base
++		// unifier's native Load<hugeint_t> would read those bytes little-endian and compare
++		// the wrong value, so decode them into a hugeint_t before comparing.
 +		auto decode = [](const string &stats) {
 +			auto _schema = ParquetColumnSchema();
 +			return ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(const_data_ptr_cast(stats.data()), stats.size(),
@@ -63,7 +67,7 @@ index 3c6d11d9ad..9e16d1b768 100644
  	}
  };
  
-@@ -781,7 +824,7 @@ struct NullStatsUnifier : public ColumnStatsUnifier {
+@@ -781,7 +828,7 @@ struct NullStatsUnifier : public ColumnStatsUnifier {
  static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &type) {
  	switch (type.id()) {
  	case LogicalTypeId::BOOLEAN:
@@ -72,7 +76,7 @@ index 3c6d11d9ad..9e16d1b768 100644
  	case LogicalTypeId::TINYINT:
  	case LogicalTypeId::SMALLINT:
  	case LogicalTypeId::INTEGER:
-@@ -826,6 +869,8 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
+@@ -826,6 +873,8 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
  			return make_uniq<DecimalStatsUnifier<int32_t>>(width, scale);
  		case PhysicalType::INT64:
  			return make_uniq<DecimalStatsUnifier<int64_t>>(width, scale);

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
@@ -1643,3 +1643,63 @@ def create_helper_functions(superuser_conn, s3, iceberg_extension):
     )
 
     superuser_conn.commit()
+
+
+def test_pg_lake_iceberg_decimal38_multi_row_group_bounds(
+    pg_conn,
+    pgduck_conn,
+    iceberg_extension,
+    s3,
+    with_default_location,
+):
+    """Manifest upper bound for a DECIMAL(38,0) column must match the data.
+
+    When such a column spans more than one row group, DuckDB's RETURN_STATS
+    used to swap min/max (big-endian decimal stats compared as little-endian),
+    so pg_lake wrote an upper bound below the real maximum (SNOW-3701832).
+    """
+    # target_row_group_size_mb caps a row group by uncompressed bytes; 1MB makes
+    # a ~16-byte NUMERIC(38,0) column flush after ~65k rows, so 80k rows produce
+    # >1 row group with distinct per-group maxima (126619 then 19308).
+    run_command("SET pg_lake_table.target_row_group_size_mb TO 1;", pg_conn)
+    run_command(
+        "CREATE TABLE dec38_bounds(c numeric(38,0)) USING iceberg;",
+        pg_conn,
+    )
+    run_command(
+        """
+        INSERT INTO dec38_bounds
+        SELECT CASE WHEN i < 40000 THEN 126619 ELSE 19308 END::numeric(38,0)
+        FROM generate_series(0, 79999) i;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    stats = run_query(
+        """
+        SELECT path, upper_bounds
+        FROM lake_iceberg.data_file_stats(
+            (SELECT metadata_location FROM iceberg_tables WHERE table_name = 'dec38_bounds')
+        );
+        """,
+        pg_conn,
+    )
+    assert len(stats) == 1, "expected a single data file"
+    path, upper_bounds = stats[0]["path"], stats[0]["upper_bounds"]
+
+    # Guard: the bug only manifests across row groups.
+    footer = run_query(
+        f"""
+        SELECT count(*), max(stats_max::DECIMAL(38,0))
+        FROM parquet_metadata('{path}') WHERE path_in_schema = 'c'
+        """,
+        pgduck_conn,
+    )
+    assert footer[0][0] >= 2, "test needs a multi-row-group file"
+    assert footer[0][1] == 126619
+
+    assert int(str(upper_bounds["1"])) == 126619
+
+    run_command("DROP TABLE dec38_bounds", pg_conn)
+    pg_conn.commit()

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
@@ -1658,19 +1658,26 @@ def test_pg_lake_iceberg_decimal38_multi_row_group_bounds(
     used to swap min/max (big-endian decimal stats compared as little-endian),
     so pg_lake wrote an upper bound below the real maximum (SNOW-3701832).
     """
+    # First half of the rows carry the higher value, second half the lower one,
+    # so the two row groups have distinct maxima that the endianness bug swaps.
+    high = 126619  # true file maximum
+    low = 19308  # true file minimum
+    half_rows = 40000  # rows per value
+    total_rows = 2 * half_rows
+
     # target_row_group_size_mb caps a row group by uncompressed bytes; 1MB makes
     # a ~16-byte NUMERIC(38,0) column flush after ~65k rows, so 80k rows produce
-    # >1 row group with distinct per-group maxima (126619 then 19308).
+    # >1 row group with distinct per-group maxima (high then low).
     run_command("SET pg_lake_table.target_row_group_size_mb TO 1;", pg_conn)
     run_command(
         "CREATE TABLE dec38_bounds(c numeric(38,0)) USING iceberg;",
         pg_conn,
     )
     run_command(
-        """
+        f"""
         INSERT INTO dec38_bounds
-        SELECT CASE WHEN i < 40000 THEN 126619 ELSE 19308 END::numeric(38,0)
-        FROM generate_series(0, 79999) i;
+        SELECT CASE WHEN i < {half_rows} THEN {high} ELSE {low} END::numeric(38,0)
+        FROM generate_series(0, {total_rows - 1}) i;
         """,
         pg_conn,
     )
@@ -1697,23 +1704,25 @@ def test_pg_lake_iceberg_decimal38_multi_row_group_bounds(
         pgduck_conn,
     )
     assert footer[0][0] >= 2, "test needs a multi-row-group file"
-    assert footer[0][1] == 126619
+    assert footer[0][1] == high
 
     # These manifest bounds also drive pg_lake's own data-file pruning. Before the
-    # fix the swapped bounds (lower=126619, upper=19308) pruned this file for
-    # `c = 126619`, so the query returned 0 rows instead of 40000; asserting the
-    # full 40000 (and the range predicate below) guards against that regression.
-    assert run_query("SELECT count(*) FROM dec38_bounds", pg_conn)[0][0] == 80000
-    matched = run_query(
-        "SELECT count(*) FROM dec38_bounds WHERE c = 126619", pg_conn
-    )[0][0]
-    assert matched == 40000, f"data file pruned on wrong bounds: got {matched}"
-    ranged = run_query(
-        "SELECT count(*) FROM dec38_bounds WHERE c > 100000", pg_conn
-    )[0][0]
-    assert ranged == 40000, f"data file pruned on wrong bounds: got {ranged}"
+    # fix the swapped bounds (lower=high, upper=low) pruned this file for `c = high`,
+    # so the query returned 0 rows instead of half_rows; asserting the full count
+    # (and the range predicate below) guards against that regression.
+    total = run_query("SELECT count(*) FROM dec38_bounds", pg_conn)
+    assert total[0][0] == total_rows
+    matched = run_query(f"SELECT count(*) FROM dec38_bounds WHERE c = {high}", pg_conn)
+    assert (
+        matched[0][0] == half_rows
+    ), f"data file pruned on wrong bounds: {matched[0][0]}"
+    ranged = run_query(f"SELECT count(*) FROM dec38_bounds WHERE c > {low}", pg_conn)
+    assert (
+        ranged[0][0] == half_rows
+    ), f"data file pruned on wrong bounds: {ranged[0][0]}"
 
-    assert int(str(upper_bounds["1"])) == 126619
+    assert int(str(upper_bounds["1"])) == high
 
     run_command("DROP TABLE dec38_bounds", pg_conn)
+    run_command("RESET pg_lake_table.target_row_group_size_mb", pg_conn)
     pg_conn.commit()

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
@@ -1699,6 +1699,18 @@ def test_pg_lake_iceberg_decimal38_multi_row_group_bounds(
     assert footer[0][0] >= 2, "test needs a multi-row-group file"
     assert footer[0][1] == 126619
 
+    # pg_lake prunes data files from these manifest bounds before scanning, so a
+    # wrong upper bound silently drops matching rows (returns 0 instead of 40000).
+    assert run_query("SELECT count(*) FROM dec38_bounds", pg_conn)[0][0] == 80000
+    matched = run_query(
+        "SELECT count(*) FROM dec38_bounds WHERE c = 126619", pg_conn
+    )[0][0]
+    assert matched == 40000, f"data file pruned on wrong bounds: got {matched}"
+    ranged = run_query(
+        "SELECT count(*) FROM dec38_bounds WHERE c > 100000", pg_conn
+    )[0][0]
+    assert ranged == 40000, f"data file pruned on wrong bounds: got {ranged}"
+
     assert int(str(upper_bounds["1"])) == 126619
 
     run_command("DROP TABLE dec38_bounds", pg_conn)

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_data_file_stats.py
@@ -1699,8 +1699,10 @@ def test_pg_lake_iceberg_decimal38_multi_row_group_bounds(
     assert footer[0][0] >= 2, "test needs a multi-row-group file"
     assert footer[0][1] == 126619
 
-    # pg_lake prunes data files from these manifest bounds before scanning, so a
-    # wrong upper bound silently drops matching rows (returns 0 instead of 40000).
+    # These manifest bounds also drive pg_lake's own data-file pruning. Before the
+    # fix the swapped bounds (lower=126619, upper=19308) pruned this file for
+    # `c = 126619`, so the query returned 0 rows instead of 40000; asserting the
+    # full 40000 (and the range predicate below) guards against that regression.
     assert run_query("SELECT count(*) FROM dec38_bounds", pg_conn)[0][0] == 80000
     matched = run_query(
         "SELECT count(*) FROM dec38_bounds WHERE c = 126619", pg_conn

--- a/pgduck_server/tests/pytests/test_return_stats_decimal.py
+++ b/pgduck_server/tests/pytests/test_return_stats_decimal.py
@@ -1,0 +1,45 @@
+import re
+
+from utils_pytest import *
+
+
+def _extract_min_max(column_statistics):
+    """Pull min/max out of a RETURN_STATS column_statistics value (single column)."""
+    text = str(column_statistics)
+    stat_min = re.search(r"\(min,(-?\d+)\)", text)
+    stat_max = re.search(r"\(max,(-?\d+)\)", text)
+    assert stat_min is not None and stat_max is not None, column_statistics
+    return stat_min.group(1), stat_max.group(1)
+
+
+def test_return_stats_decimal38_multi_row_group(pgduck_conn, tmp_path):
+    """DECIMAL(38,0) spanning >1 row group must report the true file-level min/max.
+
+    128-bit decimal stats are big-endian two's complement; a little-endian
+    comparison while unifying row-group bounds swaps min and max (SNOW-3701832).
+    """
+    path = str(tmp_path / "dec38.parquet")
+
+    copy = f"""
+        COPY (
+            SELECT CASE WHEN i < 2048 THEN 126619 ELSE 19308 END::DECIMAL(38,0) AS c
+            FROM range(4096) t(i)
+        ) TO '{path}' (FORMAT PARQUET, ROW_GROUP_SIZE 2048, RETURN_STATS)
+    """
+
+    stats = run_query(copy, pgduck_conn)
+    stat_min, stat_max = _extract_min_max(stats[0]["column_statistics"])
+    assert (stat_min, stat_max) == ("19308", "126619")
+
+    # Ground truth from the Parquet footer, which is always correct.
+    footer = run_query(
+        f"""
+        SELECT min(stats_min::DECIMAL(38,0)), max(stats_max::DECIMAL(38,0)),
+               count(*)
+        FROM parquet_metadata('{path}') WHERE path_in_schema = 'c'
+        """,
+        pgduck_conn,
+    )
+    assert footer[0][0] == 19308
+    assert footer[0][1] == 126619
+    assert footer[0][2] >= 2

--- a/pgduck_server/tests/pytests/test_return_stats_decimal.py
+++ b/pgduck_server/tests/pytests/test_return_stats_decimal.py
@@ -20,16 +20,20 @@ def test_return_stats_decimal38_multi_row_group(pgduck_conn, tmp_path):
     """
     path = str(tmp_path / "dec38.parquet")
 
+    # Two row groups with distinct maxima; the endianness bug swaps them.
+    rg0_high = 126619  # row group 0 (the true file maximum)
+    rg1_low = 19308  # row group 1 (the true file minimum)
+
     copy = f"""
         COPY (
-            SELECT CASE WHEN i < 2048 THEN 126619 ELSE 19308 END::DECIMAL(38,0) AS c
+            SELECT CASE WHEN i < 2048 THEN {rg0_high} ELSE {rg1_low} END::DECIMAL(38,0) AS c
             FROM range(4096) t(i)
         ) TO '{path}' (FORMAT PARQUET, ROW_GROUP_SIZE 2048, RETURN_STATS)
     """
 
     stats = run_query(copy, pgduck_conn)
     stat_min, stat_max = _extract_min_max(stats[0]["column_statistics"])
-    assert (stat_min, stat_max) == ("19308", "126619")
+    assert (stat_min, stat_max) == (str(rg1_low), str(rg0_high))
 
     # Ground truth from the Parquet footer, which is always correct.
     footer = run_query(
@@ -40,6 +44,6 @@ def test_return_stats_decimal38_multi_row_group(pgduck_conn, tmp_path):
         """,
         pgduck_conn,
     )
-    assert footer[0][0] == 19308
-    assert footer[0][1] == 126619
+    assert footer[0][0] == rg1_low
+    assert footer[0][1] == rg0_high
     assert footer[0][2] >= 2


### PR DESCRIPTION
## Summary

A `DECIMAL(38,0)` (128-bit) column spanning more than one Parquet row group could get an **incorrect upper/lower bound written into the Iceberg manifest**, breaking cross-engine readers (e.g. Snowflake rejects/misprunes on `min > max`). It also breaks pg_lake's own reads: these bounds drive data-file pruning, so a query like `WHERE c = <max>` could prune the file and silently return 0 rows. Reported as SNOW-3701832.

Root cause is in our DuckDB patch `duckdb_pglake/patches/duckdb/return_stats.patch`. `DecimalStatsUnifier<hugeint_t>` inherited `BaseNumericStatsUnifier::UnifyMinMax`, which merges per-row-group bounds using a native little-endian `Load<hugeint_t>`. But Parquet `FIXED_LEN_BYTE_ARRAY` decimal statistics are **big-endian two's complement**, so the cross-row-group comparison ran on byte-swapped values and could swap min/max.

Note: precision <= 18 decimals (`INT32`/`INT64` physical type) are genuinely little-endian and are unaffected; they keep using the base comparison.

## Fix

Two coordinated fixes in `DecimalStatsUnifier`, both scoped to 128-bit (`hugeint_t`) decimals via `if constexpr` so smaller widths keep the little-endian base path:

1. **`UnifyMinMax`** (the main fix): decode each row-group bound with `ParquetDecimalUtils::ReadDecimalValue<hugeint_t>` before comparing, so the file-level min/max are the true extremes.
2. **`StatsToString`**: also decode big-endian before formatting the per-file value surfaced by `COPY ... RETURN_STATS`. Without this, `RETURN_STATS` would still report byte-swapped values even once unification is correct.

This is our fork's copy of code that also exists upstream (introduced in duckdb/duckdb@174ec83); the same fix will be sent upstream.

## Tests

- `pgduck_server/tests/pytests/test_return_stats_decimal.py`: `COPY ... (RETURN_STATS)` over a 2-row-group `DECIMAL(38,0)`, asserts min/max match the Parquet footer. Fails before, passes after.
- `pg_lake_iceberg/.../test_iceberg_data_file_stats.py::test_pg_lake_iceberg_decimal38_multi_row_group_bounds`: end-to-end INSERT into an Iceberg table forced into >1 row group; asserts the manifest `upper_bounds` matches the data, and that pruning-sensitive queries (`WHERE c = max`, `WHERE c > min`) return the full row count instead of being wrongly pruned to 0.

## Test plan

- [x] Both new tests fail on the current patch and pass with the fix (verified by rebuilding libduckdb from the pre-fix patch)
- [x] Full `pgduck_server` pytest suite green (excluding unrelated azurite/env failures)
- [x] `test_iceberg_data_file_stats.py` green (excluding Spark-only tests)
- [ ] CI: `check-pgduck_server` and `check-pg_lake_iceberg` (pg17/pg18)

Made with [Cursor](https://cursor.com)