### PR TITLE
Scale Iceberg TRUNCATE metadata cleanup (CI for #457)

### DIFF
--- a/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
+++ b/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
@@ -31,6 +31,7 @@ typedef struct TableMetadataOperationTracker
 	bool		relationDataFileChanged;
 	bool		relationManifestMergeRequested;
 	bool		relationSnapshotExpirationRequested;
+	bool		relationDataFilesRemoveAllSeen;
 
 	/*
 	 * Number of single-file data-file operations recorded for this relation

--- a/pg_lake_table/pg_lake_table--3.4--3.5.sql
+++ b/pg_lake_table/pg_lake_table--3.4--3.5.sql
@@ -1,1 +1,13 @@
 -- Upgrade script for pg_lake_table from 3.4 to 3.5
+
+-- Foreign-key cascades run once per deleted lake_table.files row. Without
+-- indexes matching the referencing columns, bulk removal (especially
+-- TRUNCATE) repeatedly scans the full child catalogs.
+CREATE INDEX IF NOT EXISTS deletion_file_map_table_name_path_idx
+ON lake_table.deletion_file_map (table_name, path);
+
+CREATE INDEX IF NOT EXISTS data_file_column_stats_table_path_idx
+ON lake_table.data_file_column_stats (table_name, path);
+
+CREATE INDEX IF NOT EXISTS data_file_partition_values_id_idx
+ON lake_table.data_file_partition_values (id);

--- a/pg_lake_table/pg_lake_table--3.4--3.5.sql
+++ b/pg_lake_table/pg_lake_table--3.4--3.5.sql
@@ -3,11 +3,11 @@
 -- Foreign-key cascades run once per deleted lake_table.files row. Without
 -- indexes matching the referencing columns, bulk removal (especially
 -- TRUNCATE) repeatedly scans the full child catalogs.
-CREATE INDEX IF NOT EXISTS deletion_file_map_table_name_path_idx
+CREATE INDEX deletion_file_map_table_name_path_idx
 ON lake_table.deletion_file_map (table_name, path);
 
-CREATE INDEX IF NOT EXISTS data_file_column_stats_table_path_idx
+CREATE INDEX data_file_column_stats_table_path_idx
 ON lake_table.data_file_column_stats (table_name, path);
 
-CREATE INDEX IF NOT EXISTS data_file_partition_values_id_idx
+CREATE INDEX data_file_partition_values_id_idx
 ON lake_table.data_file_partition_values (id);

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -530,6 +530,7 @@ RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operat
 			break;
 		case DATA_FILE_REMOVE_ALL:
 			opTracker->relationDataFileChanged = true;
+			opTracker->relationDataFilesRemoveAllSeen = true;
 			opTracker->forceCommitTimeAnalyze = true;
 			break;
 		case DATA_FILE_MERGE_MANIFESTS:
@@ -1311,8 +1312,31 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	Snapshot	snapshot = GetTransactionSnapshot();
 
 	HTAB	   *currentFilesMap = GetTableDataFilesByPathHashFromCatalog(opTracker->relationId, dataOnly, newFilesOnly,
-																		 forUpdate, orderBy, snapshot, allTransforms,
-																		 true /* skipColumnStats */ );
+															 forUpdate, orderBy, snapshot, allTransforms,
+															 true /* skipColumnStats */ );
+
+	/*
+	 * Preserve the remove-all operation for a real TRUNCATE. The generic
+	 * transaction tracker normally records only that data files changed and
+	 * reconstructs individual operations by diffing the catalog against the
+	 * last Iceberg snapshot. Turning a TRUNCATE into one DATA_FILE_REMOVE per
+	 * existing file loses the linear remove-all path in the manifest writer and
+	 * makes it compare every manifest entry with every removed file.
+	 *
+	 * The tracker flags intentionally survive subtransaction rollback, so only
+	 * use this shortcut when the transaction's final catalog is actually empty.
+	 * A rolled-back TRUNCATE, or TRUNCATE followed by INSERT, falls through to
+	 * the normal diff below.
+	 */
+	if (opTracker->relationDataFilesRemoveAllSeen &&
+		hash_get_num_entries(currentFilesMap) == 0)
+	{
+		TableMetadataOperation *removeAllOp = palloc0(sizeof(TableMetadataOperation));
+
+		removeAllOp->type = DATA_FILE_REMOVE_ALL;
+
+		return list_make1(removeAllOp);
+	}
 
 	/* get last pushed metadata */
 	IcebergTableMetadata *lastMetadata = GetLastPushedIcebergMetadata(opTracker);

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1312,21 +1312,21 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	Snapshot	snapshot = GetTransactionSnapshot();
 
 	HTAB	   *currentFilesMap = GetTableDataFilesByPathHashFromCatalog(opTracker->relationId, dataOnly, newFilesOnly,
-															 forUpdate, orderBy, snapshot, allTransforms,
-															 true /* skipColumnStats */ );
+																		 forUpdate, orderBy, snapshot, allTransforms,
+																		 true /* skipColumnStats */ );
 
 	/*
 	 * Preserve the remove-all operation for a real TRUNCATE. The generic
 	 * transaction tracker normally records only that data files changed and
 	 * reconstructs individual operations by diffing the catalog against the
 	 * last Iceberg snapshot. Turning a TRUNCATE into one DATA_FILE_REMOVE per
-	 * existing file loses the linear remove-all path in the manifest writer and
-	 * makes it compare every manifest entry with every removed file.
+	 * existing file loses the linear remove-all path in the manifest writer
+	 * and makes it compare every manifest entry with every removed file.
 	 *
-	 * The tracker flags intentionally survive subtransaction rollback, so only
-	 * use this shortcut when the transaction's final catalog is actually empty.
-	 * A rolled-back TRUNCATE, or TRUNCATE followed by INSERT, falls through to
-	 * the normal diff below.
+	 * The tracker flags intentionally survive subtransaction rollback, so
+	 * only use this shortcut when the transaction's final catalog is actually
+	 * empty. A rolled-back TRUNCATE, or TRUNCATE followed by INSERT, falls
+	 * through to the normal diff below.
 	 */
 	if (opTracker->relationDataFilesRemoveAllSeen &&
 		hash_get_num_entries(currentFilesMap) == 0)

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1324,12 +1324,12 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	 * and makes it compare every manifest entry with every removed file.
 	 *
 	 * The tracker flags intentionally survive subtransaction rollback, so
