### PR TITLE
Add pushdown support for uuidv7 and uuid_extract functions

### DIFF
--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -150,6 +150,100 @@ inline void InitcapPG(DataChunk &args, ExpressionState &state, Vector &result)
 
 
 /*
+ * GetRawUuidUpper returns the first 8 bytes of a UUID as a big-endian
+ * integer.  DuckDB stores UUIDs as hugeint with the most significant bit
+ * flipped to preserve sort order, so flip it back.
+ */
+static inline uint64_t GetRawUuidUpper(hugeint_t value)
+{
+	return static_cast<uint64_t>(value.upper) ^ (uint64_t(1) << 63);
+}
+
+
+/*
+ * IsRfc9562Variant reports whether the UUID has the RFC 9562 variant, which
+ * Postgres requires before extracting any field.  The variant bits are the
+ * top two bits of byte 8, the first byte of the lower half.
+ */
+static inline bool IsRfc9562Variant(hugeint_t value)
+{
+	return ((value.lower >> 56) & 0xC0) == 0x80;
+}
+
+
+/*
+ * UuidExtractVersionPG implements Postgres' uuid_extract_version(uuid):
+ * the version nibble for RFC 9562 variant UUIDs, NULL otherwise.  DuckDB's
+ * built-in uuid_extract_version skips the variant check, so for example a
+ * nil UUID yields 0 instead of NULL.
+ */
+inline void UuidExtractVersionPG(DataChunk &args, ExpressionState &state, Vector &result)
+{
+	auto &input_vector = args.data[0];
+
+	UnaryExecutor::ExecuteWithNulls<hugeint_t, int16_t>(
+		input_vector, result, args.size(),
+		[&](hugeint_t value, ValidityMask &mask, idx_t idx) -> int16_t {
+			if (!IsRfc9562Variant(value)) {
+				mask.SetInvalid(idx);
+				return 0;
+			}
+
+			return static_cast<int16_t>((GetRawUuidUpper(value) >> 12) & 0x0F);
+		});
+}
+
+
+/*
+ * UuidExtractTimestampPG implements Postgres' uuid_extract_timestamp(uuid):
+ * a timestamp for version 1 and version 7 RFC 9562 UUIDs, NULL otherwise.
+ * DuckDB's built-in uuid_extract_timestamp errors for any version other
+ * than 7, where Postgres returns the embedded timestamp for version 1 and
+ * NULL for the rest.
+ */
+inline void UuidExtractTimestampPG(DataChunk &args, ExpressionState &state, Vector &result)
+{
+	auto &input_vector = args.data[0];
+
+	/* microseconds between the Gregorian epoch (1582-10-15) and 1970-01-01 */
+	constexpr int64_t GREGORIAN_TO_UNIX_EPOCH_US = 12219292800000000LL;
+
+	UnaryExecutor::ExecuteWithNulls<hugeint_t, timestamp_tz_t>(
+		input_vector, result, args.size(),
+		[&](hugeint_t value, ValidityMask &mask, idx_t idx) -> timestamp_tz_t {
+			if (!IsRfc9562Variant(value)) {
+				mask.SetInvalid(idx);
+				return timestamp_tz_t(0);
+			}
+
+			uint64_t upper = GetRawUuidUpper(value);
+			uint64_t version = (upper >> 12) & 0x0F;
+
+			if (version == 1) {
+				/* 60-bit count of 100-ns intervals since the Gregorian epoch */
+				uint64_t time_low = upper >> 32;
+				uint64_t time_mid = (upper >> 16) & 0xFFFF;
+				uint64_t time_hi = upper & 0x0FFF;
+				uint64_t tms = (time_hi << 48) | (time_mid << 32) | time_low;
+
+				return timestamp_tz_t(static_cast<int64_t>(tms / 10) -
+									  GREGORIAN_TO_UNIX_EPOCH_US);
+			}
+
+			if (version == 7) {
+				/* 48-bit count of milliseconds since the Unix epoch */
+				uint64_t tms = upper >> 16;
+
+				return timestamp_tz_t(static_cast<int64_t>(tms) * 1000);
+			}
+
+			mask.SetInvalid(idx);
+			return timestamp_tz_t(0);
+		});
+}
+
+
+/*
 * Postgres and DuckDB have different behavior for the SUBSTRING function when
 * the length or offset is negative. This function implements the Postgres
 * behavior for the SUBSTRING function.
@@ -664,6 +758,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	auto initcap_function = ScalarFunction("initcap_pg", {LogicalType::VARCHAR}, LogicalType::VARCHAR, InitcapPG);
 	loader.RegisterFunction(initcap_function);
+
+	auto uuid_extract_timestamp_function = ScalarFunction("uuid_extract_timestamp_pg", {LogicalType::UUID}, LogicalType::TIMESTAMP_TZ, UuidExtractTimestampPG);
+	loader.RegisterFunction(uuid_extract_timestamp_function);
+
+	auto uuid_extract_version_function = ScalarFunction("uuid_extract_version_pg", {LogicalType::UUID}, LogicalType::SMALLINT, UuidExtractVersionPG);
+	loader.RegisterFunction(uuid_extract_version_function);
 
 	auto nullify_any_type = ScalarFunction("nullify_any_type", {LogicalType::ANY}, LogicalType::SQLNULL, NullifyAnyType);
 	loader.RegisterFunction(nullify_any_type);

--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -200,17 +200,24 @@ inline void UuidExtractVersionPG(DataChunk &args, ExpressionState &state, Vector
  * DuckDB's built-in uuid_extract_timestamp errors for any version other
  * than 7, where Postgres returns the embedded timestamp for version 1 and
  * NULL for the rest.
+ *
+ * The second argument is PG_VERSION_NUM of the Postgres that planned the
+ * query.  Version 7 UUIDs only yield a timestamp on Postgres 18+; on
+ * Postgres 17 uuid_extract_timestamp returns NULL for them, so the branch is
+ * gated on the caller's version to keep pushdown results identical to local
+ * evaluation on either release.
  */
 inline void UuidExtractTimestampPG(DataChunk &args, ExpressionState &state, Vector &result)
 {
 	auto &input_vector = args.data[0];
+	auto &pg_version_vector = args.data[1];
 
 	/* microseconds between the Gregorian epoch (1582-10-15) and 1970-01-01 */
 	constexpr int64_t GREGORIAN_TO_UNIX_EPOCH_US = 12219292800000000LL;
 
-	UnaryExecutor::ExecuteWithNulls<hugeint_t, timestamp_tz_t>(
-		input_vector, result, args.size(),
-		[&](hugeint_t value, ValidityMask &mask, idx_t idx) -> timestamp_tz_t {
+	BinaryExecutor::ExecuteWithNulls<hugeint_t, int32_t, timestamp_tz_t>(
+		input_vector, pg_version_vector, result, args.size(),
+		[&](hugeint_t value, int32_t pg_version, ValidityMask &mask, idx_t idx) -> timestamp_tz_t {
 			if (!IsRfc9562Variant(value)) {
 				mask.SetInvalid(idx);
 				return timestamp_tz_t(0);
@@ -230,7 +237,7 @@ inline void UuidExtractTimestampPG(DataChunk &args, ExpressionState &state, Vect
 									  GREGORIAN_TO_UNIX_EPOCH_US);
 			}
 
-			if (version == 7) {
+			if (version == 7 && pg_version >= 180000) {
 				/* 48-bit count of milliseconds since the Unix epoch */
 				uint64_t tms = upper >> 16;
 
@@ -759,7 +766,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto initcap_function = ScalarFunction("initcap_pg", {LogicalType::VARCHAR}, LogicalType::VARCHAR, InitcapPG);
 	loader.RegisterFunction(initcap_function);
 
-	auto uuid_extract_timestamp_function = ScalarFunction("uuid_extract_timestamp_pg", {LogicalType::UUID}, LogicalType::TIMESTAMP_TZ, UuidExtractTimestampPG);
+	auto uuid_extract_timestamp_function = ScalarFunction("uuid_extract_timestamp_pg", {LogicalType::UUID, LogicalType::INTEGER}, LogicalType::TIMESTAMP_TZ, UuidExtractTimestampPG);
 	loader.RegisterFunction(uuid_extract_timestamp_function);
 
 	auto uuid_extract_version_function = ScalarFunction("uuid_extract_version_pg", {LogicalType::UUID}, LogicalType::SMALLINT, UuidExtractVersionPG);

--- a/pg_lake_engine/pg_lake_engine--3.3--3.4.sql
+++ b/pg_lake_engine/pg_lake_engine--3.3--3.4.sql
@@ -8,8 +8,11 @@ ALTER TABLE lake_engine.deletion_queue
 
 -- Postgres-semantics wrappers for uuid_extract_timestamp / uuid_extract_version
 -- pushdown; queries are rewritten to these and evaluated by the duckdb_pglake
--- implementations, so the local definitions are dummies.
-CREATE FUNCTION __lake__internal__nsp__.uuid_extract_timestamp_pg(uuid)
+-- implementations, so the local definitions are dummies.  The second argument
+-- of uuid_extract_timestamp_pg carries PG_VERSION_NUM: version 7 UUIDs only
+-- yield a timestamp on Postgres 18+, so the duckdb_pglake implementation
+-- needs the planning server's version to match Postgres semantics.
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_timestamp_pg(uuid, integer)
  RETURNS timestamp with time zone
  LANGUAGE C
  IMMUTABLE PARALLEL SAFE STRICT

--- a/pg_lake_engine/pg_lake_engine--3.3--3.4.sql
+++ b/pg_lake_engine/pg_lake_engine--3.3--3.4.sql
@@ -5,3 +5,18 @@
 -- delete, moving the object-store walk off the DROP path.
 ALTER TABLE lake_engine.deletion_queue
     ADD COLUMN resolve_metadata bool NOT NULL DEFAULT false;
+
+-- Postgres-semantics wrappers for uuid_extract_timestamp / uuid_extract_version
+-- pushdown; queries are rewritten to these and evaluated by the duckdb_pglake
+-- implementations, so the local definitions are dummies.
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_timestamp_pg(uuid)
+ RETURNS timestamp with time zone
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
+
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_version_pg(uuid)
+ RETURNS smallint
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;

--- a/pg_lake_engine/pg_lake_engine--3.3--3.4.sql
+++ b/pg_lake_engine/pg_lake_engine--3.3--3.4.sql
@@ -5,21 +5,3 @@
 -- delete, moving the object-store walk off the DROP path.
 ALTER TABLE lake_engine.deletion_queue
     ADD COLUMN resolve_metadata bool NOT NULL DEFAULT false;
-
--- Postgres-semantics wrappers for uuid_extract_timestamp / uuid_extract_version
--- pushdown; queries are rewritten to these and evaluated by the duckdb_pglake
--- implementations, so the local definitions are dummies.  The second argument
--- of uuid_extract_timestamp_pg carries PG_VERSION_NUM: version 7 UUIDs only
--- yield a timestamp on Postgres 18+, so the duckdb_pglake implementation
--- needs the planning server's version to match Postgres semantics.
-CREATE FUNCTION __lake__internal__nsp__.uuid_extract_timestamp_pg(uuid, integer)
- RETURNS timestamp with time zone
- LANGUAGE C
- IMMUTABLE PARALLEL SAFE STRICT
-AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
-
-CREATE FUNCTION __lake__internal__nsp__.uuid_extract_version_pg(uuid)
- RETURNS smallint
- LANGUAGE C
- IMMUTABLE PARALLEL SAFE STRICT
-AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;

--- a/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
+++ b/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
@@ -1,1 +1,19 @@
 -- Upgrade script for pg_lake_engine from 3.4 to 3.5
+
+-- Postgres-semantics wrappers for uuid_extract_timestamp / uuid_extract_version
+-- pushdown; queries are rewritten to these and evaluated by the duckdb_pglake
+-- implementations, so the local definitions are dummies.  The second argument
+-- of uuid_extract_timestamp_pg carries PG_VERSION_NUM: version 7 UUIDs only
+-- yield a timestamp on Postgres 18+, so the duckdb_pglake implementation
+-- needs the planning server's version to match Postgres semantics.
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_timestamp_pg(uuid, integer)
+ RETURNS timestamp with time zone
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
+
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_version_pg(uuid)
+ RETURNS smallint
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;

--- a/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
+++ b/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
@@ -6,3 +6,21 @@
 -- than how many VACUUM passes happen to reach it.
 ALTER TABLE lake_engine.deletion_queue
     ADD COLUMN last_attempt_at timestamptz;
+
+-- Postgres-semantics wrappers for uuid_extract_timestamp / uuid_extract_version
+-- pushdown; queries are rewritten to these and evaluated by the duckdb_pglake
+-- implementations, so the local definitions are dummies.  The second argument
+-- of uuid_extract_timestamp_pg carries PG_VERSION_NUM: version 7 UUIDs only
+-- yield a timestamp on Postgres 18+, so the duckdb_pglake implementation
+-- needs the planning server's version to match Postgres semantics.
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_timestamp_pg(uuid, integer)
+ RETURNS timestamp with time zone
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;
+
+CREATE FUNCTION __lake__internal__nsp__.uuid_extract_version_pg(uuid)
+ RETURNS smallint
+ LANGUAGE C
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$pg_lake_internal_dummy_function$function$;

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -165,6 +165,7 @@ static Node *RewriteFuncExprPostgisBytea(Node *node, void *context);
 static Node *RewriteFuncExprTrigonometry(Node *node, void *context);
 static Node *RewriteFuncExprInverseTrigonometry(Node *node, void *context);
 static Node *RewriteFuncExprHyperbolic(Node *node, void *context);
+static Node *RewriteFuncExprUuid(Node *node, void *context);
 static Node *RewriteFuncExprInitcap(Node *node, void *context);
 static Node *RewriteFuncExprJsonbArrayLength(Node *node, void *context);
 static Node *RewriteFuncExprEncode(Node *node, void *context);
@@ -292,6 +293,14 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 	},
 	{
 		"pg_catalog", "atanh", RewriteFuncExprHyperbolic, 0
+	},
+
+	/* uuid functions (Postgres 18+) */
+	{
+		"pg_catalog", "uuid_extract_timestamp", RewriteFuncExprUuid, 0
+	},
+	{
+		"pg_catalog", "uuid_extract_version", RewriteFuncExprUuid, 0
 	},
 
 	/* text functions */
@@ -2277,6 +2286,54 @@ RewriteFuncExprHyperbolic(Node *node, void *context)
 	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
 
 	return (Node *) funcExpr;
+}
+
+
+/*
+ * RewriteFuncExprUuid rewrites uuid_extract_timestamp(..) and
+ * uuid_extract_version(..) function calls into uuid_extract_timestamp_pg(..)
+ * and uuid_extract_version_pg(..) function calls.
+ *
+ * The wrappers are needed because DuckDB's uuid_extract_timestamp errors for
+ * any version other than 7 (Postgres returns a timestamp for version 1 and
+ * NULL for other versions), and DuckDB's uuid_extract_version skips the
+ * RFC 9562 variant check that makes Postgres return NULL.
+ *
+ * The functions only exist in Postgres 18+, so the rewrite never fires on
+ * older versions.
+ */
+static Node *
+RewriteFuncExprUuid(Node *node, void *context)
+{
+#if PG_VERSION_NUM >= 180000
+	FuncExpr   *funcExpr = castNode(FuncExpr, node);
+	List	   *funcName;
+
+	switch (funcExpr->funcid)
+	{
+		case F_UUID_EXTRACT_TIMESTAMP:
+			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
+								  makeString("uuid_extract_timestamp_pg"));
+			break;
+
+		case F_UUID_EXTRACT_VERSION:
+			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
+								  makeString("uuid_extract_version_pg"));
+			break;
+
+		default:
+			elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
+	}
+
+	Oid			argTypes[] = {UUIDOID};
+	int			argCount = 1;
+
+	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
+
+	return (Node *) funcExpr;
+#else
+	return node;
+#endif
 }
 
 

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -295,7 +295,7 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 		"pg_catalog", "atanh", RewriteFuncExprHyperbolic, 0
 	},
 
-	/* uuid functions (Postgres 18+) */
+	/* uuid functions (Postgres 17+) */
 	{
 		"pg_catalog", "uuid_extract_timestamp", RewriteFuncExprUuid, 0
 	},
@@ -2299,34 +2299,46 @@ RewriteFuncExprHyperbolic(Node *node, void *context)
  * NULL for other versions), and DuckDB's uuid_extract_version skips the
  * RFC 9562 variant check that makes Postgres return NULL.
  *
- * The functions only exist in Postgres 18+, so the rewrite never fires on
+ * uuid_extract_timestamp is also version-dependent: Postgres 17 extracts a
+ * timestamp only from version 1 UUIDs, while Postgres 18+ extracts from both
+ * version 1 and version 7.  We inject PG_VERSION_NUM as a second argument so
+ * the duckdb_pglake implementation reproduces the behavior of the Postgres
+ * that planned the query.
+ *
+ * The functions only exist in Postgres 17+, so the rewrite never fires on
  * older versions.
  */
 static Node *
 RewriteFuncExprUuid(Node *node, void *context)
 {
-#if PG_VERSION_NUM >= 180000
+#if PG_VERSION_NUM >= 170000
 	FuncExpr   *funcExpr = castNode(FuncExpr, node);
 	List	   *funcName;
+	Oid			argTypes[2];
+	int			argCount;
 
 	switch (funcExpr->funcid)
 	{
 		case F_UUID_EXTRACT_TIMESTAMP:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
 								  makeString("uuid_extract_timestamp_pg"));
+			funcExpr->args = list_make2(linitial(funcExpr->args),
+										MakeIntConst(PG_VERSION_NUM));
+			argTypes[0] = UUIDOID;
+			argTypes[1] = INT4OID;
+			argCount = 2;
 			break;
 
 		case F_UUID_EXTRACT_VERSION:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
 								  makeString("uuid_extract_version_pg"));
+			argTypes[0] = UUIDOID;
+			argCount = 1;
 			break;
 
 		default:
 			elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
 	}
