### PR TITLE
Fix flaky test_sequences_serial_and_generated_columns[rest]

### DIFF
--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -1190,8 +1190,16 @@ def test_sequences_serial_and_generated_columns(
     if installcheck:
         return
     # ---------- Setup ----------
+    # This test is marked flaky(reruns=2) and uses a module-scoped connection.
+    # A previous (failed) attempt commits these tables into the REST catalog,
+    # and REST-catalog drops only take effect on commit. Roll back any leftover
+    # transaction state and commit the schema drop before recreating the tables,
+    # otherwise the stale REST-catalog entry is still present when CREATE TABLE
+    # runs and the catalog rejects it with HTTP 409 AlreadyExists on every rerun.
+    pg_conn.rollback()
     run_command("DROP SCHEMA IF EXISTS seq_demo CASCADE;", pg_conn)
     run_command("CREATE SCHEMA seq_demo;", pg_conn)
+    pg_conn.commit()
 
     # A standalone sequence for manual use
     run_command(


### PR DESCRIPTION
## Problem

`test_polaris_catalog_writable.py::test_sequences_serial_and_generated_columns[rest]` flakes in CI (e.g. [this run](https://github.com/Snowflake-Labs/pg_lake/actions/runs/30006111280/job/89203344030?pr=464)). Although the test is marked `@pytest.mark.flaky(reruns=2)`, the reruns never recover: all three attempts fail identically with

```
psycopg2.errors.ExternalRoutineException: HTTP request failed (HTTP 409)
DETAIL:  Table already exists: seq_demo.manual_seq_table
HINT:  The rest catalog returned error type: AlreadyExistsException
```

Registering a table in the REST catalog is transactional: a `DROP` only removes the catalog entry on commit (see `test_writable_drop_table` in the same file). This test uses a module-scoped connection, and its section-1 `COMMIT;` persists the five created tables into both Postgres and the REST catalog. When a later assertion fails, those tables stay committed. The `flaky` rerun's setup then ran `DROP SCHEMA ... CASCADE`, `CREATE SCHEMA` and `CREATE TABLE` all in a single uncommitted transaction, so the `DROP`'s REST-catalog deletion was never flushed before `CREATE TABLE` tried to re-register the same table. The catalog still held the stale entry and rejected the create with HTTP 409, on every rerun.

## Solution

In the test setup, roll back any leftover transaction state from a prior attempt and commit the schema drop before recreating the tables, so stale REST-catalog entries are purged first. This makes the `flaky(reruns=2)` marker able to actually recover. The change is a no-op on a clean first run and harmless for the `[postgres]` variant.

## Test plan

- `black --check` passes on the modified file.
- The `[postgres]` and `[rest]` variants still pass on a clean run; the `[rest]` rerun path now starts from a purged catalog instead of hitting a deterministic 409.