### PR TITLE
Back off base worker restarts with an exponential delay after failures

### DIFF
--- a/pg_extension_base/include/pg_extension_base/base_workers.h
+++ b/pg_extension_base/include/pg_extension_base/base_workers.h
@@ -104,6 +104,14 @@ extern bool EnableBaseWorkerLauncher;
 #define DEFAULT_WORKER_STARTER_SLEEP_TIME (10)
 extern int	WorkerStarterSleepTimeSec;
 
+/* pg_extension_base.worker_restart_backoff_* settings */
+#define DEFAULT_WORKER_RESTART_BACKOFF_INITIAL_MS (5000)
+#define DEFAULT_WORKER_RESTART_BACKOFF_MAX_MS (60000)
+#define DEFAULT_WORKER_RESTART_HEALTHY_MS (60000)
+extern int	WorkerRestartBackoffInitialMs;
+extern int	WorkerRestartBackoffMaxMs;
+extern int	WorkerRestartHealthyMs;
+
 void		BaseWorkerSharedMemoryInit(void);
 size_t		BaseWorkerSharedMemorySize(void);
 

--- a/pg_extension_base/pg_extension_base--3.5--3.6.sql
+++ b/pg_extension_base/pg_extension_base--3.5--3.6.sql
@@ -1,0 +1,16 @@
+-- Upgrade script for pg_extension_base from 3.5 to 3.6
+
+-- Add the failure_count column to list_base_workers so the exponential restart
+-- backoff is observable. Changing the OUT parameters changes the result type,
+-- which CREATE OR REPLACE cannot do, so drop and recreate the function.
+DROP FUNCTION extension_base.list_base_workers();
+
+CREATE FUNCTION extension_base.list_base_workers(OUT database_id oid, OUT worker_id int, OUT extension_id oid, OUT pid int, OUT needs_restart bool, OUT failure_count int)
+ RETURNS SETOF record
+ LANGUAGE c
+AS 'MODULE_PATHNAME', $function$pg_extension_base_list_base_workers$function$;
+
+COMMENT ON FUNCTION extension_base.list_base_workers()
+ IS 'list all base worker states';
+
+REVOKE ALL ON FUNCTION extension_base.list_base_workers() FROM public;

--- a/pg_extension_base/pg_extension_base.control
+++ b/pg_extension_base/pg_extension_base.control
@@ -1,5 +1,5 @@
 comment = 'Extension development kit by Snowflake'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_extension_base'
 relocatable = false
 schema = pg_catalog

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -105,11 +105,17 @@
 #define MAX_WORKER_NAME_LENGTH (255)
 
 /*
- * When a base worker fails with an error, we avoid a crash loop by waiting at
- * least 5 seconds. We do not currently wake up the server and database starters,
- * so the total wait can be up to 15 seconds.
+ * When a base worker fails with an error we delay its restart to avoid a tight
+ * crash loop.  The delay grows exponentially with the number of consecutive
+ * failures: WorkerRestartBackoffInitialMs on the first failure, doubling on
+ * each subsequent failure, capped at WorkerRestartBackoffMaxMs.  The failure
+ * counter resets once a worker has stayed up for at least WorkerRestartHealthyMs,
+ * so a worker that runs fine and later hits a transient error backs off from the
+ * initial delay again instead of inheriting a stale, long delay.
+ *
+ * We do not currently wake up the server and database starters, so the total
+ * wait can be up to WorkerStarterSleepTimeSec longer than the computed delay.
  */
-#define NAP_TIME_AFTER_FAILURE (5000)
 
 #define PG_EXTENSION_BASE_EXTENSION_NAME "pg_extension_base"
 #define PG_EXTENSION_BASE_SCHEMA_NAME "extension_base"
@@ -225,6 +231,12 @@ typedef struct BaseWorkerEntry
 
 	/* when to restart the base worker (delayed after failure) */
 	TimestampTz restartAfter;
