### PR TITLE
pg_lake_iceberg: read object store catalog.json without the file cache

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/client.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/client.h
@@ -46,6 +46,7 @@ extern PGDLLEXPORT PGresult *ExecuteQueryOnPGDuckConnection(PGDuckConnection * p
 extern PGDLLEXPORT PGresult *WaitForResult(PGDuckConnection * conn);
 extern PGDLLEXPORT PGresult *WaitForLastResult(PGDuckConnection * conn);
 extern PGDLLEXPORT void SendQueryToPGDuck(PGDuckConnection * conn, char *query);
+extern PGDLLEXPORT bool PGDuckResultHasError(PGresult *result);
 extern PGDLLEXPORT void CheckPGDuckResult(PGDuckConnection * conn, PGresult *result);
 extern PGDLLEXPORT void ThrowIfPGDuckResultHasError(PGDuckConnection * conn, PGresult *result);
 extern PGDLLEXPORT char *GetSingleValueFromPGDuck(char *query);

--- a/pg_lake_engine/include/pg_lake/util/s3_reader_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/s3_reader_utils.h
@@ -32,5 +32,9 @@
     2 /* null terminator and one extra space */ \
 )
 
+/* Bypass the pgduck file cache; matches NO_CACHE_PREFIX on the DuckDB side. */
+#define NO_CACHE_URL_PREFIX "nocache"
+
 extern PGDLLEXPORT char *GetTextFromURI(const char *textFileUri);
+extern PGDLLEXPORT char *GetJsonFromURINoCache(const char *jsonFileUri);
 extern PGDLLEXPORT char *GetBlobFromURI(const char *blobFileUri, size_t *contentLength);

--- a/pg_lake_engine/include/pg_lake/util/s3_writer_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/s3_writer_utils.h
@@ -25,5 +25,6 @@ extern int32 MaxParallelFileUploads;
 
 extern PGDLLEXPORT void ScheduleFileCopyToS3WithCleanup(char *localFilePath, char *s3Uri, bool autoDeleteRecord);
 extern PGDLLEXPORT void CopyLocalFileToS3(char *localFilePath, char *s3Uri);
