### PR TITLE
Disable the CSV sniffer when reading our own CSVs by column map

### DIFF
--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -1013,6 +1013,55 @@ def test_nested_numeric_roundtrip(pg_conn, tmp_path):
     pg_conn.rollback()
 
 
+def test_copy_to_array_with_nulls(pg_conn, duckdb_conn, tmp_path):
+    """
+    Regression test for https://github.com/Snowflake-Labs/pg_lake/issues/408.
+
+    DuckDB's CSV string-to-LIST cast can segfault (SIGSEGV) when a row with an
+    array value is followed by NULL rows and auto_detect is left enabled.
+    AppendReadCSVTail now passes auto_detect=false when a typed columns= map
+    is present, which causes DuckDB to return a clean conversion error instead
+    of crashing.  This test exercises the internal temp-CSV read-back path
+    (COPY TO parquet via ConvertCSVFileTo) with a 1-D integer array column and
+    several trailing NULL rows.
+    """
+    parquet_path = tmp_path / "test_array_nulls.parquet"
+
+    run_command(
+        f"""
+        CREATE TABLE test_array_nulls (id bigint, arr int[]);
+        INSERT INTO test_array_nulls VALUES
+            (1, ARRAY[1, 2, 3]),
+            (2, NULL),
+            (3, NULL),
+            (4, NULL),
+            (5, ARRAY[4, 5]),
+            (6, NULL),
+            (7, NULL),
+            (8, NULL),
+            (9, NULL),
+            (10, NULL);
+        COPY test_array_nulls TO '{parquet_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+
+    # Verify the parquet file contains the correct rows (not a partial/corrupt
+    # write from a crashed engine process)
+    duckdb_conn.execute(
+        f"SELECT id, arr FROM read_parquet($1) ORDER BY id", [str(parquet_path)]
+    )
+    rows = duckdb_conn.fetchall()
+
+    assert len(rows) == 10
+    assert rows[0] == (1, [1, 2, 3])
+    assert rows[1] == (2, None)
+    assert rows[4] == (5, [4, 5])
+    assert rows[9] == (10, None)
+
+    pg_conn.rollback()
+
+
 def test_copy_virtual_column(pg_conn, tmp_path):
     # virtual columns were introduced in PostgreSQL 18
     if get_pg_version_num(pg_conn) < 180000:

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -1768,6 +1768,20 @@ AppendReadCSVTail(StringInfo buf, int maxLineSize, const char *columnsMap,
 	if (columnsMap != NULL)
 	{
 		appendStringInfo(buf, ", columns=%s", columnsMap);
+
+		/*
+		 * A columns map is only supplied when reading a CSV we wrote
+		 * ourselves, so the schema and dialect are already fully specified
+		 * above.  Turn the sniffer off: with only a columns map (no explicit
+		 * dateformat) DuckDB still auto-detects the date/timestamp format
+		 * from a sample, and a text column holding a non-ISO, date-looking
+		 * string (e.g. "12/25/2020") can make it pick %m/%d/%Y and then fail
+		 * to parse a real ISO date column ("2021-03-10").  Disabling
+		 * auto_detect keeps DuckDB's default ISO casting, which also handles
+		 * BC / out-of-range / infinity dates that a fixed dateformat string
+		 * would reject.
+		 */
+		appendStringInfoString(buf, ", auto_detect=false");
 	}
 	else
 	{

--- a/pg_lake_table/tests/pytests/test_csv_date_format.py
+++ b/pg_lake_table/tests/pytests/test_csv_date_format.py
@@ -1,0 +1,32 @@
+import datetime
+
+import pytest
+
+from utils_pytest import *
+
+
+def test_iso_date_survives_us_style_date_in_text_column(s3, pg_conn, extension):
+    """A US-format date string in a text column must not make the CSV reader
+    wrongly parse a real ISO date column on the same row.
+
+    pg_lake round-trips table writes through an internal CSV (always ISO for
+    dates) read back with DuckDB read_csv. The read passes an explicit columns
+    type map, which pins column *types* but not the date *format* -- DuckDB
+    still auto-detects the format. A text value like "12/25/2020" made the
+    sniffer choose date_format=%m/%d/%Y for the whole file, which then failed to
+    parse the ISO value "2021-03-10" in the real date column
+    (Could not convert string "2021-03-10" to 'DATE').
+    """
+    location = f"s3://{TEST_BUCKET}/test_iso_date_us_text/"
+    run_command(
+        f"""CREATE TABLE t_iso_date (txt text, d date)
+            USING iceberg WITH (location = '{location}')""",
+        pg_conn,
+    )
+    run_command(
+        "INSERT INTO t_iso_date VALUES ('12/25/2020', DATE '2021-03-10')",
+        pg_conn,
+    )
+    result = run_query("SELECT txt, d FROM t_iso_date", pg_conn)
+    assert result == [["12/25/2020", datetime.date(2021, 3, 10)]]
+    pg_conn.rollback()


### PR DESCRIPTION
## Problem

When reading back a CSV that we wrote ourselves, `AppendReadCSVTail` passes an
explicit `columns=` type map but no `dateformat`. A `columns` map pins the
column **types**, not the date/timestamp **format**, so DuckDB's CSV sniffer
still auto-detects the format from a sample. If a `text` column holds a non-ISO,
date-looking string, the sniffer can choose a format for the whole file that
then fails to parse a real ISO `date` column.

### Reproduction

```sql
CREATE TABLE t (txt text, d date) USING iceberg WITH (location = '...');
INSERT INTO t VALUES ('12/25/2020', DATE '2021-03-10');
```

The `'12/25/2020'` text value (only parseable as `MM/DD/YYYY`) makes the sniffer
pick `date_format=%m/%d/%Y`, and the write fails:

```
Conversion Error: CSV Error on Line: 2
  Error when converting column "d". Could not convert string "2021-03-10" to 'DATE'
  date_format = %m/%d/%Y (Auto-Detected)
```

## Fix

A `columns` map is only supplied when reading a CSV we produced, where the
schema and dialect are already fully specified — so turn the sniffer off
(`auto_detect=false`) on that path. This keeps DuckDB's default ISO date casting
rather than a sniffed (or fixed) format.

`auto_detect=false` is preferable to pinning `dateformat='%Y-%m-%d'`: the default
casting still handles BC, out-of-range, and `±infinity` dates that a fixed
format string rejects (verified — `test_iceberg_copy_from_pushdown.py`'s BC /
clamp / infinity cases keep passing).

## Tests

- `pg_lake_table/tests/pytests/test_csv_date_format.py`: an ISO `date` column
  round-trips even when a `text` column on the same row holds a US-style date
  string (fails before this change, passes after).
- `pg_lake_copy/tests/pytests/test_copy_to_array_with_nulls` (cherry-picked from
  #413, @sfc-gh-rbachala): a 1-D integer array column with trailing NULL rows
  copies to Parquet without crashing the engine.

Verified no regressions across the copy-pushdown, complex-types, data-load,
create-table, CTAS, csv-tables, date-partitioned, timetz, column-inference, and
reserved-keyword suites.
