### PR TITLE
pg_lake_iceberg: add SameIcebergStoredRepresentation helper

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
@@ -29,27 +29,57 @@ extern PGDLLEXPORT Field * PostgresTypeToIcebergField(PGType pgType,
 													  int *subFieldIndex);
 
 /*
- * SameIcebergRepresentation - Return true when two Postgres column types map to
- * the same Iceberg representation, i.e. PostgresTypeToIcebergField derives an
- * identical Iceberg type for both (ignoring field ids and default values).
+ * A leaf conversion callback lets a caller mirror storage transforms that the
+ * Iceberg-table create path applies (e.g. unsupported-numeric to double), and
+ * that a layer above pg_lake such as snowflake_cdc adds on top (e.g.
+ * compatibility-mode shaping), without pg_lake having to model any of those
+ * policies.  It is invoked at every scalar leaf while deriving the in-memory
+ * Iceberg field tree.
  *
- * This is true for pairs that differ only in a way Iceberg does not model:
- * varchar length changes and text/varchar/char (all Iceberg `string`),
- * smallint vs integer (both `int`), time vs timetz (both `time`), bytea vs
- * geometry (both `binary`), and so on.  A top-level unsupported numeric is
- * normalized the way the create path stores it (double when
- * pg_lake_iceberg.unsupported_numeric_as_double is on, otherwise the "string"
- * fallback), so a large numeric is not mistaken for text.
- *
- * A caller can use this to decide whether an ALTER COLUMN ... TYPE leaves the
- * stored Iceberg schema unchanged.  It does not decide whether such a change is
- * otherwise permitted (casts, USING clauses, engine policy) -- that is the
- * caller's concern.
+ * IcebergTypePosition tells the callback where the leaf sits: depth 0 is the
+ * top-level column type, and parent names the immediately enclosing container.
+ * Storage rules that vary by nesting (a nested uuid stored as string under a
+ * compatibility mode, say) need this to decide correctly.
  */
-extern PGDLLEXPORT bool SameIcebergRepresentation(Oid oldTypeOid,
-												  int32 oldTypeMod,
-												  Oid newTypeOid,
-												  int32 newTypeMod);
+typedef enum IcebergParentKind
+{
+	ICEBERG_POS_TOP,
+	ICEBERG_POS_ARRAY_ELEMENT,
+	ICEBERG_POS_MAP_KEY,
+	ICEBERG_POS_MAP_VALUE,
+	ICEBERG_POS_STRUCT_FIELD
+}			IcebergParentKind;
+
+typedef struct IcebergTypePosition
+{
+	int			depth;			/* 0 == top-level column type */
+	IcebergParentKind parent;	/* immediately enclosing container */
+}			IcebergTypePosition;
+
+/*
+ * Given a scalar Postgres type at a position, return the Postgres type whose
+ * Iceberg representation is actually stored there.  Return the input unchanged
+ * to leave it alone, or a PGType with an invalid Oid to signal that the create
+ * path has no faithful stored representation for this leaf -- derivation then
+ * yields a NULL field so a comparison can never over-allow.  Must be free of
+ * catalog side effects (it runs while building in-memory Field structs, not
+ * real Postgres types).
+ */
+typedef PGType(*IcebergLeafConversionFn) (PGType leafType,
+										  IcebergTypePosition pos,
+										  void *context);
+
+/*
+ * Like PostgresTypeToIcebergField, but applies `convert` (with `context`) at
+ * every scalar leaf as it recurses.  `convert` may be NULL, in which case this
+ * behaves exactly like PostgresTypeToIcebergField.  Returns NULL when `convert`
+ * reports an unrepresentable leaf.
+ */
+extern PGDLLEXPORT Field * PostgresTypeToIcebergFieldConverted(PGType pgType,
+															   bool forAddColumn,
+															   int *subFieldIndex,
+															   IcebergLeafConversionFn convert,
+															   void *context);
 extern PGDLLEXPORT void EnsureIcebergField(Field * field);
 extern PGDLLEXPORT const char *IcebergTypeNameToDuckdbTypeName(const char *icebergTypeName);
 extern PGDLLEXPORT DataFileSchema * CreatePositionDeleteDataFileSchema(void);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
@@ -29,45 +29,21 @@ extern PGDLLEXPORT Field * PostgresTypeToIcebergField(PGType pgType,
 													  int *subFieldIndex);
 
 /*
- * A leaf conversion callback lets a caller mirror storage transforms that the
- * Iceberg-table create path applies (e.g. unsupported-numeric to double), and
- * that a layer above pg_lake such as snowflake_cdc adds on top (e.g.
- * compatibility-mode shaping), without pg_lake having to model any of those
- * policies.  It is invoked at every scalar leaf while deriving the in-memory
- * Iceberg field tree.
+ * A leaf conversion lets iceberg_representation.c reproduce the storage
+ * transforms the Iceberg-table create path applies (e.g. an unsupported numeric
+ * stored as double) while it derives the in-memory Iceberg field tree, without
+ * baking that create-path policy into the structural derivation here.  It is
+ * invoked at every scalar leaf.
  *
- * IcebergTypePosition tells the callback where the leaf sits: depth 0 is the
- * top-level column type, and parent names the immediately enclosing container.
- * Storage rules that vary by nesting (a nested uuid stored as string under a
- * compatibility mode, say) need this to decide correctly.
+ * Given a scalar Postgres type, it returns the Postgres type whose Iceberg
+ * representation is actually stored there: the input unchanged to leave it
+ * alone, or a PGType with an invalid Oid to signal that the create path has no
+ * faithful stored representation for this leaf -- derivation then yields a NULL
+ * field so a comparison can never over-allow.  It must be free of catalog side
+ * effects (it runs while building in-memory Field structs, not real Postgres
+ * types).
  */
-typedef enum IcebergParentKind
-{
-	ICEBERG_POS_TOP,
-	ICEBERG_POS_ARRAY_ELEMENT,
-	ICEBERG_POS_MAP_KEY,
-	ICEBERG_POS_MAP_VALUE,
-	ICEBERG_POS_STRUCT_FIELD
-}			IcebergParentKind;
-
-typedef struct IcebergTypePosition
-{
-	int			depth;			/* 0 == top-level column type */
-	IcebergParentKind parent;	/* immediately enclosing container */
-}			IcebergTypePosition;
-
-/*
- * Given a scalar Postgres type at a position, return the Postgres type whose
- * Iceberg representation is actually stored there.  Return the input unchanged
- * to leave it alone, or a PGType with an invalid Oid to signal that the create
- * path has no faithful stored representation for this leaf -- derivation then
- * yields a NULL field so a comparison can never over-allow.  Must be free of
- * catalog side effects (it runs while building in-memory Field structs, not
- * real Postgres types).
- */
-typedef PGType(*IcebergLeafConversionFn) (PGType leafType,
-										  IcebergTypePosition pos,
-										  void *context);
+typedef PGType(*IcebergLeafConversionFn) (PGType leafType, void *context);
 
 /*
  * Like PostgresTypeToIcebergField, but applies `convert` (with `context`) at

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_field.h
@@ -27,6 +27,29 @@ extern PGDLLEXPORT PGType IcebergFieldToPostgresType(Field * field);
 extern PGDLLEXPORT Field * PostgresTypeToIcebergField(PGType pgType,
 													  bool forAddColumn,
 													  int *subFieldIndex);
+
+/*
+ * SameIcebergRepresentation - Return true when two Postgres column types map to
+ * the same Iceberg representation, i.e. PostgresTypeToIcebergField derives an
+ * identical Iceberg type for both (ignoring field ids and default values).
+ *
+ * This is true for pairs that differ only in a way Iceberg does not model:
+ * varchar length changes and text/varchar/char (all Iceberg `string`),
+ * smallint vs integer (both `int`), time vs timetz (both `time`), bytea vs
+ * geometry (both `binary`), and so on.  A top-level unsupported numeric is
+ * normalized the way the create path stores it (double when
+ * pg_lake_iceberg.unsupported_numeric_as_double is on, otherwise the "string"
+ * fallback), so a large numeric is not mistaken for text.
+ *
+ * A caller can use this to decide whether an ALTER COLUMN ... TYPE leaves the
+ * stored Iceberg schema unchanged.  It does not decide whether such a change is
+ * otherwise permitted (casts, USING clauses, engine policy) -- that is the
+ * caller's concern.
+ */
+extern PGDLLEXPORT bool SameIcebergRepresentation(Oid oldTypeOid,
+												  int32 oldTypeMod,
+												  Oid newTypeOid,
+												  int32 newTypeMod);
 extern PGDLLEXPORT void EnsureIcebergField(Field * field);
 extern PGDLLEXPORT const char *IcebergTypeNameToDuckdbTypeName(const char *icebergTypeName);
 extern PGDLLEXPORT DataFileSchema * CreatePositionDeleteDataFileSchema(void);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Snowflake Inc.
