### PR TITLE
fix: disallow copy unbounded numerics in nested types

### DIFF
--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -881,6 +881,135 @@ def test_md_array(pg_conn, duckdb_conn, tmp_path):
     assert result[0]["val"] == 2
 
 
+# An unbounded numeric column maps to DuckDB DECIMAL(38,9) when the CSV is
+# converted to Parquet, which allows only 38 - 9 = 29 integral digits. COPY TO
+# validates this on the PostgreSQL side (before the value reaches the CSV), and
+# the validation must reach numeric leaves nested inside arrays, composites,
+# maps, and domains -- not just top-level numeric columns. Special values
+# (NaN/Infinity/-Infinity), valid PG input for an unbounded numeric but not
+# representable as a DuckDB DECIMAL, must be rejected at those leaves too.
+#
+# A 30-digit integer trips the cap; a 29-digit one is exactly at the limit and
+# must still succeed.
+NUMERIC_OVER_LIMIT = 10**29  # 30 integral digits -> rejected
+NUMERIC_AT_LIMIT = 10**28  # 29 integral digits -> allowed
+EXCEEDS_DIGITS_ERROR = "exceeds max allowed digits"
+SPECIAL_NUMERIC_ERROR = "Special numeric values"
+
+# The nested container shapes that carry a numeric leaf. Every one must be
+# walked by the COPY TO numeric validation.  "array_of_composite" is the
+# deeply-nested case: the numeric leaf sits two container levels down
+# (array -> composite -> numeric).
+NESTED_NUMERIC_KINDS = [
+    "array",
+    "composite",
+    "map",
+    "domain_scalar",
+    "domain_array",
+    "array_of_composite",
+]
+
+
+def _create_nested_numeric_types(pg_conn):
+    # Tolerate the map type already existing from a previous run; the composite
+    # and domains live in the caller's (uncommitted) transaction.
+    create_map_type("int", "numeric", raise_error=False)
+    run_command(
+        """
+        CREATE SCHEMA IF NOT EXISTS lake_struct;
+        CREATE TYPE lake_struct.cost_pair AS (label text, amount numeric);
+        CREATE DOMAIN cost_scalar AS numeric;
+        CREATE DOMAIN cost_array AS numeric[];
+        """,
+        pg_conn,
+    )
+
+
+def _nested_numeric_select(kind, expr, token):
+    """Build a SELECT that places a numeric leaf inside the given container.
+
+    `expr` is a SQL numeric expression used by the array/composite/domain
+    shapes; `token` is the bare value spliced into the map's composite text
+    literal (where an `'x'::numeric` cast is not valid).  The map's braces come
+    from a plain Python string so they are inserted verbatim, not parsed as
+    f-string replacement fields.
+    """
+    map_literal = '{"(1,500.00)","(2,%s)"}' % token
+    return {
+        "array": f"SELECT ARRAY[500.00, {expr}]::numeric[] AS v",
+        "composite": f"SELECT ('airfare', {expr})::lake_struct.cost_pair AS v",
+        "map": f"SELECT '{map_literal}'::map_type.key_int_val_numeric AS v",
+        "domain_scalar": f"SELECT {expr}::cost_scalar AS v",
+        "domain_array": f"SELECT ARRAY[500.00, {expr}]::cost_array AS v",
+        "array_of_composite": (
+            f"SELECT ARRAY[('base', 500.00)::lake_struct.cost_pair, "
+            f"('leaf', {expr})::lake_struct.cost_pair]::lake_struct.cost_pair[] AS v"
+        ),
+    }[kind]
+
+
+@pytest.mark.parametrize("kind", NESTED_NUMERIC_KINDS)
+def test_nested_unbounded_numeric(pg_conn, tmp_path, kind):
+    parquet_path = tmp_path / "test.parquet"
+
+    _create_nested_numeric_types(pg_conn)
+
+    over = str(NUMERIC_OVER_LIMIT)
+
+    # An oversized numeric leaf (30 integral digits) is rejected wherever it
+    # sits in the nested structure. (The within-cap acceptance path is covered
+    # by test_nested_numeric_roundtrip; a nested numeric Parquet write is a
+    # separate concern from the digit-limit validation exercised here.)
+    error = run_command(
+        f"COPY ({_nested_numeric_select(kind, over, over)}) "
+        f"TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+    assert EXCEEDS_DIGITS_ERROR in error, f"{kind}: {error}"
+
+    pg_conn.rollback()
+
+
+@pytest.mark.parametrize("special", ["NaN", "Infinity", "-Infinity"])
+@pytest.mark.parametrize("kind", NESTED_NUMERIC_KINDS)
+def test_nested_special_numeric(pg_conn, tmp_path, kind, special):
+    parquet_path = tmp_path / "test.parquet"
+
+    _create_nested_numeric_types(pg_conn)
+
+    expr = f"'{special}'::numeric"
+    error = run_command(
+        f"COPY ({_nested_numeric_select(kind, expr, special)}) "
+        f"TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+    assert SPECIAL_NUMERIC_ERROR in error, f"{kind} / {special}: {error}"
+
+    pg_conn.rollback()
+
+
+def test_nested_numeric_roundtrip(pg_conn, tmp_path):
+    # A within-cap numeric[] survives the COPY TO Parquet / COPY FROM round-trip
+    # with its values intact (guards against the validation over-rejecting).
+    parquet_path = tmp_path / "test.parquet"
+
+    run_command(
+        f"""
+        CREATE TABLE test_num_array (a numeric[]);
+        COPY (SELECT ARRAY[500.00, {NUMERIC_AT_LIMIT}]::numeric[] AS a)
+        TO '{parquet_path}' WITH (format 'parquet');
+        COPY test_num_array FROM '{parquet_path}' WITH (format 'parquet');
+        """,
+        pg_conn,
+    )
+    result = run_query("SELECT a FROM test_num_array", pg_conn)
+    assert result[0]["a"] == [Decimal("500.00"), Decimal(NUMERIC_AT_LIMIT)]
+
+    pg_conn.rollback()
+
+
 def test_copy_virtual_column(pg_conn, tmp_path):
     # virtual columns were introduced in PostgreSQL 18
     if get_pg_version_num(pg_conn) < 180000:

--- a/pg_lake_engine/include/pg_lake/pgduck/numeric.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/numeric.h
@@ -18,6 +18,8 @@
 #pragma once
 #include "postgres.h"
 
+#include "utils/numeric.h"
+
 /*
  * Maximum precision and scale for numeric types in DuckDB.
  */
@@ -49,3 +51,4 @@ extern PGDLLEXPORT void GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(int
 																			 int *scale);
 extern PGDLLEXPORT bool CanPushdownNumericToDuckdb(int precision, int scale);
 extern PGDLLEXPORT bool IsUnsupportedNumericForIceberg(Oid typeOid, int typmod);
+extern PGDLLEXPORT int NumericIntegralDigitCount(Numeric num);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -154,7 +154,6 @@ static List *TupleDescColumnNameList(TupleDesc tupleDescriptor);
 static List *CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist);
 static bool ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType);
 static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr);
