### PR TITLE
Backport bug fixes to release-3.4

### DIFF
--- a/pg_extension_base/include/pg_extension_base/base_workers.h
+++ b/pg_extension_base/include/pg_extension_base/base_workers.h
@@ -104,6 +104,14 @@ extern bool EnableBaseWorkerLauncher;
 #define DEFAULT_WORKER_STARTER_SLEEP_TIME (10)
 extern int	WorkerStarterSleepTimeSec;
 
+/* pg_extension_base.worker_restart_backoff_* settings */
+#define DEFAULT_WORKER_RESTART_BACKOFF_INITIAL_MS (5000)
+#define DEFAULT_WORKER_RESTART_BACKOFF_MAX_MS (60000)
+#define DEFAULT_WORKER_RESTART_HEALTHY_MS (60000)
+extern int	WorkerRestartBackoffInitialMs;
+extern int	WorkerRestartBackoffMaxMs;
+extern int	WorkerRestartHealthyMs;
+
 void		BaseWorkerSharedMemoryInit(void);
 size_t		BaseWorkerSharedMemorySize(void);
 

--- a/pg_extension_base/pg_extension_base--3.5--3.6.sql
+++ b/pg_extension_base/pg_extension_base--3.5--3.6.sql
@@ -1,0 +1,16 @@
+-- Upgrade script for pg_extension_base from 3.5 to 3.6
+
+-- Add the failure_count column to list_base_workers so the exponential restart
+-- backoff is observable. Changing the OUT parameters changes the result type,
+-- which CREATE OR REPLACE cannot do, so drop and recreate the function.
+DROP FUNCTION extension_base.list_base_workers();
+
+CREATE FUNCTION extension_base.list_base_workers(OUT database_id oid, OUT worker_id int, OUT extension_id oid, OUT pid int, OUT needs_restart bool, OUT failure_count int)
+ RETURNS SETOF record
+ LANGUAGE c
+AS 'MODULE_PATHNAME', $function$pg_extension_base_list_base_workers$function$;
+
+COMMENT ON FUNCTION extension_base.list_base_workers()
+ IS 'list all base worker states';
+
+REVOKE ALL ON FUNCTION extension_base.list_base_workers() FROM public;

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -105,11 +105,17 @@
 #define MAX_WORKER_NAME_LENGTH (255)
 
 /*
- * When a base worker fails with an error, we avoid a crash loop by waiting at
- * least 5 seconds. We do not currently wake up the server and database starters,
- * so the total wait can be up to 15 seconds.
+ * When a base worker fails with an error we delay its restart to avoid a tight
+ * crash loop.  The delay grows exponentially with the number of consecutive
+ * failures: WorkerRestartBackoffInitialMs on the first failure, doubling on
+ * each subsequent failure, capped at WorkerRestartBackoffMaxMs.  The failure
+ * counter resets once a worker has stayed up for at least WorkerRestartHealthyMs,
+ * so a worker that runs fine and later hits a transient error backs off from the
+ * initial delay again instead of inheriting a stale, long delay.
+ *
+ * We do not currently wake up the server and database starters, so the total
+ * wait can be up to WorkerStarterSleepTimeSec longer than the computed delay.
  */
-#define NAP_TIME_AFTER_FAILURE (5000)
 
 #define PG_EXTENSION_BASE_EXTENSION_NAME "pg_extension_base"
 #define PG_EXTENSION_BASE_SCHEMA_NAME "extension_base"
@@ -225,6 +231,12 @@ typedef struct BaseWorkerEntry
 
 	/* when to restart the base worker (delayed after failure) */
 	TimestampTz restartAfter;
+
+	/* number of consecutive failures, used to compute the restart backoff */
+	int			failureCount;
+
+	/* when the worker last started running (for the healthy-uptime reset) */
+	TimestampTz startTime;
 }			BaseWorkerEntry;
 
 
@@ -357,6 +369,7 @@ static void BaseWorkerObjectAccessHook(ObjectAccessType access, Oid classId,
 static Oid	PgExtensionBaseExtensionId(void);
 static bool ExtensionExists(char *extensionName);
 static TimestampTz GetDelayedTimestamp(int64 millis);
+static int64 ComputeRestartBackoffMs(int failureCount);
 static void SignalDatabaseStarterLocked(Oid databaseId);
 static void DatabaseStarterNeedsRestart(Oid databaseId);
 static void PrepareForDrop(Oid databaseId, Oid extensionId);
@@ -399,6 +412,11 @@ static bool SignalServerStarter = false;
 /* pg_extension_base.worker_starter_sleep_time */
 int			WorkerStarterSleepTimeSec = DEFAULT_WORKER_STARTER_SLEEP_TIME;
 int32		MyBaseWorkerId = InvalidOid;
+
+/* pg_extension_base.worker_restart_backoff_* */
+int			WorkerRestartBackoffInitialMs = DEFAULT_WORKER_RESTART_BACKOFF_INITIAL_MS;
+int			WorkerRestartBackoffMaxMs = DEFAULT_WORKER_RESTART_BACKOFF_MAX_MS;
+int			WorkerRestartHealthyMs = DEFAULT_WORKER_RESTART_HEALTHY_MS;
 
 /*
  * InitializeBaseWorkerLauncher sets up hooks used by the base worker launcher.
@@ -1583,6 +1601,16 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 	workerEntry->state = WORKER_STARTING;
 	workerEntry->restartAfter = 0;
 
+	/*
+	 * Clear the last-run start time until the worker actually reaches
+	 * WORKER_RUNNING again.  This keeps the invariant that startTime is 0
+	 * whenever the current launch never reached WORKER_RUNNING, which the
+	 * healthy-uptime reset in PgExtensionBaseWorkerSharedMemoryExit relies on
+	 * to keep escalating the backoff through a startup crash loop rather than
+	 * reading a stale timestamp from an earlier healthy run.
+	 */
+	workerEntry->startTime = 0;
+
 	LWLockRelease(&BaseWorkerControl->lock);
 
 	/*
@@ -1893,6 +1921,7 @@ PgExtensionBaseWorkerMain(Datum arg)
 
 	workerEntry->state = WORKER_RUNNING;
 	workerEntry->workerPid = MyProcPid;
+	workerEntry->startTime = GetCurrentTimestamp();
 
 	Oid			entryPointFunctionId = workerEntry->entryPointFunctionId;
 	Oid			extensionId = workerEntry->extensionId;
@@ -2032,6 +2061,9 @@ PgExtensionBaseWorkerSharedMemoryExit(int code, Datum arg)
 
 		if (code == 0)
 		{
+			/* a clean exit is not part of a crash loop, so reset the backoff */
+			workerEntry->failureCount = 0;
+
 			/*
 			 * Clean exit - if needsRestart is already set, the worker
 			 * requested restart via its return value. Otherwise, no restart.
@@ -2069,11 +2101,35 @@ PgExtensionBaseWorkerSharedMemoryExit(int code, Datum arg)
 			}
 
 			/*
+			 * If the worker had been running for a while before it failed,
+			 * treat this as a fresh failure rather than a continuation of a
+			 * crash loop and reset the backoff.  startTime is 0 when the
+			 * worker never reached WORKER_RUNNING (i.e. it failed during
+			 * startup), in which case we keep escalating the delay.
+			 */
+			TimestampTz now = GetCurrentTimestamp();
+
+			if (workerEntry->startTime != 0 &&
+				TimestampDifferenceExceeds(workerEntry->startTime, now,
+										   WorkerRestartHealthyMs))
+				workerEntry->failureCount = 0;
+
+			workerEntry->failureCount++;
+
+			int64		backoffMs = ComputeRestartBackoffMs(workerEntry->failureCount);
+
+			/*
 			 * Also tell the database starter that we want to restart
 			 */
 			workerEntry->needsRestart = true;
 			workerEntry->state = WORKER_RESTARTING;
-			workerEntry->restartAfter = GetDelayedTimestamp(NAP_TIME_AFTER_FAILURE);
+			workerEntry->restartAfter = GetDelayedTimestamp(backoffMs);
+
+			ereport(LOG,
+					(errmsg("base worker %d in database %u failed %d time(s) in "
+							"a row; delaying restart by %ld ms",
+							workerId, databaseId, workerEntry->failureCount,
+							(long) backoffMs)));
 		}
 	}
 	else