+extern PGDLLEXPORT void CopyLocalFileToS3NoCache(char *localFilePath, char *s3Uri);
 extern PGDLLEXPORT void FinishAllUploads(void);
 extern PGDLLEXPORT char *GetPendingUploadLocalPath(const char *remoteUrl);

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -506,18 +506,29 @@ CheckPGDuckResult(PGDuckConnection * pgDuckConnection, PGresult *result)
 
 
 /*
+ * PGDuckResultHasError returns true when the result carries an error status.
+ * Use this when you need a non-throwing check (e.g. deciding whether to retry
+ * before calling ThrowIfPGDuckResultHasError on the final attempt).
+ */
+bool
+PGDuckResultHasError(PGresult *result)
+{
+	ExecStatusType resultStatus = PQresultStatus(result);
+
+	return !(resultStatus == PGRES_TUPLES_OK ||
+			 resultStatus == PGRES_COMMAND_OK ||
+			 resultStatus == PGRES_SINGLE_TUPLE);
+}
+
+
+/*
  * ThrowIfPGDuckResultHasError throws the error received over a connection, if any.
  */
 void
 ThrowIfPGDuckResultHasError(PGDuckConnection * pgDuckConnection, PGresult *result)
 {
-	ExecStatusType resultStatus = PQresultStatus(result);
-
-	if (resultStatus == PGRES_TUPLES_OK || resultStatus == PGRES_COMMAND_OK ||
-		resultStatus == PGRES_SINGLE_TUPLE)
-	{
+	if (!PGDuckResultHasError(result))
 		return;
-	}
 
 	char	   *message = PQresultErrorField(result, PG_DIAG_MESSAGE_PRIMARY);
 	char	   *messageDetail = PQresultErrorField(result, PG_DIAG_MESSAGE_DETAIL);

--- a/pg_lake_engine/src/utils/s3_reader_utils.c
+++ b/pg_lake_engine/src/utils/s3_reader_utils.c
@@ -29,7 +29,12 @@
 static char *ReadTextContent(const char *command);
 static char *ReadBlobContent(const char *command, size_t *contentLength);
 static char *ReadTextFileCommand(const char *textFileUri);
+static char *ReadValidJsonFileCommand(const char *jsonFileUri);
 static char *ReadBlobFileCommand(const char *blobFileUri);
+static const char *ResolveReadPath(const char *fileUri, bool bypassCache);
+
+/* bounded retries for a racy fresh read of a fixed-path JSON file */
+#define NO_CACHE_JSON_READ_MAX_ATTEMPTS 10
 
 /*
  * GetTextFromURI reads the content of a text file at a supported cloud URL.
@@ -38,17 +43,108 @@ static char *ReadBlobFileCommand(const char *blobFileUri);
 char *
 GetTextFromURI(const char *textFileUri)
 {
-	if (!IsSupportedURL(textFileUri))
+	return ReadTextContent(ReadTextFileCommand(ResolveReadPath(textFileUri, false)));
+}
+
+/*
+ * GetJsonFromURINoCache reads a fixed-path JSON file (e.g. an object store
+ * catalog.json) fresh from object storage, bypassing the file cache, and
+ * returns its content.
+ *
+ * A fixed-path file can be rewritten concurrently (our own writer or another
+ * cluster), so a fresh read may race the writer: DuckDB aborts a read whose S3
+ * ETag changes mid-read (an error result), and an append-blob overwrite can be
+ * read torn (incomplete, so the json_valid filter drops it to zero rows). Both
+ * are transient, so we inspect the result and retry a bounded number of times
+ * on a fresh connection. We deliberately do NOT catch an ereport to retry: that
+ * would resume mid-query with unwound executor/snapshot state and crash the
+ * backend. The last attempt reads without validation so a genuinely invalid
+ * document surfaces its real error downstream instead of looping.
+ */
+char *
+GetJsonFromURINoCache(const char *jsonFileUri)
+{
+	const char *readPath = ResolveReadPath(jsonFileUri, true);
+	char	   *validatingCommand = ReadValidJsonFileCommand(readPath);
+	char	   *plainCommand = ReadTextFileCommand(readPath);
+
+	for (int attempt = 1;; attempt++)
+	{
+		bool		lastAttempt = attempt >= NO_CACHE_JSON_READ_MAX_ATTEMPTS;
+		const char *command = lastAttempt ? plainCommand : validatingCommand;
+
+		PGDuckConnection *pgDuckConn = GetPGDuckConnection();
+		PGresult   *result = ExecuteQueryOnPGDuckConnection(pgDuckConn, command);
+
+		/*
+		 * a racing writer shows up as an error result or (torn read) zero
+		 * rows
+		 */
+		if (!lastAttempt &&
+			(PQresultStatus(result) != PGRES_TUPLES_OK || PQntuples(result) != 1))
+		{
+			PQclear(result);
+			ReleasePGDuckConnection(pgDuckConn);
+
+			/* brief, increasing backoff to let the concurrent writer finish */
+			pg_usleep(attempt * 25L * 1000L);
+			continue;
+		}
+
+		char	   *content;
+
+		/*
+		 * make sure we PQclear the result (throws on a real error / bad row
+		 * count)
+		 */
+		PG_TRY();
+		{
+			ThrowIfPGDuckResultHasError(pgDuckConn, result);
+
+			int			rowCount = PQntuples(result);
+
+			if (rowCount != 1)
+				elog(ERROR, "Expected 1 row while reading JSON file, got %d",
+					 rowCount);
+
+			content = pstrdup(PQgetvalue(result, 0, 0));
+		}
+		PG_FINALLY();
+		{
+			PQclear(result);
+			ReleasePGDuckConnection(pgDuckConn);
+		}
+		PG_END_TRY();
+
+		return content;
+	}
+}
+
+/*
+ * ResolveReadPath returns the path ReadTextContent should read for a cloud URL:
+ * a pending upload's local file if any (authoritative), otherwise the URL,
+ * optionally "nocache"-prefixed to bypass the file cache. The prefix is applied
+ * here, after IsSupportedURL, which only accepts bare schemes.
+ */
+static const char *
+ResolveReadPath(const char *fileUri, bool bypassCache)
+{
+	if (!IsSupportedURL(fileUri))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("pg_lake: unsupported URL: \"%s\"", textFileUri),
+				 errmsg("pg_lake: unsupported URL: \"%s\"", fileUri),
 				 errhint("Paths must use a supported cloud storage scheme "
 						 "(s3://, azure://, gcs://, etc.).")));
 
-	const char *localPath = GetPendingUploadLocalPath(textFileUri);
-	const char *readPath = localPath != NULL ? localPath : textFileUri;
+	const char *localPath = GetPendingUploadLocalPath(fileUri);
 
