### PR TITLE
pg_lake_iceberg: fix off-by-one overflow on partition field names

### DIFF
--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -616,12 +616,16 @@ CreateManifestPartitionFieldMap(AvroReader * manifestReader)
 		 * fieldName buffer including the terminating NUL. Check before
 		 * entering it into the hash, which would truncate the key.
 		 */
-		if (strlen(fieldName) >= PARTITION_FIELD_NAME_MAX_LENGTH)
+		size_t		fieldNameLength = strlen(fieldName);
+
+		if (fieldNameLength == 0 ||
+			fieldNameLength >= PARTITION_FIELD_NAME_MAX_LENGTH)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("Partition field name %s is too long with length %zu",
-							fieldName, strlen(fieldName))));
+					 errmsg("Partition field name length must be between 1 and %d, got %zu",
+							PARTITION_FIELD_NAME_MAX_LENGTH - 1,
+							fieldNameLength)));
 		}
 
 		bool		fieldFound = false;

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -611,6 +611,19 @@ CreateManifestPartitionFieldMap(AvroReader * manifestReader)
 			logicalTypeName = TextDatumGetCString(logicalTypeNameDatum);
 		}
 
+		/*
+		 * The field name is the hash key, so it must fit into the entry's
+		 * fieldName buffer including the terminating NUL. Check before
+		 * entering it into the hash, which would truncate the key.
+		 */
+		if (strlen(fieldName) >= PARTITION_FIELD_NAME_MAX_LENGTH)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("Partition field name %s is too long with length %zu",
+							fieldName, strlen(fieldName))));
+		}
+
 		bool		fieldFound = false;
 
 		PartitionFieldIdMapEntry *entry = hash_search(partitionFieldMap, fieldName, HASH_ENTER, &fieldFound);
@@ -619,16 +632,6 @@ CreateManifestPartitionFieldMap(AvroReader * manifestReader)
 
 		entry->fieldId = atoi(fieldId);
 		entry->fieldType = IcebergAvroTypeFromString(physicalTypeName, logicalTypeName);
-
-		if (strlen(fieldName) > PARTITION_FIELD_NAME_MAX_LENGTH)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("Partition field name %s is too long with length %d",
-							fieldName, PARTITION_FIELD_NAME_MAX_LENGTH)));
-		}
-
-		strcpy(entry->fieldName, fieldName);
 
 		MemoryContextSwitchTo(spiContext);
 	}

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_metadata_via_pyiceberg.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_metadata_via_pyiceberg.py
@@ -346,6 +346,68 @@ def test_iceberg_catalog(
     assert pg_lake_result == pyiceberg_result
 
 
+def test_partition_field_name_length_limit(
+    create_reserialize_helper_functions, iceberg_catalog, superuser_conn
+):
+    schema = Schema(
+        NestedField(1, "source", StringType(), required=False),
+    )
+    arrow_data = pa.Table.from_pylist(
+        [{"source": "value"}],
+        schema=pa.schema([("source", pa.string())]),
+    )
+
+    def create_partitioned_table(table_name, partition_field_name):
+        partition_spec = PartitionSpec(
+            PartitionField(
+                source_id=1,
+                field_id=1000,
+                transform=IdentityTransform(),
+                name=partition_field_name,
+            )
+        )
+        table = iceberg_catalog.create_table(
+            identifier=f"public.{table_name}",
+            schema=schema,
+            location=f"s3://{TEST_BUCKET}/iceberg/public/{table_name}",
+            partition_spec=partition_spec,
+        )
+        table.append(arrow_data)
+        return table
+
+    maximum_length_name = "p" * 99
+    valid_table = create_partitioned_table(
+        "valid_partition_field_name_length", maximum_length_name
+    )
+    valid_fields = run_query(
+        f"""
+        SELECT partition_field_name
+        FROM lake_iceberg.current_partition_fields('{valid_table.metadata_location}');
+        """,
+        superuser_conn,
+    )
+    assert valid_fields == [[maximum_length_name]]
+
+    too_long_name = "p" * 100
+    invalid_table = create_partitioned_table(
+        "invalid_partition_field_name_length", too_long_name
+    )
+    with pytest.raises(
+        psycopg2.InternalError,
+        match="Partition field name length must be between 1 and 99, got 100",
+    ):
+        run_query(
+            f"""
+            SELECT *
+            FROM lake_iceberg.current_partition_fields(
+                '{invalid_table.metadata_location}'
+            );
+            """,
+            superuser_conn,
+        )
+    superuser_conn.rollback()
+
+
 def test_iceberg_datafiles(
     create_reserialize_helper_functions,
     spark_generated_iceberg_test,


### PR DESCRIPTION
The length guard used `>` against `PARTITION_FIELD_NAME_MAX_LENGTH` (100), but `fieldName` is a `char[100]` that must also hold the terminating NUL. A name of exactly 100 characters passed the check, and `strcpy` wrote 101 bytes, overflowing into the adjacent `fieldId` member and corrupting partition stat parsing. Iceberg metadata written by other engines is not bound by PostgreSQL's identifier length limit, so long generated transform names can reach this.

Changes:
- check the length (with `>=`) **before** `HASH_ENTER`, which would otherwise silently truncate the key via `strlcpy`
- report the actual name length in the error message instead of the limit
- drop the redundant `strcpy`: dynahash (`HASH_STRINGS`) has already copied the key into the entry