+
+	/* number of consecutive failures, used to compute the restart backoff */
+	int			failureCount;
+
+	/* when the worker last started running (for the healthy-uptime reset) */
+	TimestampTz startTime;
 }			BaseWorkerEntry;
 
 
@@ -357,6 +369,7 @@ static void BaseWorkerObjectAccessHook(ObjectAccessType access, Oid classId,
 static Oid	PgExtensionBaseExtensionId(void);
 static bool ExtensionExists(char *extensionName);
 static TimestampTz GetDelayedTimestamp(int64 millis);
+static int64 ComputeRestartBackoffMs(int failureCount);
 static void SignalDatabaseStarterLocked(Oid databaseId);
 static void DatabaseStarterNeedsRestart(Oid databaseId);
 static void PrepareForDrop(Oid databaseId, Oid extensionId);
@@ -399,6 +412,11 @@ static bool SignalServerStarter = false;
 /* pg_extension_base.worker_starter_sleep_time */
 int			WorkerStarterSleepTimeSec = DEFAULT_WORKER_STARTER_SLEEP_TIME;
 int32		MyBaseWorkerId = InvalidOid;
+
+/* pg_extension_base.worker_restart_backoff_* */
+int			WorkerRestartBackoffInitialMs = DEFAULT_WORKER_RESTART_BACKOFF_INITIAL_MS;
+int			WorkerRestartBackoffMaxMs = DEFAULT_WORKER_RESTART_BACKOFF_MAX_MS;
+int			WorkerRestartHealthyMs = DEFAULT_WORKER_RESTART_HEALTHY_MS;
 
 /*
  * InitializeBaseWorkerLauncher sets up hooks used by the base worker launcher.
@@ -1893,6 +1911,7 @@ PgExtensionBaseWorkerMain(Datum arg)
 
 	workerEntry->state = WORKER_RUNNING;
 	workerEntry->workerPid = MyProcPid;
+	workerEntry->startTime = GetCurrentTimestamp();
 
 	Oid			entryPointFunctionId = workerEntry->entryPointFunctionId;
 	Oid			extensionId = workerEntry->extensionId;
@@ -2032,6 +2051,9 @@ PgExtensionBaseWorkerSharedMemoryExit(int code, Datum arg)
 
 		if (code == 0)
 		{
+			/* a clean exit is not part of a crash loop, so reset the backoff */
+			workerEntry->failureCount = 0;
+
 			/*
 			 * Clean exit - if needsRestart is already set, the worker
 			 * requested restart via its return value. Otherwise, no restart.
@@ -2069,11 +2091,35 @@ PgExtensionBaseWorkerSharedMemoryExit(int code, Datum arg)
 			}
 
 			/*
+			 * If the worker had been running for a while before it failed,
+			 * treat this as a fresh failure rather than a continuation of a
+			 * crash loop and reset the backoff.  startTime is 0 when the
+			 * worker never reached WORKER_RUNNING (i.e. it failed during
+			 * startup), in which case we keep escalating the delay.
+			 */
+			TimestampTz now = GetCurrentTimestamp();
+
+			if (workerEntry->startTime != 0 &&
+				TimestampDifferenceExceeds(workerEntry->startTime, now,
+										   WorkerRestartHealthyMs))
+				workerEntry->failureCount = 0;
+
+			workerEntry->failureCount++;
+
+			int64		backoffMs = ComputeRestartBackoffMs(workerEntry->failureCount);
+
+			/*
 			 * Also tell the database starter that we want to restart
 			 */
 			workerEntry->needsRestart = true;
 			workerEntry->state = WORKER_RESTARTING;
-			workerEntry->restartAfter = GetDelayedTimestamp(NAP_TIME_AFTER_FAILURE);
+			workerEntry->restartAfter = GetDelayedTimestamp(backoffMs);
+
+			ereport(LOG,
+					(errmsg("base worker %d in database %u failed %d time(s) in "
+							"a row; delaying restart by %ld ms",
+							workerId, databaseId, workerEntry->failureCount,
+							(long) backoffMs)));
 		}
 	}
 	else
