### PR TITLE
postgres_scan: reject out-of-range timestamps

### DIFF
--- a/duckdb_pglake/patches/duckdb-postgres/timestamp-range.patch
+++ b/duckdb_pglake/patches/duckdb-postgres/timestamp-range.patch
@@ -1,0 +1,84 @@
+Reject PostgreSQL timestamps that cannot be represented safely.
+
+This ports duckdb/duckdb-postgres#530 to pg_lake's older vendored revision.
+PostgreSQL has a slightly wider timestamp range than DuckDB, so unchecked
+epoch conversion can overflow in either direction. Use checked arithmetic and
+the exact PostgreSQL bounds instead of silently wrapping.
+
+diff --git a/src/include/postgres_binary_reader.hpp b/src/include/postgres_binary_reader.hpp
+index 79ab24e..2cf0b43 100644
+--- a/src/include/postgres_binary_reader.hpp
++++ b/src/include/postgres_binary_reader.hpp
+@@ -8,6 +8,8 @@
+ 
+ #pragma once
+ 
++#include "duckdb/common/exception/conversion_exception.hpp"
++#include "duckdb/common/operator/add.hpp"
+ #include "postgres_result_reader.hpp"
+ #include "postgres_connection.hpp"
+ 
+@@ -105,7 +107,16 @@ protected:
+ 		if (usec == POSTGRES_NINFINITY) {
+ 			return timestamp_t::ninfinity();
+ 		}
+-		return timestamp_t(usec + (POSTGRES_EPOCH_TS - DUCKDB_EPOCH_TS));
++		int64_t timestamp_usec;
++		if (!TryAddOperator::Operation(static_cast<int64_t>(usec),
++		                               static_cast<int64_t>(POSTGRES_EPOCH_TS - DUCKDB_EPOCH_TS), timestamp_usec)) {
++			throw ConversionException("timestamp out of range");
++		}
++		auto timestamp = timestamp_t(timestamp_usec);
++		if (!Timestamp::IsFinite(timestamp)) {
++			throw ConversionException("timestamp out of range");
++		}
++		return timestamp;
+ 	}
+ 
+ 	inline interval_t ReadInterval() {
+diff --git a/src/include/postgres_binary_writer.hpp b/src/include/postgres_binary_writer.hpp
+index eff48d1..b9b9534 100644
+--- a/src/include/postgres_binary_writer.hpp
++++ b/src/include/postgres_binary_writer.hpp
+@@ -9,6 +9,7 @@
+ #pragma once
+ 
+ #include "duckdb.hpp"
++#include "duckdb/common/operator/subtract.hpp"
+ #include "duckdb/common/types/interval.hpp"
+ #include "duckdb/common/serializer/memory_stream.hpp"
+ #include "postgres_conversion.hpp"
+@@ -118,7 +119,14 @@ public:
+ 		if (value == timestamp_t::ninfinity()) {
+ 			return POSTGRES_NINFINITY;
+ 		}
+-		return uint64_t(value.value - (POSTGRES_EPOCH_TS - DUCKDB_EPOCH_TS));
++		int64_t postgres_usec;
++		if (!TrySubtractOperator::Operation(value.value, static_cast<int64_t>(POSTGRES_EPOCH_TS - DUCKDB_EPOCH_TS),
++		                                    postgres_usec) ||
++		    postgres_usec < POSTGRES_MIN_TIMESTAMP || postgres_usec >= POSTGRES_END_TIMESTAMP) {
++			throw InvalidInputException("TIMESTAMP \"%s\" is out of range for Postgres' TIMESTAMP field",
++			                            Timestamp::ToString(value));
++		}
++		return static_cast<uint64_t>(postgres_usec);
+ 	}
+ 
+ 	void WriteTimestamp(timestamp_t value) {
+diff --git a/src/include/postgres_conversion.hpp b/src/include/postgres_conversion.hpp
+index f9049eb..0f7c111 100644
+--- a/src/include/postgres_conversion.hpp
++++ b/src/include/postgres_conversion.hpp
+@@ -29,8 +29,11 @@
+ #define POSTGRES_DATE_NINF   2147483648U
+ #define POSTGRES_EPOCH_TS    211813488000000000ULL
+ #define DUCKDB_EPOCH_TS      210866803200000000ULL
+-#define POSTGRES_INFINITY    9223372036854775807ULL
+-#define POSTGRES_NINFINITY   9223372036854775808ULL
++/* Values from PostgreSQL's datatype/timestamp.h. The end is exclusive. */
++#define POSTGRES_MIN_TIMESTAMP (-211813488000000000LL)
++#define POSTGRES_END_TIMESTAMP 9223371331200000000LL
++#define POSTGRES_INFINITY      9223372036854775807ULL
++#define POSTGRES_NINFINITY     9223372036854775808ULL
+ 
+ #define NBASE      10000
+ #define DEC_DIGITS 4 /* decimal digits per NBASE digit */

--- a/duckdb_pglake/patches/duckdb-postgres/timestamp-range.patch
+++ b/duckdb_pglake/patches/duckdb-postgres/timestamp-range.patch
@@ -3,7 +3,8 @@ Reject PostgreSQL timestamps that cannot be represented safely.
 This ports duckdb/duckdb-postgres#530 to pg_lake's older vendored revision.
 PostgreSQL has a slightly wider timestamp range than DuckDB, so unchecked
 epoch conversion can overflow in either direction. Use checked arithmetic and
-the exact PostgreSQL bounds instead of silently wrapping.
+the exact PostgreSQL bounds instead of silently wrapping. Keep the vendored
+all-types round-trip within PostgreSQL's timestamp range.
 
 diff --git a/src/include/postgres_binary_reader.hpp b/src/include/postgres_binary_reader.hpp
 index 79ab24e..2cf0b43 100644
@@ -82,3 +83,31 @@ index f9049eb..0f7c111 100644
  
  #define NBASE      10000
  #define DEC_DIGITS 4 /* decimal digits per NBASE digit */
+diff --git a/test/sql/misc/postgres_binary.test b/test/sql/misc/postgres_binary.test
+--- a/test/sql/misc/postgres_binary.test
++++ b/test/sql/misc/postgres_binary.test
+@@ -14,3 +14,9 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
++# DuckDB supports timestamps below PostgreSQL's minimum.
++statement error
++COPY (SELECT TIMESTAMP '290309-12-22 (BC)') TO '__TEST_DIR__/pg_binary.bin' (FORMAT postgres_binary);
++----
++out of range for Postgres
++
+ # straightforward integer copy
+ statement ok
+ COPY (SELECT i::INT AS i FROM range(100) t(i)) TO '__TEST_DIR__/pg_binary.bin' (FORMAT postgres_binary);
+@@ -32,8 +38,9 @@ statement ok
+ CREATE TABLE all_types_tbl AS
+ SELECT bool, smallint, int, bigint, float, double, dec_4_1, dec_9_4, dec_18_6, dec38_10,
+-	case when date < '1992-01-01' then '4712-01-01 (BC)' else '5874896-01-01' end as date, -- postgres has more constrained date ranges
+-	time,
+-	timestamp, interval, uuid, blob,
++	case when date < '1992-01-01' then '4712-01-01 (BC)' else '5874896-01-01' end as date, -- postgres has more constrained date ranges
++	time,
++	case when timestamp < TIMESTAMP '4713-01-01 (BC)' then TIMESTAMP '4713-01-01 (BC)' else timestamp end as timestamp, -- postgres has a more constrained lower timestamp bound
++	interval, uuid, blob,
+-	replace(varchar, chr(0), '') as varchar, -- postgres does not support null bytes in varchar columns
+-	blob, int_array, varchar_array
++	replace(varchar, chr(0), '') as varchar, -- postgres does not support null bytes in varchar columns
++	blob, int_array, varchar_array
+ FROM test_all_types()

--- a/pg_lake_table/tests/pytests/test_iceberg_validation.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_validation.py
@@ -124,6 +124,78 @@ def test_scalar_temporal_error(
         pg_conn.commit()
 
 
+@pytest.mark.parametrize(
+    "col_type,value,expected_clamped",
+    [
+        (
+            "timestamp",
+            "294276-12-31 23:59:59",
+            "9999-12-31 23:59:59.999999",
+        ),
+        (
+            "timestamptz",
+            "294276-12-31 23:59:59+00",
+            "9999-12-31 23:59:59.999999+00",
+        ),
+    ],
+)
+def test_postgres_range_timestamp_write_policy(
+    pg_conn,
+    extension,
+    s3,
+    with_default_location,
+    col_type,
+    value,
+    expected_clamped,
+):
+    """Apply the target Iceberg policy before serializing PostgreSQL timestamps.
+
+    PostgreSQL accepts timestamps beyond DuckDB's finite range.  Heap-to-Iceberg
+    writes stay in PostgreSQL until the target slot is normalized, so the target
+    table's out_of_range_values policy must decide whether the value is clamped
+    or rejected before it can reach DuckDB.
+    """
+    schema = f"test_pg_range_{col_type}"
+
+    run_command(f"CREATE SCHEMA {schema};", pg_conn)
+    run_command(f"SET search_path TO {schema};", pg_conn)
+    run_command("SET TIME ZONE 'UTC';", pg_conn)
+
+    try:
+        run_command(
+            f"""
+            CREATE TABLE source (col {col_type});
+            INSERT INTO source VALUES ('{value}'::{col_type});
+            CREATE TABLE target_clamp (col {col_type}) USING iceberg
+                WITH (out_of_range_values = 'clamp');
+            CREATE TABLE target_error (col {col_type}) USING iceberg
+                WITH (out_of_range_values = 'error');
+            """,
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        clamp_query = "INSERT INTO target_clamp SELECT * FROM source;"
+        assert_query_not_pushdownable(clamp_query, pg_conn)
+        run_command(clamp_query, pg_conn)
+        pg_conn.commit()
+
+        result = run_query("SELECT col::text FROM target_clamp;", pg_conn)
+        assert result[0][0] == expected_clamped
+
+        error_query = "INSERT INTO target_error SELECT * FROM source;"
+        assert_query_not_pushdownable(error_query, pg_conn)
+        err = run_command(error_query, pg_conn, raise_error=False)
+        assert f"{col_type} out of range" in str(err)
+        pg_conn.rollback()
+    finally:
+        pg_conn.rollback()
+        run_command("RESET TIME ZONE;", pg_conn)
+        run_command("RESET search_path;", pg_conn)
+        run_command(f"DROP SCHEMA IF EXISTS {schema} CASCADE;", pg_conn)
+        pg_conn.commit()
+
+
 # =====================================================================
 # Non-pushdown path: scalar numeric NaN (INSERT VALUES)
 # =====================================================================

--- a/pgduck_server/tests/pytests/test_postgres_scanner_timestamp_range.py
+++ b/pgduck_server/tests/pytests/test_postgres_scanner_timestamp_range.py
@@ -1,0 +1,143 @@
+"""
+Verify postgres_scan rejects PostgreSQL timestamps outside DuckDB's range.
+
+PostgreSQL accepts a slightly wider timestamp range than DuckDB. Without an
+explicit bounds check, postgres_scan wraps values near PostgreSQL's upper bound
+to an unrelated BC timestamp and can persist the corrupted value to Parquet.
+"""
+
+import psycopg2
+import pytest
+from utils_pytest import *
+
+
+def _connstr():
+    return (
+        f"host={server_params.PG_HOST} "
+        f"port={server_params.PG_PORT} "
+        f"dbname={server_params.PG_DATABASE} "
+        f"user={server_params.PG_USER} "
+        f"password={server_params.PG_PASSWORD}"
+    )
+
+
+def _scan(table="scanner_timestamp_range_tbl"):
+    return f"postgres_scan('{_connstr()}', 'public', '{table}')"
+
+
+@pytest.fixture(scope="module")
+def pg_timestamp_range_table(postgres):
+    """Create the issue reproduction and supported controls in PostgreSQL."""
+    conn = open_pg_conn()
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS scanner_timestamp_range_tbl")
+    cur.execute("DROP TABLE IF EXISTS scanner_timestamp_control_tbl")
+    cur.execute(
+        "CREATE TABLE scanner_timestamp_range_tbl ("
+        "  id integer PRIMARY KEY,"
+        "  ts timestamp,"
+        "  tstz timestamptz"
+        ")"
+    )
+    cur.execute(
+        "INSERT INTO scanner_timestamp_range_tbl VALUES "
+        "(1, '294276-12-31 23:59:59', '294276-12-31 23:59:59+00')"
+    )
+    cur.execute(
+        "CREATE TABLE scanner_timestamp_control_tbl ("
+        "  id integer PRIMARY KEY,"
+        "  ts timestamp,"
+        "  tstz timestamptz"
+        ")"
+    )
+    cur.execute(
+        "INSERT INTO scanner_timestamp_control_tbl VALUES "
+        "(2, '10000-01-01 00:00:00',  '10000-01-01 00:00:00+00'),"
+        "(3, '2026-01-15 12:00:00',   '2026-01-15 12:00:00+00'),"
+        "(4, '4713-01-01 BC',         '4713-01-01 BC')"
+    )
+    cur.close()
+    conn.close()
+
+    yield
+
+    conn = open_pg_conn()
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS scanner_timestamp_range_tbl")
+    cur.execute("DROP TABLE IF EXISTS scanner_timestamp_control_tbl")
+    cur.close()
+    conn.close()
+
+
+@pytest.fixture
+def timestamp_scanner_conn(pgduck_server):
+    conn = psycopg2.connect(
+        host=server_params.PGDUCK_UNIX_DOMAIN_PATH,
+        port=server_params.PGDUCK_PORT,
+    )
+    conn.autocommit = True
+    yield conn
+    conn.close()
+
+
+def test_postgres_scan_supported_timestamp_controls(
+    pg_timestamp_range_table, timestamp_scanner_conn
+):
+    rows = run_query(
+        f"""
+        SELECT id, CAST(ts AS VARCHAR), CAST(tstz AS VARCHAR)
+        FROM {_scan("scanner_timestamp_control_tbl")}
+        ORDER BY id
+        """,
+        timestamp_scanner_conn,
+    )
+    assert [tuple(row) for row in rows] == [
+        (2, "10000-01-01 00:00:00", "10000-01-01 00:00:00+00"),
+        (3, "2026-01-15 12:00:00", "2026-01-15 12:00:00+00"),
+        (4, "4713-01-01 (BC) 00:00:00", "4713-01-01 (BC) 00:00:00+00"),
+    ]
+
+
+@pytest.mark.parametrize("column", ["ts", "tstz"])
+def test_postgres_scan_rejects_out_of_range_timestamp(
+    pg_timestamp_range_table, timestamp_scanner_conn, column
+):
+    with pytest.raises(psycopg2.Error, match="timestamp out of range"):
+        run_query(
+            f"SELECT {column} FROM {_scan()} WHERE id = 1",
+            timestamp_scanner_conn,
+        )
+
+
+def test_postgres_scan_copy_rejects_out_of_range_timestamp(
+    pg_timestamp_range_table, timestamp_scanner_conn, tmp_path
+):
+    output_path = str(tmp_path / "timestamp_range.parquet").replace("'", "''")
+    with pytest.raises(psycopg2.Error, match="timestamp out of range"):
+        run_command(
+            f"""
+            COPY (
+                SELECT ts, tstz
+                FROM {_scan()}
+                WHERE id = 1
+            ) TO '{output_path}' (FORMAT PARQUET)
+            """,
+            timestamp_scanner_conn,
+        )
+
+
+def test_postgres_binary_writer_rejects_out_of_range_timestamp(
+    timestamp_scanner_conn, tmp_path
+):
+    output_path = str(tmp_path / "timestamp_range.bin").replace("'", "''")
+    with pytest.raises(psycopg2.Error, match="out of range for Postgres"):
+        run_command(
+            f"""
+            COPY (
+                SELECT TIMESTAMP '290309-12-22 (BC)'
+            ) TO '{output_path}' (FORMAT postgres_binary)
+            """,
+            timestamp_scanner_conn,
+        )

--- a/pgduck_server/tests/pytests/test_postgres_scanner_timestamp_range.py
+++ b/pgduck_server/tests/pytests/test_postgres_scanner_timestamp_range.py
@@ -44,6 +44,8 @@ def pg_timestamp_range_table(postgres):
         "INSERT INTO scanner_timestamp_range_tbl VALUES "
         "(1, '294276-12-31 23:59:59', '294276-12-31 23:59:59+00')"
     )
+    # This vendored scanner applies the outer filter after decoding the source
+    # batch, so keep valid controls separate from the deliberately invalid row.
     cur.execute(
         "CREATE TABLE scanner_timestamp_control_tbl ("
         "  id integer PRIMARY KEY,"

--- a/pgduck_server/tests/pytests/test_postgres_scanner_timestamp_range.py
+++ b/pgduck_server/tests/pytests/test_postgres_scanner_timestamp_range.py
@@ -44,8 +44,9 @@ def pg_timestamp_range_table(postgres):
         "INSERT INTO scanner_timestamp_range_tbl VALUES "
         "(1, '294276-12-31 23:59:59', '294276-12-31 23:59:59+00')"
     )
-    # This vendored scanner applies the outer filter after decoding the source
-    # batch, so keep valid controls separate from the deliberately invalid row.
+    # Unlike the newer upstream scanner regression, this vendored scanner
+    # applies the outer filter after decoding the source batch. Keep valid
+    # controls separate from the deliberately invalid row.
     cur.execute(
         "CREATE TABLE scanner_timestamp_control_tbl ("
         "  id integer PRIMARY KEY,"
@@ -75,6 +76,8 @@ def pg_timestamp_range_table(postgres):
 
 @pytest.fixture
 def timestamp_scanner_conn(pgduck_server):
+    # Expected errors would leave the shared pgduck_conn transaction aborted.
+    # Use a dedicated autocommit connection so each assertion is isolated.
     conn = psycopg2.connect(
         host=server_params.PGDUCK_UNIX_DOMAIN_PATH,
         port=server_params.PGDUCK_PORT,
@@ -116,6 +119,8 @@ def test_postgres_scan_rejects_out_of_range_timestamp(
 def test_postgres_scan_copy_rejects_out_of_range_timestamp(
     pg_timestamp_range_table, timestamp_scanner_conn, tmp_path
 ):
+    # A raw DuckDB COPY has no target Iceberg table whose
+    # out_of_range_values policy could authorize clamping.
     output_path = str(tmp_path / "timestamp_range.parquet").replace("'", "''")
     with pytest.raises(psycopg2.Error, match="timestamp out of range"):
         run_command(
@@ -130,15 +135,23 @@ def test_postgres_scan_copy_rejects_out_of_range_timestamp(
         )
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "290309-12-22 (BC)",
+        "5000-01-01 (BC)",
+    ],
+    ids=["arithmetic-underflow", "postgres-lower-bound"],
+)
 def test_postgres_binary_writer_rejects_out_of_range_timestamp(
-    timestamp_scanner_conn, tmp_path
+    timestamp_scanner_conn, tmp_path, value
 ):
     output_path = str(tmp_path / "timestamp_range.bin").replace("'", "''")
     with pytest.raises(psycopg2.Error, match="out of range for Postgres"):
         run_command(
             f"""
             COPY (
-                SELECT TIMESTAMP '290309-12-22 (BC)'
+                SELECT TIMESTAMP '{value}'
             ) TO '{output_path}' (FORMAT postgres_binary)
             """,
             timestamp_scanner_conn,


### PR DESCRIPTION
## Problem

`postgres_scan` silently corrupts out-of-range timestamps instead of rejecting them. PostgreSQL's `timestamp`/`timestamptz` range is wider than DuckDB's. When `PostgresBinaryReader::ReadTimestamp()` adds the PostgreSQL→DuckDB epoch offset to a value near either end of PostgreSQL's range, the addition overflows DuckDB's internal `int64` microseconds representation and silently wraps — e.g. a valid PostgreSQL value of `294276-12-31 23:59:59` is returned as `290279-12-14 (BC) 15:58:09.448384`. The same unchecked arithmetic exists in reverse in `postgres_binary_writer.hpp`, so a DuckDB value near its own bounds can silently wrap into a bogus PostgreSQL timestamp on write.

## Fix

This backports [duckdb/duckdb-postgres#530](https://github.com/duckdb/duckdb-postgres/pull/530) onto the older vendored `duckdb-postgres` revision pg_lake currently pins, via a new patch in `duckdb_pglake/patches/duckdb-postgres/timestamp-range.patch` (the upstream PR targets a later API — `PostgresBinaryParser` vs. this revision's `PostgresBinaryReader` — so the checks are ported rather than cherry-picked verbatim):

- **Reader**: use `TryAddOperator` for the epoch-offset addition and reject the result with `ConversionException("timestamp out of range")` on overflow or if it isn't `Timestamp::IsFinite`.
- **Writer**: use `TrySubtractOperator` and validate against PostgreSQL's exact `MIN_TIMESTAMP`/`END_TIMESTAMP` bounds (from `datatype/timestamp.h`), raising `InvalidInputException` instead of wrapping.
- Infinity/-infinity sentinels are preserved and still round-trip correctly on both sides.

## Tests

Added `pgduck_server/tests/pytests/test_postgres_scanner_timestamp_range.py`, covering the reproduction from #439:

- both `timestamp` and `timestamptz` scanning reject the out-of-range value with an error instead of returning wrapped data
- the same rejection propagates through `COPY ... TO PARQUET`
- supported boundary/control values (including a BC date) still round-trip correctly — kept in a separate source table since `postgres_scan` converts a whole batch before DuckDB's outer filter applies, so a single mixed table can't isolate the failing row
- the writer path is exercised via the existing `postgres_binary.test` fixture from `duckdb-postgres`, adjusted to use a cross-database-representable BC boundary instead of DuckDB's own (more extreme) minimum, which previously round-tripped silently through matching reader/writer overflows

Before the patch: `4 failed, 1 passed`. After: `5 passed`. Focused scanner suite (`test_postgres_scanner.py` + `test_postgres_scanner_timestamp_range.py`): `18 passed`.

Fixes #439.
Upstream fix: duckdb/duckdb-postgres#530