@@ -2864,6 +2920,29 @@ GetDelayedTimestamp(int64 millis)
 
 
 /*
+ * ComputeRestartBackoffMs returns the delay in milliseconds before a base
+ * worker that has failed failureCount times in a row should be restarted.
+ *
+ * The delay starts at WorkerRestartBackoffInitialMs on the first failure and
+ * doubles on each subsequent consecutive failure, capped at
+ * WorkerRestartBackoffMaxMs.
+ */
+static int64
+ComputeRestartBackoffMs(int failureCount)
+{
+	int64		backoffMs = WorkerRestartBackoffInitialMs;
+
+	for (int i = 1; i < failureCount && backoffMs < WorkerRestartBackoffMaxMs; i++)
+		backoffMs *= 2;
+
+	if (backoffMs > WorkerRestartBackoffMaxMs)
+		backoffMs = WorkerRestartBackoffMaxMs;
+
+	return backoffMs;
+}
+
+
+/*
  * SignalDatabaseStarterLocked signals the database starter for the given
  * database to wake up, or falls back to signaling the server starter.
  *
@@ -2983,13 +3062,14 @@ pg_extension_base_list_base_workers(PG_FUNCTION_ARGS)
 
 	while ((baseWorkerEntry = (BaseWorkerEntry *) hash_seq_search(&status)) != 0)
 	{
-		bool		nulls[] = {false, false, false, false, false};
+		bool		nulls[] = {false, false, false, false, false, false};
 		Datum		values[] = {
 			ObjectIdGetDatum(baseWorkerEntry->key.databaseId),
 			Int32GetDatum(baseWorkerEntry->key.workerId),
 			ObjectIdGetDatum(baseWorkerEntry->extensionId),
 			Int32GetDatum(baseWorkerEntry->workerPid),
 			BoolGetDatum(baseWorkerEntry->needsRestart),
+			Int32GetDatum(baseWorkerEntry->failureCount),
 		};
 
 		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);

--- a/pg_extension_base/src/pg_extension_base.c
+++ b/pg_extension_base/src/pg_extension_base.c
@@ -121,6 +121,50 @@ _PG_init(void)
 							NULL,
 							NULL);
 
+	DefineCustomIntVariable("pg_extension_base.worker_restart_backoff_initial",
+							"Sets the delay before restarting a base worker after its "
+							"first failure. The delay doubles on each subsequent "
+							"consecutive failure.",
+							NULL,
+							&WorkerRestartBackoffInitialMs,
+							DEFAULT_WORKER_RESTART_BACKOFF_INITIAL_MS,
+							0,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomIntVariable("pg_extension_base.worker_restart_backoff_max",
+							"Sets the maximum delay before restarting a base worker "
+							"that keeps failing.",
+							NULL,
+							&WorkerRestartBackoffMaxMs,
+							DEFAULT_WORKER_RESTART_BACKOFF_MAX_MS,
+							0,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomIntVariable("pg_extension_base.worker_restart_healthy_time",
+							"Sets how long a base worker must stay up before a later "
+							"failure is treated as fresh, resetting the restart "
+							"backoff to its initial delay.",
+							NULL,
+							&WorkerRestartHealthyMs,
+							DEFAULT_WORKER_RESTART_HEALTHY_MS,
+							0,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
+
 	/*
 	 * Install our ProcessUtility hook for ALTER EXTENSION ... UPDATE
 	 * dependency walking BEFORE preloading other extensions.  Postgres

--- a/pg_extension_base/tests/pg_extension_base_test_hibernate/src/pg_extension_base_hibernate.c
+++ b/pg_extension_base/tests/pg_extension_base_test_hibernate/src/pg_extension_base_hibernate.c
@@ -29,6 +29,7 @@
 #include "miscadmin.h"
 
 #include "pg_extension_base/base_workers.h"
+#include "utils/guc.h"
 
 PG_MODULE_MAGIC;
 
@@ -38,6 +39,14 @@ void		_PG_init(void);
 /* UDF implementations */
 PG_FUNCTION_INFO_V1(pg_extension_base_test_hibernate_main_worker);
 
+/*
+ * Fault-injection knob for exercising the base-worker restart backoff.  When
+ * >= 0 the worker runs for this many milliseconds and then errors out, so a
+ * test can drive a crash loop deterministically.  -1 (the default) disables the
+ * fault and the worker hibernates normally.
+ */
+static int	FailAfterMs = -1;
+
 
 /*
  * _PG_init is the entry-point for pg_extension_base_test_hibernate.
@@ -45,7 +54,19 @@ PG_FUNCTION_INFO_V1(pg_extension_base_test_hibernate_main_worker);
 void
 _PG_init(void)
 {
-	/* No GUCs needed for now */
+	DefineCustomIntVariable(
+							"pg_extension_base_test_hibernate.fail_after",
+							gettext_noop("Milliseconds the worker runs before erroring "
+										 "out, or -1 to disable (for testing the "
+										 "restart backoff)."),
+							NULL,
+							&FailAfterMs,
+							-1,
+							-1,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS,
+							NULL, NULL, NULL);
 }
 
 
@@ -59,6 +80,21 @@ pg_extension_base_test_hibernate_main_worker(PG_FUNCTION_ARGS)
 	int32		workerId = PG_GETARG_INT32(0);
 
 	elog(LOG, "pg_extension_base_test_hibernate worker %d started", workerId);
+
+	/*
+	 * Fault injection for the restart-backoff tests: optionally run for a
+	 * fixed time and then error out so the worker exits non-cleanly and the
+	 * base-worker framework applies its exponential restart backoff.
+	 */
+	if (FailAfterMs >= 0)
+	{
+		if (FailAfterMs > 0)
+			pg_usleep(FailAfterMs * 1000L);
+
+		elog(ERROR, "pg_extension_base_test_hibernate worker %d failing on "
+			 "purpose (fail_after)", workerId);
+	}
+
 	elog(LOG, "pg_extension_base_test_hibernate worker %d sleeping for 5 seconds", workerId);
 
 	pg_usleep(5000000);

--- a/pg_extension_base/tests/pytests/test_base_worker_launcher.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_launcher.py
@@ -524,3 +524,161 @@ def test_hibernate_worker_restart_delay(superuser_conn):
     superuser_conn.commit()
 
     assert count_pg_extension_base_workers(superuser_conn) == 0