@@ -2864,6 +2910,29 @@ GetDelayedTimestamp(int64 millis)
 
 
 /*
+ * ComputeRestartBackoffMs returns the delay in milliseconds before a base
+ * worker that has failed failureCount times in a row should be restarted.
+ *
+ * The delay starts at WorkerRestartBackoffInitialMs on the first failure and
+ * doubles on each subsequent consecutive failure, capped at
+ * WorkerRestartBackoffMaxMs.
+ */
+static int64
+ComputeRestartBackoffMs(int failureCount)
+{
+	int64		backoffMs = WorkerRestartBackoffInitialMs;
+
+	for (int i = 1; i < failureCount && backoffMs < WorkerRestartBackoffMaxMs; i++)
+		backoffMs *= 2;
+
+	if (backoffMs > WorkerRestartBackoffMaxMs)
+		backoffMs = WorkerRestartBackoffMaxMs;
+
+	return backoffMs;
+}
+
+
+/*
  * SignalDatabaseStarterLocked signals the database starter for the given
  * database to wake up, or falls back to signaling the server starter.
  *
@@ -2983,13 +3052,14 @@ pg_extension_base_list_base_workers(PG_FUNCTION_ARGS)
 
 	while ((baseWorkerEntry = (BaseWorkerEntry *) hash_seq_search(&status)) != 0)
 	{
-		bool		nulls[] = {false, false, false, false, false};
+		bool		nulls[] = {false, false, false, false, false, false};
 		Datum		values[] = {
 			ObjectIdGetDatum(baseWorkerEntry->key.databaseId),
 			Int32GetDatum(baseWorkerEntry->key.workerId),
 			ObjectIdGetDatum(baseWorkerEntry->extensionId),
 			Int32GetDatum(baseWorkerEntry->workerPid),
 			BoolGetDatum(baseWorkerEntry->needsRestart),
+			Int32GetDatum(baseWorkerEntry->failureCount),
 		};
 
 		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -1601,6 +1601,16 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 	workerEntry->state = WORKER_STARTING;
 	workerEntry->restartAfter = 0;
 
+	/*
+	 * Clear the last-run start time until the worker actually reaches
+	 * WORKER_RUNNING again.  This keeps the invariant that startTime is 0
+	 * whenever the current launch never reached WORKER_RUNNING, which the
+	 * healthy-uptime reset in PgExtensionBaseWorkerSharedMemoryExit relies on
+	 * to keep escalating the backoff through a startup crash loop rather than
+	 * reading a stale timestamp from an earlier healthy run.
+	 */
+	workerEntry->startTime = 0;
+
 	LWLockRelease(&BaseWorkerControl->lock);
 
 	/*

--- a/pg_extension_base/src/pg_extension_base.c
+++ b/pg_extension_base/src/pg_extension_base.c
@@ -121,6 +121,50 @@ _PG_init(void)
 							NULL,
 							NULL);
 
+	DefineCustomIntVariable("pg_extension_base.worker_restart_backoff_initial",
+							"Sets the delay before restarting a base worker after its "
+							"first failure. The delay doubles on each subsequent "
+							"consecutive failure.",
+							NULL,
+							&WorkerRestartBackoffInitialMs,
+							DEFAULT_WORKER_RESTART_BACKOFF_INITIAL_MS,
+							0,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomIntVariable("pg_extension_base.worker_restart_backoff_max",
+							"Sets the maximum delay before restarting a base worker "
+							"that keeps failing.",
+							NULL,
+							&WorkerRestartBackoffMaxMs,
+							DEFAULT_WORKER_RESTART_BACKOFF_MAX_MS,
+							0,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomIntVariable("pg_extension_base.worker_restart_healthy_time",
+							"Sets how long a base worker must stay up before a later "
+							"failure is treated as fresh, resetting the restart "
+							"backoff to its initial delay.",
+							NULL,
+							&WorkerRestartHealthyMs,
+							DEFAULT_WORKER_RESTART_HEALTHY_MS,
+							0,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
+
 	/*
 	 * Install our ProcessUtility hook for ALTER EXTENSION ... UPDATE
 	 * dependency walking BEFORE preloading other extensions.  Postgres

--- a/pg_extension_base/tests/pg_extension_base_test_hibernate/src/pg_extension_base_hibernate.c
+++ b/pg_extension_base/tests/pg_extension_base_test_hibernate/src/pg_extension_base_hibernate.c
@@ -31,8 +31,6 @@
 #include "pg_extension_base/base_workers.h"
 #include "utils/guc.h"
 
-#define GUC_STANDARD 0
-
 PG_MODULE_MAGIC;
 
 /* function declarations */
