### PR TITLE
pgduck_server: free partial output buffer on nested conversion errors

### DIFF
--- a/pgduck_server/src/duckdb/type_conversion.c
+++ b/pgduck_server/src/duckdb/type_conversion.c
@@ -1005,6 +1005,7 @@ array_to_text(duckdb_vector vector, duckdb_logical_type arrayLogicalType, int ro
 			if (status != DUCKDB_SUCCESS)
 			{
 				CleanupOutputBuffer(&elementOutputBuffer);
+				pg_free(topLevelBuffer.data);
 				goto cleanup;
 			}
 		}
@@ -1162,6 +1163,7 @@ list_to_text(duckdb_vector vector, duckdb_logical_type listLogicalType, int row,
 			if (status != DUCKDB_SUCCESS)
 			{
 				CleanupOutputBuffer(&elementOutputBuffer);
+				pg_free(topLevelBuffer.data);
 				goto cleanup;
 			}
 		}
@@ -1269,6 +1271,7 @@ struct_to_text(duckdb_vector vector, duckdb_logical_type structLogicalType, int 
 		{
 			PGDUCK_SERVER_ERROR("could not find type mapping for DuckDB type: %d", structElemTypeId);
 			status = DUCKDB_TYPE_CONVERSION_ERROR;
+			pg_free(topLevelBuffer.data);
 			goto cleanup;
 		}
 
@@ -1303,6 +1306,7 @@ struct_to_text(duckdb_vector vector, duckdb_logical_type structLogicalType, int 
 			if (status != DUCKDB_SUCCESS)
 			{
 				CleanupOutputBuffer(&elementOutputBuffer);
+				pg_free(topLevelBuffer.data);
 				goto cleanup;
 			}
 		}


### PR DESCRIPTION
`array_to_text()`, `list_to_text()`, and `struct_to_text()` build the text representation in a heap-allocated StringInfo, but the error paths (element conversion failure or unmapped element type) jumped to cleanup without freeing it, leaking the partially built buffer in the long-lived server every time a nested value fails to convert. On success the buffer is handed off to the caller via `toTextBuffer`, so only the error paths need the free.