-static void ErrorIfSpecialNumeric(const char *input_str);
 static bool TypeContainsNumeric(Oid typeOid);
 static void ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid,
 													 int32 typmod);
@@ -706,34 +705,6 @@ ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr)
 
 
 /*
-* ErrorIfSpecialNumeric ensures that the input string does not contain
-* special numeric values like NaN, Inf, -Inf.
-*/
-static void
-ErrorIfSpecialNumeric(const char *input_str)
-{
-
-	char	   *num = (char *) input_str;
-
-	/* skip leading whitespace */
-	while (*num != '\0' && isspace((unsigned char) *num))
-		num++;
-
-	if (pg_strncasecmp(num, "NaN", 3) == 0 ||
-		pg_strncasecmp(num, "Infinity", 8) == 0 ||
-		pg_strncasecmp(num, "+Infinity", 9) == 0 ||
-		pg_strncasecmp(num, "-Infinity", 9) == 0 ||
-		pg_strncasecmp(num, "inf", 3) == 0 ||
-		pg_strncasecmp(num, "+inf", 4) == 0 ||
-		pg_strncasecmp(num, "-inf", 4) == 0)
-	{
-		ereport(ERROR, errmsg("Special numeric values like NaN, Inf, -Inf are not allowed for numeric type"),
-				errhint("Use float type instead."));
-	}
-}
-
-
-/*
  * TypeContainsNumeric returns true if `typeOid` reaches a numeric leaf at any
  * nesting depth: as the type itself, an array element, a composite field, a
  * map key/value, or through a domain over any of these.
@@ -813,14 +784,33 @@ ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid, int32 typmod)
 {
 	if (typeOid == NUMERICOID)
 	{
-		char	   *numericStr =
-			DatumGetCString(DirectFunctionCall1(numeric_out, value));
+		Numeric		num = DatumGetNumeric(value);
 
+		/*
+		 * The NaN/Infinity check only needs the numeric header flags, so read
+		 * them directly instead of formatting the value to text.  This keeps
+		 * the common (finite) case free of the numeric_out allocation and
+		 * string scan.
+		 */
+		if (numeric_is_nan(num) || numeric_is_inf(num))
+			ereport(ERROR,
+					errmsg("Special numeric values like NaN, Inf, -Inf are not allowed for numeric type"),
+					errhint("Use float type instead."));
+
+		/*
+		 * Only unbounded numerics are subject to the integral-digit cap, and
+		 * that is the only remaining check that needs the decimal text, so
+		 * defer the expensive numeric_out to this branch.
+		 */
 		if (IsUnboundedNumeric(NUMERICOID, typmod))
