### PR TITLE
pg_lake_table: hoist loop-invariant lookups out of data file pruning

### DIFF
--- a/pg_lake_table/src/fdw/data_file_pruning.c
+++ b/pg_lake_table/src/fdw/data_file_pruning.c
@@ -127,6 +127,8 @@ static OpExpr *MakeOpExpression(Var *variable, int16 strategyNumber);
 static NullTest *MakeIsNullExpression(Var *variable);
 static Oid	GetOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber);
 static HTAB *TryCreateBatchFilterHash(List *baseRestrictInfoList, Var *filenameCol);
+static List *GetDataFileStatsAndPartition(bool isInternalIcebergTable, void *dataFile,
+										  List *externalLeafFields, Partition * *partition);
 
 /* partition pruning functions */
 static Expr *PartitionFieldBoundConstraint(PartitionField * partitionField,
@@ -238,37 +240,34 @@ PruneDataFiles(Oid relationId, List *dataFiles, List *baseRestrictInfoList, Prun
 
 	int			dataFileCount = list_length(dataFiles);
 
+	/*
+	 * Resolve the table type once: IsInternalIcebergTable parses the foreign
+	 * table options on every call. For external tables, also fetch the leaf
+	 * fields once; they come from the metadata file, so looking them up per
+	 * data file would re-read and re-parse the metadata every iteration.
+	 */
+	bool		isInternalIcebergTable = IsInternalIcebergTable(relationId);
+	List	   *externalLeafFields = NIL;
+
+	/*
+	 * Non-Iceberg tables returned early above, so anything that is not an
+	 * internal Iceberg table is an external one. Assert instead of erroring:
+	 * the case is unreachable, and this keeps the second option lookup out of
+	 * non-assert builds.
+	 */
+	Assert(isInternalIcebergTable || IsExternalIcebergTable(relationId));
+
+	if (!isInternalIcebergTable && dataFileCount > 0)
+		externalLeafFields = GetLeafFieldsForTable(relationId);
+
 	for (int dataFileIndex = 0; dataFileIndex < dataFileCount; ++dataFileIndex)
 	{
 		List	   *columnBoundConstraints = NIL;
-		List	   *columnStats = NIL;
 		Partition  *partition = NULL;
-
-		if (IsInternalIcebergTable(relationId))
-		{
-			TableDataFile *tableDataFile = (TableDataFile *) list_nth(dataFiles, dataFileIndex);
-
-			Assert(tableDataFile->content == CONTENT_DATA);
-			columnStats = tableDataFile->stats.columnStats;
-			partition = tableDataFile->partition;
-		}
-		else if (IsExternalIcebergTable(relationId))
-		{
-			DataFile   *dataFile = (DataFile *) list_nth(dataFiles, dataFileIndex);
-
-			List	   *leafFields = GetLeafFieldsForTable(relationId);
-			char	   *dataFilePath = (char *) ((DataFile *) dataFile)->file_path;
-
-			columnStats = GetRemoteParquetColumnStats(dataFilePath, leafFields);
-			partition = &(dataFile->partition);
-		}
-		else
-		{
-			/* never expect to get here, still better than assert */
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("Unsupported table type for data file pruning")));
-		}
+		List	   *columnStats =
+			GetDataFileStatsAndPartition(isInternalIcebergTable,
+										 list_nth(dataFiles, dataFileIndex),
+										 externalLeafFields, &partition);
 
 		/* calculate bound constraints */
 		columnBoundConstraints =
@@ -301,6 +300,36 @@ PruneDataFiles(Oid relationId, List *dataFiles, List *baseRestrictInfoList, Prun
 	return retainedDataFiles;
 }
 
+/*
+ * GetDataFileStatsAndPartition returns the column stats of a single data file
+ * and sets *partition to that file's partition.
+ *
+ * The list elements have a different type per table type, so dataFile is
+ * untyped: it points to a TableDataFile for internal Iceberg tables and to a
+ * DataFile for external ones. externalLeafFields is only used for the latter,
+ * where the stats are read from the remote Parquet footer.
+ */
+static List *
+GetDataFileStatsAndPartition(bool isInternalIcebergTable, void *dataFile,
+							 List *externalLeafFields, Partition * *partition)
+{
+	if (isInternalIcebergTable)
+	{
+		TableDataFile *tableDataFile = (TableDataFile *) dataFile;
+
+		Assert(tableDataFile->content == CONTENT_DATA);
+		*partition = tableDataFile->partition;
+		return tableDataFile->stats.columnStats;
+	}
+	else
+	{
+		DataFile   *externalDataFile = (DataFile *) dataFile;
+
+		*partition = &(externalDataFile->partition);
+		return GetRemoteParquetColumnStats((char *) externalDataFile->file_path,
+										   externalLeafFields);
+	}
+}
 
 /*
  * GetPartitionSpecFieldsUsedInQuery gets the partition spec fields that are


### PR DESCRIPTION
`PruneDataFiles()` resolved the table type and, for external Iceberg tables, called `GetLeafFieldsForTable()` inside the per-data-file loop. The table type check parses foreign table options on every call, and `GetLeafFieldsForTable()` re-reads and re-parses the entire Iceberg metadata file (object store fetch + jsonb parse) per data file. Both are invariant across the loop.

Resolve the table type and fetch the leaf fields once before the loop. Sharing one leaf-field list across iterations is safe: `GetRemoteParquetColumnStats()` copies the list before sorting and only reads the referenced fields.