### PR TITLE
pg_lake_table: allow debug plan output for restriction nodes

### DIFF
--- a/pg_lake_table/src/planner/extensible_nodes.c
+++ b/pg_lake_table/src/planner/extensible_nodes.c
@@ -29,12 +29,12 @@
 
 /* forward declarations */
 static void ReadUnsupportedPgLakeNode(READFUNC_ARGS);
-static void OutPlannerRelationRestriction(OUTFUNC_ARGS);
 static bool EqualUnsupportedPgLakeNode(const struct ExtensibleNode *a,
 									   const struct ExtensibleNode *b);
 
-/* supported copy functions */
+/* supported node functions */
 static void CopyNodePlannerRelationRestriction(COPYFUNC_ARGS);
+static void OutPlannerRelationRestriction(OUTFUNC_ARGS);
 
 
 #define DEFINE_NODE_METHODS(type) \
@@ -85,8 +85,7 @@ const char **PgLakeNodeTagNames = PgLakeNodeTagNamesArray;
 
 
 /*
-* We currently do not support reading or writing of custom nodes.
-* Could be useful for debugging purposes.
+* We currently do not support reading custom nodes.
 */
 static void
 ReadUnsupportedPgLakeNode(READFUNC_ARGS)
@@ -95,17 +94,15 @@ ReadUnsupportedPgLakeNode(READFUNC_ARGS)
 }
 
 /*
- * PlannerRelationRestriction is transient planner bookkeeping and is never
- * reconstructed from its text representation. PostgreSQL still calls nodeOut
- * when debug_print_plan is enabled, though, so the mandatory callback must not
- * fail. Core already emits the node type and extensible-node name; no private
- * fields need to be serialized.
+ * PlannerRelationRestriction is transient planner bookkeeping. pg_lake does
+ * not support reconstructing it from text, but PostgreSQL still calls nodeOut
+ * when debug_print_plan is enabled. Core already emits the node type and
+ * extensible-node name, so an empty callback is sufficient for diagnostic
+ * output without defining a serialization format for the private fields.
  */
 static void
 OutPlannerRelationRestriction(OUTFUNC_ARGS)
 {
-	(void) str;
-	(void) raw_node;
 }
 
 

--- a/pg_lake_table/src/planner/extensible_nodes.c
+++ b/pg_lake_table/src/planner/extensible_nodes.c
@@ -29,7 +29,7 @@
 
 /* forward declarations */
 static void ReadUnsupportedPgLakeNode(READFUNC_ARGS);
-static void OutUnsupportedPgLakeNode(OUTFUNC_ARGS);
+static void OutPlannerRelationRestriction(OUTFUNC_ARGS);
 static bool EqualUnsupportedPgLakeNode(const struct ExtensibleNode *a,
 									   const struct ExtensibleNode *b);
 
@@ -43,7 +43,7 @@ static void CopyNodePlannerRelationRestriction(COPYFUNC_ARGS);
 		sizeof(type), \
 		CopyNode##type, \
 		EqualUnsupportedPgLakeNode, \
-		OutUnsupportedPgLakeNode, \
+		Out##type, \
 		ReadUnsupportedPgLakeNode \
 	}
 
@@ -95,13 +95,17 @@ ReadUnsupportedPgLakeNode(READFUNC_ARGS)
 }
 
 /*
-* We currently do not support reading or writing of custom nodes.
-* Could be useful for debugging purposes.
-*/
+ * PlannerRelationRestriction is transient planner bookkeeping and is never
+ * reconstructed from its text representation. PostgreSQL still calls nodeOut
+ * when debug_print_plan is enabled, though, so the mandatory callback must not
+ * fail. Core already emits the node type and extensible-node name; no private
+ * fields need to be serialized.
+ */
 static void