+
+
+def hibernate_worker_failure_count(conn):
+    """
+    Return the restart-backoff failure count for the hibernate test worker, or
+    None if it is not currently registered.
+    """
+    rows = run_query(
+        """
+        SELECT w.failure_count
+        FROM extension_base.list_base_workers() w
+        JOIN pg_extension e ON e.oid = w.extension_id
+        WHERE e.extname = 'pg_extension_base_test_hibernate'
+        """,
+        conn,
+    )
+    return rows[0]["failure_count"] if rows else None
+
+
+def set_backoff_gucs(conn, initial_ms, max_ms, healthy_ms, fail_after_ms):
+    """
+    Configure the restart-backoff GUCs and the hibernate worker's fault
+    injection, then reload so freshly (re)started workers pick them up.
+
+    fail_after lives in the hibernate test library, so LOAD it into this
+    backend first to make the placeholder known to ALTER SYSTEM.
+    """
+    # End any transaction a prior test left open; autocommit can't be toggled
+    # while one is in progress.
+    conn.rollback()
+    conn.autocommit = True
+    try:
+        run_command("LOAD 'pg_extension_base_test_hibernate'", conn)
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base.worker_restart_backoff_initial = '{initial_ms}ms'",
+            conn,
+        )
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base.worker_restart_backoff_max = '{max_ms}ms'",
+            conn,
+        )
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base.worker_restart_healthy_time = '{healthy_ms}ms'",
+            conn,
+        )
+        run_command(
+            f"ALTER SYSTEM SET pg_extension_base_test_hibernate.fail_after = '{fail_after_ms}ms'",
+            conn,
+        )
+        run_command("SELECT pg_reload_conf()", conn)
+    finally:
+        conn.autocommit = False
+
+
+def reset_backoff_gucs(conn):
+    conn.rollback()
+    conn.autocommit = True
+    try:
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base.worker_restart_backoff_initial", conn
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base.worker_restart_backoff_max", conn
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base.worker_restart_healthy_time", conn
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_extension_base_test_hibernate.fail_after", conn
+        )
+        run_command("SELECT pg_reload_conf()", conn)
+    finally:
+        conn.autocommit = False
+
+
+def test_worker_restart_backoff_escalates(superuser_conn):
+    """
+    A worker that keeps failing at startup should have its failure count climb
+    while the exponential backoff throttles the restart rate.
+
+    fail_after=0 makes the worker error out immediately (so it never stays up
+    long enough to be considered healthy), and healthy_time is large so the
+    failure counter is never reset.
+    """
+    set_backoff_gucs(
+        superuser_conn, initial_ms=100, max_ms=400, healthy_ms=30000, fail_after_ms=0
+    )
+
+    run_command(
+        "CREATE EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+    )
+    superuser_conn.commit()
+
+    try:
+        # Poll for up to ~5s until the failure count escalates.
+        counts = []
+        for _ in range(20):
+            time.sleep(0.25)
+            fc = hibernate_worker_failure_count(superuser_conn)
+            if fc is not None:
+                counts.append(fc)
+            if counts and counts[-1] >= 3:
+                break
+
+        assert counts, "hibernate worker was never registered"
+
+        # The counter escalated, proving repeated failures are being tracked.
+        assert max(counts) >= 3, f"failure count did not escalate: {counts}"
+
+        # With a >=100ms backoff that doubles up to 400ms, the worker restarts a
+        # handful of times per second at most. Without any delay it would crash
+        # loop hundreds of times in the same window, so a modest ceiling proves
+        # the restart is actually being throttled.
+        assert max(counts) < 100, f"restarts were not throttled: {counts}"
+    finally:
+        run_command(
+            "DROP EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+        )
+        superuser_conn.commit()
+        reset_backoff_gucs(superuser_conn)
+
+
+def test_worker_restart_backoff_resets_after_healthy_uptime(superuser_conn):
+    """
+    A worker that stays up longer than the healthy threshold before failing
+    should not accumulate backoff: each failure is treated as fresh, so the
+    failure count never climbs past 1.
+    """
+    # fail_after (600ms) > healthy_time (300ms): every run is "healthy".
+    set_backoff_gucs(
+        superuser_conn, initial_ms=100, max_ms=400, healthy_ms=300, fail_after_ms=600
+    )
+
+    run_command(
+        "CREATE EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+    )
+    superuser_conn.commit()
+
+    try:
+        counts = []
+        for _ in range(12):  # ~4.8s, several fail/restart cycles
+            time.sleep(0.4)
+            fc = hibernate_worker_failure_count(superuser_conn)
+            if fc is not None:
+                counts.append(fc)
+
+        assert counts, "hibernate worker was never registered"
+
+        # We should have observed at least one failure (count reaching 1) but it
+        # must never escalate, because the healthy-uptime reset fires each time.
+        assert max(counts) <= 1, f"backoff did not reset after healthy uptime: {counts}"
+        assert 1 in counts, f"worker never failed as expected: {counts}"
+    finally:
+        run_command(
+            "DROP EXTENSION pg_extension_base_test_hibernate CASCADE", superuser_conn
+        )
+        superuser_conn.commit()
+        reset_backoff_gucs(superuser_conn)

--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -930,6 +930,133 @@ def test_copy_to_array_with_nulls(pg_conn, duckdb_conn, tmp_path):
     assert rows[4] == (5, [4, 5])
     assert rows[9] == (10, None)
 
+
+# An unbounded numeric column maps to DuckDB DECIMAL(38,9) when the CSV is
+# converted to Parquet, which allows only 38 - 9 = 29 integral digits. COPY TO
+# validates this on the PostgreSQL side (before the value reaches the CSV), and
+# the validation must reach numeric leaves nested inside arrays, composites,
+# maps, and domains -- not just top-level numeric columns. Special values
+# (NaN/Infinity/-Infinity), valid PG input for an unbounded numeric but not
+# representable as a DuckDB DECIMAL, must be rejected at those leaves too.
+#
+# A 30-digit integer trips the cap; a 29-digit one is exactly at the limit and
+# must still succeed.
+NUMERIC_OVER_LIMIT = 10**29  # 30 integral digits -> rejected
+NUMERIC_AT_LIMIT = 10**28  # 29 integral digits -> allowed
+EXCEEDS_DIGITS_ERROR = "exceeds max allowed digits"
+SPECIAL_NUMERIC_ERROR = "Special numeric values"
+
+# The nested container shapes that carry a numeric leaf. Every one must be
+# walked by the COPY TO numeric validation.  "array_of_composite" is the
+# deeply-nested case: the numeric leaf sits two container levels down
+# (array -> composite -> numeric).
+NESTED_NUMERIC_KINDS = [
+    "array",
+    "composite",
+    "map",
+    "domain_scalar",
+    "domain_array",
+    "array_of_composite",
+]
+
+
+def _create_nested_numeric_types(pg_conn):
+    # Tolerate the map type already existing from a previous run; the composite
+    # and domains live in the caller's (uncommitted) transaction.
+    create_map_type("int", "numeric", raise_error=False)
+    run_command(
+        """
+        CREATE SCHEMA IF NOT EXISTS lake_struct;
+        CREATE TYPE lake_struct.cost_pair AS (label text, amount numeric);
+        CREATE DOMAIN cost_scalar AS numeric;
+        CREATE DOMAIN cost_array AS numeric[];
+        """,
+        pg_conn,
+    )
+
+
+def _nested_numeric_select(kind, expr, token):
+    """Build a SELECT that places a numeric leaf inside the given container.
+
+    `expr` is a SQL numeric expression used by the array/composite/domain
+    shapes; `token` is the bare value spliced into the map's composite text
+    literal (where an `'x'::numeric` cast is not valid).  The map's braces come
+    from a plain Python string so they are inserted verbatim, not parsed as
+    f-string replacement fields.
+    """
+    map_literal = '{"(1,500.00)","(2,%s)"}' % token
+    return {
+        "array": f"SELECT ARRAY[500.00, {expr}]::numeric[] AS v",
+        "composite": f"SELECT ('airfare', {expr})::lake_struct.cost_pair AS v",
+        "map": f"SELECT '{map_literal}'::map_type.key_int_val_numeric AS v",
+        "domain_scalar": f"SELECT {expr}::cost_scalar AS v",
+        "domain_array": f"SELECT ARRAY[500.00, {expr}]::cost_array AS v",
+        "array_of_composite": (
+            f"SELECT ARRAY[('base', 500.00)::lake_struct.cost_pair, "
+            f"('leaf', {expr})::lake_struct.cost_pair]::lake_struct.cost_pair[] AS v"
+        ),
+    }[kind]
+
+
+@pytest.mark.parametrize("kind", NESTED_NUMERIC_KINDS)
+def test_nested_unbounded_numeric(pg_conn, tmp_path, kind):
+    parquet_path = tmp_path / "test.parquet"
+
+    _create_nested_numeric_types(pg_conn)
+
+    over = str(NUMERIC_OVER_LIMIT)
+
+    # An oversized numeric leaf (30 integral digits) is rejected wherever it
+    # sits in the nested structure. (The within-cap acceptance path is covered
+    # by test_nested_numeric_roundtrip; a nested numeric Parquet write is a
+    # separate concern from the digit-limit validation exercised here.)
+    error = run_command(
+        f"COPY ({_nested_numeric_select(kind, over, over)}) "
+        f"TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+    assert EXCEEDS_DIGITS_ERROR in error, f"{kind}: {error}"
+
+    pg_conn.rollback()
+
+
+@pytest.mark.parametrize("special", ["NaN", "Infinity", "-Infinity"])
+@pytest.mark.parametrize("kind", NESTED_NUMERIC_KINDS)
+def test_nested_special_numeric(pg_conn, tmp_path, kind, special):
+    parquet_path = tmp_path / "test.parquet"
+
+    _create_nested_numeric_types(pg_conn)
+
+    expr = f"'{special}'::numeric"
+    error = run_command(
+        f"COPY ({_nested_numeric_select(kind, expr, special)}) "
+        f"TO '{parquet_path}' WITH (format 'parquet')",
+        pg_conn,
+        raise_error=False,
+    )
+    assert SPECIAL_NUMERIC_ERROR in error, f"{kind} / {special}: {error}"
+
+    pg_conn.rollback()
+
+
+def test_nested_numeric_roundtrip(pg_conn, tmp_path):
+    # A within-cap numeric[] survives the COPY TO Parquet / COPY FROM round-trip
+    # with its values intact (guards against the validation over-rejecting).
+    parquet_path = tmp_path / "test.parquet"
+
+    run_command(
+        f"""
+        CREATE TABLE test_num_array (a numeric[]);
+        COPY (SELECT ARRAY[500.00, {NUMERIC_AT_LIMIT}]::numeric[] AS a)
+        TO '{parquet_path}' WITH (format 'parquet');
+        COPY test_num_array FROM '{parquet_path}' WITH (format 'parquet');
+        """,
+        pg_conn,
+    )
+    result = run_query("SELECT a FROM test_num_array", pg_conn)
+    assert result[0]["a"] == [Decimal("500.00"), Decimal(NUMERIC_AT_LIMIT)]
+
     pg_conn.rollback()
 
 

--- a/pg_lake_engine/include/pg_lake/pgduck/numeric.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/numeric.h
@@ -18,6 +18,8 @@
 #pragma once
 #include "postgres.h"
 
+#include "utils/numeric.h"
+
 /*
  * Maximum precision and scale for numeric types in DuckDB.
  */
@@ -49,3 +51,4 @@ extern PGDLLEXPORT void GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(int
 																			 int *scale);
 extern PGDLLEXPORT bool CanPushdownNumericToDuckdb(int precision, int scale);
 extern PGDLLEXPORT bool IsUnsupportedNumericForIceberg(Oid typeOid, int typmod);
+extern PGDLLEXPORT int NumericIntegralDigitCount(Numeric num);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -29,6 +29,7 @@
 #include "fmgr.h"
 #include "miscadmin.h"
 
+#include "access/htup_details.h"
 #include "catalog/pg_type_d.h"
 #include "commands/copy.h"
 #include "commands/defrem.h"
@@ -43,11 +44,13 @@
 #include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
 #include "port/pg_bswap.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/numeric.h"
 #include "utils/rel.h"
+#include "utils/typcache.h"
 
 
 /*
@@ -102,6 +105,13 @@ typedef struct CopyToStateData
 	MemoryContext copycontext;	/* per-copy execution context */
 
 	FmgrInfo   *out_functions;	/* lookup info for output functions */
+
+	/*
+	 * Per-column flag: the column's type reaches a numeric leaf (directly, or
+	 * nested inside an array/composite/map/domain).  Precomputed once so the
+	 * per-row numeric-limit validation only walks columns that can trip it.
+	 */
+	bool	   *needsNumericLeafCheck;
 	MemoryContext rowcontext;	/* per-row evaluation context */
 	uint64		bytes_processed;	/* number of bytes processed so far */
 
@@ -143,8 +153,10 @@ static void CopySendInt16(CopyToState cstate, int16 val);
 static List *TupleDescColumnNameList(TupleDesc tupleDescriptor);
 static List *CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist);
 static bool ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType);
-static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr);
-static void ErrorIfSpecialNumeric(const char *input_str);
+static void ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(Numeric num);
+static bool TypeContainsNumeric(Oid typeOid);
+static void ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid,
+													 int32 typmod);
 
 
 /*----------
@@ -454,6 +466,7 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 
 	/* Get info about the columns we need to process. */
 	cstate->out_functions = (FmgrInfo *) palloc(num_phys_attrs * sizeof(FmgrInfo));