-
-	Oid			argTypes[] = {UUIDOID};
-	int			argCount = 1;
 
 	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
 

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -173,6 +173,7 @@ static Node *RewriteFuncExprPostgisBytea(Node *node, void *context);
 static Node *RewriteFuncExprTrigonometry(Node *node, void *context);
 static Node *RewriteFuncExprInverseTrigonometry(Node *node, void *context);
 static Node *RewriteFuncExprHyperbolic(Node *node, void *context);
+static Node *RewriteFuncExprUuid(Node *node, void *context);
 static Node *RewriteFuncExprInitcap(Node *node, void *context);
 static Node *RewriteFuncExprJsonbArrayLength(Node *node, void *context);
 static Node *RewriteFuncExprEncode(Node *node, void *context);
@@ -300,6 +301,14 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 	},
 	{
 		"pg_catalog", "atanh", RewriteFuncExprHyperbolic, 0
+	},
+
+	/* uuid functions (Postgres 18+) */
+	{
+		"pg_catalog", "uuid_extract_timestamp", RewriteFuncExprUuid, 0
+	},
+	{
+		"pg_catalog", "uuid_extract_version", RewriteFuncExprUuid, 0
 	},
 
 	/* text functions */
@@ -2493,6 +2502,54 @@ RewriteFuncExprHyperbolic(Node *node, void *context)
 	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
 
 	return (Node *) funcExpr;