@@ -67,7 +65,7 @@ _PG_init(void)
 							-1,
 							INT32_MAX,
 							PGC_SIGHUP,
-							GUC_UNIT_MS | GUC_STANDARD,
+							GUC_UNIT_MS,
 							NULL, NULL, NULL);
 }
 

--- a/pg_extension_base/tests/pg_extension_base_test_hibernate/src/pg_extension_base_hibernate.c
+++ b/pg_extension_base/tests/pg_extension_base_test_hibernate/src/pg_extension_base_hibernate.c
@@ -29,6 +29,9 @@
 #include "miscadmin.h"
 
 #include "pg_extension_base/base_workers.h"
+#include "utils/guc.h"
+
+#define GUC_STANDARD 0
 
 PG_MODULE_MAGIC;
 
@@ -38,6 +41,14 @@ void		_PG_init(void);
 /* UDF implementations */
 PG_FUNCTION_INFO_V1(pg_extension_base_test_hibernate_main_worker);
 
+/*
+ * Fault-injection knob for exercising the base-worker restart backoff.  When
+ * >= 0 the worker runs for this many milliseconds and then errors out, so a
+ * test can drive a crash loop deterministically.  -1 (the default) disables the
+ * fault and the worker hibernates normally.
+ */
+static int	FailAfterMs = -1;
+
 
 /*
  * _PG_init is the entry-point for pg_extension_base_test_hibernate.
@@ -45,7 +56,19 @@ PG_FUNCTION_INFO_V1(pg_extension_base_test_hibernate_main_worker);
 void
 _PG_init(void)
 {
-	/* No GUCs needed for now */
+	DefineCustomIntVariable(
+							"pg_extension_base_test_hibernate.fail_after",
+							gettext_noop("Milliseconds the worker runs before erroring "
+										 "out, or -1 to disable (for testing the "
+										 "restart backoff)."),
+							NULL,
+							&FailAfterMs,
+							-1,
+							-1,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_STANDARD,
+							NULL, NULL, NULL);
 }
 
 
@@ -59,6 +82,21 @@ pg_extension_base_test_hibernate_main_worker(PG_FUNCTION_ARGS)
 	int32		workerId = PG_GETARG_INT32(0);
 
 	elog(LOG, "pg_extension_base_test_hibernate worker %d started", workerId);
+
+	/*
+	 * Fault injection for the restart-backoff tests: optionally run for a
+	 * fixed time and then error out so the worker exits non-cleanly and the
+	 * base-worker framework applies its exponential restart backoff.
+	 */
+	if (FailAfterMs >= 0)
+	{
+		if (FailAfterMs > 0)
+			pg_usleep(FailAfterMs * 1000L);
+
+		elog(ERROR, "pg_extension_base_test_hibernate worker %d failing on "
+			 "purpose (fail_after)", workerId);
+	}
+
 	elog(LOG, "pg_extension_base_test_hibernate worker %d sleeping for 5 seconds", workerId);
 
 	pg_usleep(5000000);

