### PR TITLE
pgduck_server: cap s3_uploader_thread_limit by host memory

### DIFF
--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -218,6 +218,114 @@ verify_database_file_safe(const char *databaseFilePath)
 }
 
 /*
+ * GetEffectiveMemoryLimitBytes reads DuckDB's current memory_limit back and
+ * returns it in bytes.  DuckDB reports the limit as a formatted string
+ * (e.g. "2.0 GiB", "512.0 MiB"); we parse the value and its binary unit.
+ * Reading it back (rather than parsing the CLI argument) captures the
+ * effective limit including DuckDB's default of 80% of RAM when none was
+ * given.  Returns 0 if the setting could not be read or parsed, so callers
+ * can fall back to another estimate.
+ */
+static uint64
+GetEffectiveMemoryLimitBytes(void)
+{
+	char		buffer[STACK_ALLOCATED_OUTPUT_BUFFER_SIZE];
+	TextOutputBuffer out = {
+		.buffer = buffer,
+		.needsFree = false
+	};
+	double		value = 0;
+	char		unit[16] = {0};
+	uint64		multiplier = 1;
+	uint64		bytes = 0;
+
+	if (run_command_on_duckdb_with_callback("SELECT current_setting('memory_limit')",
+											process_single_result_as_text,
+											&out) == DuckDBError ||
+		out.buffer == NULL)
+		return 0;
+
+	/* e.g. "2.0 GiB"; a missing unit means the value is already in bytes */
+	if (sscanf(out.buffer, "%lf %15s", &value, unit) >= 1 && value > 0)
+	{
+		if (pg_strcasecmp(unit, "TiB") == 0 || pg_strcasecmp(unit, "TB") == 0)
+			multiplier = UINT64CONST(1) << 40;
+		else if (pg_strcasecmp(unit, "GiB") == 0 || pg_strcasecmp(unit, "GB") == 0)
+			multiplier = UINT64CONST(1) << 30;
+		else if (pg_strcasecmp(unit, "MiB") == 0 || pg_strcasecmp(unit, "MB") == 0)
+			multiplier = UINT64CONST(1) << 20;
+		else if (pg_strcasecmp(unit, "KiB") == 0 || pg_strcasecmp(unit, "KB") == 0)
+			multiplier = UINT64CONST(1) << 10;
+
+		bytes = (uint64) (value * (double) multiplier);
+	}
+
+	if (out.needsFree)
+		pg_free(out.buffer);
+
+	return bytes;
+}
+
+
+/*
+ * DefaultS3UploaderThreadLimit computes a memory-proportional cap on the
+ * number of concurrent S3 multipart-upload part buffers DuckDB keeps in
+ * flight per open file.
+ *
+ * Each in-flight part is a ~part_size buffer (default ~80MB, derived from
+ * s3_uploader_max_filesize / s3_uploader_max_parts_per_file) allocated
+ * against DuckDB's memory_limit (MemoryTag::EXTENSION).  With the upstream
+ * httpfs default of 50, a single file being written can pin up to ~4GB,
+ * which is enough to exhaust the memory_limit on small hosts and crash the
+ * server with an out-of-memory error while a large snapshot writes to S3.
+ *
+ * Since the part buffers are charged against memory_limit, we size the cap
+ * against that budget rather than physical RAM -- the two can differ, e.g. a
+ * 2GB memory_limit on a 4GB host.  The rule is ~2 upload threads per GiB of
+ * memory_limit, rounded to the nearest GiB, clamped to [2, 50] (50 is the
+ * upstream default; we never raise above it).  So a 2GB limit -> 4, a 4GB
+ * limit -> 8.  If the limit cannot be read we fall back to physical RAM, and
+ * then to the floor of 2.  Uploads are network-bound and run on detached
+ * threads independent of DuckDB's `threads` setting, so CPU count is not the
+ * constraint.
+ *
+ * This runs after memory_limit is configured and before the init file is
+ * applied, so it reflects the effective limit and an operator can still
+ * override s3_uploader_thread_limit explicitly in the init file.
+ */
+static uint64
+DefaultS3UploaderThreadLimit(void)
+{
+	uint64		gib = UINT64CONST(1024) * 1024 * 1024;
+	uint64		memBytes = GetEffectiveMemoryLimitBytes();
+	uint64		roundedGib;
+	uint64		threads;
+
+	if (memBytes == 0)
+	{
+		/* fall back to physical RAM if the limit could not be read */
+		long		pages = sysconf(_SC_PHYS_PAGES);
+		long		pageSize = sysconf(_SC_PAGE_SIZE);
+
+		if (pages < 1 || pageSize < 1)	/* sysconf failed too */
+			return 2;
+
+		memBytes = (uint64) pages * (uint64) pageSize;
+	}
+
+	roundedGib = (memBytes + gib / 2) / gib;	/* nearest whole GiB */
+	threads = 2 * roundedGib;
+
+	if (threads < 2)
+		threads = 2;
+	if (threads > 50)
+		threads = 50;
+
+	return threads;
+}
+
+
+/*
  * duckdb_global_init initializes the DuckDB database, which can be used
  * by different threads simulteously.
  */
