### PR TITLE
Fix nested timetz reads from Iceberg

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/struct_conversion.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/struct_conversion.h
@@ -23,4 +23,3 @@
 
 extern PGDLLEXPORT char *StructOutForPGDuck(Datum myStruct, CopyDataFormat format);
 extern PGDLLEXPORT const char *QuoteDuckDBStructKey(const char *fieldName);
-extern PGDLLEXPORT const char *QuoteDuckDBStructKeySQL(const char *fieldName);

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -1160,25 +1160,16 @@ AppendIntervalStructPack(StringInfo buf, const char *expr)
  * Iceberg-storable TIME for a TIMETZ leaf.  See AppendRewriteExpression
  * (ICEBERG_REWRITE_NATIVE_ENCODE) for the why.
  *
- * The inner "CAST(... AS TIMETZ)" is deliberately retained because the
- * leaf expression can arrive at this helper in either of two shapes:
- *
- *   - Top-level TIMETZ columns from read_iceberg / postgres_scan are
- *     already TIME WITH TIME ZONE; the inner cast is a no-op.
- *   - TIMETZ fields living *inside* an Iceberg composite arrive as plain
- *     TIME (Parquet has no time-with-tz type and DuckDB does not recast
- *     struct fields back to TIMETZ on read), and DuckDB has no
- *     timezone(VARCHAR, TIME) overload, so a bare "AT TIME ZONE 'UTC'"
- *     would produce a binder error.  Casting to TIMETZ first lifts the
- *     value to +00 (semantically a no-op under the pg_lake invariant
- *     that those digits are already UTC) and keeps the outer expression
- *     well-typed.
+ * The read projection converts every TIMETZ leaf from its Iceberg TIME
+ * representation back to DuckDB TIMETZ, including leaves inside nested
+ * containers. Native write sources such as postgres_scan also expose TIMETZ,
+ * so the expression is always well-typed for AT TIME ZONE here.
  */
 static void
 AppendTimeTzUtcCast(StringInfo buf, const char *expr)
 {
 	appendStringInfo(buf,
-					 "CAST(CAST((%s) AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)",
+					 "CAST((%s) AT TIME ZONE 'UTC' AS TIME)",
 					 expr);
 }
 
