### PR TITLE
pgduck_server: stop leaking the per-connection cancellation token

### DIFF
--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -151,6 +151,11 @@ pgclient_threadpool_reserve_slot(PGClient * client)
 	if (ActiveClientThreadCount >= MaxAllowedClients)
 	{
 		pthread_rwlock_unlock(&rwlock);
+
+#if PG_VERSION_NUM >= 180000
+		pfree(cancellationToken);
+#endif
+
 		return InvalidThreadIndex;
 	}
 
@@ -181,6 +186,16 @@ pgclient_threadpool_reserve_slot(PGClient * client)
 
 	/* store the thread index, to assign the DuckDB connection later */
 	client->threadIndex = usedThreadIndex;
+
+	if (usedThreadIndex == InvalidThreadIndex)
+	{
+		/* no slot assigned, so nothing will ever use or free the token */
+#if PG_VERSION_NUM >= 180000
+		pfree(cancellationToken);
+#endif
+
+		return InvalidThreadIndex;
+	}
 
 	/* store the cancellation token, to be transmitted to the client later */
 	client->cancellationProcId = cancellationProcId;

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -496,10 +496,19 @@ pgserver_run(PGServer * pgServer)
 		{
 			PGDUCK_SERVER_ERROR("Thread creation failed for client %d", client->clientSocket);
 
+			/*
+			 * Free the slot first: it clears the pool's copy of the token
+			 * pointer under the lock, so a concurrent cancel request can no
+			 * longer read the token we are about to free.
+			 */
+			pgclient_threadpool_free_slot(threadIndex);
+
 			close(client->clientSocket);
+#if PG_VERSION_NUM >= 180000
+			pfree(client->cancellationToken);
+#endif
 			pg_free(client);
 			pg_free(initState);
-			pgclient_threadpool_free_slot(threadIndex);
 		}
 
 		if (enable_shutdown_signals() != STATUS_OK)
@@ -636,6 +645,10 @@ pgclient_thread_cleanup(void *arg)
 	/* end of the thread, free the pre-thread resources */
 	pgclient_threadpool_free_slot(initState->threadIndex);
 	closesocket(initState->pgClient->clientSocket);
+#if PG_VERSION_NUM >= 180000
+	/* the thread pool slot only kept a pointer copy; the client owns it */
+	pfree(initState->pgClient->cancellationToken);
+#endif
 	pg_free(initState->pgClient);
 	pg_free(initState);
 }


### PR DESCRIPTION
On PostgreSQL 18+ the cancellation token is heap-allocated per connection in `pgclient_threadpool_reserve_slot()`, but was never freed on any path: the thread pool slot only NULLs its pointer copy in `free_slot`, thread cleanup freed the `PGClient` but not the token, and the rejected-client and thread-creation-failure paths dropped it too. Connections churn constantly (pg_lake's cache manager connects at least every 10 seconds), so the long-lived server leaked without bound.

Changes:
- free the token in `pgclient_thread_cleanup()` for the normal path — safe because `free_slot` has already cleared the pool's pointer copy under the lock, so a concurrent cancel request can no longer see it
- on the thread-creation-failure path, free the slot **first** (clearing the published pointer under the lock), then free the token — a concurrent cancel could otherwise `memcmp` freed memory
- free the token on the reserve-failure paths where it would otherwise be orphaned