### PR TITLE
pg_lake_engine: hoist element container check out of array output loop

### DIFF
--- a/pg_lake_engine/src/pgduck/array_conversion.c
+++ b/pg_lake_engine/src/pgduck/array_conversion.c
@@ -99,6 +99,9 @@ ArrayOutForPGDuck(ArrayType *array, CopyDataFormat format)
 	Datum		itemvalue;
 	bool		isnull;
 
+	/* whether elements need quotes only depends on the element type */
+	bool		elementIsContainer = IsSerializedAsContainer(element_type, format);
+
 	for (i = 0; i < nitems && array_iterate(iter, &itemvalue, &isnull); i++)
 	{
 		bool		needquote;
@@ -116,7 +119,7 @@ ArrayOutForPGDuck(ArrayType *array, CopyDataFormat format)
 										format);
 
 			/* count data plus backslashes; detect chars needing quotes */
-			needquote = !IsSerializedAsContainer(element_type, format);
+			needquote = !elementIsContainer;
 
 			for (tmp = values[i]; *tmp != '\0'; tmp++)
 			{


### PR DESCRIPTION
`ArrayOutForPGDuck()` evaluated `IsSerializedAsContainer()` for every non-null array element, but the answer only depends on the element type and target format. Each call can cost up to two syscache probes (`type_is_array` and `get_typtype`), paid per element of every array value serialized for pushdown. Evaluate it once before the loop.