### PR TITLE
pgduck_server: fix typo and stray newlines in socket error messages

### DIFF
--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -306,7 +306,7 @@ set_unix_socket_permissions(char *unixSocketPath, char *groupName, int permissio
 		}
 		if (chown(unixSocketPath, -1, gid) == -1)
 		{
-			PGDUCK_SERVER_ERROR("could not set grou of socket file \"%s\": %m\n",
+			PGDUCK_SERVER_ERROR("could not set group of socket file \"%s\": %m",
 								unixSocketPath);
 			return STATUS_ERROR;
 		}
@@ -314,7 +314,7 @@ set_unix_socket_permissions(char *unixSocketPath, char *groupName, int permissio
 
 	if (chmod(unixSocketPath, permissionsMask) == -1)
 	{
-		PGDUCK_SERVER_ERROR("could not set Unix-socket address \"%s\" permissions: %m\n",
+		PGDUCK_SERVER_ERROR("could not set Unix-socket address \"%s\" permissions: %m",
 							unixSocketPath);
 
 		return STATUS_ERROR;


### PR DESCRIPTION
"grou" → "group" in the socket-group error message, and drop the embedded trailing `\n` in two messages: the logging macro already appends one, so these produced blank lines in the log, unlike every other message in the file.