### PR TITLE
Remove redundant pre-commit stage from pgindent hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
   - id: pgindent
     name: pgindent
     entry: pgindent
-    stages: [pre-commit]
     pass_filenames: true
     language: system
     files: \.c|\.h


### PR DESCRIPTION
The `pgindent` local hook explicitly sets `stages: [pre-commit]`, but `pre-commit` is already the default stage for hooks. The explicit declaration is redundant, so this removes it and relies on the default.

No behavioral change: the hook continues to run on `git commit` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)