-OutUnsupportedPgLakeNode(OUTFUNC_ARGS)
+OutPlannerRelationRestriction(OUTFUNC_ARGS)
 {
-	ereport(ERROR, (errmsg("out not implemented")));
+	(void) str;
+	(void) raw_node;
 }
 
 

--- a/pg_lake_table/src/planner/extensible_nodes.c
+++ b/pg_lake_table/src/planner/extensible_nodes.c
@@ -96,13 +96,19 @@ ReadUnsupportedPgLakeNode(READFUNC_ARGS)
 /*
  * PlannerRelationRestriction is transient planner bookkeeping. pg_lake does
  * not support reconstructing it from text, but PostgreSQL still calls nodeOut
- * when debug_print_plan is enabled. Core already emits the node type and
- * extensible-node name, so an empty callback is sufficient for diagnostic
- * output without defining a serialization format for the private fields.
+ * when debug_print_plan is enabled or a node is printed in the debugger. Emit
+ * the private fields to make that diagnostic output useful.
  */
 static void
 OutPlannerRelationRestriction(OUTFUNC_ARGS)
 {
+	const		PlannerRelationRestriction *node =
+		(const PlannerRelationRestriction *) raw_node;
+
+	appendStringInfoString(str, " :rte ");
+	outNode(str, node->rte);
+	appendStringInfoString(str, " :baseRestrictionList ");
+	outNode(str, node->baseRestrictionList);
 }
 
 

--- a/pg_lake_table/tests/pytests/test_relation_restriction.py
+++ b/pg_lake_table/tests/pytests/test_relation_restriction.py
@@ -15,15 +15,31 @@ def test_debug_print_plan_with_lake_table(
         """
         CREATE SCHEMA test_debug_print_plan;
         CREATE TABLE test_debug_print_plan.test(i int) USING iceberg;
-        SET LOCAL client_min_messages TO DEBUG5;
         SET LOCAL debug_print_plan TO ON;
         """,
         pg_conn,
     )
 