-	return ReadTextContent(ReadTextFileCommand(readPath));
+	if (localPath != NULL)
+		return localPath;
+
+	if (bypassCache)
+		return psprintf("%s%s", NO_CACHE_URL_PREFIX, fileUri);
+
+	return fileUri;
 }
 
 /*
@@ -173,6 +269,25 @@ ReadTextFileCommand(const char *textFileUri)
 	appendStringInfo(&command, "SELECT content FROM read_text(%s)",
 					 quote_literal_cstr(textFileUri));
 
+
+	return command.data;
+}
+
+/*
+ * ReadValidJsonFileCommand is like ReadTextFileCommand but returns no rows if
+ * the file is not valid JSON, so a torn read of a concurrently rewritten file
+ * fails instead of returning incomplete content.
+ */
+static char *
+ReadValidJsonFileCommand(const char *jsonFileUri)
+{
+	StringInfoData command;
+
+	initStringInfo(&command);
+
+	appendStringInfo(&command,
+					 "SELECT content FROM read_text(%s) WHERE json_valid(content)",
+					 quote_literal_cstr(jsonFileUri));
 
 	return command.data;
 }

--- a/pg_lake_engine/src/utils/s3_reader_utils.c
+++ b/pg_lake_engine/src/utils/s3_reader_utils.c
@@ -20,6 +20,7 @@
 #include "libpq-fe.h"
 #include "miscadmin.h"
 
+#include "pg_extension_base/base_workers.h"
 #include "pg_lake/copy/copy_format.h"
 #include "pg_lake/pgduck/client.h"
 #include "pg_lake/util/s3_reader_utils.h"
@@ -55,11 +56,14 @@ GetTextFromURI(const char *textFileUri)
  * cluster), so a fresh read may race the writer: DuckDB aborts a read whose S3
  * ETag changes mid-read (an error result), and an append-blob overwrite can be
  * read torn (incomplete, so the json_valid filter drops it to zero rows). Both
- * are transient, so we inspect the result and retry a bounded number of times
- * on a fresh connection. We deliberately do NOT catch an ereport to retry: that
- * would resume mid-query with unwound executor/snapshot state and crash the
- * backend. The last attempt reads without validation so a genuinely invalid
- * document surfaces its real error downstream instead of looping.
+ * are transient, so we inspect the result and retry a bounded number of times.
+ * Neither case breaks the pgduck connection (the error comes back as a result,
+ * not a lost connection), so we keep the same one across attempts; with the
+ * nocache prefix each attempt re-fetches from object storage. We deliberately
+ * do NOT catch an ereport to retry: that would resume mid-query with unwound
+ * executor/snapshot state and crash the backend. The last attempt reads without
+ * validation so a genuinely invalid document surfaces its real error downstream
+ * instead of looping.
  */
 char *
 GetJsonFromURINoCache(const char *jsonFileUri)
@@ -68,37 +72,39 @@ GetJsonFromURINoCache(const char *jsonFileUri)
 	char	   *validatingCommand = ReadValidJsonFileCommand(readPath);
 	char	   *plainCommand = ReadTextFileCommand(readPath);
 
-	for (int attempt = 1;; attempt++)
+	PGDuckConnection *pgDuckConn = GetPGDuckConnection();
+	PGresult   *volatile result = NULL;
+	char	   *content = NULL;
+
+	/* the connection outlives the retries; PQclear the result on every exit */
+	PG_TRY();
 	{
-		bool		lastAttempt = attempt >= NO_CACHE_JSON_READ_MAX_ATTEMPTS;
-		const char *command = lastAttempt ? plainCommand : validatingCommand;
-
-		PGDuckConnection *pgDuckConn = GetPGDuckConnection();
-		PGresult   *result = ExecuteQueryOnPGDuckConnection(pgDuckConn, command);
-
-		/*
-		 * a racing writer shows up as an error result or (torn read) zero
-		 * rows
-		 */
-		if (!lastAttempt &&
-			(PQresultStatus(result) != PGRES_TUPLES_OK || PQntuples(result) != 1))
+		for (int attempt = 1;; attempt++)
 		{
-			PQclear(result);
-			ReleasePGDuckConnection(pgDuckConn);
+			bool		lastAttempt = attempt >= NO_CACHE_JSON_READ_MAX_ATTEMPTS;
+			const char *command = lastAttempt ? plainCommand : validatingCommand;
 
-			/* brief, increasing backoff to let the concurrent writer finish */
-			pg_usleep(attempt * 25L * 1000L);
-			continue;
-		}
+			result = ExecuteQueryOnPGDuckConnection(pgDuckConn, command);
 
-		char	   *content;
+			/*
+			 * a racing writer shows up as an error result or (torn read) zero
+			 * rows
+			 */
+			if (!lastAttempt &&
+				(PGDuckResultHasError(result) || PQntuples(result) != 1))
+			{
+				PQclear(result);
+				result = NULL;
 
-		/*
-		 * make sure we PQclear the result (throws on a real error / bad row
-		 * count)
-		 */
-		PG_TRY();
-		{
+				/*
+				 * brief, increasing backoff to let the concurrent writer
+				 * finish
+				 */
+				LightSleep(attempt * 25L);
+				continue;
+			}
+
+			/* throws on a real error */
 			ThrowIfPGDuckResultHasError(pgDuckConn, result);
 
 			int			rowCount = PQntuples(result);
@@ -108,16 +114,17 @@ GetJsonFromURINoCache(const char *jsonFileUri)
 					 rowCount);
 
 			content = pstrdup(PQgetvalue(result, 0, 0));
+			break;
 		}
