### PR TITLE
pg_lake_table: fix vacuum compaction summary logging under autovacuum

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -53,6 +53,8 @@ extern PGDLLEXPORT void LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPat
 extern PGDLLEXPORT List *GetPossiblePositionDeleteFilesFromCatalog(Oid relationId, List *sourcePathList,
 																   Snapshot snapshot);
 extern PGDLLEXPORT int64 GetTableSizeFromCatalog(Oid relationId);
+extern PGDLLEXPORT void GetTableFileStatsFromCatalog(Oid relationId, int64 *tableSize,
+													 int64 *fileCount, int64 *liveRowCount);
 extern PGDLLEXPORT int64 GetTotalDeletedRowCountFromCatalog(Oid relationId);
 bool		DataFilesCatalogExists(void);
 bool		DataFilesPartitionValuesCatalogExists(void);

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -759,18 +759,41 @@ VacuumCompactDataFiles(Oid relationId, bool isFull, bool isVerbose)
 			? psprintf(", resolved " INT64_FORMAT " position-deleted rows",
 					   runStats.positionDeletedRowsResolved)
 			: "";
-		int64		tableSize = GetTableSizeFromCatalog(relationId);
+
+		/*
+		 * The compaction loop leaves the transaction without an active
+		 * snapshot, so push one for the read-only catalog query below.  A
+		 * regular backend running manual VACUUM is carried by its portal
+		 * snapshot, but the autovacuum worker has neither portal nor active
+		 * snapshot and would otherwise error out of the whole vacuum cycle.
+		 */
+		bool		pushedSnapshot = false;
+
+		if (!ActiveSnapshotSet())
+		{
+			PushActiveSnapshot(GetTransactionSnapshot());
+			pushedSnapshot = true;
+		}
+
+		int64		tableSize = 0;
+		int64		fileCount = 0;
+		int64		liveRowCount = 0;
+
+		GetTableFileStatsFromCatalog(relationId, &tableSize, &fileCount, &liveRowCount);
+
+		if (pushedSnapshot)
+			PopActiveSnapshot();
 
 		ereport(LOG,
 				(errmsg("pg_lake: compacted iceberg table %s: "
 						"rewrote " INT64_FORMAT " files (" INT64_FORMAT " bytes, " INT64_FORMAT " rows) "
 						"into " INT64_FORMAT " files (" INT64_FORMAT " bytes, " INT64_FORMAT " rows)%s; "
-						"table is now " INT64_FORMAT " bytes",
+						"table is now " INT64_FORMAT " bytes across " INT64_FORMAT " files (" INT64_FORMAT " rows)",
 						GetQualifiedRelationName(relationId),
 						runStats.filesRemoved, runStats.bytesRemoved, runStats.rowsRemoved,
 						runStats.filesAdded, runStats.bytesAdded, runStats.rowsAdded,
 						positionDeleteSuffix,
-						tableSize)));
+						tableSize, fileCount, liveRowCount)));
 	}
 }
 

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -870,6 +870,70 @@ GetTableSizeFromCatalog(Oid relationId)
 
 
 /*
+ * GetTableFileStatsFromCatalog reports, in a single pass over the data files
+ * catalog, the total size in bytes, the number of files, and the number of
+ * live rows currently in the table.  Live rows are counted over data files
+ * only (content = CONTENT_DATA) and exclude rows covered by position deletes;
+ * size and file count cover all files, matching GetTableSizeFromCatalog.
+ *
+ * Empty tables report zero for every field.  Callers must confirm the
+ * relation ID belongs to an actual writable table.
+ */
+void
+GetTableFileStatsFromCatalog(Oid relationId, int64 *tableSize,
+							 int64 *fileCount, int64 *liveRowCount)
+{
+	*tableSize = 0;
+	*fileCount = 0;
+	*liveRowCount = 0;
+
+	/* cast sum/count results to bigint to avoid returning numeric */
+	char	   *metadataQuery =
+		psprintf("select "
+				  /* 1 */ "sum(file_size)::bigint, "
+				  /* 2 */ "count(*)::bigint, "
+				  /* 3 */ "(sum(row_count - deleted_row_count) "
+				 "filter (where content OPERATOR(pg_catalog.=) %d))::bigint "
+				 "from " DATA_FILES_TABLE_QUALIFIED " "
+				 "where table_name OPERATOR(pg_catalog.=) $1",
+				 (int) CONTENT_DATA);
+
+	DECLARE_SPI_ARGS(1);
+	SPI_ARG_VALUE(1, OIDOID, relationId, false);
+
+	/* switch to schema owner, we assume callers checked permissions */
+	SPI_START_EXTENSION_OWNER(PgLakeTable);
+
+	bool		readOnly = true;
+
+	SPI_EXECUTE(metadataQuery, readOnly);
+
+	if (SPI_processed == 1)
+	{
+		bool		rowIndex = 0;
+		bool		isNull = false;
+
+		Datum		tableSizeDatum = GET_SPI_DATUM(rowIndex, 1, &isNull);
+
+		if (!isNull)
+			*tableSize = DatumGetInt64(tableSizeDatum);
+
+		Datum		fileCountDatum = GET_SPI_DATUM(rowIndex, 2, &isNull);
+
+		if (!isNull)
+			*fileCount = DatumGetInt64(fileCountDatum);
+
+		Datum		liveRowCountDatum = GET_SPI_DATUM(rowIndex, 3, &isNull);
+
+		if (!isNull)
+			*liveRowCount = DatumGetInt64(liveRowCountDatum);
+	}
+
+	SPI_END();
+}
+
+
+/*
  * GetTotalDeletedRowCountFromCatalog sums the deleted_row_count of all data
  * files in the table.  This is the total number of rows that are currently
  * covered by position delete files.

--- a/pg_lake_table/tests/pytests/test_writable_table_vacuum.py
+++ b/pg_lake_table/tests/pytests/test_writable_table_vacuum.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import re
+import time
 from collections import namedtuple
 from utils_pytest import *
 import warnings
@@ -519,7 +520,14 @@ def test_vacuum_compaction_summary_log(s3, pg_conn, extension):
     summary = summary_lines[0]
     assert "rewrote 2 files" in summary
     assert "into 1 files" in summary
-    assert "table is now" in summary
+
+    # the summary must report the totals left in the table: after merging the
+    # two single-row files there is one file holding both rows
+    m = re.search(r"table is now \d+ bytes across (\d+) files \((\d+) rows\)", summary)
+    assert m is not None, f"could not parse remaining totals from summary: {summary}"
+    files_left, rows_left = int(m.group(1)), int(m.group(2))
+    assert files_left == 1, f"expected 1 file left, got {files_left}"
+    assert rows_left == 2, f"expected 2 rows left, got {rows_left}"
 
     run_command(
         f"""
@@ -608,6 +616,85 @@ def test_vacuum_compaction_summary_resolved_rows(s3, pg_conn, extension):
     )
 
     pg_conn.autocommit = False
+
+
+def test_autovacuum_compaction_summary_log(s3, pg_conn, extension, installcheck):
+    """The compaction summary must also be emitted on the autovacuum worker
+    path.  The worker has no portal or active snapshot, so the summary's
+    catalog read used to error out and abort the whole vacuum cycle; the log
+    line never reached the server log."""
+    if installcheck:
+        return
+
+    logfile = f"{server_params.PG_DIR}/logfile"
+    table = "test_autovacuum_compaction_summary_log"
+    location = f"s3://{TEST_BUCKET}/{table}/"
+
+    run_command_outside_tx(
+        [
+            "ALTER SYSTEM SET pg_lake_iceberg.log_autovacuum_min_duration TO 0;",
+            "ALTER SYSTEM SET pg_lake_iceberg.autovacuum_naptime TO '1s';",
+            "ALTER SYSTEM SET pg_lake_table.vacuum_compact_min_input_files TO 1;",
+            "SELECT pg_reload_conf();",
+        ]
+    )
+
+    pg_conn.autocommit = True
+
+    try:
+        offset = os.path.getsize(logfile)
+
+        run_command(
+            f"""
+            CREATE TABLE {table} (id int, value text)
+            USING pg_lake_iceberg WITH (location = '{location}');
+            INSERT INTO {table} VALUES (1, 'a');
+            INSERT INTO {table} VALUES (2, 'b');
+            INSERT INTO {table} VALUES (3, 'c');
+            """,
+            pg_conn,
+        )
+
+        summary = None
+        deadline = time.monotonic() + 90
+        while time.monotonic() < deadline:
+            with open(logfile) as f:
+                f.seek(offset)
+                delta = f.read()
+            for line in delta.splitlines():
+                if "compacted iceberg table" in line and table in line:
+                    summary = line
+            if summary is not None:
+                break
+            time.sleep(2)
+
+        assert (
+            summary is not None
+        ), f"autovacuum did not emit a compaction summary for {table}"
+        assert "without an outer snapshot or portal" not in delta, (
+            "autovacuum hit the snapshot error while logging the summary: " + delta
+        )
+
+        m = re.search(
+            r"table is now \d+ bytes across (\d+) files \((\d+) rows\)", summary
+        )
+        assert (
+            m is not None
+        ), f"could not parse remaining totals from summary: {summary}"
+        assert int(m.group(1)) == 1, f"expected 1 file left, got {m.group(1)}"
+        assert int(m.group(2)) == 3, f"expected 3 rows left, got {m.group(2)}"
+
+        run_command(f"DROP TABLE {table};", pg_conn)
+    finally:
+        pg_conn.autocommit = False
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_iceberg.log_autovacuum_min_duration;",
+                "ALTER SYSTEM RESET pg_lake_iceberg.autovacuum_naptime;",
+                "ALTER SYSTEM RESET pg_lake_table.vacuum_compact_min_input_files;",
+                "SELECT pg_reload_conf();",
+            ]
+        )
 
 
 def test_vacuum_multiple_metadata_ops(s3, pg_conn, extension, with_default_location):


### PR DESCRIPTION
## Description

The compaction summary introduced in #350 runs after the compaction loop has already rotated into a fresh transaction, so no snapshot is active at that point. A backend running manual VACUUM gets away with it because the portal snapshot carries the SPI read, but the autovacuum worker has neither a portal nor an active snapshot, so the catalog query behind the summary fails:

```
WARNING:  cannot execute SQL without an outer snapshot or portal
CONTEXT:  SQL statement "select sum(file_size)::bigint from lake_table.files where table_name OPERATOR(pg_catalog.=) $1"
```

The error only gets caught at the top of the worker loop, so any autovacuum cycle that compacts something loses the summary and duration log lines and skips the remaining vacuum stages and tables for that cycle.

This PR pushes a snapshot around the catalog read so the summary works on both paths. Since the summary line previously reported only the remaining size in bytes, the same catalog query now also returns the number of files and live rows left in the table, completing the totals requested in #40:

```
LOG:  pg_lake: compacted iceberg table public.t: rewrote 3 files (849 bytes, 3 rows) into 1 files (303 bytes, 3 rows); table is now 303 bytes across 1 files (3 rows)
```

Tests: extended the existing summary test with the new totals, and added an autovacuum path test that reads the server log and verifies the summary appears from the worker without the snapshot error.

closes: #40