-    assert run_query("SELECT count(*) FROM test_debug_print_plan.test", pg_conn) == [
-        [0]
+    queries = [
+        "SELECT count(*) FROM test_debug_print_plan.test",
+        "SELECT count(*) FROM test_debug_print_plan.test WHERE i = 1",
     ]
+
+    expected_plan_nodes = {
+        "on": "Custom Scan (Query Pushdown)",
+        "off": "Foreign Scan",
+    }
+
+    for full_pushdown, expected_plan_node in expected_plan_nodes.items():
+        run_command(
+            f"SET LOCAL pg_lake_table.enable_full_query_pushdown TO {full_pushdown}",
+            pg_conn,
+        )
+
+        for query in queries:
+            explain = run_query(f"EXPLAIN {query}", pg_conn)
+            assert expected_plan_node in str(explain)
+            assert run_query(query, pg_conn) == [[0]]
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_relation_restriction.py
+++ b/pg_lake_table/tests/pytests/test_relation_restriction.py
@@ -44,11 +44,10 @@ def test_debug_print_plan_with_lake_table(
             pg_conn.notices.clear()
             assert run_query(query, pg_conn) == [[0]]
 
-            if full_pushdown == "on":
-                debug_plan = "\n".join(pg_conn.notices)
-                assert "PlannerRelationRestriction" in debug_plan
-                assert ":rte" in debug_plan
-                assert ":baseRestrictionList" in debug_plan
+            debug_plan = "\n".join(pg_conn.notices)
+            assert "PlannerRelationRestriction" in debug_plan
+            assert ":rte" in debug_plan
+            assert ":baseRestrictionList" in debug_plan
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_relation_restriction.py
+++ b/pg_lake_table/tests/pytests/test_relation_restriction.py
@@ -15,6 +15,7 @@ def test_debug_print_plan_with_lake_table(
         """
         CREATE SCHEMA test_debug_print_plan;
         CREATE TABLE test_debug_print_plan.test(i int) USING iceberg;
+        SET LOCAL client_min_messages TO LOG;
         SET LOCAL debug_print_plan TO ON;
         """,
         pg_conn,
@@ -39,7 +40,15 @@ def test_debug_print_plan_with_lake_table(
         for query in queries:
             explain = run_query(f"EXPLAIN {query}", pg_conn)
             assert expected_plan_node in str(explain)
+
+            pg_conn.notices.clear()
             assert run_query(query, pg_conn) == [[0]]
+
+            if full_pushdown == "on":
+                debug_plan = "\n".join(pg_conn.notices)
+                assert "PlannerRelationRestriction" in debug_plan
+                assert ":rte" in debug_plan
+                assert ":baseRestrictionList" in debug_plan
 
     pg_conn.rollback()
 

--- a/pg_lake_table/tests/pytests/test_relation_restriction.py
+++ b/pg_lake_table/tests/pytests/test_relation_restriction.py
@@ -8,6 +8,26 @@ import pytest
 from utils_pytest import *
 
 
+def test_debug_print_plan_with_lake_table(
+    pg_conn, s3, extension, with_default_location
+):
+    run_command(
+        """
+        CREATE SCHEMA test_debug_print_plan;
+        CREATE TABLE test_debug_print_plan.test(i int) USING iceberg;
+        SET LOCAL client_min_messages TO DEBUG5;
+        SET LOCAL debug_print_plan TO ON;
+        """,
+        pg_conn,
+    )
+
+    assert run_query("SELECT count(*) FROM test_debug_print_plan.test", pg_conn) == [
+        [0]
+    ]
+
+    pg_conn.rollback()
+
+
 def test_restrictions_on_table(pg_conn, s3, extension, with_default_location):
 
     run_command("CREATE SCHEMA test_restrictions;", pg_conn)


### PR DESCRIPTION
## Problem

PostgreSQL diagnostic node printing walks the private data attached to planned
scan nodes. Both pg_lake scan paths store `PlannerRelationRestriction`
extensible nodes in that private data:

- full-query pushdown stores them in `CustomScan.custom_private`
- the FDW path stores them in `ForeignScan.fdw_private`

PostgreSQL calls the registered `nodeOut` callback when it prints either plan.
That callback previously raised `ERROR: out not implemented`, so the diagnostic
configuration reported in #106 (`pg_ctl ... -o "-d 5"`) could make an otherwise
valid lake-table query fail during planning.

## Solution

Add a dedicated output function for `PlannerRelationRestriction`.

The callback follows PostgreSQL's node-output convention and emits both private
fields:

- `rte`
- `baseRestrictionList`

PostgreSQL continues to emit the extensible-node type and name itself. The
private fields are delegated to `outNode`, so nested `RangeTblEntry` and
`RestrictInfo` nodes, as well as NULL or empty lists, use PostgreSQL's existing
formatting behavior.

`nodeRead` remains unsupported because this node is transient planner
bookkeeping and pg_lake does not deserialize it from text. The
`DEFINE_NODE_METHODS` macro now selects `Out##type`, requiring each future
pg_lake extensible-node type to define its own output behavior.

## Regression coverage

The new test enables `debug_print_plan`, routes its `LOG` output to the client,
and exercises:

- `Custom Scan (Query Pushdown)` with full-query pushdown enabled
- `Foreign Scan` with full-query pushdown disabled
- an empty restriction list
- a non-empty restriction list produced by a `WHERE` clause

For every case, the test verifies the expected scan type, successful execution,
and diagnostic output containing `PlannerRelationRestriction`, `rte`, and
`baseRestrictionList`.

## Validation

- PostgreSQL 18 `pgindent --check --diff`
- Black 25.9.0
- focused compilation against PostgreSQL 16, 17, and 18 headers
- PostgreSQL 18 build and install of `pg_lake_table.so`
- focused pytest:
  `test_relation_restriction.py::test_debug_print_plan_with_lake_table`

Fixes #106.