-	 * only use this shortcut when the transaction's final catalog is actually
-	 * empty. In particular, TRUNCATE followed by INSERT leaves currentFilesMap
-	 * non-empty and must fall through to the normal diff below; otherwise the
-	 * remove-all shortcut would also remove the newly inserted files. A
-	 * rolled-back TRUNCATE likewise falls through because the catalog contains
-	 * the restored files.
+	 * hash_get_num_entries(currentFilesMap) == 0 checks whether the
+	 * transaction-visible file catalog is empty. This restricts the shortcut
+	 * to a TRUNCATE that leaves no files: TRUNCATE followed by INSERT has a
+	 * non-empty map and must use the normal diff below to preserve the newly
+	 * inserted files. A rolled-back TRUNCATE likewise has restored files in
+	 * the map and must use the normal diff.
 	 */
 	if (opTracker->relationDataFilesRemoveAllSeen &&
 		hash_get_num_entries(currentFilesMap) == 0)

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1325,8 +1325,11 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	 *
 	 * The tracker flags intentionally survive subtransaction rollback, so
 	 * only use this shortcut when the transaction's final catalog is actually
-	 * empty. A rolled-back TRUNCATE, or TRUNCATE followed by INSERT, falls
-	 * through to the normal diff below.
+	 * empty. In particular, TRUNCATE followed by INSERT leaves currentFilesMap
+	 * non-empty and must fall through to the normal diff below; otherwise the
+	 * remove-all shortcut would also remove the newly inserted files. A
+	 * rolled-back TRUNCATE likewise falls through because the catalog contains
+	 * the restored files.
 	 */
 	if (opTracker->relationDataFilesRemoveAllSeen &&
 		hash_get_num_entries(currentFilesMap) == 0)

--- a/pg_lake_table/tests/pytests/test_create_drop_extension.py
+++ b/pg_lake_table/tests/pytests/test_create_drop_extension.py
@@ -2,6 +2,29 @@ import pytest
 from utils_pytest import *
 
 
+def test_data_file_cascade_indexes(extension, superuser_conn):
+    result = run_query(
+        """
+        SELECT indexname
+        FROM pg_indexes
+        WHERE schemaname = 'lake_table'
+          AND indexname IN (
+              'deletion_file_map_table_name_path_idx',
+              'data_file_column_stats_table_path_idx',
+              'data_file_partition_values_id_idx'
+          )
+        ORDER BY indexname
+        """,
+        superuser_conn,
+    )
+
+    assert result == [
+        ["data_file_column_stats_table_path_idx"],
+        ["data_file_partition_values_id_idx"],
+        ["deletion_file_map_table_name_path_idx"],
+    ]
+
+
 def test_create_drop_query_engine(superuser_conn, s3, app_user):
     other_conn = open_pg_conn()
 