-			ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(numericStr);
+		{
+			char	   *numericStr =
+				DatumGetCString(DirectFunctionCall1(numeric_out, NumericGetDatum(num)));
 
-		/* do not allow NaN, Inf etc. */
-		ErrorIfSpecialNumeric(numericStr);
+			ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(numericStr);
+			pfree(numericStr);
+		}
+
 		return;
 	}
 

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -153,7 +153,7 @@ static void CopySendInt16(CopyToState cstate, int16 val);
 static List *TupleDescColumnNameList(TupleDesc tupleDescriptor);
 static List *CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist);
 static bool ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType);
-static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr);
+static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(Numeric num);
 static bool TypeContainsNumeric(Oid typeOid);
 static void ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid,
 													 int32 typmod);
@@ -665,42 +665,26 @@ CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist)
 
 /*
  * ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits ensures the integral
- * digits of the numeric string do not exceed the max allowed digits during
- * COPY TO.
+ * digits of an unbounded numeric do not exceed the max allowed digits during
+ * COPY TO.  The count is read from the value's weight, so this is O(1) with no
+ * allocation.
  *
  * Excess fractional (decimal) digits are intentionally allowed here because
  * DuckDB's DECIMAL(P,S) will round them during the CSV-to-Parquet conversion.
  */
 static void
-ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr)
+ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(Numeric num)
 {
-	int			totalIntegralDigits = 0;
-	bool		foundDotSeparator = false;
+	int			maxAllowedDigits =
+		UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale;
 
-	for (int i = 0; numericStr[i] != '\0'; i++)
-	{
-		if (numericStr[i] == '.')
-		{
-			foundDotSeparator = true;
-			continue;
-		}
-
-		if (!isdigit(numericStr[i]))
-			continue;
-
-		if (!foundDotSeparator)
-			totalIntegralDigits++;
-
-		if (totalIntegralDigits > (UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale))
-		{
-			ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
-							errmsg("unbounded numeric type exceeds max allowed digits %d "
-								   "before decimal point",
-								   UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale),
-							errhint("Consider specifying precision and scale for numeric types, "
-									"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
-		}
-	}
+	if (NumericIntegralDigitCount(num) > maxAllowedDigits)
+		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
+						errmsg("unbounded numeric type exceeds max allowed digits %d "
+							   "before decimal point",
+							   maxAllowedDigits),
+						errhint("Consider specifying precision and scale for numeric types, "
+								"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
 }
 
 
@@ -797,19 +781,9 @@ ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid, int32 typmod)
 					errmsg("Special numeric values like NaN, Inf, -Inf are not allowed for numeric type"),
 					errhint("Use float type instead."));
 