--- a/pg_extension_base/tests/pytests/test_base_worker_launcher.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_launcher.py
@@ -551,6 +551,9 @@ def set_backoff_gucs(conn, initial_ms, max_ms, healthy_ms, fail_after_ms):
     fail_after lives in the hibernate test library, so LOAD it into this
     backend first to make the placeholder known to ALTER SYSTEM.
     """
+    # End any transaction a prior test left open; autocommit can't be toggled
+    # while one is in progress.
+    conn.rollback()
     conn.autocommit = True
     try:
         run_command("LOAD 'pg_extension_base_test_hibernate'", conn)
@@ -576,6 +579,7 @@ def set_backoff_gucs(conn, initial_ms, max_ms, healthy_ms, fail_after_ms):
 
 
 def reset_backoff_gucs(conn):
+    conn.rollback()
     conn.autocommit = True
     try:
         run_command(

--- a/pg_extension_base/tests/pytests/test_base_worker_launcher.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_launcher.py
@@ -524,3 +524,157 @@ def test_hibernate_worker_restart_delay(superuser_conn):
     superuser_conn.commit()
 
     assert count_pg_extension_base_workers(superuser_conn) == 0
+
+
+def hibernate_worker_failure_count(conn):
+    """
+    Return the restart-backoff failure count for the hibernate test worker, or
+    None if it is not currently registered.
+    """
+    rows = run_query(
+        """
+        SELECT w.failure_count
+        FROM extension_base.list_base_workers() w
+        JOIN pg_extension e ON e.oid = w.extension_id
+        WHERE e.extname = 'pg_extension_base_test_hibernate'
+        """,
+        conn,
+    )
+    return rows[0]["failure_count"] if rows else None
+
+
+def set_backoff_gucs(conn, initial_ms, max_ms, healthy_ms, fail_after_ms):
+    """
+    Configure the restart-backoff GUCs and the hibernate worker's fault
+    injection, then reload so freshly (re)started workers pick them up.
+
+    fail_after lives in the hibernate test library, so LOAD it into this
+    backend first to make the placeholder known to ALTER SYSTEM.
+    """
+    conn.autocommit = True
+    try:
+        run_command("LOAD 'pg_extension_base_test_hibernate'", conn)
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base.worker_restart_backoff_initial = '{initial_ms}ms'",
+            conn,
+        )
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base.worker_restart_backoff_max = '{max_ms}ms'",
+            conn,
+        )
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base.worker_restart_healthy_time = '{healthy_ms}ms'",
+            conn,
+        )
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base_test_hibernate.fail_after = '{fail_after_ms}ms'",
+            conn,
+        )
+        run_command("SELECT pg_reload_conf()", conn)
+    finally:
+        conn.autocommit = False
+
+
+def reset_backoff_gucs(conn):
+    conn.autocommit = True
+    try:
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base.worker_restart_backoff_initial", conn
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base.worker_restart_backoff_max", conn
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base.worker_restart_healthy_time", conn
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base_test_hibernate.fail_after", conn
+        )
+        run_command("SELECT pg_reload_conf()", conn)
+    finally:
+        conn.autocommit = False
+
+
+def test_worker_restart_backoff_escalates(superuser_conn):
+    """
+    A worker that keeps failing at startup should have its failure count climb
+    while the exponential backoff throttles the restart rate.
+
+    fail_after=0 makes the worker error out immediately (so it never stays up
+    long enough to be considered healthy), and healthy_time is large so the
+    failure counter is never reset.
+    """
+    set_backoff_gucs(
+        superuser_conn, initial_ms=100, max_ms=400, healthy_ms=30000, fail_after_ms=0
+    )
+
+    run_command(
+        "CREATE EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+    )
+    superuser_conn.commit()
+
+    try:
+        # Poll for up to ~5s until the failure count escalates.
+        counts = []
+        for _ in range(20):
+            time.sleep(0.25)
+            fc = hibernate_worker_failure_count(superuser_conn)
+            if fc is not None:
+                counts.append(fc)
+            if counts and counts[-1] >= 3:
+                break
+
+        assert counts, "hibernate worker was never registered"
+
+        # The counter escalated, proving repeated failures are being tracked.
+        assert max(counts) >= 3, f"failure count did not escalate: {counts}"
+
+        # With a >=100ms backoff that doubles up to 400ms, the worker restarts a
+        # handful of times per second at most. Without any delay it would crash
+        # loop hundreds of times in the same window, so a modest ceiling proves
+        # the restart is actually being throttled.
+        assert max(counts) < 100, f"restarts were not throttled: {counts}"
+    finally:
+        run_command(
+            "DROP EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+        )
+        superuser_conn.commit()
+        reset_backoff_gucs(superuser_conn)
+
+
+def test_worker_restart_backoff_resets_after_healthy_uptime(superuser_conn):
+    """
+    A worker that stays up longer than the healthy threshold before failing
+    should not accumulate backoff: each failure is treated as fresh, so the
+    failure count never climbs past 1.
+    """
+    # fail_after (600ms) > healthy_time (300ms): every run is "healthy".
+    set_backoff_gucs(
+        superuser_conn, initial_ms=100, max_ms=400, healthy_ms=300, fail_after_ms=600
+    )
+
+    run_command(
+        "CREATE EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+    )
+    superuser_conn.commit()
+
+    try:
+        counts = []
+        for _ in range(12):  # ~4.8s, several fail/restart cycles
+            time.sleep(0.4)
+            fc = hibernate_worker_failure_count(superuser_conn)
+            if fc is not None:
+                counts.append(fc)
+
+        assert counts, "hibernate worker was never registered"
+
+        # We should have observed at least one failure (count reaching 1) but it
+        # must never escalate, because the healthy-uptime reset fires each time.
+        assert max(counts) <= 1, f"backoff did not reset after healthy uptime: {counts}"
+        assert 1 in counts, f"worker never failed as expected: {counts}"
+    finally:
+        run_command(
+            "DROP EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+        )
+        superuser_conn.commit()
+        reset_backoff_gucs(superuser_conn)


### PR DESCRIPTION
## Problem

When a base worker fails, the database starter relaunches it after a fixed delay. If the failure is persistent, this turns into a tight crash loop that repeatedly redoes the worker's start-up work. Workers that do significant work right after start-up pay that cost on every restart.

## Solution

Grow the post-failure restart delay exponentially with the number of consecutive failures: an initial delay, doubling on each subsequent failure, capped at a maximum. The consecutive-failure counter resets once a worker has stayed up longer than a configurable healthy threshold, so a worker that runs fine and later hits a transient error backs off from the initial delay again rather than inheriting a stale, long delay. A clean exit also resets the counter.

Three new GUCs control the behaviour (all `PGC_SIGHUP`):

- `pg_extension_base.worker_restart_backoff_initial` (default 5s)
- `pg_extension_base.worker_restart_backoff_max` (default 60s)
- `pg_extension_base.worker_restart_healthy_time` (default 60s)

The defaults preserve the previous fixed 5s first-failure delay. The consecutive-failure count is added to `extension_base.list_base_workers()` for observability (extension bumped to 3.5).

## Test plan

- Added a fault-injection GUC to the hibernate test extension to drive a deterministic crash loop.
- Two new pytests in `test_base_worker_launcher.py`: one asserts the failure count escalates while the restart rate stays throttled; the other asserts the count never climbs past 1 when the worker stays up past the healthy threshold before failing.
- Verified end to end on a local PostgreSQL 18 cluster: the failure count escalates under a tight crash loop, stays at 1 when each run exceeds the healthy threshold, and returns to 0 once the worker recovers.
- `pgindent` and `black` checks pass on the changed files.