+	cstate->needsNumericLeafCheck = (bool *) palloc0(num_phys_attrs * sizeof(bool));
 	foreach(cur, cstate->attnumlist)
 	{
 		int			attnum = lfirst_int(cur);
@@ -470,6 +483,9 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 							  &out_func_oid,
 							  &isvarlena);
 		fmgr_info(out_func_oid, &cstate->out_functions[attnum - 1]);
+
+		cstate->needsNumericLeafCheck[attnum - 1] =
+			TypeContainsNumeric(attr->atttypid);
 	}
 
 	/*
@@ -649,69 +665,212 @@ CopyGetAttnumsFixed(TupleDesc tupDesc, List *attnamelist)
 
 /*
  * ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits ensures the integral
- * digits of the numeric string do not exceed the max allowed digits during
- * COPY TO.
+ * digits of an unbounded numeric do not exceed the max allowed digits during
+ * COPY TO.  The count is read from the value's weight, so this is O(1) with no
+ * allocation.
  *
  * Excess fractional (decimal) digits are intentionally allowed here because
  * DuckDB's DECIMAL(P,S) will round them during the CSV-to-Parquet conversion.
  */
 static void
-ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(const char *numericStr)
+ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(Numeric num)
 {
-	int			totalIntegralDigits = 0;
-	bool		foundDotSeparator = false;
+	int			maxAllowedDigits =
+		UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale;
 
-	for (int i = 0; numericStr[i] != '\0'; i++)
-	{
-		if (numericStr[i] == '.')
-		{
-			foundDotSeparator = true;
-			continue;
-		}
-
-		if (!isdigit(numericStr[i]))
-			continue;
-
-		if (!foundDotSeparator)
-			totalIntegralDigits++;
-
-		if (totalIntegralDigits > (UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale))
-		{
-			ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
-							errmsg("unbounded numeric type exceeds max allowed digits %d "
-								   "before decimal point",
-								   UnboundedNumericDefaultPrecision - UnboundedNumericDefaultScale),
-							errhint("Consider specifying precision and scale for numeric types, "
-									"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
-		}
-	}
+	if (NumericIntegralDigitCount(num) > maxAllowedDigits)
+		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
+						errmsg("unbounded numeric type exceeds max allowed digits %d "
+							   "before decimal point",
+							   maxAllowedDigits),
+						errhint("Consider specifying precision and scale for numeric types, "
+								"i.e. \"numeric(P,S)\" instead of \"numeric\".")));
 }
 
 
 /*
-* ErrorIfSpecialNumeric ensures that the input string does not contain
-* special numeric values like NaN, Inf, -Inf.
-*/
-static void
-ErrorIfSpecialNumeric(const char *input_str)
+ * TypeContainsNumeric returns true if `typeOid` reaches a numeric leaf at any
+ * nesting depth: as the type itself, an array element, a composite field, a
+ * map key/value, or through a domain over any of these.
+ *
+ * Only structural catalog lookups are done here, so it is meant to be called
+ * once per column at COPY setup (see needsNumericLeafCheck) rather than per
+ * row.  Composite types cannot contain themselves, so the recursion always
+ * terminates.
+ */
+static bool
+TypeContainsNumeric(Oid typeOid)
 {
+	if (typeOid == NUMERICOID)
+		return true;
 
-	char	   *num = (char *) input_str;
+	Oid			elemType = get_element_type(typeOid);
 
-	/* skip leading whitespace */
-	while (*num != '\0' && isspace((unsigned char) *num))
-		num++;
+	if (OidIsValid(elemType))
+		return TypeContainsNumeric(elemType);
 
-	if (pg_strncasecmp(num, "NaN", 3) == 0 ||
-		pg_strncasecmp(num, "Infinity", 8) == 0 ||
-		pg_strncasecmp(num, "+Infinity", 9) == 0 ||
-		pg_strncasecmp(num, "-Infinity", 9) == 0 ||
-		pg_strncasecmp(num, "inf", 3) == 0 ||
-		pg_strncasecmp(num, "+inf", 4) == 0 ||
-		pg_strncasecmp(num, "-inf", 4) == 0)
+	char		typtype = get_typtype(typeOid);
+
+	/*
+	 * Domains (including pg_map, which is a domain over an array of key/value
+	 * composites) unwrap to their base type, which feeds back into the array
+	 * and composite recursion above.
+	 */
+	if (typtype == TYPTYPE_DOMAIN)
+		return TypeContainsNumeric(getBaseType(typeOid));
+
+	if (typtype == TYPTYPE_COMPOSITE)
 	{
-		ereport(ERROR, errmsg("Special numeric values like NaN, Inf, -Inf are not allowed for numeric type"),
-				errhint("Use float type instead."));
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(typeOid, -1);
+		bool		found = false;
+
+		for (int i = 0; i < tupdesc->natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+			if (attr->attisdropped)
+				continue;
+
+			if (TypeContainsNumeric(attr->atttypid))
+			{
+				found = true;
+				break;
+			}
+		}
+
+		ReleaseTupleDesc(tupdesc);
+		return found;
+	}
+
+	return false;
+}
+
+
+/*
+ * ErrorIfCopyToExceedsNumericLimitsInDatum applies the COPY TO numeric limits
+ * to every numeric leaf reachable from `value`, recursing through arrays,
+ * composites, maps, and domains.  Each numeric leaf is subject to the same
+ * checks a top-level numeric column receives: an unbounded numeric may not
+ * exceed the integral-digit cap
+ * (ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits), and no numeric may
+ * be NaN/Infinity (ErrorIfSpecialNumeric).  Non-numeric leaves are ignored.
+ *
+ * Callers gate on the column type actually containing a numeric leaf (see
+ * needsNumericLeafCheck), so this is only entered for values that can trip a
+ * limit; the inner TypeContainsNumeric guards prune subtrees with no numeric
+ * so we never deconstruct an array or deform a tuple needlessly.
+ *
+ * An array's typmod applies to its element type, so it is forwarded to the
+ * element recursion (matching how numeric(P,S)[] carries the element typmod).
+ */
+static void
+ErrorIfCopyToExceedsNumericLimitsInDatum(Datum value, Oid typeOid, int32 typmod)
+{
+	if (typeOid == NUMERICOID)
+	{
+		Numeric		num = DatumGetNumeric(value);
+
+		/*
+		 * The NaN/Infinity check only needs the numeric header flags, so read
+		 * them directly instead of formatting the value to text.  This keeps
+		 * the common (finite) case free of the numeric_out allocation and
+		 * string scan.
+		 */
+		if (numeric_is_nan(num) || numeric_is_inf(num))
+			ereport(ERROR,
+					errmsg("Special numeric values like NaN, Inf, -Inf are not allowed for numeric type"),
+					errhint("Use float type instead."));
+
+		/* only unbounded numerics are subject to the integral-digit cap */
+		if (IsUnboundedNumeric(NUMERICOID, typmod))
+			ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(num);
+
+		return;
+	}
+
+	Oid			elemType = get_element_type(typeOid);
+
+	if (OidIsValid(elemType))
+	{
+		if (!TypeContainsNumeric(elemType))
+			return;
+
+		int16		elmlen;
+		bool		elmbyval;
+		char		elmalign;
+		Datum	   *elems;
+		bool	   *nulls;
+		int			nelems;
+		ArrayType  *array = DatumGetArrayTypeP(value);
+
+		get_typlenbyvalalign(elemType, &elmlen, &elmbyval, &elmalign);
+		deconstruct_array(array, elemType, elmlen, elmbyval, elmalign,
+						  &elems, &nulls, &nelems);
+
+		for (int i = 0; i < nelems; i++)
+		{
+			if (nulls[i])
+				continue;
+
+			ErrorIfCopyToExceedsNumericLimitsInDatum(elems[i], elemType, typmod);
+		}
+
+		return;
+	}
+
+	char		typtype = get_typtype(typeOid);
+
+	/*
+	 * Domains (including maps): unwrap to the base type and recurse.  Maps
+	 * are domains over arrays of composites, so unwrapping leads to the array
+	 * -> composite recursion above.
+	 */
+	if (typtype == TYPTYPE_DOMAIN)
+	{
+		int32		baseTypmod = typmod;
+		Oid			baseType = getBaseTypeAndTypmod(typeOid, &baseTypmod);
+
+		ErrorIfCopyToExceedsNumericLimitsInDatum(value, baseType, baseTypmod);
+		return;
+	}
+
+	/* composite: deform the tuple and recurse into each field */
+	if (typtype == TYPTYPE_COMPOSITE)
+	{
+		HeapTupleHeader tup = DatumGetHeapTupleHeader(value);
+		Oid			tupType = HeapTupleHeaderGetTypeId(tup);
+		int32		tupTypmod = HeapTupleHeaderGetTypMod(tup);
+		TupleDesc	tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
+		int			natts = tupdesc->natts;
+		HeapTupleData tmptup;
+		Datum	   *values = (Datum *) palloc(natts * sizeof(Datum));
+		bool	   *attrNulls = (bool *) palloc(natts * sizeof(bool));
+
+		tmptup.t_len = HeapTupleHeaderGetDatumLength(tup);
+		ItemPointerSetInvalid(&(tmptup.t_self));
+		tmptup.t_tableOid = InvalidOid;
+		tmptup.t_data = tup;
+
+		heap_deform_tuple(&tmptup, tupdesc, values, attrNulls);
+
+		for (int i = 0; i < natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+			if (attr->attisdropped || attrNulls[i])
+				continue;
+
+			if (!TypeContainsNumeric(attr->atttypid))
+				continue;
+
+			ErrorIfCopyToExceedsNumericLimitsInDatum(values[i], attr->atttypid,
+													 attr->atttypmod);
+		}
+
+		pfree(values);
+		pfree(attrNulls);
+		ReleaseTupleDesc(tupdesc);
+		return;
 	}
 }
 