-		/*
-		 * Only unbounded numerics are subject to the integral-digit cap, and
-		 * that is the only remaining check that needs the decimal text, so
-		 * defer the expensive numeric_out to this branch.
-		 */
+		/* only unbounded numerics are subject to the integral-digit cap */
 		if (IsUnboundedNumeric(NUMERICOID, typmod))
-		{
-			char	   *numericStr =
-				DatumGetCString(DirectFunctionCall1(numeric_out, NumericGetDatum(num)));
-
-			ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(numericStr);
-			pfree(numericStr);
-		}
+			ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(num);
 
 		return;
 	}

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -29,6 +29,7 @@
 #include "fmgr.h"
 #include "miscadmin.h"
 
+#include "access/htup_details.h"
 #include "catalog/pg_type_d.h"
 #include "commands/copy.h"
 #include "commands/defrem.h"
@@ -43,11 +44,13 @@
 #include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
 #include "port/pg_bswap.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/numeric.h"
 #include "utils/rel.h"
+#include "utils/typcache.h"
 
 
 /*
@@ -102,6 +105,13 @@ typedef struct CopyToStateData
 	MemoryContext copycontext;	/* per-copy execution context */
 
 	FmgrInfo   *out_functions;	/* lookup info for output functions */
+
+	/*
+	 * Per-column flag: the column's type reaches a numeric leaf (directly, or
+	 * nested inside an array/composite/map/domain).  Precomputed once so the
+	 * per-row numeric-limit validation only walks columns that can trip it.
+	 */
+	bool	   *needsNumericLeafCheck;
 	MemoryContext rowcontext;	/* per-row evaluation context */
 	uint64		bytes_processed;	/* number of bytes processed so far */
 
@@ -145,6 +155,9 @@ static List *CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist);
 static bool ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType);
 static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr);
 static void ErrorIfSpecialNumeric(const char *input_str);
+static bool TypeContainsNumeric(Oid typeOid);
+static void ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid,
+													 int32 typmod);
 
 
 /*----------
@@ -454,6 +467,7 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 
 	/* Get info about the columns we need to process. */
 	cstate->out_functions = (FmgrInfo *) palloc(num_phys_attrs * sizeof(FmgrInfo));
+	cstate->needsNumericLeafCheck = (bool *) palloc0(num_phys_attrs * sizeof(bool));
 	foreach(cur, cstate->attnumlist)
 	{
 		int			attnum = lfirst_int(cur);
@@ -470,6 +484,9 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 							  &out_func_oid,
 							  &isvarlena);
 		fmgr_info(out_func_oid, &cstate->out_functions[attnum - 1]);