@@ -470,6 +578,24 @@ duckdb_global_init(char *databaseFilePath,
 
 		if (run_command_on_duckdb(setCommand) == DuckDBError)
 			return DUCKDB_INITIALIZATION_ERROR;
+	}
+
+	{
+		uint64		s3UploaderThreadLimit = DefaultS3UploaderThreadLimit();
+
+		if (snprintf(setCommand, 1024,
+					 "SET GLOBAL s3_uploader_thread_limit TO %" PRIu64,
+					 s3UploaderThreadLimit) < 0)
+		{
+			PGDUCK_SERVER_ERROR("s3_uploader_thread_limit value is too long");
+			return DUCKDB_INITIALIZATION_ERROR;
+		}
+
+		if (run_command_on_duckdb(setCommand) == DuckDBError)
+			return DUCKDB_INITIALIZATION_ERROR;
+
+		PGDUCK_SERVER_LOG("s3_uploader_thread_limit is set to: %" PRIu64,
+						  s3UploaderThreadLimit);
 	}
 
 	if (initFilePath != NULL)

--- a/pgduck_server/tests/pytests/test_server_start.py
+++ b/pgduck_server/tests/pytests/test_server_start.py
@@ -714,3 +714,50 @@ def test_temp_directory_via_init_file_sets_spill_location():
             cur = conn.cursor()
             cur.execute("SELECT current_setting('temp_directory')")
             assert cur.fetchone()[0] == spill_dir
+
+
+# ---------------------------------------------------------------------------
+# s3_uploader_thread_limit sizing (see DefaultS3UploaderThreadLimit in
+# duckdb_global_init)
+#
+# pgduck_server caps s3_uploader_thread_limit at ~2 per GiB of the effective
+# memory_limit, clamped to [2, 50], so a small host cannot pin gigabytes of
+# ~80MB S3 multipart-upload part buffers (each charged against memory_limit)
+# and OOM. The cap is computed from the --memory_limit CLI value, which is
+# applied before the init file; an operator SET in the init file runs
+# afterwards and still overrides it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "memory_limit,expected",
+    [
+        ("512MiB", 2),  # below 1 GiB rounds down to the floor of 2
+        ("2GiB", 4),  # ~2 threads per GiB
+        ("4GiB", 8),
+        ("64GiB", 50),  # above ~25 GiB is capped at the upstream default of 50
+    ],
+)
+def test_s3_uploader_thread_limit_scales_with_memory_limit(memory_limit, expected):
+    server = PgDuckServer(
+        port=PGDUCK_PORT,
+        extra_args=[f"--memory_limit={memory_limit}"],
+    )
+    assert is_server_listening(server.socket_path)
+
+    conn = _spill_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT current_setting('s3_uploader_thread_limit')")
+    assert int(cur.fetchone()[0]) == expected
+
+
+def test_s3_uploader_thread_limit_init_file_override():
+    """The computed default is applied before the init file, so an operator
+    SET GLOBAL s3_uploader_thread_limit in the init file overrides it."""
+    with _server_from_init_file("SET GLOBAL s3_uploader_thread_limit TO 7") as server:
+        assert is_server_listening(server.socket_path)
+
+        conn = _spill_connection()
+        cur = conn.cursor()
+        cur.execute("SELECT current_setting('s3_uploader_thread_limit')")
+        assert int(cur.fetchone()[0]) == 7


### PR DESCRIPTION
## Problem

DuckDB's httpfs S3 uploader keeps up to `s3_uploader_thread_limit` multipart-upload part buffers in flight per open file (default 50), each ~80MB and allocated against DuckDB's `memory_limit` (`MemoryTag::EXTENSION`). The default part size is ~80MB because it derives from `s3_uploader_max_filesize / s3_uploader_max_parts_per_file` (800GB / 10000). On a small host (`memory_limit` 2GB) a single large snapshot writing to S3 can pin up to ~4GB in part buffers alone, hit the limit, and crash `pgduck_server` with an out-of-memory error. systemd restarts it and the snapshot retries into the same failure, so one oversized table can crash-loop the server for hours, aborting concurrent queries for every other mirror each time.

## Solution

Set `s3_uploader_thread_limit` at startup instead of leaving it at the upstream default of 50. The part buffers are charged against `memory_limit`, so the cap is sized against that budget rather than physical RAM (the two can differ, e.g. a 2GB limit on a 4GB host). We read the effective `memory_limit` back from DuckDB and use ~2 threads per GiB, clamped to `[2, 50]` (never above the upstream default). Uploads are network-bound and run on detached threads independent of DuckDB's `threads` setting, so CPU count is not the constraint.

| `memory_limit` | `s3_uploader_thread_limit` | Worst-case S3 buffers/file | (default was 50) |
|---|---|---|---|
| ≤1 GiB | 2 (floor) | ~160 MB | ~4 GB |
| 2 GiB | 4 | ~320 MB | ~4 GB |
| 4 GiB | 8 | ~640 MB | ~4 GB |
| 8 GiB | 16 | ~1.3 GB | ~4 GB |
| 16 GiB | 32 | ~2.6 GB | ~4 GB |
| 24 GiB | 48 | ~3.8 GB | ~4 GB |
| ≥25 GiB | 50 (cap) | ~4.0 GB | ~4 GB |

The `SET GLOBAL` runs after `memory_limit` is configured and before the init file is applied, so it reflects the effective limit and an operator can still override it:

```
# init_file_path: raise the cap on a memory-rich host
SET GLOBAL s3_uploader_thread_limit TO 64;
```

## Test plan

- [x] Single TU and full `pgduck_server` build clean under the tree's `-Wall`/`-Werror=…` flags.
- [x] Started the built binary at several limits; init logs `s3_uploader_thread_limit is set to: N` and `SELECT current_setting('s3_uploader_thread_limit')` returns it: `--memory_limit=2GB` → 4, `512MB` → 2 (floor), a large limit → 50 (cap).