### PR TITLE
Set ColumnChunk.file_offset in the Parquet writer

### DIFF
--- a/duckdb_pglake/patches/duckdb/set_column_chunk_file_offset.patch
+++ b/duckdb_pglake/patches/duckdb/set_column_chunk_file_offset.patch
@@ -1,0 +1,23 @@
+diff --git a/extension/parquet/parquet_writer.cpp b/extension/parquet/parquet_writer.cpp
+index 3c6d11d9ad..41e412dab5 100644
+--- a/extension/parquet/parquet_writer.cpp
++++ b/extension/parquet/parquet_writer.cpp
+@@ -565,6 +565,18 @@ void ParquetWriter::FlushRowGroup(PreparedRowGroup &prepared) {
+ 	// let's make sure all offsets are ay-okay
+ 	ValidateColumnOffsets(file_name, writer->GetTotalWritten(), row_group);
+ 
++	// ColumnChunk.file_offset is a required field but is otherwise left at its
++	// default of 0. It is meant to point at the start of the column chunk, and
++	// some readers rely on it to locate each chunk; a zero value makes them
++	// misread files that contain more than one row group. Set it to the start
++	// of the column chunk (the dictionary page if present, else the first data
++	// page) so the value is consistent with the per-column page offsets.
++	for (auto &col_chunk : row_group.columns) {
++		col_chunk.file_offset = col_chunk.meta_data.__isset.dictionary_page_offset
++		                            ? col_chunk.meta_data.dictionary_page_offset
++		                            : col_chunk.meta_data.data_page_offset;
++	}
++
+ 	row_group.total_compressed_size = NumericCast<int64_t>(writer->GetTotalWritten()) - row_group.file_offset;
+ 	row_group.__isset.total_compressed_size = true;
+ 

--- a/pgduck_server/tests/pytests/test_parquet_file_offset.py
+++ b/pgduck_server/tests/pytests/test_parquet_file_offset.py
@@ -1,0 +1,45 @@
+from utils_pytest import *
+
+
+def test_parquet_column_chunk_file_offset_multi_row_group(pgduck_conn, tmp_path):
+    """ColumnChunk.file_offset must point at the start of each column chunk.
+
+    file_offset is a required Parquet field but is otherwise left at its
+    default of 0. Readers that use it to locate a column chunk then misread
+    files with more than one row group, because every row group resolves to
+    offset 0 and the first row group is returned repeatedly. Write a file with
+    several row groups and assert every column chunk's file_offset matches its
+    start offset (the dictionary page if present, else the first data page).
+    """
+    path = str(tmp_path / "multi_rg.parquet")
+
+    # range(8192) with ROW_GROUP_SIZE 2048 => 4 row groups, 2 columns each.
+    copy = f"""
+        COPY (
+            SELECT i AS id, repeat('x', 16) AS payload
+            FROM range(8192) t(i)
+        ) TO '{path}' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+    """
+    run_command(copy, pgduck_conn)
+
+    rows = run_query(
+        f"""
+        SELECT row_group_id,
+               column_id,
+               file_offset,
+               coalesce(dictionary_page_offset, data_page_offset) AS chunk_start
+        FROM parquet_metadata('{path}')
+        ORDER BY row_group_id, column_id
+        """,
+        pgduck_conn,
+    )
+
+    assert len(rows) > 0
+    # The test is only meaningful with more than one row group.
+    assert max(r["row_group_id"] for r in rows) >= 1
+
+    for r in rows:
+        # file_offset must equal the start of the column chunk, and therefore
+        # be non-zero (offset 0 is the file's "PAR1" magic, never a chunk).
+        assert r["file_offset"] == r["chunk_start"], r
+        assert r["file_offset"] > 0, r


### PR DESCRIPTION
## Problem

The Parquet writer leaves `ColumnChunk.file_offset` at its default of `0`. The field is required by the format and is meant to point at the start of the column chunk. Some Parquet readers use it to locate each chunk, so when it is `0` they mis-read any file that contains more than one row group: every row group resolves to offset `0`, so the first row group is returned repeatedly and the remaining row groups are dropped. Single-row-group files are unaffected.

The per-column page offsets (`data_page_offset` / `dictionary_page_offset`) are already written correctly, so the data itself is fine; only the redundant `file_offset` field is left unset.

## Solution

In `FlushRowGroup`, after the column metadata is finalized, set each column chunk's `file_offset` to the start of the chunk (the dictionary page offset if present, otherwise the first data page offset), matching the page offsets that are already written.

Shipped as a patch against the vendored DuckDB:

```
# duckdb_pglake/patches/duckdb/set_column_chunk_file_offset.patch
for (auto &col_chunk : row_group.columns) {
    col_chunk.file_offset = col_chunk.meta_data.__isset.dictionary_page_offset
                                ? col_chunk.meta_data.dictionary_page_offset
                                : col_chunk.meta_data.data_page_offset;
}
```

This is the same chunk-start offset that the writer's own `ValidateColumnOffsets` already computes.

## Test plan

- `make patch_duckdb` applies the new patch cleanly alongside the existing patches (verified in the sorted apply order).
- Reproduced the pre-fix behavior: a multi-row-group Parquet file written by the current writer reports `file_offset = 0` on every column chunk (via `parquet_metadata`), which a reader that keys off `file_offset` mis-reads by repeating the first row group.
- Still to do: rebuild the writer and confirm the emitted files carry the non-zero `file_offset` per column chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)