+ * Copyright 2026 Snowflake Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,9 +59,7 @@ extern PGDLLEXPORT void InitIcebergCreatePathContextFromGUC(IcebergCreatePathCon
  * identically by the Iceberg create path under `context`.  It reproduces the
  * full stored schema: the unsupported-numeric leaf conversion during
  * derivation, then the compatibility storage mapping over the derived field
- * tree.  This is what an ALTER-time caller (e.g. pg_lake_replication deciding
- * whether an ALTER COLUMN TYPE leaves the changelog schema unchanged) should
- * use.
+ * tree.
  */
 extern PGDLLEXPORT bool SameIcebergStoredRepresentation(PGType oldType, PGType newType,
 														const IcebergCreatePathContext * context);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -24,28 +24,6 @@
 #include "pg_lake/pgduck/compatibility_mode.h"
 
 /*
- * SameIcebergRepresentation - true when oldType and newType are stored with an
- * identical Iceberg representation, after applying `convert` at every scalar
- * leaf of each type.  It is true for pairs that differ only in ways Iceberg
- * does not model (text length, which text-family member, field ids, defaults):
- * varchar length changes and text/varchar/char (all `string`), smallint vs
- * integer (both `int`), time vs timetz (both `time`), and so on.
- *
- * This is the low-level primitive: it applies only the given leaf conversion.
- * `convert` may be NULL to compare the raw derivations.  When it reports that
- * either type has no faithful stored representation (see
- * IcebergLeafConversionFn), the two are treated as different so a caller can
- * never over-allow.  Most callers want SameIcebergStoredRepresentation, which
- * layers in the create path's compatibility storage mapping as well.
- *
- * It answers only the representation question; it does not decide whether a
- * type change is otherwise permitted (casts, USING clauses, engine policy).
- */
-extern PGDLLEXPORT bool SameIcebergRepresentation(PGType oldType, PGType newType,
-												  IcebergLeafConversionFn convert,
-												  void *context);
-
-/*
  * IcebergCreatePathContext captures the two settings that shape how the Iceberg
  * create path physically stores a column, so a comparison can reproduce the
  * stored schema faithfully:
@@ -75,18 +53,6 @@ extern PGDLLEXPORT void InitIcebergCreatePathContext(IcebergCreatePathContext * 
 													 bool unsupportedNumericAsDouble,
 													 IcebergCompatibilityMode compatibilityMode);
 extern PGDLLEXPORT void InitIcebergCreatePathContextFromGUC(IcebergCreatePathContext * context);
-
-/*
- * Stock leaf conversion mirroring the create path's unsupported-numeric
- * handling.  Depth-independent (an unsupported numeric is stored as double, or
- * unrepresentable, at every level); the IcebergTypePosition is part of the
- * callback contract for callers whose leaf rules do vary by nesting.  The
- * compatibility storage mapping is applied separately, as a Field-tree pass, by
- * SameIcebergStoredRepresentation -- see ApplyCompatibilityStorageMapping.
- */
-extern PGDLLEXPORT PGType IcebergCreatePathLeafConversion(PGType leafType,
-														  IcebergTypePosition pos,
-														  void *context);
 
 /*
  * SameIcebergStoredRepresentation - true when oldType and newType are stored

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -55,11 +55,36 @@ extern PGDLLEXPORT void InitIcebergCreatePathContext(IcebergCreatePathContext * 
 extern PGDLLEXPORT void InitIcebergCreatePathContextFromGUC(IcebergCreatePathContext * context);
 
 /*
+ * DeriveIcebergStoredField - the Iceberg field the create path stores for
+ * `type` under `context`: the unsupported-numeric leaf conversion applied
+ * during derivation, then the compatibility storage mapping over the derived
+ * tree.  Returns NULL when the type has no faithful stored form (an unsupported
+ * numeric with the GUC off), so a comparison can never over-allow.
+ *
+ * This is the single-side primitive.  A caller that already holds the
+ * actually-stored field for a column -- e.g. from field_id_mappings of an
+ * existing Iceberg table -- should derive only the candidate type here and
+ * compare it against that persisted field with IcebergFieldsEquivalent.  That
+ * is immune to the GUC/derivation drift a two-sided re-derivation has, because
+ * only the new side is recomputed.
+ */
+extern PGDLLEXPORT Field * DeriveIcebergStoredField(PGType type,
+													const IcebergCreatePathContext * context);
+
+/*
+ * IcebergFieldsEquivalent - true when two derived Iceberg field trees are the
+ * same stored representation, ignoring field ids and defaults (which are
+ * per-derivation).  varchar length / text-family members collapse to `string`,
+ * smallint and integer to `int`, and so on.
+ */
+extern PGDLLEXPORT bool IcebergFieldsEquivalent(Field * a, Field * b);
+
+/*
  * SameIcebergStoredRepresentation - true when oldType and newType are stored
- * identically by the Iceberg create path under `context`.  It reproduces the
- * full stored schema: the unsupported-numeric leaf conversion during
- * derivation, then the compatibility storage mapping over the derived field
- * tree.
+ * identically by the Iceberg create path under `context`.  A convenience over
+ * DeriveIcebergStoredField + IcebergFieldsEquivalent that re-derives both
+ * sides; prefer comparing against a persisted field (see
+ * DeriveIcebergStoredField) when one is available.
  */
 extern PGDLLEXPORT bool SameIcebergStoredRepresentation(PGType oldType, PGType newType,
 														const IcebergCreatePathContext * context);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PG_LAKE_ICEBERG_ICEBERG_REPRESENTATION_H
+#define PG_LAKE_ICEBERG_ICEBERG_REPRESENTATION_H
+
+#include "postgres.h"
+
+#include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/pgduck/compatibility_mode.h"
+
+/*
+ * SameIcebergRepresentation - true when oldType and newType are stored with an
+ * identical Iceberg representation, after applying `convert` at every scalar
+ * leaf of each type.  It is true for pairs that differ only in ways Iceberg
+ * does not model (text length, which text-family member, field ids, defaults):
+ * varchar length changes and text/varchar/char (all `string`), smallint vs
+ * integer (both `int`), time vs timetz (both `time`), and so on.
+ *
+ * This is the low-level primitive: it applies only the given leaf conversion.
+ * `convert` may be NULL to compare the raw derivations.  When it reports that
+ * either type has no faithful stored representation (see
+ * IcebergLeafConversionFn), the two are treated as different so a caller can
+ * never over-allow.  Most callers want SameIcebergStoredRepresentation, which
+ * layers in the create path's compatibility storage mapping as well.
+ *
+ * It answers only the representation question; it does not decide whether a
+ * type change is otherwise permitted (casts, USING clauses, engine policy).
+ */
+extern PGDLLEXPORT bool SameIcebergRepresentation(PGType oldType, PGType newType,
+												  IcebergLeafConversionFn convert,
+												  void *context);
+
+/*
+ * IcebergCreatePathContext captures the two settings that shape how the Iceberg
+ * create path physically stores a column, so a comparison can reproduce the
+ * stored schema faithfully:
+ *
+ *   unsupportedNumericAsDouble - the pg_lake_iceberg.unsupported_numeric_as_double
+ *       value.  On: an unsupported numeric (unbounded, or precision/scale > 38)
+ *       is stored as double at every nesting level.  Off: CREATE errors on such
+ *       a numeric at any level, so it has no stored form.
+ *   compatibilityMode - the table's compatibility_mode.  ICEBERG_COMPAT_SNOWFLAKE
+ *       stores a uuid nested inside an array/composite as string (a top-level
+ *       uuid stays native); ICEBERG_COMPAT_AUTO applies no such mapping.
+ *
+ * Both are captured, not read from live state, because the GUC is PGC_USERSET
+ * and the mode is per-table: a comparison must use the values in effect when
+ * the target table was created, which may differ now.  Prefer
+ * InitIcebergCreatePathContext with the create-time values;
+ * InitIcebergCreatePathContextFromGUC (live GUC, AUTO mode) is only correct when
+ * neither has changed since.
+ */
+typedef struct IcebergCreatePathContext
+{
+	bool		unsupportedNumericAsDouble;
+	IcebergCompatibilityMode compatibilityMode;
+}			IcebergCreatePathContext;
+
+extern PGDLLEXPORT void InitIcebergCreatePathContext(IcebergCreatePathContext * context,
+													 bool unsupportedNumericAsDouble,
+													 IcebergCompatibilityMode compatibilityMode);
+extern PGDLLEXPORT void InitIcebergCreatePathContextFromGUC(IcebergCreatePathContext * context);
+
+/*
+ * Stock leaf conversion mirroring the create path's unsupported-numeric
+ * handling.  Depth-independent (an unsupported numeric is stored as double, or
+ * unrepresentable, at every level); the IcebergTypePosition is part of the
+ * callback contract for callers whose leaf rules do vary by nesting.  The
+ * compatibility storage mapping is applied separately, as a Field-tree pass, by
+ * SameIcebergStoredRepresentation -- see ApplyCompatibilityStorageMapping.
+ */
+extern PGDLLEXPORT PGType IcebergCreatePathLeafConversion(PGType leafType,
+														  IcebergTypePosition pos,
+														  void *context);
+
+/*
+ * SameIcebergStoredRepresentation - true when oldType and newType are stored
+ * identically by the Iceberg create path under `context`.  It reproduces the
+ * full stored schema: the unsupported-numeric leaf conversion during
+ * derivation, then the compatibility storage mapping over the derived field
+ * tree.  This is what an ALTER-time caller (e.g. pg_lake_replication deciding
+ * whether an ALTER COLUMN TYPE leaves the changelog schema unchanged) should
+ * use.
+ */
+extern PGDLLEXPORT bool SameIcebergStoredRepresentation(PGType oldType, PGType newType,
+														const IcebergCreatePathContext * context);
+
+#endif							/* PG_LAKE_ICEBERG_ICEBERG_REPRESENTATION_H */

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -163,8 +163,8 @@ static const char *GetIcebergJsonSerializedConstDefaultIfExists(const char *attr
  * to an Iceberg Field, recursing through arrays, composites and maps.  It backs
  * both the plain PostgresTypeToIcebergField (convert == NULL) and the
  * conversion-aware PostgresTypeToIcebergFieldConverted, which applies `convert`
- * at every scalar leaf (passing its IcebergTypePosition) so a caller can mirror
- * create-path / storage transforms.
+ * at every scalar leaf so iceberg_representation.c can mirror create-path
+ * storage transforms.
  *
  * 2 use cases for the plain form:
  * 1. When registering new fields from Postgres columns when CREATE TABLE
@@ -176,8 +176,7 @@ static const char *GetIcebergJsonSerializedConstDefaultIfExists(const char *attr
  */
 static Field *
 PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFieldIndex,
-								   IcebergLeafConversionFn convert, void *convContext,
-								   IcebergTypePosition pos)
+								   IcebergLeafConversionFn convert, void *convContext)
 {
 	Oid			typeId = pgType.postgresTypeOid;
 	int32		typeMod = pgType.postgresTypeMod;
@@ -208,10 +207,9 @@ PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFie
 
 		*subFieldIndex = field->field.list.elementId;
 		PGType		elementPGType = MakePGType(get_element_type(typeId), typeMod);
-		IcebergTypePosition elementPos = {pos.depth + 1, ICEBERG_POS_ARRAY_ELEMENT};
 
 		field->field.list.element = PostgresTypeToIcebergFieldInternal(elementPGType, forAddColumn, subFieldIndex,
-																	   convert, convContext, elementPos);
+																	   convert, convContext);
 
 		if (field->field.list.element == NULL)
 			return NULL;
@@ -239,10 +237,9 @@ PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFie
 			structElementField->required = attr->attnotnull;
 
 			PGType		subFieldPGType = MakePGType(attr->atttypid, attr->atttypmod);
-			IcebergTypePosition subFieldPos = {pos.depth + 1, ICEBERG_POS_STRUCT_FIELD};
 
 			structElementField->type = PostgresTypeToIcebergFieldInternal(subFieldPGType, forAddColumn, subFieldIndex,
-																		  convert, convContext, subFieldPos);
+																		  convert, convContext);
 
 			if (structElementField->type == NULL)
 			{
@@ -303,10 +300,8 @@ PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFie
 		field->field.map.keyId = *subFieldIndex + 1;
 		*subFieldIndex = field->field.map.keyId;
 
-		IcebergTypePosition keyPos = {pos.depth + 1, ICEBERG_POS_MAP_KEY};
-
 		field->field.map.key = PostgresTypeToIcebergFieldInternal(keyPgType, forAddColumn, subFieldIndex,
-																  convert, convContext, keyPos);
+																  convert, convContext);
 
 		if (field->field.map.key == NULL)
 			return NULL;
