### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners for pg_lake
+#
+# Order matters: the last matching pattern for a changed file wins.
+# Listed owners are automatically requested for review on any PR that
+# touches a matching path. See:
+# https://docs.github.com/articles/about-code-owners
+#
+# The pg_lake extensions and pgduck_server are maintained by one team
+# that works across all components, so a single default owner covers the
+# whole tree. Add more specific patterns below only if a subtree grows a
+# distinct set of maintainers.
+
+# Default owners for everything in the repo.
+*       @sfc-gh-mslot @sfc-gh-okalaci @sfc-gh-abozkurt @sfc-gh-npuka @sfc-gh-dachristensen @sfc-gh-amzheng

--- a/.github/repo_meta.yaml
+++ b/.github/repo_meta.yaml
@@ -6,6 +6,6 @@ legal_exception: false
 release_branches:
   - main
   - release.*
-code_owners_file_present: false
+code_owners_file_present: true
 jira_project_issue_type: Bug
 jira_area: Bug


### PR DESCRIPTION
## Problem

The repo has no CODEOWNERS file, so PRs do not automatically request review from the maintainers and `code_owners_file_present` in `repo_meta.yaml` was set to `false`.

## Solution

Add `.github/CODEOWNERS` with a single default owner rule covering the whole tree. The pg_lake extensions and pgduck_server are all maintained by the same group, and history shows the same people working across every component, so per-directory rules would just repeat one owner set. If a subtree later grows its own maintainers, a more specific pattern can be added below the default line.

Owners are listed as individual handles rather than a team because a `@Snowflake-Labs/postgres-extensions` team reference does not currently resolve (the team is not publicly visible with write access on this repo). Once such a team is made publicly visible with write access, the list can be collapsed to a single team line.

Also flip `code_owners_file_present` to `true` in `repo_meta.yaml`.

## Test plan

Validated against the GitHub CODEOWNERS checker on the pushed branch:

    # gh api repos/Snowflake-Labs/pg_lake/codeowners/errors?ref=pgguru/codeowners
    {"errors":[]}