+}
+
+
+/*
+ * RewriteFuncExprUuid rewrites uuid_extract_timestamp(..) and
+ * uuid_extract_version(..) function calls into uuid_extract_timestamp_pg(..)
+ * and uuid_extract_version_pg(..) function calls.
+ *
+ * The wrappers are needed because DuckDB's uuid_extract_timestamp errors for
+ * any version other than 7 (Postgres returns a timestamp for version 1 and
+ * NULL for other versions), and DuckDB's uuid_extract_version skips the
+ * RFC 9562 variant check that makes Postgres return NULL.
+ *
+ * The functions only exist in Postgres 18+, so the rewrite never fires on
+ * older versions.
+ */
+static Node *
+RewriteFuncExprUuid(Node *node, void *context)
+{
+#if PG_VERSION_NUM >= 180000
+	FuncExpr   *funcExpr = castNode(FuncExpr, node);
+	List	   *funcName;
+
+	switch (funcExpr->funcid)
+	{
+		case F_UUID_EXTRACT_TIMESTAMP:
+			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
+								  makeString("uuid_extract_timestamp_pg"));
+			break;
+
+		case F_UUID_EXTRACT_VERSION:
+			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
+								  makeString("uuid_extract_version_pg"));
+			break;
+
+		default:
+			elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
+	}
+
+	Oid			argTypes[] = {UUIDOID};
+	int			argCount = 1;
+
+	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
+
+	return (Node *) funcExpr;
+#else
+	return node;
+#endif
 }
 
 

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -303,7 +303,7 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 		"pg_catalog", "atanh", RewriteFuncExprHyperbolic, 0
 	},
 