@@ -316,10 +311,8 @@ PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFie
 		field->field.map.valueId = *subFieldIndex + 1;
 		*subFieldIndex = field->field.map.valueId;
 
-		IcebergTypePosition valuePos = {pos.depth + 1, ICEBERG_POS_MAP_VALUE};
-
 		field->field.map.value = PostgresTypeToIcebergFieldInternal(valuePgType, forAddColumn, subFieldIndex,
-																	convert, convContext, valuePos);
+																	convert, convContext);
 
 		if (field->field.map.value == NULL)
 			return NULL;
@@ -329,15 +322,14 @@ PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFie
 	else
 	{
 		/*
-		 * Scalar leaf.  Give the caller's conversion the chance to substitute
-		 * the type that is actually stored here (e.g. an unsupported numeric
-		 * that the create path stores as double), position included so it can
-		 * apply depth-dependent rules.  An invalid Oid back means there is no
-		 * faithful stored representation for this leaf.
+		 * Scalar leaf.  Give the conversion the chance to substitute the type
+		 * that is actually stored here (e.g. an unsupported numeric that the
+		 * create path stores as double).  An invalid Oid back means there is
+		 * no faithful stored representation for this leaf.
 		 */
 		if (convert != NULL)
 		{
-			PGType		converted = convert(MakePGType(typeId, typeMod), pos, convContext);
+			PGType		converted = convert(MakePGType(typeId, typeMod), convContext);
 
 			if (!OidIsValid(converted.postgresTypeOid))
 				return NULL;
@@ -365,10 +357,8 @@ PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFie
 Field *
 PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 {
-	IcebergTypePosition top = {0, ICEBERG_POS_TOP};
-
 	return PostgresTypeToIcebergFieldInternal(pgType, forAddColumn, subFieldIndex,
-											  NULL, NULL, top);
+											  NULL, NULL);
 }
 
 
@@ -376,10 +366,8 @@ Field *
 PostgresTypeToIcebergFieldConverted(PGType pgType, bool forAddColumn, int *subFieldIndex,
 									IcebergLeafConversionFn convert, void *context)
 {
-	IcebergTypePosition top = {0, ICEBERG_POS_TOP};
-
 	return PostgresTypeToIcebergFieldInternal(pgType, forAddColumn, subFieldIndex,
-											  convert, context, top);
+											  convert, context);
 }
 
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -825,3 +825,108 @@ EnsureIcebergField(Field * field)
 
 #endif
 }