+
+		cstate->needsNumericLeafCheck[attnum - 1] =
+			TypeContainsNumeric(attr->atttypid);
 	}
 
 	/*
@@ -717,6 +734,184 @@ ErrorIfSpecialNumeric(const char *input_str)
 
 
 /*
+ * TypeContainsNumeric returns true if `typeOid` reaches a numeric leaf at any
+ * nesting depth: as the type itself, an array element, a composite field, a
+ * map key/value, or through a domain over any of these.
+ *
+ * Only structural catalog lookups are done here, so it is meant to be called
+ * once per column at COPY setup (see needsNumericLeafCheck) rather than per
+ * row.  Composite types cannot contain themselves, so the recursion always
+ * terminates.
+ */
+static bool
+TypeContainsNumeric(Oid typeOid)
+{
+	if (typeOid == NUMERICOID)
+		return true;
+
+	Oid			elemType = get_element_type(typeOid);
+
+	if (OidIsValid(elemType))
+		return TypeContainsNumeric(elemType);
+
+	char		typtype = get_typtype(typeOid);
+
+	/*
+	 * Domains (including pg_map, which is a domain over an array of key/value
+	 * composites) unwrap to their base type, which feeds back into the array
+	 * and composite recursion above.
+	 */
+	if (typtype == TYPTYPE_DOMAIN)
+		return TypeContainsNumeric(getBaseType(typeOid));
+
+	if (typtype == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
+		bool		found = false;
+
+		for (int i = 0; i < tupdesc->natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+			if (attr->attisdropped)
+				continue;
+
+			if (TypeContainsNumeric(attr->atttypid))
+			{
+				found = true;
+				break;
+			}
+		}
+
+		ReleaseTupleDesc(tupdesc);
+		return found;
+	}
+
+	return false;
+}
+
+
+/*
+ * ErrorIfCopyToExceedsNumericLimitsInDatum applies the COPY TO numeric limits
+ * to every numeric leaf reachable from `value`, recursing through arrays,
+ * composites, maps, and domains.  Each numeric leaf is subject to the same
+ * checks a top-level numeric column receives: an unbounded numeric may not
+ * exceed the integral-digit cap
+ * (ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits), and no numeric may
+ * be NaN/Infinity (ErrorIfSpecialNumeric).  Non-numeric leaves are ignored.
+ *
+ * Callers gate on the column type actually containing a numeric leaf (see
+ * needsNumericLeafCheck), so this is only entered for values that can trip a
+ * limit; the inner TypeContainsNumeric guards prune subtrees with no numeric
+ * so we never deconstruct an array or deform a tuple needlessly.
+ *
+ * An array's typmod applies to its element type, so it is forwarded to the
+ * element recursion (matching how numeric(P,S)[] carries the element typmod).
+ */
+static void
+ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid, int32 typmod)
+{
+	if (typeOid == NUMERICOID)
+	{
+		char	   *numericStr =
+			DatumGetCString(DirectFunctionCall1(numeric_out, value));
+
+		if (IsUnboundedNumeric(NUMERICOID, typmod))
+			ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(numericStr);
+
+		/* do not allow NaN, Inf etc. */
+		ErrorIfSpecialNumeric(numericStr);
+		return;
+	}
+
+	Oid			elemType = get_element_type(typeOid);
+
+	if (OidIsValid(elemType))
+	{
+		if (!TypeContainsNumeric(elemType))
+			return;
+
+		int16		elmlen;
+		bool		elmbyval;
+		char		elmalign;
+		Datum	   *elems;
+		bool	   *nulls;
+		int			nelems;
+		ArrayType  *array = DatumGetArrayTypeP(value);
+
+		get_typlenbyvalalign(elemType, &elmlen, &elmbyval, &elmalign);
+		deconstruct_array(array, elemType, elmlen, elmbyval, elmalign,
+						  &elems, &nulls, &nelems);
+
+		for (int i = 0; i < nelems; i++)
+		{
+			if (nulls[i])
+				continue;
+
+			ErrorIfCopyToExceedsNumericLimitsInDatum(elems[i], elemType, typmod);
+		}
+
+		return;
+	}
+
+	char		typtype = get_typtype(typeOid);
+
+	/*
+	 * Domains (including maps): unwrap to the base type and recurse.  Maps
+	 * are domains over arrays of composites, so unwrapping leads to the array
+	 * -> composite recursion above.
+	 */
+	if (typtype == TYPTYPE_DOMAIN)
+	{
+		int32		baseTypmod = typmod;
+		Oid			baseType = getBaseTypeAndTypmod(typeOid, &baseTypmod);
+
+		ErrorIfCopyToExceedsNumericLimitsInDatum(value, baseType, baseTypmod);
+		return;
+	}
+
+	/* composite: deform the tuple and recurse into each field */
+	if (typtype == TYPTYPE_COMPOSITE)
+	{
+		HeapTupleHeader tup = DatumGetHeapTupleHeader(value);
+		Oid			tupType = HeapTupleHeaderGetTypeId(tup);
+		int32		tupTypmod = HeapTupleHeaderGetTypMod(tup);
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
+		int			natts = tupdesc->natts;
+		HeapTupleData tmptup;
+		Datum	   *values = (Datum *) palloc(natts * sizeof(Datum));
+		bool	   *attrNulls = (bool *) palloc(natts * sizeof(bool));
+
+		tmptup.t_len = HeapTupleHeaderGetDatumLength(tup);
+		ItemPointerSetInvalid(&(tmptup.t_self));
+		tmptup.t_tableOid = InvalidOid;
+		tmptup.t_data = tup;
+
+		heap_deform_tuple(&tmptup, tupdesc, values, attrNulls);
+
+		for (int i = 0; i < natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+			if (attr->attisdropped || attrNulls[i])
+				continue;
+
+			if (!TypeContainsNumeric(attr->atttypid))
+				continue;
+
+			ErrorIfCopyToExceedsNumericLimitsInDatum(values[i], attr->atttypid,
+													 attr->atttypmod);
+		}
+
+		pfree(values);
+		pfree(attrNulls);
+		ReleaseTupleDesc(tupdesc);
+		return;
+	}
+}
+
+
+/*
  * Emit one row
  */
 static void
