### PR TITLE
Document file descriptor limits for partitioned writes

### DIFF
--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -354,13 +354,13 @@ SET pg_lake_table.max_open_files_for_partitioned_write = 250;
 
 or raise `max_files_per_process` to more than `15000`. Changing `max_files_per_process` requires a PostgreSQL restart. Lowering `pg_lake_table.max_open_files_for_partitioned_write` causes partitions to be flushed sooner, which can produce smaller files.
 
-For eligible `INSERT ... SELECT` and `COPY FROM` statements, partitioned writes can instead be delegated to DuckDB:
+Partitioned write pushdown is disabled by default. For eligible `INSERT ... SELECT` and `COPY FROM` statements, enable it for the current session to delegate partitioned writes to DuckDB:
 
 ```sql
 SET pg_lake_table.enable_partitioned_write_pushdown = on;
 ```
 
-Partitioned write pushdown supports identity, `year`, `month`, `day`, and `hour` partition transforms. Statements using `bucket` or `truncate`, as well as statements that otherwise cannot be pushed down, use the staging-file path described above. DuckDB does not support target file size splitting together with partitioned write pushdown.
+This avoids PostgreSQL's staging-file path and its transient file descriptor limit. Partitioned write pushdown supports identity, `year`, `month`, `day`, and `hour` partition transforms. Statements using `bucket` or `truncate`, as well as statements that otherwise cannot be pushed down, use the staging-file path described above. DuckDB does not support target file size splitting together with partitioned write pushdown.
 
 ### Partition pruning
 Partition pruning is how Iceberg avoids scanning unnecessary data files. When you filter by a partition column (or one of its transforms), only the matching partition files are read — the rest are skipped entirely. The pruning happens at the file level, using Iceberg’s metadata.

--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -332,6 +332,36 @@ Instead of **`user_id`**, prefer **`bucket(32, user_id)`** to spread users ac
     - **User-specific queries** → **`bucket(32, user_id)`**
     - **Region or category filters** → **`region`** or **`truncate(4, region)`**
 
+### Configuring open files for partitioned writes
+
+When a partitioned write cannot be pushed down, pg_lake keeps one staging file open for each distinct partition tuple touched by the statement. The number of open files therefore depends on the number of partitions, not the number of rows. A write that exceeds PostgreSQL's transient file descriptor limit fails with an error similar to:
+
+```text
+ERROR: exceeded maxAllocatedDescs (...) while trying to open file "..."
+```
+
+`pg_lake_table.max_open_files_for_partitioned_write` controls when pg_lake flushes a staging file. PostgreSQL reserves only approximately one third of [`max_files_per_process`](https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAX-FILES-PER-PROCESS) for transient file descriptors, so configure:
+
+```text
+max_files_per_process > 3 * pg_lake_table.max_open_files_for_partitioned_write
+```
+
+Leave additional headroom for files opened internally by PostgreSQL and make sure the operating system's per-process file descriptor limit is high enough. The pg_lake setting defaults to `5000`, while PostgreSQL's `max_files_per_process` defaults to `1000`. You can either lower the pg_lake setting to fit the PostgreSQL limit:
+
+```sql
+SET pg_lake_table.max_open_files_for_partitioned_write = 250;
+```
+
+or raise `max_files_per_process` to more than `15000`. Changing `max_files_per_process` requires a PostgreSQL restart. Lowering `pg_lake_table.max_open_files_for_partitioned_write` causes partitions to be flushed sooner, which can produce smaller files.
+
+For eligible `INSERT ... SELECT` and `COPY FROM` statements, partitioned writes can instead be delegated to DuckDB:
+
+```sql
+SET pg_lake_table.enable_partitioned_write_pushdown = on;
+```
+
+Partitioned write pushdown supports identity, `year`, `month`, `day`, and `hour` partition transforms. Statements using `bucket` or `truncate`, as well as statements that otherwise cannot be pushed down, use the staging-file path described above. DuckDB does not support target file size splitting together with partitioned write pushdown.
+
 ### Partition pruning
 Partition pruning is how Iceberg avoids scanning unnecessary data files. When you filter by a partition column (or one of its transforms), only the matching partition files are read — the rest are skipped entirely. The pruning happens at the file level, using Iceberg’s metadata.
 


### PR DESCRIPTION
## Description

Document how PostgreSQL's transient file descriptor budget interacts with `pg_lake_table.max_open_files_for_partitioned_write` for non-pushed-down partitioned writes.

The new section covers:

- the `exceeded maxAllocatedDescs` failure mode and why partition count matters
- the sizing relationship with `max_files_per_process`
- lowering the pg_lake limit versus raising PostgreSQL's limit
- the supported `pg_lake_table.enable_partitioned_write_pushdown` subset and its file-splitting tradeoff

Addresses #460.

## Validation

- `git diff --check`

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**