+
+
+/*
+ * SameIcebergFieldType - Recursively compare two Iceberg Fields for type
+ * equality, ignoring field ids and default values (which are assigned per
+ * derivation and are irrelevant to the stored representation).
+ */
+static bool
+SameIcebergFieldType(Field * a, Field * b)
+{
+	if (a->type != b->type)
+		return false;
+
+	switch (a->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			return strcmp(a->field.scalar.typeName, b->field.scalar.typeName) == 0;
+
+		case FIELD_TYPE_LIST:
+			return a->field.list.elementRequired == b->field.list.elementRequired &&
+				SameIcebergFieldType(a->field.list.element, b->field.list.element);
+
+		case FIELD_TYPE_MAP:
+			return a->field.map.valueRequired == b->field.map.valueRequired &&
+				SameIcebergFieldType(a->field.map.key, b->field.map.key) &&
+				SameIcebergFieldType(a->field.map.value, b->field.map.value);
+
+		case FIELD_TYPE_STRUCT:
+			{
+				if (a->field.structType.nfields != b->field.structType.nfields)
+					return false;
+
+				for (size_t i = 0; i < a->field.structType.nfields; i++)
+				{
+					FieldStructElement *ea = &a->field.structType.fields[i];
+					FieldStructElement *eb = &b->field.structType.fields[i];
+
+					if (ea->required != eb->required ||
+						strcmp(ea->name, eb->name) != 0 ||
+						!SameIcebergFieldType(ea->type, eb->type))
+						return false;
+				}
+				return true;
+			}
+	}
+
+	return false;
+}
+
+
+/*
+ * NormalizeTypeForIcebergSchema - Apply the top-level unsupported-numeric to
+ * double conversion that the Iceberg-table create path performs before deriving
+ * the schema.  An unbounded numeric or a numeric with precision > 38 cannot be
+ * an Iceberg decimal; the create path stores it as double, but only when
+ * pg_lake_iceberg.unsupported_numeric_as_double is enabled (see
+ * MaybeConvertUnsupportedNumericColumnsToDouble).  When it is disabled the
+ * numeric is left alone and maps to the "string" fallback.  Mirror both cases
+ * so this comparison matches the schema that would actually be built, rather
+ * than mistaking a large numeric for a genuine text type.
+ *
+ * This normalizes the top-level type only.  A nested unsupported numeric
+ * (inside an array or composite) is left alone here and maps to "string",
+ * whereas the create path converts it recursively.  Deriving the recursive
+ * form would mean rebuilding container types via ConvertTypeTree, which
+ * creates catalog types (GetOrCreatePGMapType and friends) as a side effect --
+ * inappropriate for a pure comparison.  The mismatch can only make two types
+ * that the create path would treat as equal compare unequal here; it never
+ * produces a false match.
+ */
+static void
+NormalizeTypeForIcebergSchema(Oid *typeOid, int32 *typeMod)
+{
+	if (UnsupportedNumericAsDouble &&
+		IsUnsupportedNumericForIceberg(*typeOid, *typeMod))
+	{
+		*typeOid = FLOAT8OID;
+		*typeMod = -1;
+	}
+}
+
+
+/*
+ * SameIcebergRepresentation - see the header comment in iceberg_field.h.
+ *
+ * Derives the Iceberg field for each type via PostgresTypeToIcebergField and
+ * compares the resulting field trees for type equality.
+ */
+bool
+SameIcebergRepresentation(Oid oldTypeOid, int32 oldTypeMod,
+						  Oid newTypeOid, int32 newTypeMod)
+{
+	int			oldSubFieldIndex = 0;
+	int			newSubFieldIndex = 0;
+
+	NormalizeTypeForIcebergSchema(&oldTypeOid, &oldTypeMod);
+	NormalizeTypeForIcebergSchema(&newTypeOid, &newTypeMod);
+
+	Field	   *oldField = PostgresTypeToIcebergField(MakePGType(oldTypeOid, oldTypeMod),
+													  false, &oldSubFieldIndex);
+	Field	   *newField = PostgresTypeToIcebergField(MakePGType(newTypeOid, newTypeMod),
+													  false, &newSubFieldIndex);
+
+	return SameIcebergFieldType(oldField, newField);
+}

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -159,10 +159,14 @@ static const char *GetIcebergJsonSerializedConstDefaultIfExists(const char *attr
 
 
 /*
- * PostgresTypeToIcebergField converts a PostgreSQL type ID and typemod
- * to an Iceberg Field.
+ * PostgresTypeToIcebergFieldInternal converts a PostgreSQL type ID and typemod
+ * to an Iceberg Field, recursing through arrays, composites and maps.  It backs
+ * both the plain PostgresTypeToIcebergField (convert == NULL) and the
+ * conversion-aware PostgresTypeToIcebergFieldConverted, which applies `convert`
+ * at every scalar leaf (passing its IcebergTypePosition) so a caller can mirror
+ * create-path / storage transforms.
  *
- * 2 use cases:
+ * 2 use cases for the plain form:
  * 1. When registering new fields from Postgres columns when CREATE TABLE
  *    or ALTER TABLE ADD COLUMN,
  * 2. When reading fields from internal catalog tables, we need to create
@@ -170,8 +174,10 @@ static const char *GetIcebergJsonSerializedConstDefaultIfExists(const char *attr
  *
  * Based on https://iceberg.apache.org/spec/#schemas
  */
-Field *
-PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
+static Field *
+PostgresTypeToIcebergFieldInternal(PGType pgType, bool forAddColumn, int *subFieldIndex,
+								   IcebergLeafConversionFn convert, void *convContext,
+								   IcebergTypePosition pos)
 {
 	Oid			typeId = pgType.postgresTypeOid;
 	int32		typeMod = pgType.postgresTypeMod;
@@ -202,8 +208,13 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 
 		*subFieldIndex = field->field.list.elementId;
 		PGType		elementPGType = MakePGType(get_element_type(typeId), typeMod);
+		IcebergTypePosition elementPos = {pos.depth + 1, ICEBERG_POS_ARRAY_ELEMENT};
 
-		field->field.list.element = PostgresTypeToIcebergField(elementPGType, forAddColumn, subFieldIndex);
+		field->field.list.element = PostgresTypeToIcebergFieldInternal(elementPGType, forAddColumn, subFieldIndex,
+																	   convert, convContext, elementPos);
+
+		if (field->field.list.element == NULL)
+			return NULL;
 	}
 	else if (get_typtype(typeId) == TYPTYPE_COMPOSITE)
 	{
@@ -228,8 +239,16 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 			structElementField->required = attr->attnotnull;
 
 			PGType		subFieldPGType = MakePGType(attr->atttypid, attr->atttypmod);
+			IcebergTypePosition subFieldPos = {pos.depth + 1, ICEBERG_POS_STRUCT_FIELD};
 
-			structElementField->type = PostgresTypeToIcebergField(subFieldPGType, forAddColumn, subFieldIndex);
+			structElementField->type = PostgresTypeToIcebergFieldInternal(subFieldPGType, forAddColumn, subFieldIndex,
+																		  convert, convContext, subFieldPos);
+
+			if (structElementField->type == NULL)
+			{
+				ReleaseTupleDesc(tupleDesc);
+				return NULL;
+			}
 
 			structElementField->writeDefault = GetIcebergJsonSerializedDefaultExpr(tupleDesc, attr->attnum, structElementField);
 
@@ -284,17 +303,48 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 		field->field.map.keyId = *subFieldIndex + 1;
 		*subFieldIndex = field->field.map.keyId;
 
-		field->field.map.key = PostgresTypeToIcebergField(keyPgType, forAddColumn, subFieldIndex);
+		IcebergTypePosition keyPos = {pos.depth + 1, ICEBERG_POS_MAP_KEY};
+
+		field->field.map.key = PostgresTypeToIcebergFieldInternal(keyPgType, forAddColumn, subFieldIndex,
+																  convert, convContext, keyPos);
+
+		if (field->field.map.key == NULL)
+			return NULL;
 
 		PGType		valuePgType = GetMapValueType(typeId);
 
 		field->field.map.valueId = *subFieldIndex + 1;
 		*subFieldIndex = field->field.map.valueId;
-		field->field.map.value = PostgresTypeToIcebergField(valuePgType, forAddColumn, subFieldIndex);
+
+		IcebergTypePosition valuePos = {pos.depth + 1, ICEBERG_POS_MAP_VALUE};
+
+		field->field.map.value = PostgresTypeToIcebergFieldInternal(valuePgType, forAddColumn, subFieldIndex,
+																	convert, convContext, valuePos);
+
+		if (field->field.map.value == NULL)
+			return NULL;
+
 		field->field.map.valueRequired = false;
 	}
 	else
 	{
+		/*
+		 * Scalar leaf.  Give the caller's conversion the chance to substitute
+		 * the type that is actually stored here (e.g. an unsupported numeric
+		 * that the create path stores as double), position included so it can
+		 * apply depth-dependent rules.  An invalid Oid back means there is no
+		 * faithful stored representation for this leaf.
+		 */
+		if (convert != NULL)
+		{
+			PGType		converted = convert(MakePGType(typeId, typeMod), pos, convContext);
+
+			if (!OidIsValid(converted.postgresTypeOid))
+				return NULL;
+
+			pgType = converted;
+		}
+
 		char	   *icebergTypeName = PostgresBaseTypeIdToIcebergTypeName(pgType);
 
 		field->type = FIELD_TYPE_SCALAR;
@@ -304,6 +354,32 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 	EnsureIcebergField(field);
 
 	return field;
+}
+
+
+/*
+ * PostgresTypeToIcebergField - derive the Iceberg field for a Postgres type,
+ * applying no leaf conversion.  See PostgresTypeToIcebergFieldConverted for the
+ * variant that mirrors create-path / storage transforms.
+ */
+Field *
+PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
+{
+	IcebergTypePosition top = {0, ICEBERG_POS_TOP};
+
+	return PostgresTypeToIcebergFieldInternal(pgType, forAddColumn, subFieldIndex,
+											  NULL, NULL, top);
+}
+
+
+Field *
+PostgresTypeToIcebergFieldConverted(PGType pgType, bool forAddColumn, int *subFieldIndex,
+									IcebergLeafConversionFn convert, void *context)
+{
+	IcebergTypePosition top = {0, ICEBERG_POS_TOP};
+
+	return PostgresTypeToIcebergFieldInternal(pgType, forAddColumn, subFieldIndex,
+											  convert, context, top);
 }
 
 
@@ -824,109 +900,4 @@ EnsureIcebergField(Field * field)
 	}
 
 #endif
