### PR TITLE
pg_lake_engine: don't leak the PGresult when COPY stats parsing throws

### DIFF
--- a/pg_lake_engine/src/data_file/data_file_stats.c
+++ b/pg_lake_engine/src/data_file/data_file_stats.c
@@ -87,13 +87,19 @@ ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 									   CopyDataFormat destinationFormat)
 {
 	PGDuckConnection *pgDuckConn = GetPGDuckConnection();
-	PGresult   *result;
+	PGresult   *volatile result = NULL;
 	StatsCollector *statsCollector = NULL;
 
 	PG_TRY();
 	{
 		result = ExecuteQueryOnPGDuckConnection(pgDuckConn, copyCommand);
-		CheckPGDuckResult(pgDuckConn, result);
+
+		/*
+		 * Use the non-clearing check: the PG_FINALLY below owns the result
+		 * and CheckPGDuckResult would already PQclear it before throwing,
+		 * leading to a double free.
+		 */
+		ThrowIfPGDuckResultHasError(pgDuckConn, result);
 
 		if (destinationFormat == DATA_FORMAT_PARQUET ||
 			destinationFormat == DATA_FORMAT_ICEBERG)
@@ -133,11 +139,11 @@ ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 				statsCollector->dataFileStats = list_make1(fileStats);
 			}
 		}
-
-		PQclear(result);
 	}
 	PG_FINALLY();
 	{
+		/* PQclear is a no-op on NULL, so this is safe on early errors */
+		PQclear(result);
 		ReleasePGDuckConnection(pgDuckConn);
 	}
 	PG_END_TRY();


### PR DESCRIPTION
`ExecuteCopyToCommandOnPGDuckConnection()` only cleared the libpq result on the success path; if parsing the returned stats or the per-file stats lookup threw, the `PG_FINALLY` released the connection but leaked the malloc'ed `PGresult` (libpq results are not tracked by memory contexts).

Move `PQclear` into the `PG_FINALLY` and switch the error check to `ThrowIfPGDuckResultHasError()` — the clearing variant `CheckPGDuckResult()` would already free the result before throwing, which would cause a double free once the FINALLY owns cleanup. `result` is `volatile` per the `PG_TRY` contract, and `PQclear(NULL)` is a no-op for the early-error case.