### PR TITLE
Revert CDWRegionTest environments; skip cross-region tests when creds absent

### DIFF
--- a/.github/workflows/pytest_all.yml
+++ b/.github/workflows/pytest_all.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on:
       labels:
         ubuntu-latest
-    environment: CDWRegionTest
     permissions:
       contents: read
       packages: write
@@ -32,8 +31,6 @@ jobs:
       BASE_IMAGE_NAME: almalinux
       BASE_IMAGE_TAG: 9
       FINAL_IMAGE_NAME: pg-lake-ci-pg-almalinux
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     steps:
       - name: Checkout repository
@@ -53,7 +50,6 @@ jobs:
     runs-on:
       labels:
         ubuntu-latest
-    environment: CDWRegionTest
     permissions:
       contents: read
       packages: write
@@ -67,8 +63,6 @@ jobs:
       BASE_IMAGE_NAME: debian
       BASE_IMAGE_TAG: bookworm-slim
       FINAL_IMAGE_NAME: pg-lake-ci-pg-debian
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     steps:
       - name: Checkout repository
@@ -87,7 +81,6 @@ jobs:
   build-and-install-almalinux:
     needs: build-image-almalinux
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
 
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-almalinux:${{ needs.build-image-almalinux.outputs.tag }}
@@ -95,10 +88,6 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       matrix:
@@ -117,7 +106,6 @@ jobs:
   build-and-install-debian:
     needs: build-image-debian
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
 
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-debian:${{ needs.build-image-debian.outputs.tag }}
@@ -125,10 +113,6 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       matrix:
@@ -155,17 +139,12 @@ jobs:
   test-check:
     needs: [build-image-almalinux, build-and-install-almalinux]
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-almalinux:${{ needs.build-image-almalinux.outputs.tag }}
       options: --user 1001 --shm-size=128MB
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       fail-fast: false
@@ -198,17 +177,12 @@ jobs:
   test-check-pg-lake-table:
     needs: [build-image-almalinux, build-and-install-almalinux]
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-almalinux:${{ needs.build-image-almalinux.outputs.tag }}
       options: --user 1001 --shm-size=128MB
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       fail-fast: false
@@ -235,17 +209,12 @@ jobs:
   test-installcheck:
     needs: [build-image-debian, build-and-install-debian]
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-debian:${{ needs.build-image-debian.outputs.tag }}
       options: --user 1001 --shm-size=128MB
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       fail-fast: false
@@ -276,17 +245,12 @@ jobs:
   test-installcheck-postgres:
     needs: [build-image-debian, build-and-install-debian]
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-debian:${{ needs.build-image-debian.outputs.tag }}
       options: --user 1001 --shm-size=128MB
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       fail-fast: false
@@ -320,17 +284,12 @@ jobs:
   test-installcheck-pg-lake-table:
     needs: [build-image-debian, build-and-install-debian]
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-debian:${{ needs.build-image-debian.outputs.tag }}
       options: --user 1001 --shm-size=128MB
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       fail-fast: false
@@ -358,17 +317,12 @@ jobs:
   test-isolation:
     needs: [build-image-almalinux, build-and-install-almalinux]
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-almalinux:${{ needs.build-image-almalinux.outputs.tag }}
       options: --user 1001 --shm-size=128MB
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       fail-fast: false
@@ -392,17 +346,12 @@ jobs:
   test-upgrade:
     needs: [build-image-almalinux, build-and-install-almalinux]
     runs-on: ubuntu-latest
-    environment: CDWRegionTest
     container:
       image: ghcr.io/snowflake-labs/pg-lake-ci-pg-almalinux:${{ needs.build-image-almalinux.outputs.tag }}
       options: --user 1001 --shm-size=128MB
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-
-    env:
-      CDWREGIONTEST_ACCESS_KEY_ID: ${{ secrets.cdwregiontest_access_key_id }}
-      CDWREGIONTEST_SECRET_ACCESS_KEY: ${{ secrets.cdwregiontest_secret_access_key }}
 
     strategy:
       fail-fast: false

--- a/pg_lake_table/tests/e2e/test_region_switch.py
+++ b/pg_lake_table/tests/e2e/test_region_switch.py
@@ -3,6 +3,17 @@ import pytest
 from utils_pytest import *
 
 
+# These tests need real AWS credentials pointed at a cross-region bucket. The
+# credentials are supplied via CDWREGIONTEST_ACCESS_KEY_ID /
+# CDWREGIONTEST_SECRET_ACCESS_KEY. When those are not set (e.g. in GHA CI, which
+# no longer defines them) there is nothing meaningful to exercise, so skip.
+requires_cdwregiontest = pytest.mark.skipif(
+    not os.getenv("CDWREGIONTEST_ACCESS_KEY_ID"),
+    reason="CDWREGIONTEST_ACCESS_KEY_ID / CDWREGIONTEST_SECRET_ACCESS_KEY not set",
+)
+
+
+@requires_cdwregiontest
 def test_region_switch(s3, pg_conn, pgduck_conn, extension):
     # The following URLs point to real files in a real bucket which reside
     # in us-east-2
@@ -15,36 +26,19 @@ def test_region_switch(s3, pg_conn, pgduck_conn, extension):
 
     # Set up credentials from environment variables (with the wrong region)
     # Otherwise, we sign requests with our nonsense credentials, which S3 rejects