@@ -1224,6 +1215,10 @@ LeafSubtreeNeedsRewrite(Oid typeOid, int32 typmod, int rewriteKinds,
  * untouched branch is reused by reference.  One traversal handles both
  * families, so a struct mixing an encoded sibling and a storage-cast sibling is
  * rebuilt by a single struct_pack, never two stacked ones.
+ *
+ * AppendIcebergReadConversion in read_data.c is the read-side inverse of the
+ * NATIVE_ENCODE family and mirrors this traversal; a new native type must be
+ * added there as well.
  *
  * Returns true if a transformed expression was written to buf.
  */

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -1160,16 +1160,25 @@ AppendIntervalStructPack(StringInfo buf, const char *expr)
  * Iceberg-storable TIME for a TIMETZ leaf.  See AppendRewriteExpression
  * (ICEBERG_REWRITE_NATIVE_ENCODE) for the why.
  *
- * The read projection converts every TIMETZ leaf from its Iceberg TIME
- * representation back to DuckDB TIMETZ, including leaves inside nested
- * containers. Native write sources such as postgres_scan also expose TIMETZ,
- * so the expression is always well-typed for AT TIME ZONE here.
+ * The inner "CAST(... AS TIMETZ)" is deliberately retained because the
+ * leaf expression can arrive at this helper in either of two shapes:
+ *
+ *   - Top-level TIMETZ columns from read_iceberg / postgres_scan are
+ *     already TIME WITH TIME ZONE; the inner cast is a no-op.
+ *   - TIMETZ fields living *inside* an Iceberg composite arrive as plain
+ *     TIME (Parquet has no time-with-tz type and DuckDB does not recast
+ *     struct fields back to TIMETZ on read), and DuckDB has no
+ *     timezone(VARCHAR, TIME) overload, so a bare "AT TIME ZONE 'UTC'"
+ *     would produce a binder error.  Casting to TIMETZ first lifts the
+ *     value to +00 (semantically a no-op under the pg_lake invariant
+ *     that those digits are already UTC) and keeps the outer expression
+ *     well-typed.
  */
 static void
 AppendTimeTzUtcCast(StringInfo buf, const char *expr)
 {
 	appendStringInfo(buf,
-					 "CAST((%s) AT TIME ZONE 'UTC' AS TIME)",
+					 "CAST(CAST((%s) AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)",
 					 expr);
 }
 

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -72,7 +72,11 @@ static char *BuildColumnProjection(char *expression,
 								   CopyDataFormat sourceFormat,
 								   List *formatOptions,
 								   bool addAlias);
-static char *BuildMapWithIntervalProjection(char *columnName, Oid mapTypeId);
+static bool TypeNeedsIcebergReadConversion(Oid typeOid);
+static bool AppendIcebergReadConversion(StringInfo buf, const char *expression,
+										Oid typeOid, int32 typmod, int depth);
+static char *BuildIcebergReadConversion(const char *expression, Oid typeOid,
+										int32 typmod);
 static char *BuildStorageToSurfaceProjection(const char *columnName,
 											 Oid columnTypeId, int32 columnTypeMod,
 											 DuckDBTypeInfo duckdbType,
@@ -894,136 +898,286 @@ TupleDescToAliasList(TupleDesc tupleDesc)
 
 
 /*
- * BuildMapWithIntervalProjection generates a DuckDB expression that
- * reconstructs interval values inside a MAP type from their
- * struct(months, days, microseconds) Iceberg representation.
- *
- * Returns NULL if the map value type is not INTERVAL.
+ * TypeNeedsIcebergReadConversion recursively checks whether a PostgreSQL type
+ * contains a value whose Iceberg representation must be converted before it
+ * is sent back to PostgreSQL. Iceberg stores INTERVAL as a struct and TIMETZ
+ * as a UTC-normalized TIME, so both need an explicit read-side conversion.
  */
-static char *
-BuildMapWithIntervalProjection(char *columnName, Oid mapTypeId)
+static bool
+TypeNeedsIcebergReadConversion(Oid typeOid)
 {
-	PGType		valType = GetMapValueType(mapTypeId);
+	if (typeOid == INTERVALOID || typeOid == TIMETZOID)
+		return true;
 
-	if (valType.postgresTypeOid != INTERVALOID)
-		return NULL;
+	Oid			elementType = get_element_type(typeOid);
 
-	const char *col = duckdb_quote_identifier(columnName);
+	if (OidIsValid(elementType))
+		return TypeNeedsIcebergReadConversion(elementType);
 
-	return psprintf(
-					"map_from_entries("
-					"list_transform(map_entries(%s), _x -> "
-					"struct_pack(key := _x.key, value := "
-					"(to_months(_x.value.months) + "
-					"to_days(_x.value.days) + "
-					"to_microseconds(_x.value.microseconds))"
-					")))",
-					col);
+	/*
+	 * Maps are domains over arrays. The get_element_type() check above does
+	 * not swallow them (it only recognizes true arrays and returns InvalidOid
+	 * for domains over arrays), but the generic domain unwrap below would, so
+	 * maps must be recognized here first.
+	 */
+	if (IsMapTypeOid(typeOid))
+	{
+		PGType		keyType = GetMapKeyType(typeOid);
+		PGType		valueType = GetMapValueType(typeOid);
+
+		return TypeNeedsIcebergReadConversion(keyType.postgresTypeOid) ||
+			TypeNeedsIcebergReadConversion(valueType.postgresTypeOid);
+	}
+
+	char		typeKind = get_typtype(typeOid);
+
+	if (typeKind == TYPTYPE_DOMAIN)
+		return TypeNeedsIcebergReadConversion(getBaseType(typeOid));
+
+	if (typeKind == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeOid, -1);
+		bool		needsConversion = false;
+
+		for (int attributeIndex = 0;
+			 attributeIndex < tupleDesc->natts;
+			 attributeIndex++)
+		{
+			Form_pg_attribute attribute =
+				TupleDescAttr(tupleDesc, attributeIndex);
+
+			if (attribute->attisdropped)
+				continue;
+
+			if (TypeNeedsIcebergReadConversion(attribute->atttypid))
+			{
+				needsConversion = true;
+				break;
+			}
+		}
+
+		ReleaseTupleDesc(tupleDesc);
+		return needsConversion;
+	}
+
+	return false;
 }
 
 
 /*
- * BuildStructWithIntervalProjection generates a DuckDB expression that
- * reconstructs interval fields inside a composite type from their
- * struct(months, days, microseconds) Parquet representation.
+ * AppendIcebergReadConversion emits the read-side inverse of the native-type
+ * Iceberg write conversion for one expression. It recursively rebuilds only
+ * containers with an INTERVAL or TIMETZ descendant and returns false when the
+ * expression can pass through unchanged.
  *
- * Returns NULL if the composite type has no interval fields.
+ * The traversal deliberately mirrors AppendRewriteExpression's
+ * ICEBERG_REWRITE_NATIVE_ENCODE family in iceberg_query_validation.c (branch
+ * order, lambda variable naming, NULL handling), with
+ * TypeNeedsIcebergReadConversion twinning TypeNeedsNativeConversion as the
+ * gate. A new native type must be added to all four.
  */
-static char *
-BuildStructWithIntervalProjection(char *columnName, Oid compositeTypeId)
+static bool
+AppendIcebergReadConversion(StringInfo buf, const char *expression,
+							Oid typeOid, int32 typmod, int depth)
 {
-	Oid			baseTypeId = get_element_type(compositeTypeId);
-
-	if (!OidIsValid(baseTypeId))
-		baseTypeId = compositeTypeId;
-
-	if (get_typtype(baseTypeId) != TYPTYPE_COMPOSITE)
-		return NULL;
-
-	TupleDesc	tupdesc = lookup_rowtype_tupdesc(baseTypeId, -1);
-	bool		hasInterval = false;
-
-	for (int i = 0; i < tupdesc->natts; i++)
+	if (typeOid == INTERVALOID)
 	{
-		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
-
-		if (att->attisdropped)
-			continue;
-
-		Oid			fieldBaseType = get_element_type(att->atttypid);
-
-		if (!OidIsValid(fieldBaseType))
-			fieldBaseType = att->atttypid;
-
-		if (fieldBaseType == INTERVALOID)
-		{
-			hasInterval = true;
-			break;
-		}
+		appendStringInfo(buf,
+						 "(to_months((%s).months) + "
+						 "to_days((%s).days) + "
+						 "to_microseconds((%s).microseconds))",
+						 expression, expression, expression);
+		return true;
 	}
 
-	if (!hasInterval)
+	if (typeOid == TIMETZOID)
 	{
-		ReleaseTupleDesc(tupdesc);
-		return NULL;
+		/*
+		 * Iceberg has no time-with-time-zone type. The stored TIME digits are
+		 * already UTC-normalized; casting in DuckDB attaches +00 before the
+		 * value reaches PostgreSQL, avoiding session-timezone
+		 * reinterpretation by timetz_in.
+		 */
+		appendStringInfo(buf, "CAST((%s) AS TIMETZ)", expression);
+		return true;
 	}
 
-	StringInfoData buf;
-	const char *col = duckdb_quote_identifier(columnName);
+	Oid			elementType = get_element_type(typeOid);
 
-	initStringInfo(&buf);
-	appendStringInfoChar(&buf, '{');
-
-	bool		first = true;
-
-	for (int i = 0; i < tupdesc->natts; i++)
+	if (OidIsValid(elementType))
 	{
-		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+		if (!TypeNeedsIcebergReadConversion(elementType))
+			return false;
 
-		if (att->attisdropped)
-			continue;
+		char	   *lambdaVariable = psprintf("_x%d", depth);
+		bool		converted = false;
 
-		if (!first)
-			appendStringInfoString(&buf, ", ");
-		first = false;
+		appendStringInfo(buf, "list_transform(%s, %s -> ",
+						 expression, lambdaVariable);
 
-		char	   *fieldName = NameStr(att->attname);
+		/*
+		 * An array's typmod applies to its element type. The recursion must
+		 * produce an expression here: TypeNeedsIcebergReadConversion approved
+		 * the element type above, and the two functions walk types
+		 * identically.
+		 */
+		converted = AppendIcebergReadConversion(buf, lambdaVariable,
+												elementType, typmod,
+												depth + 1);
+		Assert(converted);
+		(void) converted;
+		appendStringInfoChar(buf, ')');
+		return true;
+	}
 
-		appendStringInfo(&buf, "%s: ", QuoteDuckDBStructKeySQL(fieldName));
+	/*
+	 * pg_map represents a map as a domain over an array of key/value
+	 * composites. The array branch above does not capture it
+	 * (get_element_type only recognizes true arrays, not domains over
+	 * arrays), but the generic domain unwrap below would, and rebuilding the
+	 * base array with list_transform would lose DuckDB's MAP shape.
+	 */
+	if (IsMapTypeOid(typeOid))
+	{
+		PGType		keyType = GetMapKeyType(typeOid);
+		PGType		valueType = GetMapValueType(typeOid);
+		bool		convertKey =
+			TypeNeedsIcebergReadConversion(keyType.postgresTypeOid);
+		bool		convertValue =
+			TypeNeedsIcebergReadConversion(valueType.postgresTypeOid);
 
-		Oid			fieldElementType = get_element_type(att->atttypid);
-		bool		isIntervalArray = OidIsValid(fieldElementType) &&
-			fieldElementType == INTERVALOID;
+		if (!convertKey && !convertValue)
+			return false;
 
-		if (att->atttypid == INTERVALOID)
+		char	   *lambdaVariable = psprintf("_x%d", depth);
+		char	   *keyExpression = psprintf("%s.key", lambdaVariable);
+		char	   *valueExpression = psprintf("%s.value", lambdaVariable);
+		bool		converted = false;
+
+		appendStringInfo(buf,
+						 "map_from_entries(list_transform(map_entries(%s), "
+						 "%s -> struct_pack(key := ",
+						 expression, lambdaVariable);
+
+		/*
+		 * Same invariant as the array branch: TypeNeedsIcebergReadConversion
+		 * approved whichever side we recurse into, so the recursion must
+		 * produce an expression.
+		 */
+		if (convertKey)
 		{
-			appendStringInfo(&buf,
-							 "(to_months(%s.%s.months) + to_days(%s.%s.days) + "
-							 "to_microseconds(%s.%s.microseconds))",
-							 col, duckdb_quote_identifier(fieldName),
-							 col, duckdb_quote_identifier(fieldName),
-							 col, duckdb_quote_identifier(fieldName));
-		}
-		else if (isIntervalArray)
-		{
-			appendStringInfo(&buf,
-							 "list_transform(%s.%s, _x -> "
-							 "(to_months(_x.months) + to_days(_x.days) + "
-							 "to_microseconds(_x.microseconds)))",
-							 col, duckdb_quote_identifier(fieldName));
+			converted = AppendIcebergReadConversion(buf, keyExpression,
+													keyType.postgresTypeOid,
+													keyType.postgresTypeMod,
+													depth + 1);
+			Assert(converted);
+			(void) converted;
 		}
 		else
+			appendStringInfoString(buf, keyExpression);
+
+		appendStringInfoString(buf, ", value := ");
+
+		if (convertValue)
 		{
-			appendStringInfo(&buf, "%s.%s",
-							 col, duckdb_quote_identifier(fieldName));
+			converted = AppendIcebergReadConversion(buf, valueExpression,
+													valueType.postgresTypeOid,
+													valueType.postgresTypeMod,
+													depth + 1);
+			Assert(converted);
+			(void) converted;
 		}
+		else
+			appendStringInfoString(buf, valueExpression);
+
+		appendStringInfoString(buf, ")))");
+		return true;
 	}
 
-	appendStringInfoChar(&buf, '}');
+	char		typeKind = get_typtype(typeOid);
 
-	ReleaseTupleDesc(tupdesc);
+	if (typeKind == TYPTYPE_DOMAIN)
+	{
+		Oid			baseType = getBaseTypeAndTypmod(typeOid, &typmod);
 
-	return buf.data;
+		return AppendIcebergReadConversion(buf, expression, baseType, typmod,
+										   depth);
+	}
+
+	if (typeKind == TYPTYPE_COMPOSITE)
+	{
+		if (!TypeNeedsIcebergReadConversion(typeOid))
+			return false;
+
+		TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeOid, -1);
+		bool		firstField = true;
+
+		/*
+		 * struct_pack builds a fresh struct with reset validity, so without
+		 * the CASE guard a NULL composite would come back as a non-NULL
+		 * struct of NULL fields (DuckDB's IS NOT NULL on structs is
+		 * value-level, not the SQL per-field row rule). See the matching
+		 * rebuild in AppendRewriteExpression for the full story.
+		 */
+		appendStringInfo(buf, "CASE WHEN %s IS NOT NULL THEN struct_pack(",
+						 expression);
+
+		for (int attributeIndex = 0;
+			 attributeIndex < tupleDesc->natts;
+			 attributeIndex++)
+		{
+			Form_pg_attribute attribute =
+				TupleDescAttr(tupleDesc, attributeIndex);
+
+			if (attribute->attisdropped)
+				continue;
+
+			if (!firstField)
+				appendStringInfoString(buf, ", ");
+
+			const char *fieldName = NameStr(attribute->attname);
+			const char *quotedFieldName =
+				duckdb_quote_identifier((char *) fieldName);
+			char	   *fieldExpression =
+				psprintf("%s.%s", expression, quotedFieldName);
+
+			appendStringInfo(buf, "%s := ", quotedFieldName);
+
+			if (!AppendIcebergReadConversion(buf, fieldExpression,
+											 attribute->atttypid,
+											 attribute->atttypmod,
+											 depth))
+				appendStringInfoString(buf, fieldExpression);
+
+			firstField = false;
+		}
+
+		appendStringInfoString(buf, ") ELSE NULL END");
+		ReleaseTupleDesc(tupleDesc);
+		return true;
+	}
+
+	return false;
+}
+
+
+/*
+ * BuildIcebergReadConversion returns a DuckDB expression that converts all
+ * native-type leaves in expression from their Iceberg representation to their
+ * PostgreSQL/DuckDB surface type, or NULL when no conversion is required.
+ */
+static char *
+BuildIcebergReadConversion(const char *expression, Oid typeOid, int32 typmod)
+{
+	StringInfoData conversion;
+
+	initStringInfo(&conversion);
+
+	if (!AppendIcebergReadConversion(&conversion, expression, typeOid, typmod,
+									 0))
+		return NULL;
+
+	return conversion.data;
 }
 
 