-	/* uuid functions (Postgres 18+) */
+	/* uuid functions (Postgres 17+) */
 	{
 		"pg_catalog", "uuid_extract_timestamp", RewriteFuncExprUuid, 0
 	},
@@ -2515,34 +2515,46 @@ RewriteFuncExprHyperbolic(Node *node, void *context)
  * NULL for other versions), and DuckDB's uuid_extract_version skips the
  * RFC 9562 variant check that makes Postgres return NULL.
  *
- * The functions only exist in Postgres 18+, so the rewrite never fires on
+ * uuid_extract_timestamp is also version-dependent: Postgres 17 extracts a
+ * timestamp only from version 1 UUIDs, while Postgres 18+ extracts from both
+ * version 1 and version 7.  We inject PG_VERSION_NUM as a second argument so
+ * the duckdb_pglake implementation reproduces the behavior of the Postgres
+ * that planned the query.
+ *
+ * The functions only exist in Postgres 17+, so the rewrite never fires on
  * older versions.
  */
 static Node *
 RewriteFuncExprUuid(Node *node, void *context)
 {
-#if PG_VERSION_NUM >= 180000
+#if PG_VERSION_NUM >= 170000
 	FuncExpr   *funcExpr = castNode(FuncExpr, node);
 	List	   *funcName;
+	Oid			argTypes[2];
+	int			argCount;
 
 	switch (funcExpr->funcid)
 	{
 		case F_UUID_EXTRACT_TIMESTAMP:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
 								  makeString("uuid_extract_timestamp_pg"));
+			funcExpr->args = list_make2(linitial(funcExpr->args),
+										MakeIntConst(PG_VERSION_NUM));
+			argTypes[0] = UUIDOID;
+			argTypes[1] = INT4OID;
+			argCount = 2;
 			break;
 
 		case F_UUID_EXTRACT_VERSION:
 			funcName = list_make2(makeString(PG_LAKE_INTERNAL_NSP),
 								  makeString("uuid_extract_version_pg"));
+			argTypes[0] = UUIDOID;
+			argCount = 1;
 			break;
 
 		default:
 			elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
 	}