-    if access_key_id:
-        run_command(
-            f"""
-            CREATE OR REPLACE SECRET s3pglregiontest (
-                TYPE S3,
-                KEY_ID '{access_key_id}',
-                SECRET '{secret_access_key}',
-                SCOPE 's3://aws-public-blockchain',
-                REGION 'us-east-1',
-                ENDPOINT 's3.amazonaws.com'
-            );
-        """,
-            pgduck_conn,
-        )
-
-    # Locally, use ~/.aws/credentials
-    else:
-        run_command(
-            f"""
-            CREATE OR REPLACE SECRET s3pglregiontest (
-                TYPE S3,
-                SCOPE 's3://aws-public-blockchain',
-                PROVIDER CREDENTIAL_CHAIN,
-                REGION 'us-east-1',
-                ENDPOINT 's3.amazonaws.com',
-                CHAIN 'config'
-            );
-        """,
-            pgduck_conn,
-        )
+    run_command(
+        f"""
+        CREATE OR REPLACE SECRET s3pglregiontest (
+            TYPE S3,
+            KEY_ID '{access_key_id}',
+            SECRET '{secret_access_key}',
+            SCOPE 's3://aws-public-blockchain',
+            REGION 'us-east-1',
+            ENDPOINT 's3.amazonaws.com'
+        );
+    """,
+        pgduck_conn,
+    )
 
     pgduck_conn.commit()
 
@@ -116,6 +110,7 @@ def test_region_switch(s3, pg_conn, pgduck_conn, extension):
     pg_conn.rollback()
 
 
+@requires_cdwregiontest
 def test_file_exists_cross_region(s3, pg_conn, pgduck_conn, extension):
     # Exercises the region-aware FileExists path. Without the fix,
     # pg_lake_file_exists() returned false on cross-region buckets because it
@@ -127,34 +122,19 @@ def test_file_exists_cross_region(s3, pg_conn, pgduck_conn, extension):
     secret_access_key = os.getenv("CDWREGIONTEST_SECRET_ACCESS_KEY")
 
     # Set up credentials with the wrong region (bucket is us-east-2)
-    if access_key_id:
-        run_command(
-            f"""
-            CREATE OR REPLACE SECRET s3pglregiontest_exists (
-                TYPE S3,
-                KEY_ID '{access_key_id}',
-                SECRET '{secret_access_key}',
-                SCOPE 's3://aws-public-blockchain',
-                REGION 'us-east-1',
-                ENDPOINT 's3.amazonaws.com'
-            );
-        """,
-            pgduck_conn,
-        )
-    else:
-        run_command(
-            f"""
-            CREATE OR REPLACE SECRET s3pglregiontest_exists (
-                TYPE S3,
-                SCOPE 's3://aws-public-blockchain',
-                PROVIDER CREDENTIAL_CHAIN,
-                REGION 'us-east-1',
-                ENDPOINT 's3.amazonaws.com',
-                CHAIN 'config'
-            );
-        """,
-            pgduck_conn,
-        )
+    run_command(
+        f"""
+        CREATE OR REPLACE SECRET s3pglregiontest_exists (
+            TYPE S3,
+            KEY_ID '{access_key_id}',
+            SECRET '{secret_access_key}',
+            SCOPE 's3://aws-public-blockchain',
+            REGION 'us-east-1',
+            ENDPOINT 's3.amazonaws.com'
+        );
+    """,
+        pgduck_conn,
+    )
 
     pgduck_conn.commit()
 


### PR DESCRIPTION
## Problem

PR #453 moved the `CDWREGIONTEST_*` S3 credentials out of the top-level `env:`
block and into a per-job `env:` map gated behind `environment: CDWRegionTest`
on every job in `pytest_all.yml`. That wired the secret into ~10 jobs and
coupled the entire test matrix to a GitHub environment just so two
cross-region S3 tests could read the credentials.

We would rather not carry those credentials in CI at all. The two tests that
use them exercise real cross-region S3 buckets and only make sense when a
developer has real AWS credentials available locally.

## Solution

Remove the CDWRegionTest wiring from the workflow entirely:

- Drop every `environment: CDWRegionTest` block.
- Drop the per-job `CDWREGIONTEST_ACCESS_KEY_ID` / `CDWREGIONTEST_SECRET_ACCESS_KEY`
  `env:` maps that PR #453 added.
- Drop the original top-level definitions too, so the workflow no longer
  references the `cdwregiontest_*` secrets anywhere.

Change the two tests that read those vars to skip when the vars are unset:

    # skips in GHA CI (vars no longer defined), runs locally when exported
    @pytest.mark.skipif(not os.getenv("CDWREGIONTEST_ACCESS_KEY_ID"), reason=...)
    def test_region_switch(...): ...

The old credential-chain `else` fallback is removed since the test now skips
rather than trying a path that does not apply. `test_managed_storage_region`
is left unchanged because it never read those env vars.

## Test plan

- `test_region_switch` and `test_file_exists_cross_region` skip in GHA CI now
  that the credentials are gone.
- Both still run locally when `CDWREGIONTEST_ACCESS_KEY_ID` /
  `CDWREGIONTEST_SECRET_ACCESS_KEY` are exported.