@@ -789,17 +948,19 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 
 				/*
 				 * iceberg validation is handled separately for numeric types
-				 * (see IcebergErrorOrClampDatum)
+				 * (see IcebergErrorOrClampDatum).
+				 *
+				 * For every other target format, validate each numeric leaf
+				 * of the column -- including those nested inside arrays,
+				 * composites, maps, and domains -- against the numeric limits
+				 * DuckDB enforces when it converts the intermediate CSV to
+				 * the target type.
 				 */
-				if (attr->atttypid == NUMERICOID &&
-					cstate->targetFormat != DATA_FORMAT_ICEBERG)
-				{
-					if (IsUnboundedNumeric(NUMERICOID, attr->atttypmod))
-						ErrorIfCopyToExceedsUnboundedNumericMaxAllowedDigits(string);
-
-					/* do not allow Nan, Inf etc. */
-					ErrorIfSpecialNumeric(string);
-				}
+				if (cstate->targetFormat != DATA_FORMAT_ICEBERG &&
+					cstate->needsNumericLeafCheck[attnum - 1])
+					ErrorIfCopyToExceedsNumericLimitsInDatum(value,
+															 attr->atttypid,
+															 attr->atttypmod);
 
 
 				if (cstate->opts.csv_mode)

--- a/pg_lake_engine/src/data_file/data_file_stats.c
+++ b/pg_lake_engine/src/data_file/data_file_stats.c
@@ -87,13 +87,19 @@ ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 									   CopyDataFormat destinationFormat)
 {
 	PGDuckConnection *pgDuckConn = GetPGDuckConnection();
-	PGresult   *result;
+	PGresult   *volatile result = NULL;
 	StatsCollector *statsCollector = NULL;
 
 	PG_TRY();
 	{
 		result = ExecuteQueryOnPGDuckConnection(pgDuckConn, copyCommand);
-		CheckPGDuckResult(pgDuckConn, result);
+
+		/*
+		 * Use the non-clearing check: the PG_FINALLY below owns the result
+		 * and CheckPGDuckResult would already PQclear it before throwing,
+		 * leading to a double free.
+		 */
+		ThrowIfPGDuckResultHasError(pgDuckConn, result);
 
 		if (destinationFormat == DATA_FORMAT_PARQUET ||
 			destinationFormat == DATA_FORMAT_ICEBERG)
@@ -133,11 +139,11 @@ ExecuteCopyToCommandOnPGDuckConnection(char *copyCommand,
 				statsCollector->dataFileStats = list_make1(fileStats);
 			}
 		}
-
-		PQclear(result);
 	}
 	PG_FINALLY();
 	{
+		/* PQclear is a no-op on NULL, so this is safe on early errors */
+		PQclear(result);
 		ReleasePGDuckConnection(pgDuckConn);
 	}
 	PG_END_TRY();

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -347,8 +347,15 @@ ExecuteOptionalCommandInPGDuck(char *command)
 
 
 /*
- * ExecuteQueryOnPGDuckConnection executes the given query in PGDuck on the given
- * connection.
+ * ExecuteQueryOnPGDuckConnection executes the given query in PGDuck on the
+ * given connection.
+ *
+ * On a send failure we error instead of reconnecting and re-sending:
+ * PQsendQuery can report failure after the query already reached the server,
+ * so re-sending a write (e.g. a COPY ... TO that creates a data file) could
+ * execute it twice. Every caller gets a fresh connection right before this,
+ * so there is nothing to rescue by resending; the transaction just aborts and
+ * retries.
  */
 PGresult *
 ExecuteQueryOnPGDuckConnection(PGDuckConnection * pgDuckConnection,
@@ -359,25 +366,10 @@ ExecuteQueryOnPGDuckConnection(PGDuckConnection * pgDuckConnection,
 	elog(DEBUG2, "PGDuck: %s", query);
 #endif
 
-	int			sentQuery = PQsendQuery(conn, query);
+	if (PQsendQuery(conn, query) == 0)
+		ereport(ERROR, (errmsg("lost connection to query engine")));
 
-	if (sentQuery == 0)
-	{
-		ReleasePGDuckConnection(pgDuckConnection);
-
-		/* may have lost connection, retry once */
-		pgDuckConnection = GetPGDuckConnection();
-		conn = pgDuckConnection->conn;
-		sentQuery = PQsendQuery(conn, query);
-		if (sentQuery == 0)
-		{
-			ereport(ERROR, (errmsg("lost connection to query engine")));
-		}
-	}
-
-	PGresult   *result = WaitForLastResult(pgDuckConnection);
-
-	return result;
+	return WaitForLastResult(pgDuckConnection);
 }
 
 
@@ -417,20 +409,14 @@ WaitForResult(PGDuckConnection * pgDuckConnection)
 			if (!PQconsumeInput(conn))
 			{
 				/*
-				 * Do not release the connection here — WaitForResult does
-				 * not own it.  Connection lifetime is the caller's
+				 * Do not release the connection here: WaitForResult does not
+				 * own it.  Connection lifetime is the caller's
 				 * responsibility: either an enclosing PG_TRY/PG_FINALLY
 				 * releases it, or the transaction/subtransaction abort
 				 * callback (PGDuckClientTransactionCallback /
 				 * ...SubtransactionCallback) sweeps it on XACT_EVENT_ABORT.
-				 *
-				 * Releasing here is actively harmful:
-				 * ExecuteQueryOnPGDuckConnection's retry path may have
-				 * already swapped the hash slot out from under the caller's
-				 * pointer, so the caller's subsequent release either
-				 * double-frees the *new* connection (if dynahash reused the
-				 * slab) or PQfinish()'s an already-freed PGconn (if it
-				 * didn't).
+				 * Releasing here would risk a double-free or PQfinish() of a
+				 * connection the caller still holds a pointer to.
 				 */
 				ereport(ERROR, (errmsg("lost connection to query engine")));
 			}

--- a/pg_lake_engine/src/pgduck/numeric.c
+++ b/pg_lake_engine/src/pgduck/numeric.c
@@ -17,6 +17,8 @@
 
 #include "postgres.h"
 
+#include "varatt.h"
+
 #include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/numeric.h"
 #include "catalog/pg_type.h"
@@ -102,6 +104,113 @@ IsUnsupportedNumericForIceberg(Oid typeOid, int typmod)
 
 	return precision > DUCKDB_MAX_NUMERIC_PRECISION ||
 		scale > DUCKDB_MAX_NUMERIC_SCALE;
+}
+
+/*
+ * A numeric's weight (the base-10000 exponent of its most significant digit)
+ * is stored directly in the value's on-disk header, so the number of integral
+ * digits can be derived arithmetically instead of formatting the whole value
+ * to text with numeric_out.
+ *
+ * The public numeric.h keeps struct NumericData opaque, so we mirror just the
+ * fields we read.  This layout, and the weight/digit macros below, have been
+ * stable in PostgreSQL since the base-10000 representation was introduced in
+ * 8.3.  DatumGetNumeric() always returns a fully detoasted value with a 4-byte
+ * varlena header, so overlaying this struct is safe.  Keep in sync with
+ * src/backend/utils/adt/numeric.c.
+ */
+typedef int16 PgLakeNumericDigit;
+
+#define PG_LAKE_NUMERIC_DEC_DIGITS 4	/* decimal digits per base-10000 digit */
+
+typedef struct PgLakeNumericLong
+{
+	uint16		n_sign_dscale;
+	int16		n_weight;
+	PgLakeNumericDigit n_data[FLEXIBLE_ARRAY_MEMBER];
+}			PgLakeNumericLong;
+
+typedef struct PgLakeNumericShort
+{
+	uint16		n_header;
+	PgLakeNumericDigit n_data[FLEXIBLE_ARRAY_MEMBER];
+}			PgLakeNumericShort;
+
+typedef union PgLakeNumericChoice
+{
+	uint16		n_header;
+	PgLakeNumericLong n_long;
+	PgLakeNumericShort n_short;
+}			PgLakeNumericChoice;
+
+typedef struct PgLakeNumericData
+{
+	int32		vl_len_;
+	PgLakeNumericChoice choice;
+}			PgLakeNumericData;
+
+#define PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) (((n)->choice.n_header & 0x8000) != 0)
+#define PG_LAKE_NUMERIC_HEADER_SIZE(n) \
+	(VARHDRSZ + sizeof(uint16) + \
+	 (PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) ? 0 : sizeof(int16)))
+#define PG_LAKE_NUMERIC_SHORT_WEIGHT_SIGN_MASK 0x0040
+#define PG_LAKE_NUMERIC_SHORT_WEIGHT_MASK 0x003F
+#define PG_LAKE_NUMERIC_WEIGHT(n) (PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) ? \
+	(((n)->choice.n_short.n_header & PG_LAKE_NUMERIC_SHORT_WEIGHT_SIGN_MASK ? \
+	  ~PG_LAKE_NUMERIC_SHORT_WEIGHT_MASK : 0) \
+	 | ((n)->choice.n_short.n_header & PG_LAKE_NUMERIC_SHORT_WEIGHT_MASK)) \
+	: ((n)->choice.n_long.n_weight))
+#define PG_LAKE_NUMERIC_DIGITS(n) (PG_LAKE_NUMERIC_HEADER_IS_SHORT(n) ? \
+	(n)->choice.n_short.n_data : (n)->choice.n_long.n_data)
+#define PG_LAKE_NUMERIC_NDIGITS(n) \
+	((VARSIZE(n) - PG_LAKE_NUMERIC_HEADER_SIZE(n)) / sizeof(PgLakeNumericDigit))
+
+/*
+ * NumericIntegralDigitCount returns the number of digits numeric_out would
+ * emit before the decimal point of `num`, derived from the value's weight
+ * rather than by formatting it.  `num` must be a finite value already
+ * detoasted via DatumGetNumeric().
+ *
+ * numeric_out always emits at least one integral digit (a leading "0" for zero
+ * and for |value| < 1), which this mirrors so callers match textual output.
+ */
+int
+NumericIntegralDigitCount(Numeric num)
+{
+	PgLakeNumericData *n = (PgLakeNumericData *) num;
+	int			ndigits = PG_LAKE_NUMERIC_NDIGITS(n);
+	int			weight;
+	PgLakeNumericDigit firstDigit;
+	int			firstDigitLen;
+
+	/* zero is stored with no digits and rendered as a single "0" */
+	if (ndigits <= 0)
+		return 1;
+
+	weight = PG_LAKE_NUMERIC_WEIGHT(n);
+
+	/* |value| < 1 still renders a single leading "0" before the point */
+	if (weight < 0)
+		return 1;
+
+	/*
+	 * Leading zero base-10000 digits are stripped in storage, so the first
+	 * digit is in [1, 9999]; its decimal length plus the four decimal digits
+	 * contributed by each remaining full weight step gives the integral
+	 * count.
+	 */
+	firstDigit = PG_LAKE_NUMERIC_DIGITS(n)[0];
+
+	if (firstDigit >= 1000)
+		firstDigitLen = 4;
+	else if (firstDigit >= 100)
+		firstDigitLen = 3;
+	else if (firstDigit >= 10)
+		firstDigitLen = 2;
+	else
+		firstDigitLen = 1;
+
+	return weight * PG_LAKE_NUMERIC_DEC_DIGITS + firstDigitLen;
 }
 
 /*

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -611,6 +611,23 @@ CreateManifestPartitionFieldMap(AvroReader * manifestReader)
 			logicalTypeName = TextDatumGetCString(logicalTypeNameDatum);
 		}
 
+		/*
+		 * The field name is the hash key, so it must fit into the entry's
+		 * fieldName buffer including the terminating NUL. Check before
+		 * entering it into the hash, which would truncate the key.
+		 */
+		size_t		fieldNameLength = strlen(fieldName);
+
+		if (fieldNameLength == 0 ||
+			fieldNameLength >= PARTITION_FIELD_NAME_MAX_LENGTH)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("Partition field name length must be between 1 and %d, got %zu",
+							PARTITION_FIELD_NAME_MAX_LENGTH - 1,
+							fieldNameLength)));
+		}
+
 		bool		fieldFound = false;
 
 		PartitionFieldIdMapEntry *entry = hash_search(partitionFieldMap, fieldName, HASH_ENTER, &fieldFound);