-}
-
-
-/*
- * SameIcebergFieldType - Recursively compare two Iceberg Fields for type
- * equality, ignoring field ids and default values (which are assigned per
- * derivation and are irrelevant to the stored representation).
- */
-static bool
-SameIcebergFieldType(Field * a, Field * b)
-{
-	if (a->type != b->type)
-		return false;
-
-	switch (a->type)
-	{
-		case FIELD_TYPE_SCALAR:
-			return strcmp(a->field.scalar.typeName, b->field.scalar.typeName) == 0;
-
-		case FIELD_TYPE_LIST:
-			return a->field.list.elementRequired == b->field.list.elementRequired &&
-				SameIcebergFieldType(a->field.list.element, b->field.list.element);
-
-		case FIELD_TYPE_MAP:
-			return a->field.map.valueRequired == b->field.map.valueRequired &&
-				SameIcebergFieldType(a->field.map.key, b->field.map.key) &&
-				SameIcebergFieldType(a->field.map.value, b->field.map.value);
-
-		case FIELD_TYPE_STRUCT:
-			{
-				if (a->field.structType.nfields != b->field.structType.nfields)
-					return false;
-
-				for (size_t i = 0; i < a->field.structType.nfields; i++)
-				{
-					FieldStructElement *ea = &a->field.structType.fields[i];
-					FieldStructElement *eb = &b->field.structType.fields[i];
-
-					if (ea->required != eb->required ||
-						strcmp(ea->name, eb->name) != 0 ||
-						!SameIcebergFieldType(ea->type, eb->type))
-						return false;
-				}
-				return true;
-			}
-	}
-
-	return false;
-}
-
-
-/*
- * NormalizeTypeForIcebergSchema - Apply the top-level unsupported-numeric to
- * double conversion that the Iceberg-table create path performs before deriving
- * the schema.  An unbounded numeric or a numeric with precision > 38 cannot be
- * an Iceberg decimal; the create path stores it as double, but only when
- * pg_lake_iceberg.unsupported_numeric_as_double is enabled (see
- * MaybeConvertUnsupportedNumericColumnsToDouble).  When it is disabled the
- * numeric is left alone and maps to the "string" fallback.  Mirror both cases
- * so this comparison matches the schema that would actually be built, rather
- * than mistaking a large numeric for a genuine text type.
- *
- * This normalizes the top-level type only.  A nested unsupported numeric
- * (inside an array or composite) is left alone here and maps to "string",
- * whereas the create path converts it recursively.  Deriving the recursive
- * form would mean rebuilding container types via ConvertTypeTree, which
- * creates catalog types (GetOrCreatePGMapType and friends) as a side effect --
- * inappropriate for a pure comparison.  The mismatch can only make two types
- * that the create path would treat as equal compare unequal here; it never
- * produces a false match.
- */
-static void
-NormalizeTypeForIcebergSchema(Oid *typeOid, int32 *typeMod)
-{
-	if (UnsupportedNumericAsDouble &&
-		IsUnsupportedNumericForIceberg(*typeOid, *typeMod))
-	{
-		*typeOid = FLOAT8OID;
-		*typeMod = -1;
-	}
-}
-
-
-/*
- * SameIcebergRepresentation - see the header comment in iceberg_field.h.
- *
- * Derives the Iceberg field for each type via PostgresTypeToIcebergField and
- * compares the resulting field trees for type equality.
- */
-bool
-SameIcebergRepresentation(Oid oldTypeOid, int32 oldTypeMod,
-						  Oid newTypeOid, int32 newTypeMod)
-{
-	int			oldSubFieldIndex = 0;
-	int			newSubFieldIndex = 0;
-
-	NormalizeTypeForIcebergSchema(&oldTypeOid, &oldTypeMod);
-	NormalizeTypeForIcebergSchema(&newTypeOid, &newTypeMod);
-
-	Field	   *oldField = PostgresTypeToIcebergField(MakePGType(oldTypeOid, oldTypeMod),
-													  false, &oldSubFieldIndex);
-	Field	   *newField = PostgresTypeToIcebergField(MakePGType(newTypeOid, newTypeMod),
-													  false, &newSubFieldIndex);
-
-	return SameIcebergFieldType(oldField, newField);
 }

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Snowflake Inc.
+ * Copyright 2026 Snowflake Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "postgres.h"
+
+#include "catalog/pg_type_d.h"
+
+#include "pg_lake/iceberg/compatibility_mode.h"
+#include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/iceberg/iceberg_representation.h"
+#include "pg_lake/pgduck/numeric.h"
+#include "pg_lake/pgduck/type.h"
+
+
+static bool SameIcebergFieldType(Field * a, Field * b);
+
+
+/*
+ * SameIcebergRepresentation - see iceberg_representation.h.
+ *
+ * Derives the Iceberg field tree for each type (applying `convert` at every
+ * scalar leaf) and compares the trees for type equality.  A NULL field means
+ * `convert` reported an unrepresentable leaf, so the types are not equal.
+ */
+bool
+SameIcebergRepresentation(PGType oldType, PGType newType,
+						  IcebergLeafConversionFn convert, void *context)
+{
+	int			oldSubFieldIndex = 0;
+	int			newSubFieldIndex = 0;
+
+	Field	   *oldField = PostgresTypeToIcebergFieldConverted(oldType, false,
+															   &oldSubFieldIndex,
+															   convert, context);
+	Field	   *newField = PostgresTypeToIcebergFieldConverted(newType, false,
+															   &newSubFieldIndex,
+															   convert, context);
+
+	if (oldField == NULL || newField == NULL)
+		return false;
+
+	return SameIcebergFieldType(oldField, newField);
+}
+
+
+/*
+ * SameIcebergFieldType - Recursively compare two Iceberg Fields for type
+ * equality, ignoring field ids and default values (which are assigned per
+ * derivation and are irrelevant to the stored representation).
+ */
+static bool
+SameIcebergFieldType(Field * a, Field * b)
+{
+	if (a->type != b->type)
+		return false;
+
+	switch (a->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			return strcmp(a->field.scalar.typeName, b->field.scalar.typeName) == 0;
+
+		case FIELD_TYPE_LIST:
+			return a->field.list.elementRequired == b->field.list.elementRequired &&
+				SameIcebergFieldType(a->field.list.element, b->field.list.element);
+
+		case FIELD_TYPE_MAP:
+			return a->field.map.valueRequired == b->field.map.valueRequired &&
+				SameIcebergFieldType(a->field.map.key, b->field.map.key) &&
+				SameIcebergFieldType(a->field.map.value, b->field.map.value);
+
+		case FIELD_TYPE_STRUCT:
+			{
+				if (a->field.structType.nfields != b->field.structType.nfields)
+					return false;
+
+				for (size_t i = 0; i < a->field.structType.nfields; i++)
+				{
+					FieldStructElement *ea = &a->field.structType.fields[i];
+					FieldStructElement *eb = &b->field.structType.fields[i];
+
+					if (ea->required != eb->required ||
+						strcmp(ea->name, eb->name) != 0 ||
+						!SameIcebergFieldType(ea->type, eb->type))
+						return false;
+				}
+				return true;
+			}
+	}
+
+	return false;
+}
+
+
+void
+InitIcebergCreatePathContext(IcebergCreatePathContext * context,
+							 bool unsupportedNumericAsDouble,
+							 IcebergCompatibilityMode compatibilityMode)
+{
+	context->unsupportedNumericAsDouble = unsupportedNumericAsDouble;
+	context->compatibilityMode = compatibilityMode;
+}
+
+
+void
+InitIcebergCreatePathContextFromGUC(IcebergCreatePathContext * context)
+{
+	context->unsupportedNumericAsDouble = UnsupportedNumericAsDouble;
+	context->compatibilityMode = ICEBERG_COMPAT_AUTO;
+}
+
+
+/*
+ * SameIcebergStoredRepresentation - see iceberg_representation.h.
+ *
+ * Reproduces the full create-path stored schema: derive each type applying the
+ * unsupported-numeric leaf conversion, then apply the compatibility storage
+ * mapping over the derived field tree (nested uuid -> string, etc.), then
+ * compare.  A NULL field means the numeric conversion reported an
+ * unrepresentable leaf, so the types are not equal.
+ */
+bool
+SameIcebergStoredRepresentation(PGType oldType, PGType newType,
+								const IcebergCreatePathContext * context)
+{
+	int			oldSubFieldIndex = 0;
+	int			newSubFieldIndex = 0;
+
+	/* the leaf conversion callback takes a non-const void *context */
+	IcebergCreatePathContext leafContext = *context;
+
+	Field	   *oldField = PostgresTypeToIcebergFieldConverted(oldType, false,
+															   &oldSubFieldIndex,
+															   IcebergCreatePathLeafConversion,
+															   &leafContext);
+	Field	   *newField = PostgresTypeToIcebergFieldConverted(newType, false,
+															   &newSubFieldIndex,
+															   IcebergCreatePathLeafConversion,
+															   &leafContext);
+
+	if (oldField == NULL || newField == NULL)
+		return false;
+
+	ApplyCompatibilityStorageMapping(oldField, context->compatibilityMode);
+	ApplyCompatibilityStorageMapping(newField, context->compatibilityMode);
+
+	return SameIcebergFieldType(oldField, newField);
+}
+
+
+/*
+ * IcebergCreatePathLeafConversion - stock leaf conversion mirroring the Iceberg
+ * create path's unsupported-numeric handling.  See iceberg_representation.h.
+ */
+PGType
+IcebergCreatePathLeafConversion(PGType leafType, IcebergTypePosition pos, void *context)
+{
+	IcebergCreatePathContext *createContext = (IcebergCreatePathContext *) context;
+
+	/* numeric handling is uniform across nesting levels; position is unused */
+	(void) pos;
+
+	if (!IsUnsupportedNumericForIceberg(leafType.postgresTypeOid,
+										leafType.postgresTypeMod))
+		return leafType;
+
+	if (createContext->unsupportedNumericAsDouble)
+		return MakePGTypeOid(FLOAT8OID);
+
+	/*
+	 * With the GUC off, CREATE errors on an unsupported numeric at any level,
+	 * so there is no faithful stored representation: report the leaf as
+	 * unrepresentable (invalid Oid) rather than pretending it is `string`.
+	 */
+	return MakePGTypeOid(InvalidOid);
+}

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -27,34 +27,7 @@
 
 
 static bool SameIcebergFieldType(Field * a, Field * b);