-
-	Oid			argTypes[] = {UUIDOID};
-	int			argCount = 1;
 
 	funcExpr->funcid = LookupFuncName(funcName, argCount, argTypes, false);
 

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -330,17 +330,20 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"random", 'f', 0, {}, NULL},
 
 	/*
-	 * UUID functions, which only exist in Postgres 18+; listing them on older
+	 * UUID functions.  uuid_extract_timestamp / uuid_extract_version exist in
+	 * Postgres 17+, uuidv7() only in Postgres 18+; listing them on older
 	 * versions would make the eager catalog lookup in
 	 * LoadShippablePgduckFunctions error out.  Only the zero-arg uuidv7() is
 	 * shippable: DuckDB has no equivalent of uuidv7(interval).  The extract
 	 * functions diverge from Postgres semantics in DuckDB, so they are
 	 * rewritten to _pg wrappers at deparse time (see rewrite_query.c).
 	 */
-#if PG_VERSION_NUM >= 180000
-	{"uuidv7", 'f', 0, {}, NULL},
+#if PG_VERSION_NUM >= 170000
 	{"uuid_extract_timestamp", 'f', 1, {"uuid"}, NULL},
 	{"uuid_extract_version", 'f', 1, {"uuid"}, NULL},
+#endif
+#if PG_VERSION_NUM >= 180000
+	{"uuidv7", 'f', 0, {}, NULL},
 #endif
 
 	/* Trigonometric functions */

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -329,6 +329,20 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	/* Random functions */
 	{"random", 'f', 0, {}, NULL},
 