--- a/pg_lake_table/tests/pytests/test_iceberg_in_tx.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_in_tx.py
@@ -817,6 +817,64 @@ def test_in_tx_with_truncate(
     pg_conn.commit()
 
 
+def test_truncate_remove_all_transaction_guards(
+    pg_conn,
+    extension,
+    with_default_location,
+):
+    table_namespace = "test_truncate_remove_all_transaction_guards"
+    table_name = "tbl"
+    table = f"{table_namespace}.{table_name}"
+
+    run_command(
+        f"""
+        CREATE SCHEMA {table_namespace};
+        CREATE TABLE {table} (a int) USING iceberg
+            WITH (autovacuum_enabled='False');
+        INSERT INTO {table} VALUES (1), (2);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # The remove-all tracker flag survives subtransaction rollback. The
+    # catalog is not empty after rollback, so commit must use the normal diff
+    # and retain the original files.
+    run_command(
+        f"""
+        SAVEPOINT before_truncate;
+        TRUNCATE {table};
+        ROLLBACK TO SAVEPOINT before_truncate;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    assert run_query(f"SELECT a FROM {table} ORDER BY a", pg_conn) == [[1], [2]]
+
+    # A truncate followed by an insert also leaves a non-empty catalog. It
+    # must fall back to the per-file diff so the newly added file survives.
+    run_command(
+        f"""
+        TRUNCATE {table};
+        INSERT INTO {table} VALUES (3);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    assert run_query(f"SELECT a FROM {table} ORDER BY a", pg_conn) == [[3]]
+
+    # A final empty catalog is the real remove-all case.
+    run_command(f"TRUNCATE {table}", pg_conn)
+    pg_conn.commit()
+
+    assert run_query(f"SELECT a FROM {table}", pg_conn) == []
+
+    run_command(f"DROP SCHEMA {table_namespace} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 def test_in_subtx_fail_with_truncate(
     installcheck,
     s3,

--- a/pg_lake_table/tests/upgrade/test_post_upgrade.py
+++ b/pg_lake_table/tests/upgrade/test_post_upgrade.py
@@ -8,6 +8,33 @@ from utils_pytest import *
     os.getenv("TEST_PG_UPGRADE_FROM_BINDIR") == None,
     reason="set TEST_PG_UPGRADE_FROM_BINDIR to the old PG version to run",
 )
+def test_data_file_cascade_indexes(superuser_conn, extension):
+    result = run_query(
+        """
+        SELECT indexname
+        FROM pg_indexes
+        WHERE schemaname = 'lake_table'
+          AND indexname IN (
+              'deletion_file_map_table_name_path_idx',
+              'data_file_column_stats_table_path_idx',
+              'data_file_partition_values_id_idx'
+          )
+        ORDER BY indexname
+        """,
+        superuser_conn,
+    )
+
+    assert result == [
+        ["data_file_column_stats_table_path_idx"],
+        ["data_file_partition_values_id_idx"],
+        ["deletion_file_map_table_name_path_idx"],
+    ]
+
+
+@pytest.mark.skipif(
+    os.getenv("TEST_PG_UPGRADE_FROM_BINDIR") == None,
+    reason="set TEST_PG_UPGRADE_FROM_BINDIR to the old PG version to run",
+)
 def test_iceberg_query(superuser_conn, s3, extension):
     # Check whether we can update post-upgrade
     run_command("UPDATE pre_upgrade.iceberg SET id = id + 1", superuser_conn)


### PR DESCRIPTION
CI run for #457 by @marknefedov (pushed to a branch in this repo so the credentialed CI jobs run). Original PR: https://github.com/Snowflake-Labs/pg_lake/pull/457

## Problem

Iceberg `TRUNCATE` on a large table did not scale. Two separate issues compounded:

1. The `ON DELETE CASCADE` foreign keys from `lake_table.files` had no index on the referencing columns of three child catalogs (`deletion_file_map (table_name, path)`, `data_file_column_stats (table_name, path)`, `data_file_partition_values (id)`). Each parent-row delete triggered a full sequential scan of the child catalog, so a single `DELETE FROM lake_table.files` during `TRUNCATE` became O(files x child_rows).

2. Commit-time transaction tracking collapsed `DATA_FILE_REMOVE_ALL` into the generic "data files changed" flag. The commit diff then reconstructed one `DATA_FILE_REMOVE` per file, which pushed the manifest writer onto its nested per-entry/per-removal path instead of the linear remove-all shortcut.

## Solution

- Add the three missing cascade indexes in the `3.4 -> 3.5` upgrade script.
- Track that a `DATA_FILE_REMOVE_ALL` was seen and, when the transaction's final file catalog is empty, re-emit a single `DATA_FILE_REMOVE_ALL` instead of per-file removals. The guard is the transaction-visible catalog state, so a rolled-back `TRUNCATE`, or a `TRUNCATE` followed by `INSERT`, correctly falls through to the normal diff.

## Test plan

- Fresh-install and post-upgrade tests assert the three indexes exist.
- Transactional tests cover rollback-to-savepoint, truncate-then-insert, and the final-empty-catalog remove-all case.
- Full CI.