-
-
-/*
- * SameIcebergRepresentation - see iceberg_representation.h.
- *
- * Derives the Iceberg field tree for each type (applying `convert` at every
- * scalar leaf) and compares the trees for type equality.  A NULL field means
- * `convert` reported an unrepresentable leaf, so the types are not equal.
- */
-bool
-SameIcebergRepresentation(PGType oldType, PGType newType,
-						  IcebergLeafConversionFn convert, void *context)
-{
-	int			oldSubFieldIndex = 0;
-	int			newSubFieldIndex = 0;
-
-	Field	   *oldField = PostgresTypeToIcebergFieldConverted(oldType, false,
-															   &oldSubFieldIndex,
-															   convert, context);
-	Field	   *newField = PostgresTypeToIcebergFieldConverted(newType, false,
-															   &newSubFieldIndex,
-															   convert, context);
-
-	if (oldField == NULL || newField == NULL)
-		return false;
-
-	return SameIcebergFieldType(oldField, newField);
-}
+static PGType IcebergCreatePathLeafConversion(PGType leafType, void *context);
 
 
 /*
@@ -162,16 +135,17 @@ SameIcebergStoredRepresentation(PGType oldType, PGType newType,
 
 
 /*
- * IcebergCreatePathLeafConversion - stock leaf conversion mirroring the Iceberg
- * create path's unsupported-numeric handling.  See iceberg_representation.h.
+ * IcebergCreatePathLeafConversion - leaf conversion mirroring the Iceberg create
+ * path's unsupported-numeric handling, applied at every scalar leaf while
+ * deriving the stored field tree.  The unsupported-numeric rule is uniform
+ * across nesting levels; the depth-dependent compatibility mapping is applied
+ * separately, as a Field-tree pass, by SameIcebergStoredRepresentation (see
+ * ApplyCompatibilityStorageMapping).
  */
