### PR TITLE
pgduck_server: free query result when sending CopyDone fails

### DIFF
--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -1123,6 +1123,8 @@ return_query_result_to_pgsession(DuckDBSession * duckSession, duckdb_result duck
 		/* send CopyDone response */
 		if (!IsOK(pgsession_putemptymessage(duckSession->clientSession, 'c')))
 		{
+			duckdb_query_result_destroy(&duckdb_query_result);
+
 			PGDUCK_SERVER_ERROR("could not send CopyDone");
 
 			return DUCKDB_PG_COMMUNICATION_ERROR;


### PR DESCRIPTION
Every other error path in `return_query_result_to_pgsession()` destroys the `DuckDBQueryResult` before returning, but the failed-CopyDone path in transmit mode returned without doing so, leaking the accumulated message buffer and the column metadata array. The path fires when a client disconnects in the window after the last data chunk was sent, and pgduck_server is long-lived, so the leaked buffers accumulate over time.