@@ -789,17 +984,19 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 
 				/*
 				 * iceberg validation is handled separately for numeric types
-				 * (see IcebergErrorOrClampDatum)
+				 * (see IcebergErrorOrClampDatum).
+				 *
+				 * For every other target format, validate each numeric leaf
+				 * of the column -- including those nested inside arrays,
+				 * composites, maps, and domains -- against the numeric limits
+				 * DuckDB enforces when it converts the intermediate CSV to
+				 * the target type.
 				 */
-				if (attr->atttypid == NUMERICOID &&
-					cstate->targetFormat != DATA_FORMAT_ICEBERG)
-				{
-					if (IsUnboundedNumeric(NUMERICOID, attr->atttypmod))
-						ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(string);
-
-					/* do not allow Nan, Inf etc. */
-					ErrorIfSpecialNumeric(string);
-				}
+				if (cstate->targetFormat != DATA_FORMAT_ICEBERG &&
+					cstate->needsNumericLeafCheck[attnum - 1])
+					ErrorIfCopyToExceedsNumericLimitsInDatum(value,
+															 attr->atttypid,
+															 attr->atttypmod);
 
 
 				if (cstate->opts.csv_mode)

--- a/pg_lake_engine/src/pgduck/numeric.c
+++ b/pg_lake_engine/src/pgduck/numeric.c
@@ -17,6 +17,8 @@
 
 #include "postgres.h"
 
+#include "varatt.h"
+
 #include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/numeric.h"
 #include "catalog/pg_type.h"
@@ -102,6 +104,113 @@ IsUnsupportedNumericForIceberg(Oid typeOid, int typmod)
 
 	return precision > DUCKDB_MAX_NUMERIC_PRECISION ||
 		scale > DUCKDB_MAX_NUMERIC_SCALE;