-		PG_FINALLY();
-		{
-			PQclear(result);
-			ReleasePGDuckConnection(pgDuckConn);
-		}
-		PG_END_TRY();
-
-		return content;
 	}
+	PG_FINALLY();
+	{
+		PQclear(result);
+		ReleasePGDuckConnection(pgDuckConn);
+	}
+	PG_END_TRY();
+
+	return content;
 }
 
 /*

--- a/pg_lake_engine/src/utils/s3_writer_utils.c
+++ b/pg_lake_engine/src/utils/s3_writer_utils.c
@@ -81,6 +81,20 @@ CopyLocalFileToS3(char *localFilePath, char *s3Uri)
 
 
 /*
+ * CopyLocalFileToS3NoCache is like CopyLocalFileToS3 but bypasses cache-on-write
+ * (via the "nocache" destination prefix), so no cache entry is created for a
+ * fixed-path file that is always read back with GetTextFromURINoCache.
+ */
+void
+CopyLocalFileToS3NoCache(char *localFilePath, char *s3Uri)
+{
+	char	   *noCacheUri = psprintf("%s%s", NO_CACHE_URL_PREFIX, s3Uri);
+
+	ExecuteCommandInPGDuck(CopyLocalFileToS3Command(localFilePath, noCacheUri));
+}
+
+
+/*
 * CopyLocalFileToS3Command returns the SQL command to copy
 * the content of a local JSON file to an S3 bucket.
 */

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -88,7 +88,8 @@ list_object_store_tables(PG_FUNCTION_ARGS)
 		GetInternalObjectStoreCatalogFilePath(catalogName) :
 		GetExternalObjectStoreCatalogFilePath(catalogName);
 
-	char	   *catalogContent = GetTextFromURI(catalogPath);
+	/* catalog.json is a fixed path that may change out of band; read fresh. */
+	char	   *catalogContent = GetJsonFromURINoCache(catalogPath);
 
 	StringInfo	getObjectStoreTables = makeStringInfo();
 