@@ -1054,31 +1208,26 @@ BuildStorageToSurfaceProjection(const char *columnName, Oid columnTypeId,
 	const char *castTargetType = duckdbType.typeName;
 
 	/*
-	 * Interval fields living alongside a diverging leaf inside a composite
-	 * are first reconstructed into a DuckDB INTERVAL (which then casts to
-	 * itself as a no-op), since a struct cannot be cast directly to INTERVAL.
+	 * Native-type fields living alongside a diverging leaf are reconstructed
+	 * before the whole value is cast back to its surface type. A struct
+	 * cannot cast an Iceberg interval struct directly to INTERVAL, and
+	 * casting its UTC-normalized TIME fields straight to the PostgreSQL
+	 * composite would leave nested TIMETZ values vulnerable to
+	 * session-timezone parsing.
 	 */
-	if (duckdbType.typeId == DUCKDB_TYPE_STRUCT)
-		reconstruction = BuildStructWithIntervalProjection((char *) columnName,
-														   columnTypeId);
+	reconstruction =
+		BuildIcebergReadConversion(duckdb_quote_identifier((char *) columnName),
+								   columnTypeId, columnTypeMod);
 
 	if (reconstruction == NULL)
 		reconstruction = duckdb_quote_identifier((char *) columnName);
 	else
 	{
 		/*
-		 * BuildStructWithIntervalProjection already rebuilt the interval
-		 * leaves into DuckDB INTERVAL values, so the surface cast must
-		 * describe those leaves as INTERVAL too. duckdbType.typeName is built
-		 * with DATA_FORMAT_ICEBERG, which renders interval as
-		 * STRUCT(months,days,microseconds) (its on-disk shape) -- casting
-		 * against that would attempt INTERVAL -> STRUCT and fail. Re-deriving
-		 * the type name with a non-Iceberg format flips only the interval
-		 * rendering to INTERVAL; every other leaf (including the
-		 * storage-diverging uuid->string) is format-independent, so the cast
-		 * stays "interval -> interval" (a no-op) for the reconstructed fields
-		 * while still bringing the diverging leaves back to their surface
-		 * type.
+		 * The reconstructed expression contains native INTERVAL/TIMETZ
+		 * leaves, so the cast target must use their surface representation
+		 * rather than the Iceberg storage shape. Every other leaf (including
+		 * the storage-diverging uuid->string) is format-independent.
 		 */
 		castTargetType =
 			GetFullDuckDBTypeNameForPGType(MakePGType(columnTypeId,
@@ -1163,17 +1312,18 @@ TupleDescToProjectionList(TupleDesc tupleDesc, CopyDataFormat sourceFormat,
 		}
 
 		/*
-		 * For composite types containing interval fields, we need to
-		 * reconstruct the intervals from struct(months, days, microseconds)
-		 * on the read path.
+		 * Convert every INTERVAL/TIMETZ leaf from its Iceberg storage
+		 * representation to the DuckDB surface type before transmission to
+		 * PostgreSQL. The conversion recursively handles arrays, composites,
+		 * maps, and domains.
 		 */
-		if (duckdbType.typeId == DUCKDB_TYPE_STRUCT &&
-			sourceFormat == DATA_FORMAT_ICEBERG)
+		if (sourceFormat == DATA_FORMAT_ICEBERG)
 		{
-			char	   *structProjection =
-				BuildStructWithIntervalProjection(columnName, columnTypeId);
+			char	   *nativeProjection =
+				BuildIcebergReadConversion(duckdb_quote_identifier(columnName),
+										   columnTypeId, columnTypeMod);
 
-			if (structProjection != NULL)
+			if (nativeProjection != NULL)
 			{
 				char	   *columnAliasString =
 					!addCast ? psprintf(" AS %s", duckdb_quote_identifier(columnName)) : "";
@@ -1182,33 +1332,7 @@ TupleDescToProjectionList(TupleDesc tupleDesc, CopyDataFormat sourceFormat,
 					appendStringInfoString(&projection, ", ");
 
 				appendStringInfo(&projection, "%s%s",
-								 structProjection, columnAliasString);
-
-				hasColumns = true;
-				continue;
-			}
-		}
-
-		/*
-		 * For MAP types with interval values, reconstruct intervals from
-		 * struct(months, days, microseconds) on the read path.
-		 */
-		if (duckdbType.typeId == DUCKDB_TYPE_MAP &&
-			sourceFormat == DATA_FORMAT_ICEBERG)
-		{
-			char	   *mapProjection =
-				BuildMapWithIntervalProjection(columnName, columnTypeId);
-
-			if (mapProjection != NULL)
-			{
-				char	   *columnAliasString =
-					!addCast ? psprintf(" AS %s", duckdb_quote_identifier(columnName)) : "";
-
-				if (hasColumns)
-					appendStringInfoString(&projection, ", ");
-
-				appendStringInfo(&projection, "%s%s",
-								 mapProjection, columnAliasString);
+								 nativeProjection, columnAliasString);
 
 				hasColumns = true;
 				continue;
@@ -1490,33 +1614,6 @@ BuildColumnProjection(char *columnName,
 {
 	char	   *columnAliasString = !addCast ? psprintf(" AS %s", duckdb_quote_identifier(columnName)) : "";
 
-	if (engineType.typeId == DUCKDB_TYPE_INTERVAL)
-	{
-		if (sourceFormat == DATA_FORMAT_ICEBERG)
-		{
-			/*
-			 * Iceberg stores intervals as struct(months, days, microseconds).
-			 * We reconstruct the interval using DuckDB interval constructors.
-			 * Plain Parquet files use DuckDB's native INTERVAL type.
-			 */
-			const char *col = duckdb_quote_identifier(columnName);
-
-			if (engineType.isArrayType)
-				return psprintf(
-								"list_transform(%s, _x -> "
-								"(to_months(_x.months) + "
-								"to_days(_x.days) + "
-								"to_microseconds(_x.microseconds)))%s",
-								col, columnAliasString);
-			else
-				return psprintf(
-								"(to_months(%s.months) + "
-								"to_days(%s.days) + "
-								"to_microseconds(%s.microseconds))%s",
-								col, col, col, columnAliasString);
-		}
-	}
-
 	if (engineType.typeId == DUCKDB_TYPE_GEOMETRY && !engineType.isArrayType)
 	{
 		/*
@@ -1537,27 +1634,6 @@ BuildColumnProjection(char *columnName,
 			/* assume geometry in JSON is stored as GeoJSON */
 			return psprintf("ST_GeomFromGeoJSON(%s)%s", duckdb_quote_identifier(columnName),
 							columnAliasString);
-	}
-
-	if (engineType.typeId == DUCKDB_TYPE_TIME_TZ)
-	{
-		if (sourceFormat == DATA_FORMAT_ICEBERG)
-		{
-			/*
-			 * TimeTZ is stored as TIME (UTC-normalized) in Iceberg. Cast to
-			 * TIMETZ so the UTC offset (+00) is preserved rather than having
-			 * the session timezone applied during text parsing.
-			 */
-			const char *col = duckdb_quote_identifier(columnName);
-
-			if (engineType.isArrayType)
-				return psprintf(
-								"list_transform(%s, _x -> _x::TIMETZ)%s",
-								col, columnAliasString);
-			else
-				return psprintf("%s::TIMETZ%s",
-								col, columnAliasString);
-		}
 	}
 
 	if (sourceFormat == DATA_FORMAT_LOG)

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -74,7 +74,7 @@ static char *BuildColumnProjection(char *expression,
 								   List *formatOptions,
 								   bool addAlias);
 static bool TypeNeedsIcebergReadConversion(Oid typeOid);
-static bool AppendIcebergReadConversion(StringInfo buf, const char *expression,
+static void AppendIcebergReadConversion(StringInfo buf, const char *expression,
 										Oid typeOid, int32 typmod, int depth);
 static char *BuildIcebergReadConversion(const char *expression, Oid typeOid,
 										int32 typmod);
@@ -715,17 +715,18 @@ GetSchemaType(Field * field)
 static char *
 GetEmptyIcebergInputTypeName(Oid typeOid, int32 typmod)
 {
-	DuckDBTypeInfo duckdbType = ChooseCompatibleDuckDBType(typeOid, typmod,
-														   DATA_FORMAT_ICEBERG,
-														   false);
-	DuckDBTypeInfo storageType = GuessStorageType(duckdbType,
-												  DATA_FORMAT_ICEBERG);
+	bool		needsConversion = TypeNeedsIcebergReadConversion(typeOid);
 
-	if (!TypeNeedsIcebergReadConversion(typeOid))
-		return storageType.typeName;
+	if (!needsConversion || typeOid == INTERVALOID || typeOid == TIMETZOID)
+	{
+		DuckDBTypeInfo duckdbType = ChooseCompatibleDuckDBType(typeOid, typmod,
+															   DATA_FORMAT_ICEBERG,
+															   false);
+		DuckDBTypeInfo storageType = GuessStorageType(duckdbType,
+													  DATA_FORMAT_ICEBERG);
 
-	if (typeOid == INTERVALOID || typeOid == TIMETZOID)
 		return storageType.typeName;
+	}
 
 	Oid			elementType = get_element_type(typeOid);
 
@@ -796,8 +797,7 @@ GetEmptyIcebergInputTypeName(Oid typeOid, int32 typmod)
 	 * TypeNeedsIcebergReadConversion and this renderer walk the same type
 	 * families, so a conversion-requiring type must have returned above.
 	 */
-	Assert(false);
-	return storageType.typeName;
+	elog(ERROR, "unexpected type for empty Iceberg input: %u", typeOid);
 }
 
 
@@ -837,7 +837,7 @@ ReadEmptyDataSource(TupleDesc tupleDesc, CopyDataFormat sourceFormat, bool prefe
 			/*
 			 * Iceberg's read projection always performs native leaf
 			 * conversions, so its empty input must expose the structure those
-			 * conversions expect even when the caller prefers VARCHAR.
+			 * conversions expect.
 			 */
 			inputTypeName =
 				GetEmptyIcebergInputTypeName(columnTypeId, columnTypeMod);
@@ -1088,8 +1088,9 @@ TypeNeedsIcebergReadConversion(Oid typeOid)
 /*
  * AppendIcebergReadConversion emits the read-side inverse of the native-type
  * Iceberg write conversion for one expression. It recursively rebuilds only
- * containers with an INTERVAL or TIMETZ descendant and returns false when the
- * expression can pass through unchanged.
+ * containers with an INTERVAL or TIMETZ descendant. The caller must first
+ * establish that typeOid needs conversion with
+ * TypeNeedsIcebergReadConversion.
  *
  * The traversal deliberately mirrors AppendRewriteExpression's
  * ICEBERG_REWRITE_NATIVE_ENCODE family in iceberg_query_validation.c (branch
@@ -1097,7 +1098,7 @@ TypeNeedsIcebergReadConversion(Oid typeOid)
  * TypeNeedsIcebergReadConversion twinning TypeNeedsNativeConversion as the
  * gate. A new native type must be added to all four.
  */
-static bool
+static void
 AppendIcebergReadConversion(StringInfo buf, const char *expression,
 							Oid typeOid, int32 typmod, int depth)
 {
@@ -1108,7 +1109,7 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 						 "to_days((%s).days) + "
 						 "to_microseconds((%s).microseconds))",
 						 expression, expression, expression);
-		return true;
+		return;
 	}
 
 	if (typeOid == TIMETZOID)
@@ -1120,18 +1121,14 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 		 * reinterpretation by timetz_in.
 		 */
 		appendStringInfo(buf, "CAST((%s) AS TIMETZ)", expression);
-		return true;
+		return;
 	}
 
 	Oid			elementType = get_element_type(typeOid);
 
 	if (OidIsValid(elementType))
 	{
-		if (!TypeNeedsIcebergReadConversion(elementType))
-			return false;
-
 		char	   *lambdaVariable = psprintf("_x%d", depth);
-		bool		converted = false;
 
 		appendStringInfo(buf, "list_transform(%s, %s -> ",
 						 expression, lambdaVariable);
@@ -1142,13 +1139,10 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 		 * the element type above, and the two functions walk types
 		 * identically.
 		 */
-		converted = AppendIcebergReadConversion(buf, lambdaVariable,
-												elementType, typmod,
-												depth + 1);
-		Assert(converted);
-		(void) converted;
+		AppendIcebergReadConversion(buf, lambdaVariable, elementType, typmod,
+									depth + 1);
 		appendStringInfoChar(buf, ')');
-		return true;
+		return;
 	}
 
 	/*
@@ -1167,13 +1161,9 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 		bool		convertValue =
 			TypeNeedsIcebergReadConversion(valueType.postgresTypeOid);
 
-		if (!convertKey && !convertValue)
-			return false;
-
 		char	   *lambdaVariable = psprintf("_x%d", depth);
 		char	   *keyExpression = psprintf("%s.key", lambdaVariable);
 		char	   *valueExpression = psprintf("%s.value", lambdaVariable);
-		bool		converted = false;
 
 		appendStringInfo(buf,
 						 "map_from_entries(list_transform(map_entries(%s), "
@@ -1187,12 +1177,10 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 		 */
 		if (convertKey)
 		{
-			converted = AppendIcebergReadConversion(buf, keyExpression,
-													keyType.postgresTypeOid,
-													keyType.postgresTypeMod,
-													depth + 1);
-			Assert(converted);
-			(void) converted;
+			AppendIcebergReadConversion(buf, keyExpression,
+										keyType.postgresTypeOid,
+										keyType.postgresTypeMod,
+										depth + 1);
 		}
 		else
 			appendStringInfoString(buf, keyExpression);
@@ -1201,18 +1189,16 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 
 		if (convertValue)
 		{
-			converted = AppendIcebergReadConversion(buf, valueExpression,
-													valueType.postgresTypeOid,
-													valueType.postgresTypeMod,
-													depth + 1);
-			Assert(converted);
-			(void) converted;
+			AppendIcebergReadConversion(buf, valueExpression,
+										valueType.postgresTypeOid,
+										valueType.postgresTypeMod,
+										depth + 1);
 		}
 		else
 			appendStringInfoString(buf, valueExpression);
 
 		appendStringInfoString(buf, ")))");
-		return true;
+		return;
 	}
 
 	char		typeKind = get_typtype(typeOid);
@@ -1221,15 +1207,12 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 	{
 		Oid			baseType = getBaseTypeAndTypmod(typeOid, &typmod);
 
-		return AppendIcebergReadConversion(buf, expression, baseType, typmod,
-										   depth);
+		AppendIcebergReadConversion(buf, expression, baseType, typmod, depth);
+		return;
 	}
 
 	if (typeKind == TYPTYPE_COMPOSITE)
 	{
-		if (!TypeNeedsIcebergReadConversion(typeOid))
-			return false;
-
 		TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeOid, -1);
 		bool		firstField = true;
 
@@ -1258,16 +1241,18 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 
 			const char *fieldName = NameStr(attribute->attname);
 			const char *quotedFieldName =
-				duckdb_quote_identifier((char *) fieldName);
+				duckdb_quote_identifier(fieldName);
 			char	   *fieldExpression =
 				psprintf("%s.%s", expression, quotedFieldName);
 
 			appendStringInfo(buf, "%s := ", quotedFieldName);
 
-			if (!AppendIcebergReadConversion(buf, fieldExpression,
-											 attribute->atttypid,
-											 attribute->atttypmod,
-											 depth))
+			if (TypeNeedsIcebergReadConversion(attribute->atttypid))
+				AppendIcebergReadConversion(buf, fieldExpression,
+											attribute->atttypid,
+											attribute->atttypmod,
+											depth);
+			else
 				appendStringInfoString(buf, fieldExpression);
 
 			firstField = false;
@@ -1275,10 +1260,10 @@ AppendIcebergReadConversion(StringInfo buf, const char *expression,
 
 		appendStringInfoString(buf, ") ELSE NULL END");
 		ReleaseTupleDesc(tupleDesc);
-		return true;
+		return;
 	}
 
-	return false;
+	elog(ERROR, "unexpected type for Iceberg read conversion: %u", typeOid);
 }
 
 
@@ -1292,12 +1277,11 @@ BuildIcebergReadConversion(const char *expression, Oid typeOid, int32 typmod)
 {
 	StringInfoData conversion;
 
-	initStringInfo(&conversion);
-
-	if (!AppendIcebergReadConversion(&conversion, expression, typeOid, typmod,
-									 0))
+	if (!TypeNeedsIcebergReadConversion(typeOid))
 		return NULL;
 
+	initStringInfo(&conversion);
+	AppendIcebergReadConversion(&conversion, expression, typeOid, typmod, 0);
 	return conversion.data;
 }
 
@@ -1337,11 +1321,11 @@ BuildStorageToSurfaceProjection(const char *columnName, Oid columnTypeId,
 	 * session-timezone parsing.
 	 */
 	reconstruction =
-		BuildIcebergReadConversion(duckdb_quote_identifier((char *) columnName),
+		BuildIcebergReadConversion(duckdb_quote_identifier(columnName),
 								   columnTypeId, columnTypeMod);
 
 	if (reconstruction == NULL)
-		reconstruction = duckdb_quote_identifier((char *) columnName);
+		reconstruction = duckdb_quote_identifier(columnName);
 	else
 	{
 		/*
@@ -1359,7 +1343,7 @@ BuildStorageToSurfaceProjection(const char *columnName, Oid columnTypeId,
 	return psprintf("CAST(%s AS %s) AS %s",
 					reconstruction,
 					castTargetType,
-					duckdb_quote_identifier((char *) columnName));
+					duckdb_quote_identifier(columnName));
 }
 
 

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -67,6 +67,7 @@ static DuckDBTypeInfo ChooseCompatibleDuckDBType(Oid postgresTypeId, int postgre
 												 bool preferVarchar);
 static DuckDBTypeInfo GuessStorageType(DuckDBTypeInfo engineType,
 									   CopyDataFormat sourceFormat);
+static char *GetEmptyIcebergInputTypeName(Oid typeOid, int32 typmod);
 static char *BuildColumnProjection(char *expression,
 								   DuckDBTypeInfo engineType,
 								   CopyDataFormat sourceFormat,
@@ -697,6 +698,109 @@ GetSchemaType(Field * field)
 }
 
 
+/*
+ * GetEmptyIcebergInputTypeName returns the DuckDB type that an empty Iceberg
+ * input must expose to the target-derived read projection.
+ *
+ * Start with the same compatible-type and storage-type inference used by the
+ * existing empty-source path. This preserves its DuckDB capability clamps and
+ * fallbacks, as well as unrelated storage rewrites such as geometry -> BLOB.
+ * Only recurse into a type subtree when the Iceberg read conversion needs its
+ * structure in order to reach an INTERVAL or TIMETZ leaf.
+ *
+ * The type must be derived from the target descriptor, not the source schema:
+ * external Iceberg COPY aliases source columns to target names positionally,
+ * so the source field names and shapes need not describe the projection.
+ */
+static char *
+GetEmptyIcebergInputTypeName(Oid typeOid, int32 typmod)
+{
+	DuckDBTypeInfo duckdbType = ChooseCompatibleDuckDBType(typeOid, typmod,
+														   DATA_FORMAT_ICEBERG,
+														   false);
+	DuckDBTypeInfo storageType = GuessStorageType(duckdbType,
+												  DATA_FORMAT_ICEBERG);
+
+	if (!TypeNeedsIcebergReadConversion(typeOid))
+		return storageType.typeName;
+
+	if (typeOid == INTERVALOID || typeOid == TIMETZOID)
+		return storageType.typeName;
+
+	Oid			elementType = get_element_type(typeOid);
+
+	if (OidIsValid(elementType))
+		return psprintf("%s[]",
+						GetEmptyIcebergInputTypeName(elementType, typmod));
+
+	/*
+	 * Maps are domains over arrays, so recognize them before the generic
+	 * domain branch to preserve their DuckDB MAP shape.
+	 */
+	if (IsMapTypeOid(typeOid))
+	{
+		PGType		keyType = GetMapKeyType(typeOid);
+		PGType		valueType = GetMapValueType(typeOid);
+
+		return psprintf("MAP(%s,%s)",
+						GetEmptyIcebergInputTypeName(keyType.postgresTypeOid,
+													 keyType.postgresTypeMod),
+						GetEmptyIcebergInputTypeName(valueType.postgresTypeOid,
+													 valueType.postgresTypeMod));
+	}
+
+	char		typeKind = get_typtype(typeOid);
+
+	if (typeKind == TYPTYPE_DOMAIN)
+	{
+		Oid			baseType = getBaseTypeAndTypmod(typeOid, &typmod);
+
+		return GetEmptyIcebergInputTypeName(baseType, typmod);
+	}
+
+	if (typeKind == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeOid, -1);
+		StringInfoData typeName;
+		bool		firstField = true;
+
+		initStringInfo(&typeName);
+		appendStringInfoString(&typeName, "STRUCT(");
+
+		for (int attributeIndex = 0;
+			 attributeIndex < tupleDesc->natts;
+			 attributeIndex++)
+		{
+			Form_pg_attribute attribute =
+				TupleDescAttr(tupleDesc, attributeIndex);
+
+			if (attribute->attisdropped)
+				continue;
+
+			if (!firstField)
+				appendStringInfoString(&typeName, ", ");
+
+			appendStringInfo(&typeName, "%s %s",
+							 duckdb_quote_identifier(NameStr(attribute->attname)),
+							 GetEmptyIcebergInputTypeName(attribute->atttypid,
+														  attribute->atttypmod));
+			firstField = false;
+		}
+
+		appendStringInfoChar(&typeName, ')');
+		ReleaseTupleDesc(tupleDesc);
+		return typeName.data;
+	}
+
+	/*
+	 * TypeNeedsIcebergReadConversion and this renderer walk the same type
+	 * families, so a conversion-requiring type must have returned above.
+	 */
+	Assert(false);
+	return storageType.typeName;
+}
+
+
 
 /*
  * ReadEmptyDataSource generates a query that returns 0 results, but with
@@ -726,15 +830,32 @@ ReadEmptyDataSource(TupleDesc tupleDesc, CopyDataFormat sourceFormat, bool prefe
 		Oid			columnTypeId = column->atttypid;
 		int			columnTypeMod = column->atttypmod;
 
-		DuckDBTypeInfo duckdbTypeInfo = ChooseCompatibleDuckDBType(columnTypeId,
-																   columnTypeMod,
-																   sourceFormat,
-																   preferVarchar);
-		DuckDBTypeInfo storageType = GuessStorageType(duckdbTypeInfo, sourceFormat);
+		char	   *inputTypeName;
+
+		if (sourceFormat == DATA_FORMAT_ICEBERG)
+		{
+			/*
+			 * Iceberg's read projection always performs native leaf
+			 * conversions, so its empty input must expose the structure those
+			 * conversions expect even when the caller prefers VARCHAR.
+			 */
+			inputTypeName =
+				GetEmptyIcebergInputTypeName(columnTypeId, columnTypeMod);
+		}
+		else
+		{
+			DuckDBTypeInfo duckdbTypeInfo =
+				ChooseCompatibleDuckDBType(columnTypeId, columnTypeMod,
+										   sourceFormat, preferVarchar);
+			DuckDBTypeInfo storageType =
+				GuessStorageType(duckdbTypeInfo, sourceFormat);
+
+			inputTypeName = storageType.typeName;
+		}
 
 		appendStringInfo(&query, "%s NULL::%s AS %s",
 						 addComma ? "," : "",
-						 storageType.typeName,
+						 inputTypeName,
 						 duckdb_quote_identifier(columnName));
 
 		addComma = true;

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -1446,14 +1446,17 @@ TupleDescToProjectionList(TupleDesc tupleDesc, CopyDataFormat sourceFormat,
 
 			if (nativeProjection != NULL)
 			{
-				char	   *columnAliasString =
-					!addCast ? psprintf(" AS %s", duckdb_quote_identifier(columnName)) : "";
+				const char *castTargetType =
+					GetFullDuckDBTypeNameForPGType(MakePGType(columnTypeId,
+															  columnTypeMod),
+												   DATA_FORMAT_PARQUET);
 
 				if (hasColumns)
 					appendStringInfoString(&projection, ", ");
 
-				appendStringInfo(&projection, "%s%s",
-								 nativeProjection, columnAliasString);
+				appendStringInfo(&projection, "CAST(%s AS %s) AS %s",
+								 nativeProjection, castTargetType,
+								 duckdb_quote_identifier(columnName));
 
 				hasColumns = true;
 				continue;

--- a/pg_lake_engine/src/pgduck/struct_conversion.c
+++ b/pg_lake_engine/src/pgduck/struct_conversion.c
@@ -50,10 +50,6 @@ typedef struct RecordIOData
  * inside a STRUCT literal that will travel through CSV.  DuckDB reads the
  * literal after CSV un-quoting, so we use backslash escaping (single-quotes
  * become \' and backslashes become \\) to round-trip through both layers.
- *
- * For struct literals that are concatenated directly into a SQL query text
- * (not travelling through CSV), use QuoteDuckDBStructKeySQL instead — the
- * DuckDB parser expects SQL-standard '' doubling in that context.
  */
 const char *
 QuoteDuckDBStructKey(const char *fieldName)
@@ -67,32 +63,6 @@ QuoteDuckDBStructKey(const char *fieldName)
 	{
 		if (*s == '\'' || *s == '\\')
 			*p++ = '\\';
-		*p++ = *s;
-	}
-	*p++ = '\'';
-	*p = '\0';
-	return result;
-}
-
-/*
- * QuoteDuckDBStructKeySQL — same role as QuoteDuckDBStructKey but for
- * struct literals emitted directly into SQL query text (e.g. the struct
- * projection builder in read_data.c).  Uses SQL-standard single-quote
- * doubling: '  ->  ''.  Backslashes are copied verbatim because
- * standard_conforming_strings keeps them literal in single-quoted text.
- */
-const char *
-QuoteDuckDBStructKeySQL(const char *fieldName)
-{
-	char	   *result = palloc(2 * strlen(fieldName) + 3);
-	char	   *p = result;
-	const char *s;
-
-	*p++ = '\'';
-	for (s = fieldName; *s; s++)
-	{
-		if (*s == '\'')
-			*p++ = '\'';
 		*p++ = *s;
 	}
 	*p++ = '\'';

--- a/pg_lake_table/tests/pytests/test_iceberg_interval_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_interval_type.py
@@ -823,6 +823,84 @@ def test_interval_array_in_composite(pg_conn, s3, with_default_location):
     pg_conn.commit()
 
 
+def test_interval_composite_in_array_and_map(pg_conn, s3, with_default_location):
+    """
+    Verify recursive read conversion when an interval-bearing composite is
+    itself nested in an array or used as a map value.
+    """
+    schema_name = "test_interval_comp_containers"
+
+    try:
+        run_command(
+            f"""
+            CREATE SCHEMA {schema_name};
+            CREATE TYPE {schema_name}.event_duration AS (
+                name     text,
+                duration interval
+            );
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        map_type_name = create_map_type("text", f"{schema_name}.event_duration")
+
+        run_command(
+            f"""
+            CREATE TABLE {schema_name}.test (
+                id             integer,
+                events         {schema_name}.event_duration[],
+                events_by_name {map_type_name}
+            ) USING iceberg;
+
+            INSERT INTO {schema_name}.test VALUES
+                (1,
+                 ARRAY[
+                     ROW('meeting', '90 minutes'::interval)::{schema_name}.event_duration,
+                     ROW('sprint', '14 days'::interval)::{schema_name}.event_duration
+                 ],
+                 ARRAY[
+                     ROW('meeting', ROW('meeting', '90 minutes'::interval)::{schema_name}.event_duration),
+                     ROW('sprint', ROW('sprint', '14 days'::interval)::{schema_name}.event_duration)
+                 ]::{map_type_name}),
+                (2, NULL, NULL);
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        assert (
+            run_query(
+                f"""
+            SELECT id,
+                   (events[1]).name,
+                   (events[1]).duration,
+                   (events[2]).duration,
+                   (map_type.extract(events_by_name, 'meeting')).duration,
+                   (map_type.extract(events_by_name, 'sprint')).duration
+            FROM {schema_name}.test
+            ORDER BY id
+            """,
+                pg_conn,
+            )
+            == [
+                [
+                    1,
+                    "meeting",
+                    datetime.timedelta(minutes=90),
+                    datetime.timedelta(days=14),
+                    datetime.timedelta(minutes=90),
+                    datetime.timedelta(days=14),
+                ],
+                [2, None, None, None, None, None],
+            ]
+        )
+    finally:
+        pg_conn.rollback()
+        run_command(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE", pg_conn)
+        pg_conn.commit()
+
+
 def test_interval_array_update(pg_conn, s3, with_default_location):
     """
     Verify UPDATE and DELETE on interval[] columns.

--- a/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
@@ -1136,6 +1136,196 @@ def test_timetz_nested_read_is_session_timezone_independent(
         pg_conn.commit()
 
 
+def test_nested_timetz_writes_and_updates_are_session_timezone_independent(
+    pg_conn, pgduck_conn, s3, with_default_location
+):
+    """
+    Writes and read-modify-write updates must store the same TIMETZ instants
+    regardless of the PostgreSQL session timezone.
+
+    Iceberg stores TIMETZ leaves as UTC-normalized TIME digits. Read both the
+    initial and updated snapshots through DuckDB's independent Iceberg reader
+    so the assertions observe the physical Iceberg types without pg_lake's
+    read-side conversion.
+
+    Before the recursive read conversion, PostgreSQL attached the session
+    timezone to nested TIME digits. A read-modify-write UPDATE could then
+    normalize that misinterpreted value back to UTC and persist shifted digits.
+    """
+    utc = timezone.utc
+    map_typename = create_map_type("text", "timetz")
+
+    def metadata_location():
+        return run_query(
+            "SELECT metadata_location FROM lake_iceberg.tables "
+            "WHERE table_name = 'test' "
+            "AND table_namespace = 'test_timetz_update_drift'",
+            pg_conn,
+        )[0][0]
+
+    def raw_snapshot(metadata_path):
+        return run_query(
+            f"""
+            SELECT id,
+                   note,
+                   slot.at_time,
+                   slot.extras[1],
+                   slots[1].at_time,
+                   map_extract_value(by_name, 'open')
+            FROM iceberg_scan('{metadata_path}')
+            ORDER BY id
+            """,
+            pgduck_conn,
+        )
+
+    def insert_row(row_id, session_timezone):
+        run_command(
+            f"""
+            SET TIME ZONE '{session_timezone}';
+            INSERT INTO test VALUES
+                ({row_id},
+                 'written {session_timezone}',
+                 ROW(
+                     'single',
+                     '12:30:00+04'::timetz,
+                     ARRAY['23:30:00-02'::timetz]
+                 )::event_slot,
+                 ARRAY[
+                     ROW(
+                         'array element',
+                         '08:00:00+04'::timetz,
+                         NULL
+                     )::event_slot
+                 ],
+                 ARRAY[
+                     ROW('open', '09:00:00+04'::timetz)
+                 ]::{map_typename});
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+    try:
+        run_command(
+            f"""
+            CREATE SCHEMA test_timetz_update_drift;
+            SET search_path TO test_timetz_update_drift;
+
+            CREATE TYPE event_slot AS (
+                label       text,
+                at_time     timetz,
+                extras      timetz[]
+            );
+
+            CREATE TABLE test (
+                id          int,
+                note        text,
+                slot        event_slot,
+                slots       event_slot[],
+                by_name     {map_typename}
+            ) USING iceberg;
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        insert_row(1, "UTC")
+        insert_row(2, "America/New_York")
+
+        metadata_before = metadata_location()
+        raw_before = raw_snapshot(metadata_before)
+
+        # Both sessions must persist the same offsetless UTC digits.
+        assert raw_before == [
+            [
+                1,
+                "written UTC",
+                time(8, 30),
+                time(1, 30),
+                time(4, 0),
+                time(5, 0),
+            ],
+            [
+                2,
+                "written America/New_York",
+                time(8, 30),
+                time(1, 30),
+                time(4, 0),
+                time(5, 0),
+            ],
+        ]
+
+        run_command("SET TIME ZONE 'UTC';", pg_conn)
+        run_command("UPDATE test SET note = 'updated UTC' WHERE id = 1;", pg_conn)
+        pg_conn.commit()
+
+        run_command("SET TIME ZONE 'America/New_York';", pg_conn)
+        run_command(
+            "UPDATE test SET note = 'updated America/New_York' WHERE id = 2;",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        metadata_after = metadata_location()
+        assert metadata_after != metadata_before
+
+        raw_after = raw_snapshot(metadata_after)
+        assert raw_after == [
+            [
+                1,
+                "updated UTC",
+                time(8, 30),
+                time(1, 30),
+                time(4, 0),
+                time(5, 0),
+            ],
+            [
+                2,
+                "updated America/New_York",
+                time(8, 30),
+                time(1, 30),
+                time(4, 0),
+                time(5, 0),
+            ],
+        ]
+        assert [row[2:] for row in raw_after] == [row[2:] for row in raw_before]
+
+        # pg_lake's surface values represent the same UTC instants too.
+        assert (
+            run_query(
+                """
+            SELECT (slot).at_time,
+                   ((slot).extras)[1],
+                   ((slots)[1]).at_time,
+                   map_type.extract(by_name, 'open')
+            FROM test
+            ORDER BY id
+            """,
+                pg_conn,
+            )
+            == [
+                [
+                    time(8, 30, tzinfo=utc),
+                    time(1, 30, tzinfo=utc),
+                    time(4, 0, tzinfo=utc),
+                    time(5, 0, tzinfo=utc),
+                ],
+                [
+                    time(8, 30, tzinfo=utc),
+                    time(1, 30, tzinfo=utc),
+                    time(4, 0, tzinfo=utc),
+                    time(5, 0, tzinfo=utc),
+                ],
+            ]
+        )
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("DROP SCHEMA IF EXISTS test_timetz_update_drift CASCADE", pg_conn)
+        pg_conn.commit()
+
+
 @pytest.fixture(scope="module")
 def create_helper_functions(superuser_conn, app_user):
     run_command(

--- a/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
@@ -216,13 +216,9 @@ def _assert_timetz_utc_cast_in_explain(query, pg_conn):
     IcebergWrapQueryWithNativeTypeConversion emits for TIMETZ columns.
 
     The wrapper emits
-    ``CAST(CAST((<expr>) AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)`` for
-    every TIMETZ leaf reachable from the target tuple descriptor (the
-    inner ``::TIMETZ`` is defensive: it keeps the outer ``AT TIME ZONE
-    'UTC'`` well-typed even when the source expression is already plain
-    TIME, which happens for TIMETZ fields read back from inside an
-    Iceberg composite).  The outer substring is enough to detect that
-    the wrapper fired -- without it, DuckDB's implicit
+    ``CAST((<expr>) AT TIME ZONE 'UTC' AS TIME)`` for every TIMETZ leaf
+    reachable from the target tuple descriptor. The substring is enough
+    to detect that the wrapper fired -- without it, DuckDB's implicit
     ``CAST(TIMETZ AS TIME)`` silently drops the offset.
     """
     explain = _get_explain_text(query, pg_conn)
@@ -987,6 +983,156 @@ def test_insert_select_timetz_with_oor_clamp_and_aggregate_pushdown(
         run_command("RESET search_path;", pg_conn)
         run_command("RESET TIME ZONE;", pg_conn)
         run_command("DROP SCHEMA IF EXISTS test_timetz_oor_agg_pd CASCADE", pg_conn)
+        pg_conn.commit()
+
+
+def test_timetz_nested_read_is_session_timezone_independent(
+    pg_conn, s3, with_default_location
+):
+    """
+    TIMETZ leaves stored inside Iceberg composites, arrays, and maps must be
+    promoted from DuckDB TIME to TIMETZ before PostgreSQL parses the value.
+
+    Iceberg stores the UTC-normalized time digits without an offset. Without
+    the recursive read projection, PostgreSQL's timetz input function attaches
+    the current session offset to those digits and changes the represented
+    instant.
+    """
+    utc = timezone.utc
+    map_typename = create_map_type("text", "timetz")
+
+    try:
+        run_command(
+            f"""
+            CREATE SCHEMA test_timetz_nested_read;
+            SET search_path TO test_timetz_nested_read;
+
+            CREATE TYPE inner_event AS (
+                label       text,
+                "At Time"   timetz,
+                extras      timetz[]
+            );
+            CREATE TYPE outer_session AS (
+                title       text,
+                start_at    timetz,
+                repeats     timetz[],
+                events      inner_event[]
+            );
+            CREATE TYPE mixed_storage AS (
+                uid         uuid,
+                at_time     timetz
+            );
+
+            CREATE TABLE test (
+                id          int,
+                single      outer_session,
+                many        outer_session[],
+                by_name     {map_typename}
+            ) USING iceberg;
+            CREATE TABLE mixed_test (
+                id          int,
+                mixed       mixed_storage
+            ) USING iceberg WITH (compatibility_mode = 'snowflake');
+
+            INSERT INTO test VALUES
+                (1,
+                 ROW(
+                     'single',
+                     '12:30:00+04'::timetz,
+                     ARRAY['23:30:00-02'::timetz],
+                     ARRAY[
+                         ROW(
+                             'nested',
+                             '23:59:59.999+05:30'::timetz,
+                             ARRAY['09:45:00+04'::timetz]
+                         )::inner_event
+                     ]
+                 )::outer_session,
+                 ARRAY[
+                     ROW(
+                         'array element',
+                         '08:00:00+04'::timetz,
+                         ARRAY['00:00:00+00'::timetz],
+                         ARRAY[
+                             ROW('deep null', NULL, NULL)::inner_event
+                         ]
+                     )::outer_session
+                 ],
+                 ARRAY[
+                     ROW('open', '09:00:00+04'::timetz),
+                     ROW('close', '23:00:00-02'::timetz)
+                 ]::{map_typename}),
+                (2, NULL, NULL, NULL);
+
+            INSERT INTO mixed_test VALUES
+                (1,
+                 ROW(
+                     '11111111-1111-1111-1111-111111111111'::uuid,
+                     '07:00:00+03'::timetz
+                 )::mixed_storage),
+                (2, NULL);
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        run_command("SET TIME ZONE 'America/New_York';", pg_conn)
+
+        result = run_query(
+            """
+            SELECT id,
+                   (single).start_at,
+                   (single).repeats,
+                   ((single).events)[1]."At Time",
+                   ((single).events)[1].extras,
+                   ((many)[1]).start_at,
+                   ((many)[1]).repeats,
+                   (((many)[1]).events)[1]."At Time",
+                   map_type.extract(by_name, 'open'),
+                   map_type.extract(by_name, 'close')
+            FROM test
+            WHERE id = 1
+            """,
+            pg_conn,
+        )
+
+        assert result == [
+            [
+                1,
+                time(8, 30, 0, tzinfo=utc),
+                [time(1, 30, 0, tzinfo=utc)],
+                time(18, 29, 59, 999000, tzinfo=utc),
+                [time(5, 45, 0, tzinfo=utc)],
+                time(4, 0, 0, tzinfo=utc),
+                [time(0, 0, 0, tzinfo=utc)],
+                None,
+                time(5, 0, 0, tzinfo=utc),
+                time(1, 0, 0, tzinfo=utc),
+            ]
+        ]
+
+        assert run_query(
+            "SELECT single, many, by_name FROM test WHERE id = 2",
+            pg_conn,
+        ) == [[None, None, None]]
+
+        assert run_query(
+            "SELECT id, (mixed).uid::text, (mixed).at_time "
+            "FROM mixed_test ORDER BY id",
+            pg_conn,
+        ) == [
+            [
+                1,
+                "11111111-1111-1111-1111-111111111111",
+                time(4, 0, 0, tzinfo=utc),
+            ],
+            [2, None, None],
+        ]
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("DROP SCHEMA IF EXISTS test_timetz_nested_read CASCADE", pg_conn)
         pg_conn.commit()
 
 

--- a/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
@@ -1136,6 +1136,179 @@ def test_timetz_nested_read_is_session_timezone_independent(
         pg_conn.commit()
 
 
+def test_empty_iceberg_domain_over_composite_with_timetz(
+    pg_conn, s3, with_default_location
+):
+    """
+    Empty Iceberg inputs must retain the structure that the recursive TIMETZ
+    read conversion expects, even when the PostgreSQL column is a domain.
+    """
+    try:
+        run_command(
+            """
+            CREATE SCHEMA test_empty_timetz_domain;
+            SET search_path TO test_empty_timetz_domain;
+
+            CREATE TYPE event_slot AS (
+                label       text,
+                at_time     timetz
+            );
+            CREATE DOMAIN event_slot_domain AS event_slot;
+
+            CREATE TABLE test (
+                id          int,
+                slot        event_slot_domain
+            ) USING iceberg;
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        assert (
+            run_query(
+                "SELECT id, (slot).label, (slot).at_time FROM test",
+                pg_conn,
+            )
+            == []
+        )
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command("DROP SCHEMA IF EXISTS test_empty_timetz_domain CASCADE", pg_conn)
+        pg_conn.commit()
+
+
+def test_empty_iceberg_composite_with_timetz_matches_nonempty_shape(
+    pg_conn, s3, with_default_location
+):
+    """
+    The synthesized empty input and a physical Iceberg input must satisfy the
+    same target-derived recursive projection.
+    """
+    utc = timezone.utc
+
+    try:
+        run_command(
+            """
+            CREATE SCHEMA test_empty_timetz_composite;
+            SET search_path TO test_empty_timetz_composite;
+
+            CREATE TYPE event_slot AS (
+                label       text,
+                "At Time"   timetz
+            );
+
+            CREATE TABLE test (
+                id          int,
+                slot        event_slot
+            ) USING iceberg;
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        assert (
+            run_query(
+                'SELECT id, (slot).label, (slot)."At Time" FROM test',
+                pg_conn,
+            )
+            == []
+        )
+
+        run_command(
+            """
+            INSERT INTO test VALUES
+                (1, ROW('open', '09:00:00+04'::timetz)::event_slot);
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        assert run_query(
+            'SELECT id, (slot).label, (slot)."At Time" FROM test',
+            pg_conn,
+        ) == [[1, "open", time(5, 0, tzinfo=utc)]]
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command(
+            "DROP SCHEMA IF EXISTS test_empty_timetz_composite CASCADE", pg_conn
+        )
+        pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "case_name, source_column, source_type",
+    [
+        ("renamed", "source_slot", "event_slot_domain"),
+        ("type_mismatch", "target_slot", "integer"),
+    ],
+)
+def test_empty_external_iceberg_copy_uses_target_projection_shape(
+    pg_conn,
+    s3,
+    with_default_location,
+    case_name,
+    source_column,
+    source_type,
+):
+    """
+    Empty external Iceberg COPY aliases source columns to target names
+    positionally. Its synthesized input must therefore follow the target
+    descriptor even when the source field name or type disagrees.
+    """
+    schema_name = f"test_empty_timetz_copy_{case_name}"
+    source_table = f"source_{case_name}"
+    target_table = f"target_{case_name}"
+
+    try:
+        run_command(
+            f"""
+            CREATE SCHEMA {schema_name};
+            SET search_path TO {schema_name};
+
+            CREATE TYPE event_slot AS (
+                label       text,
+                at_time     timetz
+            );
+            CREATE DOMAIN event_slot_domain AS event_slot;
+
+            CREATE TABLE {source_table} (
+                {source_column} {source_type}
+            ) USING iceberg;
+
+            CREATE TABLE {target_table} (
+                target_slot event_slot_domain
+            );
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        metadata_location = run_query(
+            "SELECT metadata_location FROM lake_iceberg.tables "
+            f"WHERE table_namespace = '{schema_name}' "
+            f"AND table_name = '{source_table}'",
+            pg_conn,
+        )[0][0]
+
+        run_command(
+            f"""
+            COPY {target_table} (target_slot)
+            FROM '{metadata_location}'
+            WITH (FORMAT 'iceberg');
+            """,
+            pg_conn,
+        )
+
+        assert run_query(f"SELECT count(*) FROM {target_table}", pg_conn) == [[0]]
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE", pg_conn)
+        pg_conn.commit()
+
+
 def test_nested_timetz_writes_and_updates_are_session_timezone_independent(
     pg_conn, pgduck_conn, s3, with_default_location
 ):

--- a/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
@@ -216,16 +216,16 @@ def _assert_timetz_utc_cast_in_explain(query, pg_conn):
     IcebergWrapQueryWithNativeTypeConversion emits for TIMETZ columns.
 
     The wrapper emits
-    ``CAST((<expr>) AT TIME ZONE 'UTC' AS TIME)`` for every TIMETZ leaf
-    reachable from the target tuple descriptor. The substring is enough
-    to detect that the wrapper fired -- without it, DuckDB's implicit
-    ``CAST(TIMETZ AS TIME)`` silently drops the offset.
+    ``CAST(CAST((<expr>) AS TIMETZ) AT TIME ZONE 'UTC' AS TIME)`` for every
+    TIMETZ leaf reachable from the target tuple descriptor. Without the inner
+    cast, DuckDB can resolve a nested value as TIME and reinterpret its digits
+    in the session timezone before UTC normalization.
     """
     explain = _get_explain_text(query, pg_conn)
     assert "Custom Scan (Query Pushdown)" in explain, (
         "Expected Query Pushdown for: " + query + "\n" + explain
     )
-    assert "AT TIME ZONE 'UTC' AS TIME" in explain, (
+    assert "AS TIMETZ) AT TIME ZONE 'UTC' AS TIME" in explain, (
         "Expected TIMETZ UTC-normalizing cast in EXPLAIN output:\n" + explain
     )
 

--- a/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_timetz_type.py
@@ -1,7 +1,7 @@
 from utils_pytest import *
 import json
 import pytest
-from datetime import time, timezone
+from datetime import time, timedelta, timezone
 
 
 def test_iceberg_timetz_as_utc_time(
@@ -1305,6 +1305,106 @@ def test_empty_external_iceberg_copy_uses_target_projection_shape(
     finally:
         pg_conn.rollback()
         run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE", pg_conn)
+        pg_conn.commit()
+
+
+def test_external_iceberg_copy_preserves_nested_native_projection_aliases(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    create_helper_functions,
+):
+    """
+    COPY FROM an Iceberg metadata location must retain names for reconstructed
+    composite columns so the outer write-side rewrite can bind them.
+
+    Exercise both TIMETZ and INTERVAL because they share the recursive native
+    read conversion; the old interval-only projection had the same alias bug.
+    """
+    schema_name = "test_nested_native_external_copy"
+
+    try:
+        run_command(
+            f"""
+            CREATE SCHEMA {schema_name};
+            SET search_path TO {schema_name};
+            SET TIME ZONE 'America/New_York';
+
+            CREATE TYPE time_slot AS (
+                label   text,
+                at_time timetz
+            );
+            CREATE TYPE duration_slot AS (
+                label    text,
+                duration interval
+            );
+
+            CREATE TABLE source (
+                id             integer,
+                time_value     time_slot,
+                interval_value duration_slot
+            ) USING iceberg;
+            CREATE TABLE target (
+                id             integer,
+                time_value     time_slot,
+                interval_value duration_slot
+            ) USING iceberg;
+
+            INSERT INTO source VALUES
+                (1,
+                 ROW('open', '09:00:00+04'::timetz)::time_slot,
+                 ROW('elapsed', '2 days 3 hours'::interval)::duration_slot),
+                (2, NULL, NULL);
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        metadata_location = run_query(
+            "SELECT metadata_location FROM lake_iceberg.tables "
+            f"WHERE table_namespace = '{schema_name}' AND table_name = 'source'",
+            pg_conn,
+        )[0][0]
+
+        run_command(
+            f"COPY target FROM '{metadata_location}' WITH (FORMAT 'iceberg');",
+            pg_conn,
+        )
+
+        assert (
+            run_query(
+                """
+            SELECT id,
+                   (time_value).label,
+                   (time_value).at_time,
+                   (interval_value).label,
+                   (interval_value).duration
+            FROM target
+            ORDER BY id
+            """,
+                pg_conn,
+            )
+            == [
+                [
+                    1,
+                    "open",
+                    time(5, 0, tzinfo=timezone.utc),
+                    "elapsed",
+                    timedelta(days=2, hours=3),
+                ],
+                [2, None, None, None, None],
+            ]
+        )
+        assert run_query(
+            "SELECT public.pg_lake_last_copy_pushed_down_test() pushed_down",
+            pg_conn,
+        )[0]["pushed_down"]
+    finally:
+        pg_conn.rollback()
+        run_command("RESET search_path;", pg_conn)
+        run_command("RESET TIME ZONE;", pg_conn)
         run_command(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE", pg_conn)
         pg_conn.commit()
 


### PR DESCRIPTION
## Problem

Iceberg stores `timetz` as a UTC-normalized `TIME` because Iceberg has no time-with-time-zone type. The read path converted top-level `timetz` values back to `TIMETZ`, but did not perform the same conversion for values nested inside composites, arrays, maps, or domains.

Under a non-UTC PostgreSQL session, a nested value therefore reached PostgreSQL as offsetless time digits. PostgreSQL attached the session offset, returning a different instant. For example, a stored `08:30:00` UTC value could be exposed as `08:30:00-04` instead of `08:30:00+00`.

Initial writes were already correct regardless of the session timezone. However, a row-by-row update could persist drift after reading an existing nested value through the broken projection and writing that misinterpreted value back. UTC sessions and top-level `timetz` columns were unaffected.

## Fix

- Replace the struct/map interval special cases with one recursive Iceberg read conversion for arrays, composites, maps, and domains.
- Convert nested `TIMETZ` leaves from stored UTC `TIME` values to `TIMETZ +00` before PostgreSQL parses them.
- Reconstruct nested `INTERVAL` leaves from the Iceberg months/days/microseconds struct representation through the same traversal.
- Preserve null containers and rebuild empty Iceberg input types with the structure required by these conversions.
- Keep the defensive write-side `CAST(... AS TIMETZ)` before UTC normalization.
- Cast converted projections to their PostgreSQL surface type and always restore the column alias. This fixes `COPY FROM` external Iceberg metadata for composite columns and preserves the type enforcement expected by the pushdown write path.

Installing this fix does not rewrite existing Iceberg files. Correctly stored data remains unchanged. It prevents future read/rewrite drift, but it cannot automatically identify or repair values that were already shifted by an affected update.

## Coverage

Regression coverage includes:

- nested `timetz` in composites, arrays, maps, map keys and values, and domains;
- non-UTC reads and raw-storage comparisons across UTC and non-UTC writes and updates;
- null and empty Iceberg inputs;
- compatibility mode and quoted/reserved struct field names;
- external-Iceberg `COPY FROM` with composite `timetz` and `interval` values, including pushdown verification;
- arrays of composites containing `interval` and maps with composite interval values.

## Testing

Built and installed the complete branch in the PostgreSQL 18 Docker development image.

- 31 affected TIMETZ and INTERVAL tests passed after the full rebuild.
- 152 neighboring Iceberg, COPY-pushdown, compatibility, domain, type, and complex-type tests passed.
- 183 distinct tests passed in total.
- Black, Python compilation, pgindent, and `git diff --check` passed.

Fixes #332.