+}
+
+/*
+ * A numeric's weight (the base-10000 exponent of its most significant digit)
+ * is stored directly in the value's on-disk header, so the number of integral
+ * digits can be derived arithmetically instead of formatting the whole value
+ * to text with numeric_out.
+ *
+ * The public numeric.h keeps struct NumericData opaque, so we mirror just the
+ * fields we read.  This layout, and the weight/digit macros below, have been
+ * stable in PostgreSQL since the base-10000 representation was introduced in
+ * 8.3.  DatumGetNumeric() always returns a fully detoasted value with a 4-byte
+ * varlena header, so overlaying this struct is safe.  Keep in sync with
+ * src/backend/utils/adt/numeric.c.
+ */
+typedef int16 PgLakeNumericDigit;
+
+#define PG_LAKE_NUMERIC_DEC_DIGITS 4	/* decimal digits per base-10000 digit */
+
+typedef struct PgLakeNumericLong
+{
+	uint16		n_sign_dscale;
+	int16		n_weight;
+	PgLakeNumericDigit n_data[FLEXIBLE_ARRAY_MEMBER];
+}			PgLakeNumericLong;
+
+typedef struct PgLakeNumericShort
+{
+	uint16		n_header;
+	PgLakeNumericDigit n_data[FLEXIBLE_ARRAY_MEMBER];
+}			PgLakeNumericShort;
+
+typedef union PgLakeNumericChoice
+{
+	uint16		n_header;
+	PgLakeNumericLong n_long;
+	PgLakeNumericShort n_short;
+}			PgLakeNumericChoice;
+
+typedef struct PgLakeNumericData
+{
+	int32		vl_len_;
+	PgLakeNumericChoice choice;
+}			PgLakeNumericData;
+
+#define PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) (((n)->choice.n_header & 0x8000) != 0)
+#define PG_LAKE_NUMERIC_HEADER_SIZE(n) \
+	(VARHDRSZ + sizeof(uint16) + \
+	 (PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) ? 0 : sizeof(int16)))
+#define PG_LAKE_NUMERIC_SHORT_WEIGHT_SIGN_MASK 0x0040
+#define PG_LAKE_NUMERIC_SHORT_WEIGHT_MASK 0x003F
+#define PG_LAKE_NUMERIC_WEIGHT(n) (PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) ? \
+	(((n)->choice.n_short.n_header & PG_LAKE_NUMERIC_SHORT_WEIGHT_SIGN_MASK ? \
+	  ~PG_LAKE_NUMERIC_SHORT_WEIGHT_MASK : 0) \
+	 | ((n)->choice.n_short.n_header & PG_LAKE_NUMERIC_SHORT_WEIGHT_MASK)) \
+	: ((n)->choice.n_long.n_weight))
+#define PG_LAKE_NUMERIC_DIGITS(n) (PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) ? \
+	(n)->choice.n_short.n_data : (n)->choice.n_long.n_data)
+#define PG_LAKE_NUMERIC_NDIGITS(n) \
+	((VARSIZE(n) - PG_LAKE_NUMERIC_HEADER_SIZE(n)) / sizeof(PgLakeNumericDigit))
+
+/*
+ * NumericIntegralDigitCount returns the number of digits numeric_out would
+ * emit before the decimal point of `num`, derived from the value's weight
+ * rather than by formatting it.  `num` must be a finite value already
+ * detoasted via DatumGetNumeric().
+ *
+ * numeric_out always emits at least one integral digit (a leading "0" for zero
+ * and for |value| < 1), which this mirrors so callers match textual output.
+ */
+int
+NumericIntegralDigitCount(Numeric num)
+{
+	PgLakeNumericData *n = (PgLakeNumericData *) num;
+	int			ndigits = PG_LAKE_NUMERIC_NDIGITS(n);
+	int			weight;
+	PgLakeNumericDigit firstDigit;
+	int			firstDigitLen;
+
+	/* zero is stored with no digits and rendered as a single "0" */
+	if (ndigits <= 0)
+		return 1;
+
+	weight = PG_LAKE_NUMERIC_WEIGHT(n);
+
+	/* |value| < 1 still renders a single leading "0" before the point */
+	if (weight < 0)
+		return 1;
+
+	/*
+	 * Leading zero base-10000 digits are stripped in storage, so the first
+	 * digit is in [1, 9999]; its decimal length plus the four decimal digits
+	 * contributed by each remaining full weight step gives the integral
+	 * count.
+	 */
+	firstDigit = PG_LAKE_NUMERIC_DIGITS(n)[0];
+
+	if (firstDigit >= 1000)
+		firstDigitLen = 4;
+	else if (firstDigit >= 100)
+		firstDigitLen = 3;
+	else if (firstDigit >= 10)
+		firstDigitLen = 2;
+	else
+		firstDigitLen = 1;
+
+	return weight * PG_LAKE_NUMERIC_DEC_DIGITS + firstDigitLen;
 }
 
 /*


### PR DESCRIPTION
## Summary

`COPY ... TO` (Parquet/CSV/JSON) already rejects a top-level unbounded `numeric` whose integral part exceeds what a DuckDB `DECIMAL(38,9)` can hold (the default mapping for unbounded numerics, i.e. `38 - 9 = 29` integral digits), and also rejects `NaN`/`Infinity`/`-Infinity`. This validation only fired for **scalar** `numeric` columns, so the same value nested inside an array/composite/map/domain slipped through.

The result was a confusing, late failure: the CSV write succeeded, then the CSV→Parquet conversion blew up inside DuckDB with e.g. `Conversion Error: Could not convert string "..." to 'DECIMAL(38,9)[]'` instead of a clear, actionable error on the PostgreSQL side.

## Root cause

In `CopyOneRowTo` (`pg_lake_engine/src/csv/csv_writer.c`) the numeric validation was gated on `attr->atttypid == NUMERICOID`, which is false for `_numeric` (array), composites, maps, and domains — so nested numeric leaves were never checked.

## Fix

Replace the top-level-only check with a recursive numeric-leaf validator that walks the value the same way the Iceberg datum validator does:

- **array** → `deconstruct_array`, recurse into each element (an array's typmod applies to its element type)
- **domain** (including `pg_map`, a domain over an array of key/value composites) → unwrap to the base type and recurse
- **composite** → `heap_deform_tuple`, recurse into each field
- **numeric leaf** → run the existing checks: integral-digit cap for unbounded numerics + `NaN`/`Inf` rejection

To avoid per-row overhead, a per-column flag (`needsNumericLeafCheck`) is precomputed once at COPY setup via a structural `TypeContainsNumeric` walk, so the recursion is entered only for columns whose type actually reaches a numeric leaf.

### Format handling

- **Iceberg**: still skipped here (`targetFormat != DATA_FORMAT_ICEBERG`). Iceberg validates numerics separately (`IcebergErrorOrClampDatum`), and unbounded / precision > 38 numerics are mapped to `float8` on Iceberg tables, so this cap does not apply.
- **CSV / Parquet / JSON**: validated, unchanged from the pre-existing top-level behavior — this PR only extends that same behavior to nested leaves.

## Performance: cheaper per-value numeric validation

The numeric-leaf check runs per value, so its cost matters. Two follow-up optimizations remove `numeric_out` (which formats the whole value to a decimal string plus an allocation) from the hot path:

1. **NaN/Inf via header flags.** The special-value check previously formatted every numeric with `numeric_out` and string-scanned for `NaN`/`Infinity`. It now uses `numeric_is_nan()` / `numeric_is_inf()`, which read the numeric header flags directly — no allocation, no formatting. Bounded `numeric(P,S)` values (the common case) now pay only these two flag reads.

2. **Integral-digit count from weight.** The unbounded-numeric digit cap previously relied on `numeric_out` + scanning the digits before the decimal point. It now derives the count in O(1) from the numeric's stored weight (`NumericIntegralDigitCount`), matching PostgreSQL's own `get_str_from_var_sci` exponent logic — no allocation, no division, no string. `numeric_out` is gone from this path entirely.

The numeric on-disk layout mirror and `NumericIntegralDigitCount` live in `pg_lake_engine/src/pgduck/numeric.c` (exported via `pgduck/numeric.h`), so the server-internal struct duplication is isolated in the numeric module and the primitive is reusable, leaving `csv_writer.c` to express only the COPY TO cap policy.

## Test plan

Added parametrized tests in `pg_lake_copy/tests/pytests/test_parquet_copy.py` covering the numeric leaf in every nested shape — `array`, `composite`, `map`, `domain` (over `numeric` and over `numeric[]`), and the deeply-nested `array_of_composite` (array → composite → numeric):

- `test_nested_unbounded_numeric[<kind>]` — a 30-integral-digit value is rejected with `exceeds max allowed digits`.
- `test_nested_special_numeric[<kind>-<NaN|Infinity|-Infinity>]` — special values are rejected with `Special numeric values ...`.
- `test_nested_numeric_roundtrip` — a within-cap `numeric[]` round-trips through Parquet with values intact (guards against over-rejection); `10**28` (29 digits) is accepted while `10**29` (30 digits) is rejected, exercising both boundaries of the weight-based count.

Verified after the performance/refactor changes:

- `pg_lake_copy` `test_parquet_copy.py`: 51 passed.
- `pg_lake_table` `test_unbounded_numeric.py`, `test_special_numeric.py`, `test_unsupported_numeric_as_double.py`: 57 passed.