@@ -619,16 +636,6 @@ CreateManifestPartitionFieldMap(AvroReader * manifestReader)
 
 		entry->fieldId = atoi(fieldId);
 		entry->fieldType = IcebergAvroTypeFromString(physicalTypeName, logicalTypeName);
-
-		if (strlen(fieldName) > PARTITION_FIELD_NAME_MAX_LENGTH)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("Partition field name %s is too long with length %d",
-							fieldName, PARTITION_FIELD_NAME_MAX_LENGTH)));
-		}
-
-		strcpy(entry->fieldName, fieldName);
 
 		MemoryContextSwitchTo(spiContext);
 	}

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_metadata_via_pyiceberg.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_metadata_via_pyiceberg.py
@@ -346,6 +346,68 @@ def test_iceberg_catalog(
     assert pg_lake_result == pyiceberg_result
 
 
+def test_partition_field_name_length_limit(
+    create_reserialize_helper_functions, iceberg_catalog, superuser_conn
+):
+    schema = Schema(
+        NestedField(1, "source", StringType(), required=False),
+    )
+    arrow_data = pa.Table.from_pylist(
+        [{"source": "value"}],
+        schema=pa.schema([("source", pa.string())]),
+    )
+
+    def create_partitioned_table(table_name, partition_field_name):
+        partition_spec = PartitionSpec(
+            PartitionField(
+                source_id=1,
+                field_id=1000,
+                transform=IdentityTransform(),
+                name=partition_field_name,
+            )
+        )
+        table = iceberg_catalog.create_table(
+            identifier=f"public.{table_name}",
+            schema=schema,
+            location=f"s3://{TEST_BUCKET}/iceberg/public/{table_name}",
+            partition_spec=partition_spec,
+        )
+        table.append(arrow_data)
+        return table
+
+    maximum_length_name = "p" * 99
+    valid_table = create_partitioned_table(
+        "valid_partition_field_name_length", maximum_length_name
+    )
+    valid_fields = run_query(
+        f"""
+        SELECT partition_field_name
+        FROM lake_iceberg.current_partition_fields('{valid_table.metadata_location}');
+        """,
+        superuser_conn,
+    )
+    assert valid_fields == [[maximum_length_name]]
+
+    too_long_name = "p" * 100
+    invalid_table = create_partitioned_table(
+        "invalid_partition_field_name_length", too_long_name
+    )
+    with pytest.raises(
+        psycopg2.InternalError,
+        match="Partition field name length must be between 1 and 99, got 100",
+    ):
+        run_query(
+            f"""
+            SELECT *
+            FROM lake_iceberg.current_partition_fields(
+                '{invalid_table.metadata_location}'
+            );
+            """,
+            superuser_conn,
+        )
+    superuser_conn.rollback()
+
+
 def test_iceberg_datafiles(
     create_reserialize_helper_functions,
     spark_generated_iceberg_test,

--- a/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
+++ b/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
@@ -31,6 +31,7 @@ typedef struct TableMetadataOperationTracker
 	bool		relationDataFileChanged;
 	bool		relationManifestMergeRequested;
 	bool		relationSnapshotExpirationRequested;
+	bool		relationDataFilesRemoveAllSeen;
 
 	/*
 	 * Number of single-file data-file operations recorded for this relation

--- a/pg_lake_table/pg_lake_table--3.4--3.5.sql
+++ b/pg_lake_table/pg_lake_table--3.4--3.5.sql
@@ -1,0 +1,13 @@
+-- Upgrade script for pg_lake_table from 3.4 to 3.5
+
+-- Foreign-key cascades run once per deleted lake_table.files row. Without
+-- indexes matching the referencing columns, bulk removal (especially
+-- TRUNCATE) repeatedly scans the full child catalogs.
+CREATE INDEX deletion_file_map_table_name_path_idx
+ON lake_table.deletion_file_map (table_name, path);
+
+CREATE INDEX data_file_column_stats_table_path_idx
+ON lake_table.data_file_column_stats (table_name, path);
+
+CREATE INDEX data_file_partition_values_id_idx
+ON lake_table.data_file_partition_values (id);

--- a/pg_lake_table/src/fdw/option.c
+++ b/pg_lake_table/src/fdw/option.c
@@ -857,6 +857,9 @@ pg_lake_iceberg_validator(PG_FUNCTION_ARGS)
 				strncpy(columnStatsTruncateLenStr, truncateLenStrStart + 1, truncateLenStrEnd - truncateLenStrStart - 1);
 
 				char	   *parseEnd = NULL;
+
+				errno = 0;
+
 				int64_t		columnStatsTruncateLen = strtoi64(columnStatsTruncateLenStr, &parseEnd, 10);
 
 				if (errno == EINVAL || *parseEnd != '\0')

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -530,6 +530,7 @@ RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operat
 			break;
 		case DATA_FILE_REMOVE_ALL:
 			opTracker->relationDataFileChanged = true;
+			opTracker->relationDataFilesRemoveAllSeen = true;
 			opTracker->forceCommitTimeAnalyze = true;
 			break;
 		case DATA_FILE_MERGE_MANIFESTS:
@@ -1313,6 +1314,32 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	HTAB	   *currentFilesMap = GetTableDataFilesByPathHashFromCatalog(opTracker->relationId, dataOnly, newFilesOnly,
 																		 forUpdate, orderBy, snapshot, allTransforms,
 																		 true /* skipColumnStats */ );
+
+	/*
+	 * Preserve the remove-all operation for a real TRUNCATE. The generic
+	 * transaction tracker normally records only that data files changed and
+	 * reconstructs individual operations by diffing the catalog against the
+	 * last Iceberg snapshot. Turning a TRUNCATE into one DATA_FILE_REMOVE per
+	 * existing file loses the linear remove-all path in the manifest writer
+	 * and makes it compare every manifest entry with every removed file.
+	 *
+	 * The tracker flags intentionally survive subtransaction rollback, so
+	 * hash_get_num_entries(currentFilesMap) == 0 checks whether the
+	 * transaction-visible file catalog is empty. This restricts the shortcut
+	 * to a TRUNCATE that leaves no files: TRUNCATE followed by INSERT has a
+	 * non-empty map and must use the normal diff below to preserve the newly
+	 * inserted files. A rolled-back TRUNCATE likewise has restored files in
+	 * the map and must use the normal diff.
+	 */
+	if (opTracker->relationDataFilesRemoveAllSeen &&
+		hash_get_num_entries(currentFilesMap) == 0)
+	{
+		TableMetadataOperation *removeAllOp = palloc0(sizeof(TableMetadataOperation));
+
+		removeAllOp->type = DATA_FILE_REMOVE_ALL;
+
+		return list_make1(removeAllOp);
+	}
 
 	/* get last pushed metadata */
 	IcebergTableMetadata *lastMetadata = GetLastPushedIcebergMetadata(opTracker);

--- a/pg_lake_table/tests/pytests/test_create_drop_extension.py
+++ b/pg_lake_table/tests/pytests/test_create_drop_extension.py
@@ -2,6 +2,29 @@ import pytest
 from utils_pytest import *
 
 
+def test_data_file_cascade_indexes(extension, superuser_conn):
+    result = run_query(
+        """
+        SELECT indexname
+        FROM pg_indexes
+        WHERE schemaname = 'lake_table'
+          AND indexname IN (
+              'deletion_file_map_table_name_path_idx',
+              'data_file_column_stats_table_path_idx',
+              'data_file_partition_values_id_idx'
+          )
+        ORDER BY indexname
+        """,
+        superuser_conn,
+    )
+
+    assert result == [
+        ["data_file_column_stats_table_path_idx"],
+        ["data_file_partition_values_id_idx"],
+        ["deletion_file_map_table_name_path_idx"],
+    ]
+
+
 def test_create_drop_query_engine(superuser_conn, s3, app_user):
     other_conn = open_pg_conn()
 

--- a/pg_lake_table/tests/pytests/test_iceberg_in_tx.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_in_tx.py
@@ -817,6 +817,64 @@ def test_in_tx_with_truncate(
     pg_conn.commit()
 
 
+def test_truncate_remove_all_transaction_guards(
+    pg_conn,
+    extension,
+    with_default_location,
+):
+    table_namespace = "test_truncate_remove_all_transaction_guards"
+    table_name = "tbl"
+    table = f"{table_namespace}.{table_name}"
+
+    run_command(
+        f"""
+        CREATE SCHEMA {table_namespace};
+        CREATE TABLE {table} (a int) USING iceberg
+            WITH (autovacuum_enabled='False');
+        INSERT INTO {table} VALUES (1), (2);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # The remove-all tracker flag survives subtransaction rollback. The
+    # catalog is not empty after rollback, so commit must use the normal diff
+    # and retain the original files.
+    run_command(
+        f"""
+        SAVEPOINT before_truncate;
+        TRUNCATE {table};
+        ROLLBACK TO SAVEPOINT before_truncate;
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    assert run_query(f"SELECT a FROM {table} ORDER BY a", pg_conn) == [[1], [2]]
+
+    # A truncate followed by an insert also leaves a non-empty catalog. It
+    # must fall back to the per-file diff so the newly added file survives.
+    run_command(
+        f"""
+        TRUNCATE {table};
+        INSERT INTO {table} VALUES (3);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    assert run_query(f"SELECT a FROM {table} ORDER BY a", pg_conn) == [[3]]
+
+    # A final empty catalog is the real remove-all case.
+    run_command(f"TRUNCATE {table}", pg_conn)
+    pg_conn.commit()
+
+    assert run_query(f"SELECT a FROM {table}", pg_conn) == []
+
+    run_command(f"DROP SCHEMA {table_namespace} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 def test_in_subtx_fail_with_truncate(
     installcheck,
     s3,

--- a/pg_lake_table/tests/upgrade/test_post_upgrade.py
+++ b/pg_lake_table/tests/upgrade/test_post_upgrade.py
@@ -8,6 +8,33 @@ from utils_pytest import *
     os.getenv("TEST_PG_UPGRADE_FROM_BINDIR") == None,
     reason="set TEST_PG_UPGRADE_FROM_BINDIR to the old PG version to run",
 )
+def test_data_file_cascade_indexes(superuser_conn, extension):
+    result = run_query(
+        """
+        SELECT indexname
+        FROM pg_indexes
+        WHERE schemaname = 'lake_table'
+          AND indexname IN (
+              'deletion_file_map_table_name_path_idx',
+              'data_file_column_stats_table_path_idx',
+              'data_file_partition_values_id_idx'
+          )
+        ORDER BY indexname
+        """,
+        superuser_conn,
+    )
+
+    assert result == [
+        ["data_file_column_stats_table_path_idx"],
+        ["data_file_partition_values_id_idx"],
+        ["deletion_file_map_table_name_path_idx"],
+    ]
+
+
+@pytest.mark.skipif(
+    os.getenv("TEST_PG_UPGRADE_FROM_BINDIR") == None,
+    reason="set TEST_PG_UPGRADE_FROM_BINDIR to the old PG version to run",
+)
 def test_iceberg_query(superuser_conn, s3, extension):
     # Check whether we can update post-upgrade
     run_command("UPDATE pre_upgrade.iceberg SET id = id + 1", superuser_conn)

--- a/pgduck_server/src/duckdb/duckdb.c
+++ b/pgduck_server/src/duckdb/duckdb.c
@@ -1123,6 +1123,8 @@ return_query_result_to_pgsession(DuckDBSession * duckSession, duckdb_result duck
 		/* send CopyDone response */
 		if (!IsOK(pgsession_putemptymessage(duckSession->clientSession, 'c')))
 		{
+			duckdb_query_result_destroy(&duckdb_query_result);
+
 			PGDUCK_SERVER_ERROR("could not send CopyDone");
 
 			return DUCKDB_PG_COMMUNICATION_ERROR;

--- a/pgduck_server/src/duckdb/type_conversion.c
+++ b/pgduck_server/src/duckdb/type_conversion.c
@@ -537,18 +537,24 @@ blob_to_text(duckdb_vector vector, duckdb_logical_type blobType, int row, TextOu
 
 	if (typeAlias != NULL)
 	{
-		if (strcmp(typeAlias, "GEOMETRY") == 0)
+		bool		isGeometry = strcmp(typeAlias, "GEOMETRY") == 0;
+
+		if (strcmp(typeAlias, "WKB_BLOB") == 0)
+		{
+			/* output WKB_BLOB as pure hex to be parseable as geometry */
+			emitEscapeSequence = false;
+		}
+
+		/* the alias string is allocated by DuckDB and owned by us */
+		duckdb_free(typeAlias);
+
+		if (isGeometry)
 		{
 			/* output geometry via st_ashexwkb */
 			toTextBuffer->buffer = (char *) duckdb_pglake_geometry_to_string(DuckDB, val);
 			toTextBuffer->needsFree = true;
 
 			return CHECK_OOM(toTextBuffer->buffer);
-		}
-		else if (strcmp(typeAlias, "WKB_BLOB") == 0)
-		{
-			/* output WKB_BLOB as pure hex to be parseable as geometry */
-			emitEscapeSequence = false;
 		}
 	}
 

--- a/pgduck_server/src/duckdb/type_conversion.c
+++ b/pgduck_server/src/duckdb/type_conversion.c
@@ -1011,6 +1011,7 @@ array_to_text(duckdb_vector vector, duckdb_logical_type arrayLogicalType, int ro
 			if (status != DUCKDB_SUCCESS)
 			{
 				CleanupOutputBuffer(&elementOutputBuffer);
+				pg_free(topLevelBuffer.data);
 				goto cleanup;
 			}
 		}
@@ -1168,6 +1169,7 @@ list_to_text(duckdb_vector vector, duckdb_logical_type listLogicalType, int row,
 			if (status != DUCKDB_SUCCESS)
 			{
 				CleanupOutputBuffer(&elementOutputBuffer);
+				pg_free(topLevelBuffer.data);
 				goto cleanup;
 			}
 		}
@@ -1275,6 +1277,7 @@ struct_to_text(duckdb_vector vector, duckdb_logical_type structLogicalType, int 
 		{
 			PGDUCK_SERVER_ERROR("could not find type mapping for DuckDB type: %d", structElemTypeId);
 			status = DUCKDB_TYPE_CONVERSION_ERROR;
+			pg_free(topLevelBuffer.data);
 			goto cleanup;
 		}
 
@@ -1309,6 +1312,7 @@ struct_to_text(duckdb_vector vector, duckdb_logical_type structLogicalType, int 
 			if (status != DUCKDB_SUCCESS)
 			{
 				CleanupOutputBuffer(&elementOutputBuffer);
+				pg_free(topLevelBuffer.data);
 				goto cleanup;
 			}
 		}

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -151,6 +151,11 @@ pgclient_threadpool_reserve_slot(PGClient * client)
 	if (ActiveClientThreadCount >= MaxAllowedClients)
 	{
 		pthread_rwlock_unlock(&rwlock);
+
+#if PG_VERSION_NUM >= 180000
+		pfree(cancellationToken);
+#endif
+
 		return InvalidThreadIndex;
 	}
 
@@ -181,6 +186,16 @@ pgclient_threadpool_reserve_slot(PGClient * client)
 
 	/* store the thread index, to assign the DuckDB connection later */
 	client->threadIndex = usedThreadIndex;
+
+	if (usedThreadIndex == InvalidThreadIndex)
+	{
+		/* no slot assigned, so nothing will ever use or free the token */
+#if PG_VERSION_NUM >= 180000
+		pfree(cancellationToken);
+#endif
+
+		return InvalidThreadIndex;
+	}
 
 	/* store the cancellation token, to be transmitted to the client later */
 	client->cancellationProcId = cancellationProcId;

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -496,10 +496,19 @@ pgserver_run(PGServer * pgServer)
 		{
 			PGDUCK_SERVER_ERROR("Thread creation failed for client %d", client->clientSocket);
 
+			/*
+			 * Free the slot first: it clears the pool's copy of the token
+			 * pointer under the lock, so a concurrent cancel request can no
+			 * longer read the token we are about to free.
+			 */
+			pgclient_threadpool_free_slot(threadIndex);
+
 			close(client->clientSocket);
+#if PG_VERSION_NUM >= 180000
+			pfree(client->cancellationToken);
+#endif
 			pg_free(client);
 			pg_free(initState);
-			pgclient_threadpool_free_slot(threadIndex);
 		}
 
 		if (enable_shutdown_signals() != STATUS_OK)
@@ -636,6 +645,10 @@ pgclient_thread_cleanup(void *arg)
 	/* end of the thread, free the pre-thread resources */
 	pgclient_threadpool_free_slot(initState->threadIndex);
 	closesocket(initState->pgClient->clientSocket);
+#if PG_VERSION_NUM >= 180000
+	/* the thread pool slot only kept a pointer copy; the client owns it */
+	pfree(initState->pgClient->cancellationToken);
+#endif
 	pg_free(initState->pgClient);
 	pg_free(initState);
 }


### PR DESCRIPTION
Patch release cherry-picks — bug fixes from main, no SQL/schema changes, version stays at 3.4.

## Changes

- **pgduck: never re-send a COPY on send failure** (#485) — prevents duplicate data-file writes when a send error occurs mid-COPY
- **pg_lake_iceberg: fix off-by-one overflow on partition field names** (#467) — buffer overflow on long partition field strings
- **fix: disallow copy unbounded numerics in nested types** (#448) — validates numeric leaves inside arrays, composites, maps, and domains before the value reaches the CSV; rejects NaN/Inf special values
- **pgduck_server: free query result when sending CopyDone fails** (#470) — memory leak
- **pgduck_server: free the logical type alias in blob_to_text** (#472) — memory leak
- **pg_lake_engine: don't leak the PGresult when COPY stats parsing throws** (#474) — memory leak
- **pgduck_server: free partial output buffer on nested conversion errors** — memory leak
- **pgduck_server: stop leaking the per-connection cancellation token** — resource leak
- **pg_lake_table: reset errno before parsing column_stats_mode length** — stale errno could cause a false-positive parse error

Not included (touch SQL migration files): `d5270b2` (base worker backoff, adds `pg_extension_base--3.5--3.6.sql`) and `f619d31` (TRUNCATE metadata scaling, adds `pg_lake_table--3.4--3.5.sql`).