### PR TITLE
Backport to release-3.4: manifest leak fix (#454), multidim array clamp (#461), CSV sniffer fix (#463)

### DIFF
--- a/duckdb_pglake/src/duckdb_pglake_extension.cpp
+++ b/duckdb_pglake/src/duckdb_pglake_extension.cpp
@@ -553,6 +553,42 @@ IcebergSizeClampBlobFun(DataChunk &args, ExpressionState &state, Vector &result)
 
 
 /*
+ * IcebergSizeClampContainerPassthroughFun is the LIST-typed overload of the
+ * size clamp/check functions.  It returns its first argument unchanged.
+ *
+ * Why this exists: the Iceberg size-clamp rewrite in pg_lake_engine derives
+ * array nesting depth from the Postgres type OID.  A multi-dimensional array
+ * (text[][], bytea[][], varchar[][]) shares the same OID as its 1-D
+ * counterpart (Postgres does not encode dimensionality in the type system),
+ * so the rewrite emits a single level of list_transform:
+ *
+ *   list_transform(col, _x0 -> iceberg_size_clamp_text(_x0, $cap))
+ *
+ * DuckDB, however, stores the value as a genuine nested list (VARCHAR[][]),
+ * so _x0 binds as VARCHAR[] rather than a scalar VARCHAR.  Without a
+ * LIST-typed overload the call fails to bind ("No function matches ...
+ * iceberg_size_clamp_text(VARCHAR[], INTEGER)") and every write query for
+ * such a column errors forever.
+ *
+ * Passing the list through unchanged is correct, not merely a bind fix:
+ * multi-dimensional arrays cannot be represented in Iceberg at all, so the
+ * pg_nullify_nested_list / pg_error_nested_list wrapper that runs *before*
+ * the size-clamp wrapper has already reduced any depth>1 value to NULL
+ * (clamp policy) or raised (error policy).  A value that still reaches this
+ * overload is therefore NULL, and its scalar leaves never needed clamping
+ * because the whole value is on its way to being stored as NULL -- exactly
+ * how a multi-dimensional int[][] already behaves.  The scalar overload
+ * continues to clamp genuine 1-D array leaves.
+ */
+static void
+IcebergSizeClampContainerPassthroughFun(DataChunk &args, ExpressionState &state,
+										Vector &result)
+{
+	result.Reference(args.data[0]);
+}
+
+
+/*
  * IcebergSizeCheckTextFun raises if a VARCHAR value's UTF-8 byte length
  * exceeds the second argument; otherwise passes through unchanged.  The
  * third argument is the source column name, included in the error message
@@ -660,32 +696,60 @@ static void LoadInternal(ExtensionLoader &loader) {
 	}
 
 	{
-		ScalarFunction iceberg_size_clamp_text(
-			"iceberg_size_clamp_text",
+		/*
+		 * Each size clamp/check function is registered as a set: the scalar
+		 * overload that does the actual work, plus a LIST-typed overload that
+		 * passes the value through.  The LIST overload lets the single-level
+		 * list_transform the rewrite emits for a multi-dimensional array bind
+		 * (its lambda variable is itself a list); see
+		 * IcebergSizeClampContainerPassthroughFun for the full rationale.  The
+		 * pass-through overloads reuse NestedListBind to resolve their return
+		 * type to the (LIST) input type.
+		 */
+		ScalarFunctionSet iceberg_size_clamp_text("iceberg_size_clamp_text");
+		iceberg_size_clamp_text.AddFunction(ScalarFunction(
 			{LogicalType::VARCHAR, LogicalType::INTEGER},
 			LogicalType::VARCHAR,
-			IcebergSizeClampTextFun);
+			IcebergSizeClampTextFun));
+		iceberg_size_clamp_text.AddFunction(ScalarFunction(
+			{LogicalType::LIST(LogicalType::ANY), LogicalType::INTEGER},
+			LogicalType::LIST(LogicalType::ANY),
+			IcebergSizeClampContainerPassthroughFun, NestedListBind));
 		loader.RegisterFunction(iceberg_size_clamp_text);
 
-		ScalarFunction iceberg_size_clamp_blob(
-			"iceberg_size_clamp_blob",
+		ScalarFunctionSet iceberg_size_clamp_blob("iceberg_size_clamp_blob");
+		iceberg_size_clamp_blob.AddFunction(ScalarFunction(
 			{LogicalType::BLOB, LogicalType::INTEGER},
 			LogicalType::BLOB,
-			IcebergSizeClampBlobFun);
+			IcebergSizeClampBlobFun));
+		iceberg_size_clamp_blob.AddFunction(ScalarFunction(
+			{LogicalType::LIST(LogicalType::ANY), LogicalType::INTEGER},
+			LogicalType::LIST(LogicalType::ANY),
+			IcebergSizeClampContainerPassthroughFun, NestedListBind));
 		loader.RegisterFunction(iceberg_size_clamp_blob);
 
