### PR TITLE
Fix memory leaks during Iceberg manifest processing

### DIFF
--- a/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
+++ b/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
@@ -482,7 +482,7 @@ IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot * snapshot, HTAB *fileHash)
 		{
 			DataFile   *dataFile = lfirst(dataFileCell);
 
-			AppendFileToHash(MemoryContextStrdup(oldContext, dataFile->file_path), fileHash);
+			AppendFileToHash(dataFile->file_path, fileHash);
 		}
 
 		MemoryContextSwitchTo(oldContext);

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -96,6 +96,8 @@ ReadIcebergManifests(const char *manifestListPath)
 
 	int			writtenLength = FileWrite(manifestListLocalFile, manifestListBlob, contentLength, 0, WAIT_EVENT_COPY_FILE_WRITE);
 
+	pfree(manifestListBlob);
+
 	if (writtenLength != contentLength)
 	{
 		ereport(ERROR,
@@ -141,6 +143,8 @@ ReadManifestEntries(const char *manifestPath)
 	const char *manifestLocalPath = FilePathName(manifestLocalFile);
 
 	int			writtenLength = FileWrite(manifestLocalFile, manifestBlob, contentLength, 0, WAIT_EVENT_COPY_FILE_WRITE);
+
+	pfree(manifestBlob);
 
 	if (writtenLength != contentLength)
 	{


### PR DESCRIPTION
## Description

Avoid retaining redundant copies of every data-file path while scanning manifests during Iceberg snapshot reference discovery. `AppendFileToHash` uses a `HASH_STRINGS` table and copies the key synchronously, so copying each path into `CurTransactionContext` first unnecessarily retains memory for every file occurrence across retained snapshots.

Also free the blobs returned by `GetBlobFromURI` after `FileWrite` in `ReadIcebergManifests` and `ReadManifestEntries`, since ownership belongs to the caller.

Fixes Snowflake-Labs/pg_lake#451

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**
