### PR TITLE
pg_lake_table: mark fully matched data files with a linear merge

### DIFF
--- a/pg_lake_table/include/pg_lake/fdw/data_file_pruning.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_file_pruning.h
@@ -26,6 +26,11 @@
  * PruneDataFiles can prune in two ways:
  * - find files that might match the filters
  * - find files that are fully implied by the filters
+ *
+ * The returned list preserves the relative order and the element identity of
+ * dataFiles. Callers rely on this to merge the result against the input in a
+ * single pass, so a new return path must keep filtering dataFiles in order
+ * rather than rebuilding or reordering it.
  */
 typedef enum PruneType
 {

--- a/pg_lake_table/src/fdw/snapshot.c
+++ b/pg_lake_table/src/fdw/snapshot.c
@@ -224,6 +224,14 @@ CreateTableScanForRelation(Oid relationId, Snapshot snapshot, int uniqueRelation
 		if (isResultRelation)
 			fullMatches = PruneDataFiles(relationId, prunedDataFiles, baseRestrictInfoList, FULL_MATCH);
 
+		/*
+		 * fullMatches is produced by filtering prunedDataFiles in order, so
+		 * it is an ordered sublist and a tandem cursor suffices to mark the
+		 * fully matched files, instead of an O(files * matches)
+		 * list_member_ptr scan.
+		 */
+		ListCell   *fullMatchCell = list_head(fullMatches);
+
 		foreach_ptr(TableDataFile, dataFile, prunedDataFiles)
 		{
 			PgLakeFileScan *fileScan = palloc0(sizeof(PgLakeFileScan));
@@ -231,7 +239,12 @@ CreateTableScanForRelation(Oid relationId, Snapshot snapshot, int uniqueRelation
 			fileScan->path = dataFile->path;
 			fileScan->rowCount = dataFile->stats.rowCount;
 			fileScan->deletedRowCount = dataFile->stats.deletedRowCount;
-			fileScan->allRowsMatch = list_member_ptr(fullMatches, dataFile);
+
+			if (fullMatchCell != NULL && lfirst(fullMatchCell) == dataFile)
+			{
+				fileScan->allRowsMatch = true;
+				fullMatchCell = lnext(fullMatches, fullMatchCell);
+			}
 
 			fileScans = lappend(fileScans, fileScan);
 		}

--- a/pg_lake_table/src/fdw/snapshot.c
+++ b/pg_lake_table/src/fdw/snapshot.c
@@ -229,6 +229,12 @@ CreateTableScanForRelation(Oid relationId, Snapshot snapshot, int uniqueRelation
 		 * it is an ordered sublist and a tandem cursor suffices to mark the
 		 * fully matched files, instead of an O(files * matches)
 		 * list_member_ptr scan.
+		 *
+		 * The cursor only ever dereferences cells of fullMatches, so it
+		 * cannot mark a file that PruneDataFiles did not return. If that
+		 * ordering assumption were ever broken the cursor would desync and
+		 * leave files unmarked, which costs us the optimization but never
+		 * skips a file that still has rows to keep.
 		 */
 		ListCell   *fullMatchCell = list_head(fullMatches);
 
@@ -248,6 +254,9 @@ CreateTableScanForRelation(Oid relationId, Snapshot snapshot, int uniqueRelation
 
 			fileScans = lappend(fileScans, fileScan);
 		}
+
+		/* every full match is in prunedDataFiles, so all cells were consumed */
+		Assert(fullMatchCell == NULL);
 
 		foreach_ptr(TableDataFile, deletionFile, positionDeleteFiles)
 		{


### PR DESCRIPTION
`CreateTableScanForRelation()` checked `list_member_ptr(fullMatches, dataFile)` for every pruned data file, an O(files x matches) pointer scan per query on result relations. `fullMatches` comes from `PruneDataFiles()` filtering `prunedDataFiles`, which preserves pointer identity and order on every return path, so it is an ordered sublist and a tandem cursor finds the matches in a single linear pass.