+	/*
+	 * UUID functions, which only exist in Postgres 18+; listing them on older
+	 * versions would make the eager catalog lookup in
+	 * LoadShippablePgduckFunctions error out.  Only the zero-arg uuidv7() is
+	 * shippable: DuckDB has no equivalent of uuidv7(interval).  The extract
+	 * functions diverge from Postgres semantics in DuckDB, so they are
+	 * rewritten to _pg wrappers at deparse time (see rewrite_query.c).
+	 */
+#if PG_VERSION_NUM >= 180000
+	{"uuidv7", 'f', 0, {}, NULL},
+	{"uuid_extract_timestamp", 'f', 1, {"uuid"}, NULL},
+	{"uuid_extract_version", 'f', 1, {"uuid"}, NULL},
+#endif
+
 	/* Trigonometric functions */
 	{"acos", 'f', 1, {"float8"}, NULL},
 	{"acosd", 'f', 1, {"float8"}, NULL},

--- a/pg_lake_spatial/tests/pytests/test_internal_schema.py
+++ b/pg_lake_spatial/tests/pytests/test_internal_schema.py
@@ -21,6 +21,6 @@ def test_internal_schema(
     """,
         pg_conn,
     )[0][0]
-    assert result == 64
+    assert result == 66
 
     pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_uuid_function_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_uuid_function_pushdown.py
@@ -18,8 +18,10 @@ UUID_SAMPLES = [
 
 @pytest.fixture(scope="module")
 def create_uuid_pushdown_tables(pg_conn, s3, extension):
-    if get_pg_version_num(pg_conn) < 180000:
-        pytest.skip("uuidv7 and uuid_extract_* require PostgreSQL 18+")
+    # uuid_extract_timestamp / uuid_extract_version exist in PostgreSQL 17+;
+    # uuidv7 only in 18+ (those tests skip themselves below).
+    if get_pg_version_num(pg_conn) < 170000:
+        pytest.skip("uuid_extract_* require PostgreSQL 17+")
 
     location = f"s3://{TEST_BUCKET}/uuid_f_pushdown/"
 
@@ -87,6 +89,9 @@ def test_uuid_extract_pushdown(
 
 
 def test_uuidv7_pushdown(create_uuid_pushdown_tables, pg_conn):
+    if get_pg_version_num(pg_conn) < 180000:
+        pytest.skip("uuidv7 requires PostgreSQL 18+")
+
     query = "SELECT uuidv7() FROM uuid_f_pushdowntbl"
 
     assert_remote_query_contains_expression(query, '"uuidv7"()', pg_conn)
@@ -109,6 +114,9 @@ def test_uuidv7_pushdown(create_uuid_pushdown_tables, pg_conn):
 
 
 def test_uuidv7_interval_not_pushed_down(create_uuid_pushdown_tables, pg_conn):
+    if get_pg_version_num(pg_conn) < 180000:
+        pytest.skip("uuidv7 requires PostgreSQL 18+")
+
     # uuidv7(interval) has no DuckDB equivalent and must stay unshipped;
     # the query still works with Postgres evaluating the function locally
     query = "SELECT uuidv7(interval '1 hour') FROM uuid_f_pushdowntbl"

--- a/pg_lake_table/tests/pytests/test_uuid_function_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_uuid_function_pushdown.py
@@ -1,0 +1,128 @@
+import pytest
+from utils_pytest import *
+
+
+# Fixed sample UUIDs covering every semantic branch:
+# - v1: RFC 9562 test vector, embeds 2022-02-22 19:22:22 UTC
+# - v4: random UUID, has a version but no timestamp
+# - v7: embeds a Unix millisecond timestamp
+# - nil/max: not RFC 9562 variant, so version and timestamp are both NULL
+UUID_SAMPLES = [
+    ("v1", "c232ab00-9414-11ec-b3c8-9f68deced846"),
+    ("v4", "5a8b2d1c-3f4e-4a6b-8c9d-0e1f2a3b4c5d"),
+    ("v7", "01890a5d-ac96-774b-bcce-b302099a8057"),
+    ("nil", "00000000-0000-0000-0000-000000000000"),
+    ("max", "ffffffff-ffff-ffff-ffff-ffffffffffff"),
+]
+
+
+@pytest.fixture(scope="module")
+def create_uuid_pushdown_tables(pg_conn, s3, extension):
+    if get_pg_version_num(pg_conn) < 180000:
+        pytest.skip("uuidv7 and uuid_extract_* require PostgreSQL 18+")
+
+    location = f"s3://{TEST_BUCKET}/uuid_f_pushdown/"
+
+    values = ",".join(f"('{name}', '{uuid}')" for name, uuid in UUID_SAMPLES)
+
+    run_command(
+        f"""
+        CREATE SCHEMA uuid_f_pushdown;
+        CREATE TABLE uuid_f_pushdowntbl (name text, col_uuid uuid)
+        USING pg_lake_iceberg WITH (location = '{location}');
+        INSERT INTO uuid_f_pushdowntbl VALUES {values};
+        CREATE TABLE uuid_f_pushdown_heap (name text, col_uuid uuid);
+        INSERT INTO uuid_f_pushdown_heap VALUES {values};
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    yield
+
+    run_command(
+        """
+        DROP TABLE uuid_f_pushdowntbl;
+        DROP TABLE uuid_f_pushdown_heap;
+        DROP SCHEMA uuid_f_pushdown CASCADE;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "test_id, func_expression, expected_expression",
+    [
+        (
+            "uuid_extract_timestamp",
+            "SELECT name, uuid_extract_timestamp(col_uuid) FROM uuid_f_pushdowntbl",
+            '"uuid_extract_timestamp_pg"(',
+        ),
+        (
+            "uuid_extract_version",
+            "SELECT name, uuid_extract_version(col_uuid) FROM uuid_f_pushdowntbl",
+            '"uuid_extract_version_pg"(',
+        ),
+    ],
+    ids=["uuid_extract_timestamp", "uuid_extract_version"],
+)
+def test_uuid_extract_pushdown(
+    create_uuid_pushdown_tables,
+    pg_conn,
+    test_id,
+    func_expression,
+    expected_expression,
+):
+    assert_remote_query_contains_expression(
+        func_expression, expected_expression, pg_conn
+    )
+
+    # the pushed-down result must match Postgres evaluating the same
+    # expression locally on an identical heap table, including the NULLs
+    # for the v4, nil, and max UUIDs and the timestamp for the v1 UUID
+    assert_query_results_on_tables(
+        func_expression, pg_conn, ["uuid_f_pushdowntbl"], ["uuid_f_pushdown_heap"]
+    )
+
+
+def test_uuidv7_pushdown(create_uuid_pushdown_tables, pg_conn):
+    query = "SELECT uuidv7() FROM uuid_f_pushdowntbl"
+
+    assert_remote_query_contains_expression(query, '"uuidv7"()', pg_conn)
+
+    # generated UUIDs must be version 7 with a timestamp close to now();
+    # uuid_extract_* here also run inside DuckDB via the _pg wrappers
+    result = run_query(
+        """
+        SELECT count(*)
+        FROM (
+            SELECT uuidv7() AS u FROM uuid_f_pushdowntbl
+        ) s
+        WHERE uuid_extract_version(u) = 7
+          AND uuid_extract_timestamp(u) BETWEEN now() - interval '1 minute'
+                                            AND now() + interval '1 minute'
+        """,
+        pg_conn,
+    )
+    assert result[0][0] == len(UUID_SAMPLES)
+
+
+def test_uuidv7_interval_not_pushed_down(create_uuid_pushdown_tables, pg_conn):
+    # uuidv7(interval) has no DuckDB equivalent and must stay unshipped;
+    # the query still works with Postgres evaluating the function locally
+    query = "SELECT uuidv7(interval '1 hour') FROM uuid_f_pushdowntbl"
+
+    assert_remote_query_not_contains_expression(query, '"uuidv7"', pg_conn)
+
+    result = run_query(
+        f"""
+        SELECT count(*)
+        FROM (
+            SELECT uuidv7(interval '1 hour') AS u FROM uuid_f_pushdowntbl
+        ) s
+        WHERE uuid_extract_version(u) = 7
+        """,
+        pg_conn,
+    )
+    assert result[0][0] == len(UUID_SAMPLES)


### PR DESCRIPTION
CI run for #449 by @darshil929 (external contributor fork). Rebased onto current `main` and pushed to a `marcoslot/*` branch so the CI pipeline runs.

Original PR: https://github.com/Snowflake-Labs/pg_lake/pull/449

---

## Description

Adds pushdown support for the UUID functions `uuidv7()`, `uuid_extract_timestamp()` and `uuid_extract_version()`.

The zero-arg `uuidv7()` (new in Postgres 18) is shipped directly since DuckDB's implementation matches Postgres. The two extract functions exist since Postgres 17 but cannot be shipped as-is, because DuckDB's semantics diverge:

- `uuid_extract_timestamp` errors in DuckDB for anything that is not v7, while Postgres returns the embedded timestamp for v1 UUIDs and NULL for other versions.
- `uuid_extract_version` in DuckDB returns the raw version nibble without the RFC 9562 variant check, so for example a nil UUID yields 0 where Postgres returns NULL.

Following the existing `acosh_pg` / `initcap_pg` pattern, queries are rewritten to `uuid_extract_timestamp_pg` / `uuid_extract_version_pg` wrappers implemented in duckdb_pglake with the Postgres semantics ported from the Postgres sources, including the v1 Gregorian timestamp arithmetic and the variant check.

`uuid_extract_timestamp` is version-dependent: Postgres 17 extracts a timestamp from version 1 UUIDs only, Postgres 18+ from version 1 and 7. To keep pushdown results identical to local evaluation on either release, it is rewritten to `uuid_extract_timestamp_pg(uuid, integer)` with `PG_VERSION_NUM` injected, and the duckdb_pglake implementation returns NULL for version 7 when the caller's version is below 18.

`uuidv7(interval)` has no DuckDB equivalent and stays unshipped, evaluated by Postgres as before. The shippable entries are gated to the version that introduced each function (17+ for the extract functions, 18+ for `uuidv7`) so the eager catalog lookup keeps working on older releases.

Tests cover the rewrite in the remote query, result parity between an iceberg table and an identical heap table for v1/v4/v7/nil/max UUIDs, v7 generation via pushed-down `uuidv7()`, and the interval variant staying local. The extract-function tests run on Postgres 17+ and self-adjust to each version's v7 semantics; the `uuidv7` tests skip below 18.

closes: #149