-		ScalarFunction iceberg_size_check_text(
-			"iceberg_size_check_text",
+		ScalarFunctionSet iceberg_size_check_text("iceberg_size_check_text");
+		iceberg_size_check_text.AddFunction(ScalarFunction(
 			{LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
 			LogicalType::VARCHAR,
-			IcebergSizeCheckTextFun);
+			IcebergSizeCheckTextFun));
+		iceberg_size_check_text.AddFunction(ScalarFunction(
+			{LogicalType::LIST(LogicalType::ANY), LogicalType::INTEGER,
+			 LogicalType::VARCHAR},
+			LogicalType::LIST(LogicalType::ANY),
+			IcebergSizeClampContainerPassthroughFun, NestedListBind));
 		loader.RegisterFunction(iceberg_size_check_text);
 
-		ScalarFunction iceberg_size_check_blob(
-			"iceberg_size_check_blob",
+		ScalarFunctionSet iceberg_size_check_blob("iceberg_size_check_blob");
+		iceberg_size_check_blob.AddFunction(ScalarFunction(
 			{LogicalType::BLOB, LogicalType::INTEGER, LogicalType::VARCHAR},
 			LogicalType::BLOB,
-			IcebergSizeCheckBlobFun);
+			IcebergSizeCheckBlobFun));
+		iceberg_size_check_blob.AddFunction(ScalarFunction(
+			{LogicalType::LIST(LogicalType::ANY), LogicalType::INTEGER,
+			 LogicalType::VARCHAR},
+			LogicalType::LIST(LogicalType::ANY),
+			IcebergSizeClampContainerPassthroughFun, NestedListBind));
 		loader.RegisterFunction(iceberg_size_check_blob);
 
 		ScalarFunction iceberg_byte_size(

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -884,6 +884,55 @@ def test_md_array(pg_conn, duckdb_conn, tmp_path):
     assert result[0]["val"] == 2
 
 
+def test_copy_to_array_with_nulls(pg_conn, duckdb_conn, tmp_path):
+    """
+    Regression test for https://github.com/Snowflake-Labs/pg_lake/issues/408.
+
+    DuckDB's CSV string-to-LIST cast can segfault (SIGSEGV) when a row with an
+    array value is followed by NULL rows and auto_detect is left enabled.
+    AppendReadCSVTail now passes auto_detect=false when a typed columns= map
+    is present, which causes DuckDB to return a clean conversion error instead
+    of crashing.  This test exercises the internal temp-CSV read-back path
+    (COPY TO parquet via ConvertCSVFileTo) with a 1-D integer array column and
+    several trailing NULL rows.
+    """
+    parquet_path = tmp_path / "test_array_nulls.parquet"
+
+    run_command(
+        f"""
+        CREATE TABLE test_array_nulls (id bigint, arr int[]);
+        INSERT INTO test_array_nulls VALUES
+            (1, ARRAY[1, 2, 3]),
+            (2, NULL),
+            (3, NULL),
+            (4, NULL),
+            (5, ARRAY[4, 5]),
+            (6, NULL),
+            (7, NULL),
+            (8, NULL),
+            (9, NULL),
+            (10, NULL);
+        COPY test_array_nulls TO '{parquet_path}' WITH (format 'parquet');
+    """,
+        pg_conn,
+    )
+
+    # Verify the parquet file contains the correct rows (not a partial/corrupt
+    # write from a crashed engine process)
+    duckdb_conn.execute(
+        f"SELECT id, arr FROM read_parquet($1) ORDER BY id", [str(parquet_path)]
+    )
+    rows = duckdb_conn.fetchall()
+
+    assert len(rows) == 10
+    assert rows[0] == (1, [1, 2, 3])
+    assert rows[1] == (2, None)
+    assert rows[4] == (5, [4, 5])
+    assert rows[9] == (10, None)
+
+    pg_conn.rollback()
+
+
 def test_copy_virtual_column(pg_conn, tmp_path):
     # virtual columns were introduced in PostgreSQL 18
     if get_pg_version_num(pg_conn) < 180000:

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -1768,6 +1768,20 @@ AppendReadCSVTail(StringInfo buf, int maxLineSize, const char *columnsMap,
 	if (columnsMap != NULL)
 	{
 		appendStringInfo(buf, ", columns=%s", columnsMap);
+
+		/*
+		 * A columns map is only supplied when reading a CSV we wrote
+		 * ourselves, so the schema and dialect are already fully specified
+		 * above.  Turn the sniffer off: with only a columns map (no explicit
+		 * dateformat) DuckDB still auto-detects the date/timestamp format
+		 * from a sample, and a text column holding a non-ISO, date-looking
+		 * string (e.g. "12/25/2020") can make it pick %m/%d/%Y and then fail
+		 * to parse a real ISO date column ("2021-03-10").  Disabling
+		 * auto_detect keeps DuckDB's default ISO casting, which also handles
+		 * BC / out-of-range / infinity dates that a fixed dateformat string
+		 * would reject.
+		 */
+		appendStringInfoString(buf, ", auto_detect=false");
 	}
 	else
 	{

--- a/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
+++ b/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
@@ -482,7 +482,7 @@ IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot * snapshot, HTAB *fileHash)
 		{
 			DataFile   *dataFile = lfirst(dataFileCell);
 
-			AppendFileToHash(MemoryContextStrdup(oldContext, dataFile->file_path), fileHash);
+			AppendFileToHash(dataFile->file_path, fileHash);
 		}
 
 		MemoryContextSwitchTo(oldContext);

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -96,6 +96,8 @@ ReadIcebergManifests(const char *manifestListPath)
 
 	int			writtenLength = FileWrite(manifestListLocalFile, manifestListBlob, contentLength, 0, WAIT_EVENT_COPY_FILE_WRITE);
 
+	pfree(manifestListBlob);
+
 	if (writtenLength != contentLength)
 	{
 		ereport(ERROR,
@@ -141,6 +143,8 @@ ReadManifestEntries(const char *manifestPath)
 	const char *manifestLocalPath = FilePathName(manifestLocalFile);
 
 	int			writtenLength = FileWrite(manifestLocalFile, manifestBlob, contentLength, 0, WAIT_EVENT_COPY_FILE_WRITE);
+
+	pfree(manifestBlob);
 
 	if (writtenLength != contentLength)
 	{

--- a/pg_lake_table/tests/pytests/test_csv_date_format.py
+++ b/pg_lake_table/tests/pytests/test_csv_date_format.py
@@ -1,0 +1,32 @@
+import datetime
+
+import pytest
+
+from utils_pytest import *
+
+
+def test_iso_date_survives_us_style_date_in_text_column(s3, pg_conn, extension):
+    """A US-format date string in a text column must not make the CSV reader
+    wrongly parse a real ISO date column on the same row.
+
+    pg_lake round-trips table writes through an internal CSV (always ISO for
+    dates) read back with DuckDB read_csv. The read passes an explicit columns
+    type map, which pins column *types* but not the date *format* -- DuckDB
+    still auto-detects the format. A text value like "12/25/2020" made the
+    sniffer choose date_format=%m/%d/%Y for the whole file, which then failed to
+    parse the ISO value "2021-03-10" in the real date column
+    (Could not convert string "2021-03-10" to 'DATE').
+    """
+    location = f"s3://{TEST_BUCKET}/test_iso_date_us_text/"
+    run_command(
+        f"""CREATE TABLE t_iso_date (txt text, d date)
+            USING iceberg WITH (location = '{location}')""",
+        pg_conn,
+    )
+    run_command(
+        "INSERT INTO t_iso_date VALUES ('12/25/2020', DATE '2021-03-10')",
+        pg_conn,
+    )
+    result = run_query("SELECT txt, d FROM t_iso_date", pg_conn)
+    assert result == [["12/25/2020", datetime.date(2021, 3, 10)]]
+    pg_conn.rollback()

--- a/pg_lake_table/tests/pytests/test_iceberg_size_clamping_containers.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_size_clamping_containers.py
@@ -484,3 +484,162 @@ def test_small_container_roundtrips_unchanged_under_snowflake(
     run_command("RESET search_path;", pg_conn)
     run_command("DROP SCHEMA test_size_passthrough CASCADE;", pg_conn)
     pg_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Multi-dimensional string/binary arrays under compatibility_mode='snowflake'.
+#
+# A multi-dimensional array (text[][], varchar[][], bpchar[][], bytea[][])
+# shares its Postgres OID with the 1-D counterpart, so the size-clamp rewrite
+# derives a single array level and emits one list_transform wrapping the
+# per-leaf clamp/check function:
+#
+#     list_transform(v, _x0 -> iceberg_size_clamp_text(_x0, <cap>))
+#
+# DuckDB, however, materializes the value as a genuine nested list
+# (VARCHAR[][] / BLOB[][]), so the lambda variable _x0 binds as a LIST, not a
+# scalar.  Without the LIST-typed pass-through overload registered in
+# duckdb_pglake (iceberg_size_clamp_text/_blob, iceberg_size_check_text/_blob)
+# the write query fails to bind ("No function matches
+# iceberg_size_clamp_text(VARCHAR[], INTEGER)") and every INSERT..SELECT into
+# the snowflake-mode table errors out.  The pass-through is correct rather than
+# merely a bind fix: the pg_nullify_nested_list / pg_error_nested_list wrapper
+# runs first (inner SELECT) and has already reduced any depth>1 value to NULL
+# (clamp) or raised (error), so a value that reaches the size clamp is NULL --
+# exactly how a multi-dimensional int[][] already behaves.
+#
+# These cases drive the *pushdown* path (a genuinely-nested parquet source,
+# read back as VARCHAR[][]/BLOB[][]) with compatibility_mode='snowflake', which
+# is what enables the size-clamp wrapper.  The plain-iceberg multidim coverage
+# in test_iceberg_validation.py does not set snowflake mode, so it never
+# exercises this wrapper and did not catch the bind failure.
+#
+# int[] is a control: a fixed-width leaf is never wrapped by a per-leaf clamp,
+# so it binds regardless and must still clamp the multidim value to NULL.
+# json / jsonb are intentionally not covered here: they route through a
+# strlen(::VARCHAR) expression that already binds on a list, so they were never
+# affected by this bug.
+# ---------------------------------------------------------------------------
+
+MULTIDIM_SNOWFLAKE_STRING_BINARY_PARAMS = [
+    pytest.param("text[]", "[['a','b'],['c','d']]", id="text"),
+    pytest.param("varchar[]", "[['a','b'],['c','d']]", id="varchar"),
+    pytest.param("bpchar[]", "[['a','b'],['c','d']]", id="bpchar"),
+    pytest.param(
+        "bytea[]",
+        "[['a'::blob,'b'::blob],['c'::blob,'d'::blob]]",
+        id="bytea",
+    ),
+]
+
+
+def _write_nested_parquet(pgduck_conn, parquet_url, duckdb_nested_expr):
+    """Write a single-row parquet whose ``col`` is a genuinely nested list, via
+    DuckDB directly, so the pg_lake foreign scan reads it back as VARCHAR[][] /
+    BLOB[][] -- the shape that triggers the single-level list_transform bind."""
+    run_command(
+        f"COPY (SELECT 1 AS id, {duckdb_nested_expr} AS col) "
+        f"TO '{parquet_url}' (FORMAT PARQUET);",
+        pgduck_conn,
+    )
+    pgduck_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,duckdb_nested_expr",
+    MULTIDIM_SNOWFLAKE_STRING_BINARY_PARAMS
+    + [pytest.param("int[]", "[[1,2],[3,4]]", id="int_control")],
+)
+def test_multidim_array_clamps_to_null_under_snowflake_pushdown(
+    pg_conn,
+    pgduck_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    duckdb_nested_expr,
+):
+    """A multi-dimensional array binds and clamps to NULL on the snowflake
+    size-clamp pushdown path.  Regression for the missing LIST-typed overload of
+    iceberg_size_clamp_text / iceberg_size_clamp_blob: before the fix this
+    INSERT..SELECT failed to bind for the string/binary element types."""
+    schema = "test_md_sf_clamp_" + col_type.strip("[]")
+    parquet_url = f"s3://{TEST_BUCKET}/{schema}/data.parquet"
+
+    _write_nested_parquet(pgduck_conn, parquet_url, duckdb_nested_expr)
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    try:
+        run_command(
+            f"CREATE FOREIGN TABLE source (id int, col {col_type}) "
+            f"SERVER pg_lake OPTIONS (path '{parquet_url}');",
+            pg_conn,
+        )
+        run_command(
+            f"CREATE TABLE dst (id int, col {col_type}) USING iceberg "
+            "WITH (compatibility_mode = 'snowflake', out_of_range_values = 'clamp');",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        run_command("INSERT INTO dst SELECT * FROM source;", pg_conn)
+        pg_conn.commit()
+
+        # The multidimensional value is not representable in Iceberg, so it is
+        # clamped to NULL (the 1-D leaves are never reached).
+        result = run_query("SELECT id, col IS NULL AS is_null FROM dst;", pg_conn)
+        assert [[r[0], r[1]] for r in result] == [[1, True]]
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col_type,duckdb_nested_expr", MULTIDIM_SNOWFLAKE_STRING_BINARY_PARAMS
+)
+def test_multidim_array_errors_under_snowflake_pushdown(
+    pg_conn,
+    pgduck_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    duckdb_nested_expr,
+):
+    """Under out_of_range_values='error', a multi-dimensional string/binary
+    array on the snowflake pushdown path binds and raises the
+    multidimensional-arrays error (from pg_error_nested_list, which runs before
+    the size check).  Exercises the LIST overload of iceberg_size_check_text /
+    iceberg_size_check_blob, which must still bind even though the row errors."""
+    schema = "test_md_sf_err_" + col_type.strip("[]")
+    parquet_url = f"s3://{TEST_BUCKET}/{schema}/data.parquet"
+
+    _write_nested_parquet(pgduck_conn, parquet_url, duckdb_nested_expr)
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    try:
+        run_command(
+            f"CREATE FOREIGN TABLE source (id int, col {col_type}) "
+            f"SERVER pg_lake OPTIONS (path '{parquet_url}');",
+            pg_conn,
+        )
+        run_command(
+            f"CREATE TABLE dst (id int, col {col_type}) USING iceberg "
+            "WITH (compatibility_mode = 'snowflake', out_of_range_values = 'error');",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        with pytest.raises(Exception) as exc:
+            run_command("INSERT INTO dst SELECT * FROM source;", pg_conn)
+        pg_conn.rollback()
+        assert "multidimensional arrays are not supported" in str(exc.value).lower()
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
+++ b/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
@@ -1632,7 +1632,14 @@ def test_reject_writable_table_on_server_with_catalog_name(
     )
     superuser_conn.commit()
 
-    run_command(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA_NAME}", pg_conn)
+    # Own the schema with pg_conn so the CREATE TABLE below reaches the
+    # catalog_name rejection rather than tripping a permission check. Drop any
+    # leftover first (as superuser, so it works regardless of who leaked it):
+    # this test shares TABLE_NAMESPACE with the other writable-REST tests, and
+    # they may land in the same pytest-split group in any order.
+    run_command(f"DROP SCHEMA IF EXISTS {SCHEMA_NAME} CASCADE", superuser_conn)
+    superuser_conn.commit()
+    run_command(f"CREATE SCHEMA {SCHEMA_NAME}", pg_conn)
     pg_conn.commit()
 
     err = run_command(
@@ -1647,6 +1654,10 @@ def test_reject_writable_table_on_server_with_catalog_name(
         in str(err)
     )
     pg_conn.rollback()
+
+    # Clean up so we do not leak the schema to a later test in the same group.
+    run_command(f"DROP SCHEMA IF EXISTS {SCHEMA_NAME} CASCADE", pg_conn)
+    pg_conn.commit()
 
     superuser_conn.rollback()
     run_command(f"DROP SERVER {SERVER_NAME} CASCADE", superuser_conn)


### PR DESCRIPTION
## Summary

Backports three already-merged `main` fixes onto `release-3.4`:

- **#454** — Fix memory leaks during Iceberg manifest processing (@marknefedov)
- **#461** — `duckdb_pglake`: bind size-clamp on multi-dimensional arrays (@sfc-gh-okalaci)
- **#463** — Disable the CSV sniffer when reading our own CSVs by column map
  (@sfc-gh-mslot fix + @sfc-gh-rbachala test), which resolves both a `date`
  mis-parse that wedges reads and the array-NULL `pgduck_server` segfault (#408).

## Commits (cherry-picked from `main`, `-x` provenance preserved)

| Commit | Origin | Author |
|---|---|---|
| Fix memory leaks during manifest processing | #454 | Mark Nefedov |
| duckdb_pglake: bind size-clamp on multi-dimensional arrays | #461 | Önder Kalacı |
| pg_lake_engine: disable the CSV sniffer when reading our own CSVs by column map | #463 | Marco Slot |
| pg_lake_copy: pass auto_detect=false on internal CSV read-back | #463 | Richie Bachala |

No conflicts other than the `test_parquet_copy.py` insertion point (the unrelated
nested-numeric tests from #448 are not part of this backport and were not pulled in).
