### PR TITLE
docker: add gettext-devel to fix pg_cron build on AlmaLinux

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,6 +54,7 @@ RUN if [ "$BASE_IMAGE_OS" = "almalinux" ]; then \
             jansson-devel \
             jq \
             diffutils \
+            gettext-devel \
             libcurl-devel \
             pam-devel \
             patch \


### PR DESCRIPTION
## Summary
- Adds `gettext-devel` to the AlmaLinux package list in the Docker build
- Fixes `cannot find -lintl` linker error when compiling pg_cron

## Problem

Building the Docker image on AlmaLinux fails at the pg_cron compilation step:

```
/usr/bin/ld: cannot find -lintl
collect2: error: ld returned 1 exit status
make: *** [pg_cron.so] Error 1
```

This happens because pg_cron links against `libintl` (provided by GNU gettext) via the PostgreSQL `pg_config --libs` output, but `gettext-devel` is not installed in the container.

## Fix

Add `gettext-devel` to the AlmaLinux `dnf install` list in `docker/Dockerfile`. This provides the `libintl.so` and headers needed at link time.

Note: The `install.sh` script already includes `gmp-devel` for RHEL but was also missing `gettext-devel` — that can be addressed separately if needed.

## Test plan
- [ ] Trigger Docker build with `task build:local PG_MAJOR=18` on AlmaLinux base
- [ ] Verify pg_cron compiles successfully for PG 16, 17, and 18
- [ ] Verify final image starts and `CREATE EXTENSION pg_cron` works

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)