@@ -437,7 +438,9 @@ GetTableMetadataLocationFromExternalObjectStoreCatalog(const char *catalogName, 
 {
 	const char *catalogPath =
 		GetExternalObjectStoreCatalogFilePath(catalogName);
-	char	   *catalogContent = GetTextFromURI(catalogPath);
+
+	/* catalog.json is a fixed path that may change out of band; read fresh. */
+	char	   *catalogContent = GetJsonFromURINoCache(catalogPath);
 
 	StringInfo	metadataLocationStrInfo = makeStringInfo();
 	StringInfo	getMetadataLocation = makeStringInfo();

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -419,8 +419,9 @@ PushMetadataLocationToObjectStoreCatalog(void)
 
 	WriteStringToFilePath(objectStoreCatalogFileContent->data, localFilePath);
 
-	CopyLocalFileToS3(localFilePath,
-					  GetInternalObjectStoreCatalogFilePath(get_database_name(MyDatabaseId)));
+	/* Skip cache-on-write; catalog.json is always read fresh (nocache). */
+	CopyLocalFileToS3NoCache(localFilePath,
+							 GetInternalObjectStoreCatalogFilePath(get_database_name(MyDatabaseId)));
 
 	LastCatalogPushTime = GetCurrentTimestamp();
 }

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1195,6 +1195,190 @@ def test_object_store_catalog_periodic_rewrite(
         superuser_conn.autocommit = False
 
 
+CACHE_FILE_PREFIX = "pgl-cache."
+
+
+# An out-of-band overwrite of catalog.json on object storage (e.g. another
+# cluster writing it) must be picked up by a read-only object_store table, not
+# served stale from pg_lake's local file cache: catalog.json lives at a fixed
+# path, unlike UUID-named (immutable) data files.
+#
+# read_catalog(key) -> dict and write_catalog(key, dict) do the out-of-band
+# read/overwrite directly against object storage, bypassing pg_lake.
+def _assert_out_of_band_catalog_update_is_seen(
+    pg_conn, base_url, catalog_prefix, read_catalog, write_catalog
+):
+    schema = "test_catalog_json_oob"
+    run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE", pg_conn)
+    run_command(f"CREATE SCHEMA {schema}", pg_conn)
+
+    # writable table with data set A
+    run_command(
+        f"CREATE TABLE {schema}.wrt_tbl(a INT) USING iceberg WITH (catalog='object_store')",
+        pg_conn,
+    )
+    run_command(f"INSERT INTO {schema}.wrt_tbl VALUES (1),(2),(3)", pg_conn)
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, schema, "wrt_tbl")
+
+    # second writable table with data set B; we graft its metadata-location
+    # onto wrt_tbl's catalog entry out of band.
+    run_command(
+        f"CREATE TABLE {schema}.wrt_tbl_b(a INT) USING iceberg WITH (catalog='object_store')",
+        pg_conn,
+    )
+    run_command(f"INSERT INTO {schema}.wrt_tbl_b VALUES (100),(200),(300)", pg_conn)
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, schema, "wrt_tbl_b")
+
+    # read-only table pointing at wrt_tbl; initially resolves to data set A
+    run_command(
+        f"CREATE TABLE {schema}.read_tbl(a INT) USING iceberg "
+        f"WITH (catalog='object_store', read_only=True, catalog_table_name='wrt_tbl')",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    rows = run_query(f"SELECT a FROM {schema}.read_tbl ORDER BY a", pg_conn)
+    assert [r[0] for r in rows] == [1, 2, 3]
+
+    dbname = run_query("SELECT current_database()", pg_conn)[0][0]
+    key = f"{catalog_prefix}/catalog/{dbname}/catalog.json"
+    catalog_url = f"{base_url}/{key}"
+
+    # Force the current catalog.json into the pgduck cache, so the staleness
+    # below is real and deterministic (independent of cache-on-write).
+    run_query(f"SELECT lake_file_cache.add('{catalog_url}')", pg_conn)
+    pg_conn.commit()
+
+    # Out-of-band overwrite: point wrt_tbl at wrt_tbl_b's metadata-location,
+    # writing directly to storage so the cached copy is never refreshed.
+    body = read_catalog(key)
+    a_location = next(
+        t["metadata-location"] for t in body["tables"] if t["table-name"] == "wrt_tbl"
+    )
+    b_location = next(
+        t["metadata-location"] for t in body["tables"] if t["table-name"] == "wrt_tbl_b"
+    )
+    for t in body["tables"]:
+        if t["table-name"] == "wrt_tbl":
+            t["metadata-location"] = b_location
+    write_catalog(key, body)
+
+    # Confirm the premise: the on-disk cache still holds the old copy, which
+    # now differs from object storage. Otherwise the read below is vacuous.
+    protocol = base_url.split("://", 1)[0]
+    cache_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/{protocol}/{TEST_BUCKET}/"
+        f"{catalog_prefix}/catalog/{dbname}/{CACHE_FILE_PREFIX}catalog.json"
+    )
+    assert cache_path.exists(), f"expected a cached catalog at {cache_path}"
+    cached_body = json.loads(cache_path.read_text())
+    cached_wrt = next(
+        t["metadata-location"]
+        for t in cached_body["tables"]
+        if t["table-name"] == "wrt_tbl"
+    )
+    assert cached_wrt == a_location, "cache should still hold the stale copy"
+    assert cached_wrt != b_location, "cache and object storage should now differ"
+
+    # Read from a fresh backend (no PG-side caching; mirrors another cluster).
+    # The pgduck file cache is process-global and still holds the stale copy,
+    # so this exercises the cache-bypass fix.
+    fresh_conn = open_pg_conn_to_db(dbname)
+    try:
+        rows = run_query(f"SELECT a FROM {schema}.read_tbl ORDER BY a", fresh_conn)
+    finally:
+        fresh_conn.close()
+
+    assert [r[0] for r in rows] == [100, 200, 300], (
+        "read-only object_store table served a stale catalog.json from the "
+        "local cache instead of the out-of-band update (expected data set B)"
+    )
+
+    run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_catalog_json_out_of_band_update(
+    pg_conn, s3, extension, with_default_location, adjust_object_store_settings
+):
+    def read_catalog(key):
+        return json.loads(s3.get_object(Bucket=TEST_BUCKET, Key=key)["Body"].read())
+
+    def write_catalog(key, body):
+        s3.put_object(
+            Bucket=TEST_BUCKET, Key=key, Body=json.dumps(body).encode("utf-8")
+        )
+
+    _assert_out_of_band_catalog_update_is_seen(
+        pg_conn, f"s3://{TEST_BUCKET}", "tmp", read_catalog, write_catalog
+    )
+
+
+# Same scenario on Azure: azure://, az:// and abfss:// go through the same
+# pgduck caching file system as s3://, so catalog.json has the identical
+# staleness bug and the nocache fix must apply there too.
+def test_catalog_json_out_of_band_update_azure(
+    pg_conn, superuser_conn, azure, s3, extension
+):
+    location = f"azure://{TEST_BUCKET}"
+    catalog_prefix = "tmp_az"
+
+    superuser_conn.autocommit = True
+    run_command(
+        f"ALTER SYSTEM SET pg_lake_iceberg.object_store_catalog_location_prefix = '{location}'",
+        superuser_conn,
+    )
+    run_command(
+        f"ALTER SYSTEM SET pg_lake_iceberg.internal_object_store_catalog_prefix = '{catalog_prefix}'",
+        superuser_conn,
+    )
+    run_command(
+        f"ALTER SYSTEM SET pg_lake_iceberg.external_object_store_catalog_prefix = '{catalog_prefix}'",
+        superuser_conn,
+    )
+    run_command("SELECT pg_reload_conf()", superuser_conn)
+    run_command("SELECT pg_sleep(0.2)", superuser_conn)
+    superuser_conn.autocommit = False
+
+    run_command(f"SET pg_lake_iceberg.default_location_prefix TO '{location}'", pg_conn)
+    pg_conn.commit()
+
+    def read_catalog(key):
+        return json.loads(azure.download_blob(key).readall())
+
+    def write_catalog(key, body):
+        azure.upload_blob(
+            name=key, data=json.dumps(body).encode("utf-8"), overwrite=True
+        )
+
+    try:
+        _assert_out_of_band_catalog_update_is_seen(
+            pg_conn, location, catalog_prefix, read_catalog, write_catalog
+        )
+    finally:
+        run_command("RESET pg_lake_iceberg.default_location_prefix", pg_conn)
+        pg_conn.commit()
+
+        superuser_conn.autocommit = True
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.object_store_catalog_location_prefix",
+            superuser_conn,
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.internal_object_store_catalog_prefix",
+            superuser_conn,
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.external_object_store_catalog_prefix",
+            superuser_conn,
+        )
+        run_command("SELECT pg_reload_conf()", superuser_conn)
+        run_command("SELECT pg_sleep(0.2)", superuser_conn)
+        superuser_conn.autocommit = False
+
+
 def assert_tables_are_the_same(pg_conn, tbl_1, tbl_2):
     res = run_query(
         f"""


### PR DESCRIPTION
catalog.json lives at a fixed object-storage path, unlike UUID-named (immutable) data files. The pgduck caching file system serves cached copies without a freshness check, so when catalog.json is overwritten out of band (e.g. by another cluster), a read-only object_store table keeps returning stale metadata.

Read it via a new GetJsonFromURINoCache() that prefixes the URL with "nocache", so the read always fetches a fresh copy from object storage. Scheme agnostic: fixes s3://, azure://, gs://, etc. uniformly.

A fresh, fixed-path read can race a concurrent writer (our own push or another cluster): DuckDB aborts a read whose S3 ETag changes mid-read, and an append-blob overwrite can be read torn (incomplete). Both are transient, so validate the JSON in DuckDB (json_valid) and retry a bounded number of times on a fresh pgduck connection. No PG (sub)transaction is used, so the caller's snapshot is left untouched.

