### PR TITLE
Fix oid type mapping: BIGINT in Parquet, 'long' in Iceberg metadata

### DIFF
--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -47,7 +47,7 @@ def test_types(pg_conn, duckdb_conn, superuser_conn, tmp_path, app_user):
         "c_numeric": "DECIMAL(38,9)",
         "c_numeric_large": "VARCHAR",
         "c_numeric_mod": "DECIMAL(4,2)",
-        "c_oid": "UINTEGER",
+        "c_oid": "BIGINT",
         "c_text": "VARCHAR",
         "c_tid": "VARCHAR",
         "c_time": "TIME",

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -247,6 +247,7 @@ PostgresBaseTypeIdToIcebergTypeName(PGType pgType)
 		case INT2OID:
 			return "int";
 		case INT8OID:
+		case OIDOID:
 			return "long";
 		case FLOAT4OID:
 			return "float";

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -466,7 +466,7 @@ GetDuckDBTypeForPGType(PGType postgresType)
 			return DUCKDB_TYPE_DECIMAL;
 
 		case OIDOID:
-			return DUCKDB_TYPE_UINTEGER;
+			return DUCKDB_TYPE_BIGINT;
 
 		case TIMESTAMPOID:
 			return DUCKDB_TYPE_TIMESTAMP;

--- a/pg_lake_table/tests/pytests/test_iceberg_types.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_types.py
@@ -2988,3 +2988,65 @@ def create_helper_functions(superuser_conn, app_user):
         superuser_conn,
     )
     superuser_conn.commit()
+
+
+def test_oid_iceberg_field_type(
+    extension, pg_conn, superuser_conn, pgduck_conn, s3, with_default_location
+):
+    """oid column must produce 'long' in Iceberg metadata and BIGINT in Parquet, not string."""
+    run_command(
+        """
+        create schema test_oid_field_type;
+        create table test_oid_field_type.oid_types (
+            id  oid,
+            txt text
+        ) using iceberg;
+        insert into test_oid_field_type.oid_types values (16385, 'hello');
+        insert into test_oid_field_type.oid_types values (2147483648, 'big');
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    results = run_query(
+        "SELECT metadata_location FROM lake_iceberg.tables"
+        " WHERE table_name = 'oid_types' AND table_namespace = 'test_oid_field_type'",
+        superuser_conn,
+    )
+    assert len(results) == 1
+    metadata_path = results[0][0]
+
+    data = read_s3_operations(s3, metadata_path)
+    parsed = json.loads(data)
+    fields = {f["name"]: f["type"] for f in parsed["schemas"][0]["fields"]}
+
+    assert (
+        fields["id"] == "long"
+    ), f"oid should be 'long' in Iceberg metadata, got {fields['id']!r}"
+    assert fields["txt"] == "string"
+
+    files = run_query(
+        "SELECT path FROM lake_table.files WHERE table_name = 'test_oid_field_type.oid_types'::regclass",
+        superuser_conn,
+    )
+    assert len(files) > 0
+    for file in files:
+        columns = run_query(
+            f"DESCRIBE SELECT * FROM read_parquet('{file[0]}')", pgduck_conn
+        )
+        col_types = {row[0]: row[1] for row in columns}
+        assert (
+            col_types["id"] == "BIGINT"
+        ), f"oid should be BIGINT in Parquet, got {col_types['id']!r}"
+
+    result = run_query(
+        "SELECT id, txt FROM test_oid_field_type.oid_types ORDER BY id", pg_conn
+    )
+    assert result[0]["id"] == 16385
+    assert result[1]["id"] == 2147483648
+    assert result[0]["txt"] == "hello"
+    assert result[1]["txt"] == "big"
+
+    pg_conn.rollback()
+    run_command("drop schema if exists test_oid_field_type cascade;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
## Problem

OID columns in Iceberg tables were stored as UINT32 in Parquet files (via `DUCKDB_TYPE_UINTEGER`) but the Iceberg schema metadata recorded them as `"string"`. This schema/physical-type mismatch caused the following error in APPLY_CHANGE_BATCHES:

> Parquet file schema data type is incompatible with table column. Kind: '\<redacted\>'

## Root cause

`GetDuckDBTypeForPGType` had `OIDOID → DUCKDB_TYPE_UINTEGER`, which writes 4-byte UINT32 to Parquet. `PostgresBaseTypeIdToIcebergTypeName` had no case for `OIDOID`, so it fell through to the `"string"` default. The write path and the metadata path disagreed on the column's type.

This is the same class of bug fixed for domain types in #370, but OID is already a base type so no `ResolveDomainBaseType` unwrapping was needed — only the two missing mappings.

## Fix

- `pg_lake_engine/src/pgduck/type.c`: `OIDOID → DUCKDB_TYPE_BIGINT` — DuckDB now writes INT64 to Parquet instead of UINT32
- `pg_lake_engine/src/parquet/field.c`: add `case OIDOID:` to `PostgresBaseTypeIdToIcebergTypeName` returning `"long"` — Iceberg metadata now matches the INT64 physical storage

OID is a 32-bit unsigned type in PostgreSQL with no unsigned equivalent in Iceberg. INT64/`"long"` safely covers the full OID range (0–4,294,967,295) without overflow. `DUCKDB_TYPE_BIGINT` already maps back to `INT8OID` on the read path, so the FDW correctly reconstructs OID values from int8.

## Backward compatibility

- **CDC batch files**: no issue — each batch is self-contained; new batches write INT64, which unblocks APPLY_CHANGE_BATCHES
- **Existing Iceberg tables with OID columns** : not sure will confirm

## Test plan

- `test_oid_iceberg_field_type` in `test_iceberg_types.py` verifies:
  - Iceberg metadata field type is `"long"` (not `"string"`)
  - Parquet physical column type is `BIGINT` (confirmed via `DESCRIBE SELECT * FROM read_parquet(...)` on pgduck)
  - Round-trip correctness including a value above the signed int32 boundary (2,147,483,648) to confirm no overflow