### PR TITLE
pg_lake_table: reset errno before parsing column_stats_mode length

### DIFF
--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -857,6 +857,9 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 				strncpy(columnStatsTruncateLenStr, truncateLenStrStart + 1, truncateLenStrEnd - truncateLenStrStart - 1);
 
 				char	   *parseEnd = NULL;
+
+				errno = 0;
+
 				int64_t		columnStatsTruncateLen = strtoi64(columnStatsTruncateLenStr, &parseEnd, 10);
 
 				if (errno == EINVAL || *parseEnd != '\0')


### PR DESCRIPTION
The `truncate(N)` parser checked `errno` for `EINVAL`/`ERANGE` after `strtoi64` without clearing it first. A stale `errno` left behind by any earlier libc call could make a perfectly valid option like `column_stats_mode 'truncate(100)'` fail with "truncate length must be a valid integer".

One-line fix: `errno = 0` before the call, per the standard `strtol` family contract.