### PR TITLE
pg_lake_engine: cap the CSV read buffer DuckDB allocates

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/client.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/client.h
@@ -25,6 +25,8 @@
 #define DEFAULT_PGDUCK_SERVER_CONNINFO "host=/tmp port=5332"
 
 #define DEFAULT_DUCKDB_MAX_LINE_SIZE (2097152)
+#define DEFAULT_DUCKDB_CSV_BUFFER_SIZE (32000000)
+#define PGLAKE_CSV_BUFFER_LINE_MULTIPLE (4)
 
 /* settings */
 extern char *PgduckServerConninfo;

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -1752,7 +1752,38 @@ AppendReadCSVTail(StringInfo buf, int maxLineSize, const char *columnsMap,
 	if (maxLineSize > 0)
 	{
 		/* use maxLineSize + 1 to include end-of-line */
-		appendStringInfo(buf, ", max_line_size=%d", maxLineSize + 1);
+		int64		lineSizeLimit = (int64) maxLineSize + 1;
+
+		/*
+		 * Pin buffer_size as well as max_line_size.
+		 *
+		 * DuckDB reads a CSV in chunks and, given only max_line_size, sizes
+		 * each chunk to hold 16 lines of that length -- allocated in one
+		 * piece, regardless of how large the file really is.  A file holding
+		 * a few very wide rows therefore costs the same up-front allocation
+		 * as one holding thousands.  Since we serialize bytea as four bytes
+		 * per input byte, a single 10MB bytea makes a 40MB line and DuckDB
+		 * asks for 640MB to read a file that may only hold 76MB, which is
+		 * enough to OOM the query engine outright.
+		 *
+		 * Setting buffer_size suppresses that rule, since DuckDB only derives
+		 * it when buffer_size was left alone.  We ask for a few lines' worth
+		 * and never less than DuckDB's own default, so ordinary row widths
+		 * read exactly as before and only the wide-line case gets a smaller
+		 * request.  It has to be a multiple of the line size rather than the
+		 * line size itself: a value spanning a buffer boundary cannot be
+		 * referenced in place and is copied into the vector's string heap, so
+		 * a buffer only as large as one line makes every wide value pay for a
+		 * copy.
+		 */
+		int64		bufferSize = Max(DEFAULT_DUCKDB_CSV_BUFFER_SIZE,
+									 PGLAKE_CSV_BUFFER_LINE_MULTIPLE *
+									 lineSizeLimit);
+
+		appendStringInfo(buf,
+						 ", max_line_size=" INT64_FORMAT
+						 ", buffer_size=" INT64_FORMAT,
+						 lineSizeLimit, bufferSize);
 	}
 
 	/*


### PR DESCRIPTION
DuckDB reads a CSV in chunks, and it sizes each chunk to hold 16 of the widest line the file is allowed to contain.  It allocates that in one piece, up front, without looking at how large the file actually is.  So a file holding a few very wide rows costs the same allocation as one holding thousands of them.

We pass max_line_size on every internal CSV read, measured from the file we just wrote, so this applies to every exchange file we hand back to the engine.  One large bytea value is enough to make it hurt: we serialize bytea as \xNN, four bytes per input byte, so a 10MB value becomes a 40MB line and DuckDB asks for 640MB to read a file that may hold four rows and 76MB of data.  When that allocation fails, pgduck_server classifies a genuine OOM as fatal and exits, dropping every connection:

  ERROR unrecoverable failure from duckdb; terminating:
  Out of Memory Error: Failed to allocate block of 671092736 bytes

671092736 is exactly align_4096(16 * 41943119), where 41943119 was the max_line_size for a change batch containing a 10MB bytea.

Ask for 4 lines' worth instead of 16, floored at DuckDB's own default of 32MB.  Setting buffer_size at all is what suppresses the multiplier -- DuckDB only derives it when the caller left buffer_size alone.

For a batch whose widest line is 40MB:

  batch file      buffer before    buffer after
  76MB                   640MB           160MB
  305MB                  640MB           320MB
  610MB                  640MB           640MB   (unchanged)
  1.2GB                 1280MB          1280MB   (unchanged)

Tables with ordinary row widths are unaffected: under the 32MB floor we ask for exactly what DuckDB would have picked anyway.  Large batches are unaffected too -- buffers are reused as the scan walks the file, so total buffer memory tracks file size rather than chunk size.  The saving is confined to files that are small relative to 16 lines: a few wide rows, which is the ordinary shape for a mirror flushing on a timer.

Why a multiple of 4 and not 1: total buffer memory is the same either way, but the multiple decides whether a wide value fits inside a single chunk.  At buffer_size = max_line_size every wide value straddles a boundary and is copied into the vector's string heap instead of being referenced in place.  Measured on a 610MB batch of 40MB lines under a 2GB memory limit, 1x fails reproducibly where DuckDB's own 16x succeeds, while 2x, 4x and 16x all pass -- and 4x shows the lowest peak allocator usage of the four.

Verified against the pinned DuckDB 1.4.3, running the generated query through pgduck_server:

  76MB batch (4 wide rows), 512MB limit:  16x fails on the 640MB block;
                                          4x peaks at 160MB and passes
  610MB batch (32 wide rows), 2GB limit:  4x passes, 1x fails