-PGType
-IcebergCreatePathLeafConversion(PGType leafType, IcebergTypePosition pos, void *context)
+static PGType
+IcebergCreatePathLeafConversion(PGType leafType, void *context)
 {
 	IcebergCreatePathContext *createContext = (IcebergCreatePathContext *) context;
-
-	/* numeric handling is uniform across nesting levels; position is unused */
-	(void) pos;
 
 	if (!IsUnsupportedNumericForIceberg(leafType.postgresTypeOid,
 										leafType.postgresTypeMod))

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -26,17 +26,18 @@
 #include "pg_lake/pgduck/type.h"
 
 
-static bool SameIcebergFieldType(Field * a, Field * b);
 static PGType IcebergCreatePathLeafConversion(PGType leafType, void *context);
 
 
 /*
- * SameIcebergFieldType - Recursively compare two Iceberg Fields for type
- * equality, ignoring field ids and default values (which are assigned per
- * derivation and are irrelevant to the stored representation).
+ * IcebergFieldsEquivalent - see iceberg_representation.h.
+ *
+ * Recursively compare two Iceberg Fields for type equality, ignoring field ids
+ * and default values (which are assigned per derivation and are irrelevant to
+ * the stored representation).
  */
-static bool
-SameIcebergFieldType(Field * a, Field * b)
+bool
+IcebergFieldsEquivalent(Field * a, Field * b)
 {
 	if (a->type != b->type)
 		return false;
@@ -48,12 +49,12 @@ SameIcebergFieldType(Field * a, Field * b)
 
 		case FIELD_TYPE_LIST:
 			return a->field.list.elementRequired == b->field.list.elementRequired &&
-				SameIcebergFieldType(a->field.list.element, b->field.list.element);
+				IcebergFieldsEquivalent(a->field.list.element, b->field.list.element);
 
 		case FIELD_TYPE_MAP:
 			return a->field.map.valueRequired == b->field.map.valueRequired &&
-				SameIcebergFieldType(a->field.map.key, b->field.map.key) &&
-				SameIcebergFieldType(a->field.map.value, b->field.map.value);
+				IcebergFieldsEquivalent(a->field.map.key, b->field.map.key) &&
+				IcebergFieldsEquivalent(a->field.map.value, b->field.map.value);
 
 		case FIELD_TYPE_STRUCT:
 			{
@@ -67,7 +68,7 @@ SameIcebergFieldType(Field * a, Field * b)
 
 					if (ea->required != eb->required ||
 						strcmp(ea->name, eb->name) != 0 ||
-						!SameIcebergFieldType(ea->type, eb->type))
+						!IcebergFieldsEquivalent(ea->type, eb->type))
 						return false;
 				}
 				return true;
@@ -97,40 +98,58 @@ InitIcebergCreatePathContextFromGUC(IcebergCreatePathContext * context)
 
 
 /*
+ * DeriveIcebergStoredField - see iceberg_representation.h.
+ *
+ * Reproduces the full create-path stored field for a single type: derive the
+ * Iceberg field applying the unsupported-numeric leaf conversion, then apply
+ * the compatibility storage mapping over the derived tree (nested uuid ->
+ * string, etc.).  Returns NULL when the numeric conversion reports an
+ * unrepresentable leaf (an unsupported numeric with the GUC off), so a caller
+ * comparing against a persisted field can never treat that as a match.
+ */
+Field *
+DeriveIcebergStoredField(PGType type, const IcebergCreatePathContext * context)
+{
+	int			subFieldIndex = 0;
+
+	/* the leaf conversion callback takes a non-const void *context */
+	IcebergCreatePathContext leafContext = *context;
+
+	Field	   *field = PostgresTypeToIcebergFieldConverted(type, false,
+															&subFieldIndex,
+															IcebergCreatePathLeafConversion,
+															&leafContext);
+
+	if (field == NULL)
+		return NULL;
+
+	ApplyCompatibilityStorageMapping(field, context->compatibilityMode);
+
+	return field;
+}
+
+
+/*
  * SameIcebergStoredRepresentation - see iceberg_representation.h.
  *
- * Reproduces the full create-path stored schema: derive each type applying the
- * unsupported-numeric leaf conversion, then apply the compatibility storage
- * mapping over the derived field tree (nested uuid -> string, etc.), then
- * compare.  A NULL field means the numeric conversion reported an
- * unrepresentable leaf, so the types are not equal.
+ * Derives the stored field for each type (see DeriveIcebergStoredField) and
+ * compares the two.  A NULL field means the numeric conversion reported an
+ * unrepresentable leaf, so the types are not equal.  Callers that hold the
+ * actually-stored field (e.g. from field_id_mappings) should instead derive
+ * only the new type and compare it against that persisted field, which is
+ * immune to GUC/derivation drift on the old side.
  */
 bool
 SameIcebergStoredRepresentation(PGType oldType, PGType newType,
 								const IcebergCreatePathContext * context)
 {
-	int			oldSubFieldIndex = 0;
-	int			newSubFieldIndex = 0;
-
-	/* the leaf conversion callback takes a non-const void *context */
-	IcebergCreatePathContext leafContext = *context;
-
-	Field	   *oldField = PostgresTypeToIcebergFieldConverted(oldType, false,
-															   &oldSubFieldIndex,
-															   IcebergCreatePathLeafConversion,
-															   &leafContext);
-	Field	   *newField = PostgresTypeToIcebergFieldConverted(newType, false,
-															   &newSubFieldIndex,
-															   IcebergCreatePathLeafConversion,
-															   &leafContext);
+	Field	   *oldField = DeriveIcebergStoredField(oldType, context);
+	Field	   *newField = DeriveIcebergStoredField(newType, context);
 
 	if (oldField == NULL || newField == NULL)
 		return false;
 
-	ApplyCompatibilityStorageMapping(oldField, context->compatibilityMode);
-	ApplyCompatibilityStorageMapping(newField, context->compatibilityMode);
-
-	return SameIcebergFieldType(oldField, newField);
+	return IcebergFieldsEquivalent(oldField, newField);
 }
 
 
@@ -139,7 +158,7 @@ SameIcebergStoredRepresentation(PGType oldType, PGType newType,
  * path's unsupported-numeric handling, applied at every scalar leaf while
  * deriving the stored field tree.  The unsupported-numeric rule is uniform
  * across nesting levels; the depth-dependent compatibility mapping is applied
- * separately, as a Field-tree pass, by SameIcebergStoredRepresentation (see
+ * separately, as a Field-tree pass, by DeriveIcebergStoredField (see
  * ApplyCompatibilityStorageMapping).
  */
 static PGType

--- a/pg_lake_iceberg/src/test/test_same_iceberg_representation.c
+++ b/pg_lake_iceberg/src/test/test_same_iceberg_representation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Snowflake Inc.
+ * Copyright 2026 Snowflake Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pg_lake_iceberg/src/test/test_same_iceberg_representation.c
+++ b/pg_lake_iceberg/src/test/test_same_iceberg_representation.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+
+#include "pg_lake/iceberg/iceberg_field.h"
+
+#include "parser/parse_type.h"
+#include "utils/builtins.h"
+
+
+PG_FUNCTION_INFO_V1(pg_lake_same_iceberg_representation);
+
+/*
+ * pg_lake_same_iceberg_representation(old_type text, new_type text) -> bool
+ *
+ * Test helper that parses two Postgres type strings (e.g. 'varchar(50)',
+ * 'text', 'numeric(50,2)') and returns SameIcebergRepresentation for them.
+ */
+Datum
+pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
+{
+	char	   *oldTypeStr = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *newTypeStr = text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+	Oid			oldTypeOid;
+	int32		oldTypeMod;
+	Oid			newTypeOid;
+	int32		newTypeMod;
+
+	parseTypeString(oldTypeStr, &oldTypeOid, &oldTypeMod, NULL);
+	parseTypeString(newTypeStr, &newTypeOid, &newTypeMod, NULL);
+
+	PG_RETURN_BOOL(SameIcebergRepresentation(oldTypeOid, oldTypeMod,
+											 newTypeOid, newTypeMod));
+}

--- a/pg_lake_iceberg/src/test/test_same_iceberg_representation.c
+++ b/pg_lake_iceberg/src/test/test_same_iceberg_representation.c
@@ -18,7 +18,10 @@
 #include "postgres.h"
 #include "fmgr.h"
 
+#include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/iceberg/iceberg_representation.h"
+#include "pg_lake/pgduck/type.h"
 
 #include "parser/parse_type.h"
 #include "utils/builtins.h"
@@ -27,14 +30,25 @@
 PG_FUNCTION_INFO_V1(pg_lake_same_iceberg_representation);
 
 /*
- * pg_lake_same_iceberg_representation(old_type text, new_type text) -> bool
+ * pg_lake_same_iceberg_representation(old_type text, new_type text,
+ *                                     unsupported_numeric_as_double bool,
+ *                                     compatibility_mode text) -> bool
  *
  * Test helper that parses two Postgres type strings (e.g. 'varchar(50)',
- * 'text', 'numeric(50,2)') and returns SameIcebergRepresentation for them.
+ * 'text', 'numeric(50,2)', 'numeric(50,2)[]', 'uuid[]') and returns
+ * SameIcebergStoredRepresentation for them.
+ *
+ * The third and fourth arguments pin the create-path settings the comparison
+ * uses: unsupported_numeric_as_double (NULL -> live GUC) and compatibility_mode
+ * (NULL -> auto/none).  They let tests exercise both GUC states and the
+ * snowflake compatibility mapping without session-wide SETs or a real table.
  */
 Datum
 pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
 {
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+
 	char	   *oldTypeStr = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *newTypeStr = text_to_cstring(PG_GETARG_TEXT_PP(1));
 
@@ -46,6 +60,21 @@ pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
 	parseTypeString(oldTypeStr, &oldTypeOid, &oldTypeMod, NULL);
 	parseTypeString(newTypeStr, &newTypeOid, &newTypeMod, NULL);
 
-	PG_RETURN_BOOL(SameIcebergRepresentation(oldTypeOid, oldTypeMod,
-											 newTypeOid, newTypeMod));
+	IcebergCreatePathContext createContext;
+
+	if (PG_ARGISNULL(2))
+		InitIcebergCreatePathContextFromGUC(&createContext);
+	else
+		InitIcebergCreatePathContext(&createContext, PG_GETARG_BOOL(2),
+									 ICEBERG_COMPAT_AUTO);
+
+	if (!PG_ARGISNULL(3))
+		createContext.compatibilityMode =
+			ParseIcebergCompatibilityMode(text_to_cstring(PG_GETARG_TEXT_PP(3)));
+
+	bool		same = SameIcebergStoredRepresentation(MakePGType(oldTypeOid, oldTypeMod),
+													   MakePGType(newTypeOid, newTypeMod),
+													   &createContext);
+
+	PG_RETURN_BOOL(same);
 }

--- a/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
+++ b/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
@@ -4,8 +4,8 @@ from utils_pytest import *
 
 @pytest.fixture(scope="module")
 def same_iceberg_representation_fn(superuser_conn, iceberg_extension):
-    """Register a SQL wrapper over the exported SameIcebergRepresentation C
-    function so the tests can exercise it with plain type strings."""
+    """Register a SQL wrapper over the exported SameIcebergStoredRepresentation
+    C function so the tests can exercise it with plain type strings."""
     run_command(
         """
         CREATE OR REPLACE FUNCTION lake_iceberg.same_iceberg_representation(

--- a/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
+++ b/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
@@ -9,9 +9,11 @@ def same_iceberg_representation_fn(superuser_conn, iceberg_extension):
     run_command(
         """
         CREATE OR REPLACE FUNCTION lake_iceberg.same_iceberg_representation(
-            old_type text, new_type text)
+            old_type text, new_type text,
+            unsupported_numeric_as_double bool DEFAULT NULL,
+            compatibility_mode text DEFAULT NULL)
         RETURNS bool
-        LANGUAGE C STRICT
+        LANGUAGE C
         AS 'pg_lake_iceberg', $$pg_lake_same_iceberg_representation$$;
         """,
         superuser_conn,
@@ -21,7 +23,7 @@ def same_iceberg_representation_fn(superuser_conn, iceberg_extension):
     yield
 
     run_command(
-        "DROP FUNCTION IF EXISTS lake_iceberg.same_iceberg_representation(text, text);",
+        "DROP FUNCTION IF EXISTS lake_iceberg.same_iceberg_representation(text, text, bool, text);",
         superuser_conn,
     )
     superuser_conn.commit()
@@ -75,3 +77,117 @@ def test_same_iceberg_representation_false(
     )[0][0]
     superuser_conn.rollback()
     assert got is False, f"{old_type} -> {new_type}: expected different representation"
+
+
+def _same(
+    conn,
+    old_type,
+    new_type,
+    unsupported_numeric_as_double=None,
+    compatibility_mode=None,
+):
+    """Call the wrapper, optionally pinning the create-path settings the
+    comparison uses (unsupported_numeric_as_double and compatibility_mode)."""
+    flag = (
+        "NULL"
+        if unsupported_numeric_as_double is None
+        else ("true" if unsupported_numeric_as_double else "false")
+    )
+    mode = "NULL" if compatibility_mode is None else f"'{compatibility_mode}'"
+    sql = (
+        "SELECT lake_iceberg.same_iceberg_representation"
+        f"('{old_type}', '{new_type}', {flag}, {mode})"
+    )
+    got = run_query(sql, conn)[0][0]
+    conn.rollback()
+    return got
+
+
+# Nested type pairs, evaluated with the default GUC
+# (unsupported_numeric_as_double on).  These exercise the recursive derivation:
+# an unsupported numeric is stored as double at every level, so it must not be
+# conflated with the `string` fallback that a genuine text type maps to.
+NESTED_SAME = [
+    ("numeric(50,2)[]", "numeric(60,3)[]"),  # both list<double>
+    ("numeric[]", "numeric(50,2)[]"),  # both unsupported -> list<double>
+    ("varchar(10)[]", "text[]"),  # both list<string>
+]
+
+NESTED_DIFFERENT = [
+    # The false match this change fixes: a nested unsupported numeric is stored
+    # as list<double>, not list<string>, so it differs from text[].
+    ("numeric(50,2)[]", "text[]"),
+    ("numeric(50,2)[]", "numeric(10,2)[]"),  # list<double> vs list<decimal(10,2)>
+    ("integer[]", "bigint[]"),  # list<int> vs list<long>
+]
+
+
+@pytest.mark.parametrize("old_type,new_type", NESTED_SAME)
+def test_nested_same_representation(
+    old_type, new_type, superuser_conn, same_iceberg_representation_fn
+):
+    assert (
+        _same(superuser_conn, old_type, new_type) is True
+    ), f"{old_type} -> {new_type}: expected same representation"
+
+
+@pytest.mark.parametrize("old_type,new_type", NESTED_DIFFERENT)
+def test_nested_different_representation(
+    old_type, new_type, superuser_conn, same_iceberg_representation_fn
+):
+    assert (
+        _same(superuser_conn, old_type, new_type) is False
+    ), f"{old_type} -> {new_type}: expected different representation"
+
+
+def test_unsupported_numeric_double_when_enabled(
+    superuser_conn, same_iceberg_representation_fn
+):
+    """With unsupported_numeric_as_double on, an unsupported numeric is stored
+    as double at every nesting level, so it matches another unsupported numeric
+    but not text."""
+    assert _same(superuser_conn, "numeric(50,2)[]", "text[]", True) is False
+    assert _same(superuser_conn, "numeric(50,2)[]", "numeric(60,3)[]", True) is True
+    assert _same(superuser_conn, "numeric(50,2)", "numeric(60,3)", True) is True
+
+
+def test_unsupported_numeric_not_representable_when_disabled(
+    superuser_conn, same_iceberg_representation_fn
+):
+    """With unsupported_numeric_as_double off, CREATE errors on an unsupported
+    numeric at any level, so it has no stored representation: the comparison is
+    conservatively false even for identical types.  Bounded numerics, which are
+    genuine Iceberg decimals, are unaffected."""
+    assert _same(superuser_conn, "numeric(50,2)", "numeric(50,2)", False) is False
+    assert _same(superuser_conn, "numeric(50,2)[]", "numeric(50,2)[]", False) is False
+    assert _same(superuser_conn, "numeric", "numeric", False) is False
+    # bounded numerics remain comparable when the GUC is off
+    assert _same(superuser_conn, "numeric(10,2)", "numeric(10,2)", False) is True
+    assert _same(superuser_conn, "numeric(10,2)[]", "numeric(10,2)[]", False) is True
+
+
+def test_compatibility_uuid_is_depth_dependent(
+    superuser_conn, same_iceberg_representation_fn
+):
+    """Under the snowflake compatibility mode a uuid nested inside a container is
+    stored as string, while a top-level uuid stays native.  So the same uuid vs
+    text comparison flips with nesting -- the case that requires the comparison
+    to be position-aware."""
+    # nested: uuid[] and text[] are both stored as list<string> -> same
+    assert (
+        _same(superuser_conn, "uuid[]", "text[]", compatibility_mode="snowflake")
+        is True
+    )
+    # top-level: uuid stays native `uuid`, text is `string` -> different
+    assert (
+        _same(superuser_conn, "uuid", "text", compatibility_mode="snowflake") is False
+    )
+
+
+def test_compatibility_auto_keeps_uuid_native(
+    superuser_conn, same_iceberg_representation_fn
+):
+    """With no compatibility mode (auto), a nested uuid stays native `uuid`, so a
+    nested uuid and a nested text differ."""
+    assert _same(superuser_conn, "uuid[]", "text[]") is False
+    assert _same(superuser_conn, "uuid[]", "uuid[]") is True

--- a/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
+++ b/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
@@ -1,0 +1,77 @@
+import pytest
+from utils_pytest import *
+
+
+@pytest.fixture(scope="module")
+def same_iceberg_representation_fn(superuser_conn, iceberg_extension):
+    """Register a SQL wrapper over the exported SameIcebergRepresentation C
+    function so the tests can exercise it with plain type strings."""
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION lake_iceberg.same_iceberg_representation(
+            old_type text, new_type text)
+        RETURNS bool
+        LANGUAGE C STRICT
+        AS 'pg_lake_iceberg', $$pg_lake_same_iceberg_representation$$;
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command(
+        "DROP FUNCTION IF EXISTS lake_iceberg.same_iceberg_representation(text, text);",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
+# Type pairs whose Iceberg representation is identical (ignoring anything
+# Iceberg does not model: text length, which text-family member, etc.).
+SAME_REPRESENTATION = [
+    ("varchar(50)", "varchar(100)"),  # both Iceberg `string`
+    ("varchar(100)", "varchar(20)"),  # narrowing is still `string`
+    ("varchar(50)", "text"),
+    ("char(10)", "varchar(30)"),  # bpchar and varchar are both `string`
+    ("char(10)", "text"),
+    ("smallint", "integer"),  # both `int`
+    ("time", "timetz"),  # both `time`
+    ("json", "text"),  # json falls back to `string`, same as text
+    ("jsonb", "text"),
+    ("numeric", "numeric(50,2)"),  # both unsupported -> normalized to `double`
+]
+
+# Type pairs whose Iceberg representation differs.
+DIFFERENT_REPRESENTATION = [
+    ("integer", "bigint"),  # `int` vs `long`
+    ("integer", "text"),  # `int` vs `string`
+    ("numeric(10,2)", "text"),  # `decimal(10,2)` vs `string`
+    ("numeric(10,2)", "numeric(12,4)"),  # `decimal(10,2)` vs `decimal(12,4)`
+    ("timestamp", "timestamptz"),  # `timestamp` vs `timestamptz`
+    ("real", "double precision"),  # `float` vs `double`
+]
+
+
+@pytest.mark.parametrize("old_type,new_type", SAME_REPRESENTATION)
+def test_same_iceberg_representation_true(
+    old_type, new_type, superuser_conn, same_iceberg_representation_fn
+):
+    got = run_query(
+        f"SELECT lake_iceberg.same_iceberg_representation('{old_type}', '{new_type}')",
+        superuser_conn,
+    )[0][0]
+    superuser_conn.rollback()
+    assert got is True, f"{old_type} -> {new_type}: expected same representation"
+
+
+@pytest.mark.parametrize("old_type,new_type", DIFFERENT_REPRESENTATION)
+def test_same_iceberg_representation_false(
+    old_type, new_type, superuser_conn, same_iceberg_representation_fn
+):
+    got = run_query(
+        f"SELECT lake_iceberg.same_iceberg_representation('{old_type}', '{new_type}')",
+        superuser_conn,
+    )[0][0]
+    superuser_conn.rollback()
+    assert got is False, f"{old_type} -> {new_type}: expected different representation"

--- a/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
+++ b/pg_lake_iceberg/tests/pytests/test_same_iceberg_representation.py
@@ -145,10 +145,14 @@ def test_unsupported_numeric_double_when_enabled(
 ):
     """With unsupported_numeric_as_double on, an unsupported numeric is stored
     as double at every nesting level, so it matches another unsupported numeric
-    but not text."""
+    -- and an actual double, the type the create path converts it to -- but not
+    text."""
     assert _same(superuser_conn, "numeric(50,2)[]", "text[]", True) is False
     assert _same(superuser_conn, "numeric(50,2)[]", "numeric(60,3)[]", True) is True
     assert _same(superuser_conn, "numeric(50,2)", "numeric(60,3)", True) is True
+    # the converted leaf really is `double`, so it matches a genuine float8
+    assert _same(superuser_conn, "numeric(50,2)[]", "double precision[]", True) is True
+    assert _same(superuser_conn, "numeric[]", "double precision[]", True) is True
 
 
 def test_unsupported_numeric_not_representable_when_disabled(
@@ -191,3 +195,25 @@ def test_compatibility_auto_keeps_uuid_native(
     nested uuid and a nested text differ."""
     assert _same(superuser_conn, "uuid[]", "text[]") is False
     assert _same(superuser_conn, "uuid[]", "uuid[]") is True
+
+
+def test_composite_unsupported_numeric_matches_float8_composite(
+    superuser_conn, same_iceberg_representation_fn
+):
+    """The recursion also descends into composites: a composite whose field is an
+    unsupported numeric is stored as the same struct<double, ...> the create path
+    produces for a float8 field, so it matches a float8 composite but not a text
+    one."""
+    run_command("DROP TYPE IF EXISTS rep_num, rep_dbl, rep_txt;", superuser_conn)
+    run_command("CREATE TYPE rep_num AS (a numeric(50,2), b int);", superuser_conn)
+    run_command("CREATE TYPE rep_dbl AS (a double precision, b int);", superuser_conn)
+    run_command("CREATE TYPE rep_txt AS (a text, b int);", superuser_conn)
+    superuser_conn.commit()
+    try:
+        # numeric field -> double, matches a genuine float8 composite
+        assert _same(superuser_conn, "rep_num", "rep_dbl", True) is True
+        # but not a composite whose field is text (`string`)
+        assert _same(superuser_conn, "rep_num", "rep_txt", True) is False
+    finally:
+        run_command("DROP TYPE IF EXISTS rep_num, rep_dbl, rep_txt;", superuser_conn)
+        superuser_conn.commit()


### PR DESCRIPTION
## Problem

Deciding whether an `ALTER COLUMN ... TYPE` leaves an Iceberg table's stored schema unchanged means asking "do these two Postgres types get stored with the same Iceberg representation?" The transforms that shape how a column is physically stored already live in `pg_lake` — the create path's recursive unsupported-numeric-to-double conversion, and the compatibility-mode storage mapping — but there is no single entry point that reproduces them, so consumers reimplement the comparison (and can get it wrong: a top-level-only check treats `numeric(50,2)[]` as equal to `text[]` while the create path stores `list<double>` vs `list<string>`).

## Solution

Add an exported `SameIcebergStoredRepresentation(oldType, newType, context)` to `pg_lake_iceberg`. It reproduces the full stored schema for each type and compares the derived Iceberg field trees for type equality (ignoring field ids and defaults, which are per-derivation):

- derive each type's field tree with a conversion-aware derivation (`PostgresTypeToIcebergFieldConverted`) that applies the create path's unsupported-numeric rule at **every scalar leaf, recursively** — so a nested `numeric(50,2)[]` becomes `list<double>`, not the `string` fallback;
- then apply the compatibility storage mapping over the derived tree (`ApplyCompatibilityStorageMapping`), so e.g. a nested `uuid` is stored as `string` under `compatibility_mode='snowflake'` while a top-level `uuid` stays native.

The create-path settings that shape storage — `unsupported_numeric_as_double` and `compatibility_mode` — are passed in via an `IcebergCreatePathContext` rather than read from live state, because the GUC is `PGC_USERSET` and the mode is per-table: the comparison must use the values in effect when the target table was created. With the GUC off, an unsupported numeric has no faithful stored form (CREATE rejects it at any level), so the leaf is reported unrepresentable and the comparison is conservatively `false` rather than treating `numeric` as equal to `text`.

It answers only the representation question; it does not decide whether a given type change is otherwise permitted (casts, `USING` clauses, engine policy) — that stays with the caller.

## Test plan

- Adds a SQL-callable test wrapper `pg_lake_same_iceberg_representation(old_type text, new_type text, unsupported_numeric_as_double bool, compatibility_mode text)` and a pytest in `pg_lake_iceberg/tests/pytests/`, covering:
  - top-level same/different pairs: varchar length changes, varchar/char/text, smallint/integer, time/timetz, json/jsonb→text; int/bigint, numeric precision changes, timestamp/timestamptz, real/double;
  - nested/recursive cases: `numeric(50,2)[]` vs `text[]` (different — the false match this fixes), unsupported-numeric arrays vs a genuine `double precision[]` (same), and a composite with an unsupported-numeric field vs a float8 composite (same — exercises the struct recursion);
  - both GUC states: unsupported numeric → `double` at every level when on; unrepresentable (conservatively false) when off, with bounded numerics unaffected;
  - the depth-dependent snowflake compatibility uuid mapping: nested `uuid` ≈ `text` (both `string`), top-level `uuid` ≠ `text`.
- `make check-indent` clean (pgindent PG18 + black); builds with `-Werror`.
