### PR TITLE
Register Iceberg size-clamp syscache callbacks once, not per cache rebuild

### DIFF
--- a/pg_lake_engine/src/pgduck/iceberg_datum_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_datum_validation.c
@@ -116,6 +116,16 @@ typedef struct
 
 static HTAB *TypeContainsJsonbLeafCache = NULL;
 
+/*
+ * Syscache callbacks can never be unregistered and are appended to a
+ * fixed-size array (MAX_SYSCACHE_CALLBACKS).  Track registration separately
+ * from the cache lifetime so a cache rebuild after invalidation does not
+ * re-register them: the invalidation callback nulls TypeContainsJsonbLeafCache,
+ * and without this guard every TYPEOID/RELOID invalidation would leak two more
+ * slots, exhausting the array under DDL churn.
+ */
+static bool TypeContainsJsonbLeafCallbackRegistered = false;
+
 static void
 TypeContainsJsonbLeafCacheInval(Datum arg, int cacheid, uint32 hashvalue)
 {
@@ -194,12 +204,16 @@ TypeContainsJsonbLeaf(Oid typeOid)
 			hash_create("Iceberg TypeContainsJsonbLeaf cache", 64, &ctl,
 						HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
-		CacheRegisterSyscacheCallback(TYPEOID,
-									  TypeContainsJsonbLeafCacheInval,
-									  (Datum) 0);
-		CacheRegisterSyscacheCallback(RELOID,
-									  TypeContainsJsonbLeafCacheInval,
-									  (Datum) 0);
+		if (!TypeContainsJsonbLeafCallbackRegistered)
+		{
+			CacheRegisterSyscacheCallback(TYPEOID,
+										  TypeContainsJsonbLeafCacheInval,
+										  (Datum) 0);
+			CacheRegisterSyscacheCallback(RELOID,
+										  TypeContainsJsonbLeafCacheInval,
+										  (Datum) 0);
+			TypeContainsJsonbLeafCallbackRegistered = true;
+		}
 	}
 
 	entry = hash_search(TypeContainsJsonbLeafCache, &typeOid,


### PR DESCRIPTION
## Problem

`TypeContainsJsonbLeaf` in `iceberg_datum_validation.c` (added in #371) registers its `TYPEOID` and `RELOID` syscache callbacks inside the `if (TypeContainsJsonbLeafCache == NULL)` rebuild guard. Its invalidation callback nulls that same pointer:

```c
TypeContainsJsonbLeafCacheInval(...) { hash_destroy(cache); cache = NULL; }
```

So every `TYPEOID`/`RELOID` invalidation makes the next lookup rebuild the hash and re-register both callbacks. Syscache callbacks cannot be unregistered and are appended to a fixed-size array (`MAX_SYSCACHE_CALLBACKS`, 64). Under steady catalog churn the array fills, two slots per invalidation, until the backend dies with:

```
FATAL:  out of syscache_callback_list slots
```

This surfaced in snowflake_cdc CI (sfpg-extension-pg_lake_replication #497, which bumps the pg_lake submodule to include #371). The `test_random_dml_ddl_stress` case does hundreds of random `CREATE`/`DROP TABLE` / `ADD`/`DROP PRIMARY KEY` operations; the CDC worker calls into the size-clamp path on every change-batch write, exhausts the callback slots after ~32 invalidations, and enters a crash-restart loop. The replication slot never advances, so the test fails with "Slot did not reach LSN within timeout" and the server logs a wall of restarts.

## Solution

Guard the registration with a dedicated `static bool TypeContainsJsonbLeafCallbackRegistered`, set once and never reset, so the callbacks are registered exactly once per backend while the cache is still rebuilt on invalidation. This matches the existing pattern for the REST catalog token cache (`TokenCacheCallbackRegistered` in `rest_catalog/rest_catalog_auth.c`), whose comment already documents this exact hazard.

## Test plan

- [x] Reproduced locally against pg_lake `3544ca4`: `test_random_dml_ddl_stress` (seed 1783420803) fails after 300s with the CDC worker looping on `out of syscache_callback_list slots` (32 occurrences in the server log).
- [x] With this fix, the same seed passes in ~22s, zero `out of syscache_callback_list slots`, slot advances normally.
- [x] The size-clamp behavior is unchanged: the snowflake_cdc `test_iceberg_size_clamping.py` suite (9 cases) still passes.