### PR TITLE
pg_lake_iceberg: allow extra properties in the Iceberg snapshot summary

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/metadata_operations.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/metadata_operations.h
@@ -20,5 +20,6 @@
 #include "nodes/pg_list.h"
 
 extern PGDLLEXPORT List *ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allTransforms, int maxSnapshotAgeInSecs, bool isVerbose);
+extern PGDLLEXPORT List *ApplyIcebergMetadataChangesExt(Oid relationId, List *metadataOperations, List *allTransforms, int maxSnapshotAgeInSecs, bool isVerbose, List *extraSummaryProperties);
 extern PGDLLEXPORT bool ShouldSkipMetadataChangeToIceberg(List *metadataOperationTypes);
 extern PGDLLEXPORT List *GetMetadataOperationTypes(List *metadataOperations);

--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -103,6 +103,12 @@ typedef struct IcebergSnapshotBuilder
 
 	/* snapshot operation */
 	SnapshotOperation operation;
+
+	/*
+	 * extra properties (List of Property *) to merge into the new snapshot's
+	 * summary, in addition to the mandatory "operation" key.
+	 */
+	List	   *extraSummaryProperties;
 }			IcebergSnapshotBuilder;
 
 
@@ -116,8 +122,10 @@ typedef struct PartitionSpecManifestsEntries
 	List	   *manifestEntries;
 }			PartitionSpecManifestsEntries;
 
-static IcebergSnapshotBuilder * CreateIcebergSnapshotBuilder(IcebergTableMetadata * metadata, List *metadataOperations);
-static void SetSnapshotOperation(IcebergSnapshot * snapshot, SnapshotOperation operation);
+static IcebergSnapshotBuilder * CreateIcebergSnapshotBuilder(IcebergTableMetadata * metadata, List *metadataOperations,
+															 List *extraSummaryProperties);
+static void SetSnapshotSummary(IcebergSnapshot * snapshot, SnapshotOperation operation,
+							   List *extraProperties);
 static SnapshotOperation SnapshotOperationSummary(List *metadataOperations);
 static void ProcessIcebergMetadataOperations(Oid relationId, List *metadataOperations,
 											 IcebergSnapshotBuilder * builder);
@@ -154,10 +162,34 @@ static void DeleteInProgressManifests(Oid relationId, List *manifests);
 /*
  * ApplyIcebergMetadataChanges applies the given metadata operations to the
  * iceberg metadata for the given relation.
+ *
+ * This is a thin wrapper around ApplyIcebergMetadataChangesExt that adds no
+ * extra snapshot summary properties. It is kept as-is so existing callers do
+ * not have to change.
  */
 List *
 ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allTransforms,
 							int maxSnapshotAgeInSecs, bool isVerbose)
+{
+	return ApplyIcebergMetadataChangesExt(relationId, metadataOperations, allTransforms,
+										  maxSnapshotAgeInSecs, isVerbose, NIL);
+}
+
+
+/*
+ * ApplyIcebergMetadataChangesExt is like ApplyIcebergMetadataChanges but also
+ * merges the given extra properties (a List of Property *) into the summary of
+ * the snapshot created by this operation. The reserved "operation" key is
+ * always controlled by pg_lake and cannot be overridden by extraSummaryProperties.
+ *
+ * The extra properties surface verbatim in the Iceberg snapshot summary map in
+ * metadata.json, which downstream readers (e.g. Snowflake's
+ * SYSTEM$AUTO_REFRESH_STATUS() currentSnapshotSummary) expose as-is.
+ */
+List *
+ApplyIcebergMetadataChangesExt(Oid relationId, List *metadataOperations, List *allTransforms,
+							   int maxSnapshotAgeInSecs, bool isVerbose,
+							   List *extraSummaryProperties)
 {
 	List	   *restCatalogRequests = NIL;
 
@@ -226,7 +258,8 @@ ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allT
 		}
 	}
 
-	IcebergSnapshotBuilder *builder = CreateIcebergSnapshotBuilder(metadata, metadataOperations);
+	IcebergSnapshotBuilder *builder = CreateIcebergSnapshotBuilder(metadata, metadataOperations,
+																   extraSummaryProperties);
 
 	ProcessIcebergMetadataOperations(relationId, metadataOperations, builder);
 
@@ -416,7 +449,8 @@ ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allT
  * of all the changes to the current snapshot.
  */
 static IcebergSnapshotBuilder *
-CreateIcebergSnapshotBuilder(IcebergTableMetadata * metadata, List *metadataOperations)
+CreateIcebergSnapshotBuilder(IcebergTableMetadata * metadata, List *metadataOperations,
+							 List *extraSummaryProperties)
 {
 	IcebergSnapshotBuilder *builder = palloc0(sizeof(IcebergSnapshotBuilder));
 
@@ -432,6 +466,7 @@ CreateIcebergSnapshotBuilder(IcebergTableMetadata * metadata, List *metadataOper
 	builder->positionalDeleteEntries = MakePartitionManifestEntryHash();
 
 	builder->operation = SnapshotOperationSummary(metadataOperations);
+	builder->extraSummaryProperties = extraSummaryProperties;
 
 	return builder;
 }
@@ -478,35 +513,68 @@ AddManifestEntryToHash(HTAB *hash, int32 partitionSpecId, IcebergManifestEntry *
 
 
 /*
-* SetSnapshotOperation sets the operation of the snapshot.
+* SetSnapshotSummary sets the summary of the snapshot.
+*
+* The mandatory "operation" key is always set by pg_lake. Any extraProperties
+* (a List of Property *) are appended after it, letting callers stamp custom
+* key/value pairs (e.g. a source LSN or data version) into the snapshot summary.
+* The reserved "operation" key cannot be overridden by extraProperties.
 */
 static void
-SetSnapshotOperation(IcebergSnapshot * snapshot, SnapshotOperation operation)
+SetSnapshotSummary(IcebergSnapshot * snapshot, SnapshotOperation operation,
+				   List *extraProperties)
 {
-	Property   *summary = palloc0(sizeof(Property));
+	int			nExtra = list_length(extraProperties);
+	Property   *summary = palloc0(sizeof(Property) * (1 + nExtra));
 
-	summary->key = "operation";
+	summary[0].key = "operation";
 
 	switch (operation)
 	{
 		case SNAPSHOT_OPERATION_APPEND:
-			summary->value = "append";
+			summary[0].value = "append";
 			break;
 		case SNAPSHOT_OPERATION_REPLACE:
-			summary->value = "replace";
+			summary[0].value = "replace";
 			break;
 		case SNAPSHOT_OPERATION_OVERWRITE:
-			summary->value = "overwrite";
+			summary[0].value = "overwrite";
 			break;
 		case SNAPSHOT_OPERATION_DELETE:
-			summary->value = "delete";
+			summary[0].value = "delete";
 			break;
 		default:
 			ereport(ERROR, (errmsg("Unsupported snapshot operation: %d", operation)));
 	}
 
+	int			summaryLength = 1;
+	ListCell   *propertyCell = NULL;
+
+	foreach(propertyCell, extraProperties)
+	{
+		Property   *property = (Property *) lfirst(propertyCell);
+
+		/*
+		 * Skip incomplete properties: summary values are always serialized as
+		 * strings and copied unconditionally (see CopyPropertiesArray), so a
+		 * NULL key or value is not representable.
+		 */
+		if (property->key == NULL || property->value == NULL)
+			continue;
+
+		/* "operation" is reserved for pg_lake and cannot be overridden */
+		if (strcmp(property->key, "operation") == 0)
+			continue;
+
+		summary[summaryLength].key = pstrdup(property->key);
+		summary[summaryLength].key_length = strlen(property->key);
+		summary[summaryLength].value = pstrdup(property->value);
+		summary[summaryLength].value_length = strlen(property->value);
+		summaryLength++;
+	}
+
 	snapshot->summary = summary;
-	snapshot->summary_length = 1;
+	snapshot->summary_length = summaryLength;
 }
 
 /*
@@ -1025,7 +1093,7 @@ FinalizeNewSnapshot(IcebergSnapshotBuilder * builder, Oid relationId, const char
 
 	DeleteInProgressManifests(relationId, newPersistedManifestList);
 
-	SetSnapshotOperation(newSnapshot, builder->operation);
+	SetSnapshotSummary(newSnapshot, builder->operation, builder->extraSummaryProperties);
 
 	/*
 	 * Write the manifest list file that contains the list of manifest files.

--- a/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
+++ b/pg_lake_table/include/pg_lake/transaction/track_iceberg_metadata_changes.h
@@ -48,6 +48,15 @@ typedef struct TableMetadataOperationTracker
 	 * commit-time ANALYZE regardless of dataFileChangeCount.
 	 */
 	bool		forceCommitTimeAnalyze;
+
+	/*
+	 * Extra key/value properties (a List of Property *) to merge into the
+	 * summary of the Iceberg snapshot created for this relation at commit
+	 * time, populated via AddIcebergSnapshotSummaryProperties(). Allocated in
+	 * the same memory context as the tracker hash so it survives until the
+	 * commit-time flush. NIL when nothing extra was requested.
+	 */
+	List	   *extraSummaryProperties;
 }			TableMetadataOperationTracker;
 
 extern PGDLLEXPORT int CommitTimeCatalogAnalyzeThreshold;
@@ -55,6 +64,7 @@ extern PGDLLEXPORT int CommitTimeCatalogAnalyzeThreshold;
 extern PGDLLEXPORT void ConsumeTrackedIcebergMetadataChanges(bool isVerbose);
 extern PGDLLEXPORT void PostAllRestCatalogRequests(void);
 extern PGDLLEXPORT void TrackIcebergMetadataChangesInTx(Oid relationId, List *metadataOperationTypes);
+extern PGDLLEXPORT void AddIcebergSnapshotSummaryProperties(Oid relationId, List *properties);
 extern PGDLLEXPORT void RecordRestCatalogRequestInTx(Oid relationId, RestCatalogOperationType operationType,
 													 const char *body);
 extern PGDLLEXPORT void ResetTrackedIcebergMetadataOperation(void);

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -547,6 +547,73 @@ RecordIcebergMetadataOperation(Oid relationId, TableMetadataOperationType operat
 
 
 /*
+ * AddIcebergSnapshotSummaryProperties records extra key/value properties to
+ * merge into the summary of the Iceberg snapshot that will be created for the
+ * given relation at commit time. Each element of properties is a Property *.
+ *
+ * Properties are copied into TopTransactionContext (the same context as the
+ * tracker hash), so the caller may build them in any (even transient) context.
+ * The reserved "operation" key is controlled by pg_lake and is dropped here so
+ * it can never override the snapshot operation. Properties with a NULL key or
+ * value are ignored.
+ *
+ * The properties surface verbatim in the Iceberg snapshot summary map in
+ * metadata.json, which downstream readers (e.g. Snowflake's
+ * SYSTEM$AUTO_REFRESH_STATUS() currentSnapshotSummary) expose as-is.
+ */
+void
+AddIcebergSnapshotSummaryProperties(Oid relationId, List *properties)
+{
+	if (properties == NIL)
+		return;
+
+	InitTableMetadataTrackerHashIfNeeded();
+
+	bool		isFound = false;
+	TableMetadataOperationTracker *opTracker =
+		hash_search(TrackedIcebergMetadataOperationsHash,
+					&relationId, HASH_ENTER, &isFound);
+
+	if (!isFound)
+	{
+		memset(opTracker, 0, sizeof(TableMetadataOperationTracker));
+		opTracker->relationId = relationId;
+	}
+
+	/*
+	 * The tracker hash lives in TopTransactionContext and is read by the
+	 * commit-time flush, so the copied properties must live there too.
+	 */
+	MemoryContext oldContext = MemoryContextSwitchTo(TopTransactionContext);
+	ListCell   *propertyCell = NULL;
+
+	foreach(propertyCell, properties)
+	{
+		Property   *source = (Property *) lfirst(propertyCell);
+
+		if (source->key == NULL || source->value == NULL)
+			continue;
+
+		/* "operation" is reserved for pg_lake and cannot be overridden */
+		if (strcmp(source->key, "operation") == 0)
+			continue;
+
+		Property   *copy = palloc0(sizeof(Property));
+
+		copy->key = pstrdup(source->key);
+		copy->key_length = strlen(source->key);
+		copy->value = pstrdup(source->value);
+		copy->value_length = strlen(source->value);
+
+		opTracker->extraSummaryProperties =
+			lappend(opTracker->extraSummaryProperties, copy);
+	}
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+
+/*
  * InitTableMetadataTrackerHashIfNeeded is a helper function to manage the initialization
  * of the hash. We allocate the hash and entries in TopTransactionContext.
  */
@@ -988,7 +1055,7 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 		if (metadataOperations != NIL)
 		{
 			int			maxSnapshotAgeInSecs = GetEffectiveMaxSnapshotAgeInSecs(relationId);
-			List	   *restRequests = ApplyIcebergMetadataChanges(relationId, metadataOperations, allTransforms, maxSnapshotAgeInSecs, isVerbose);
+			List	   *restRequests = ApplyIcebergMetadataChangesExt(relationId, metadataOperations, allTransforms, maxSnapshotAgeInSecs, isVerbose, opTracker->extraSummaryProperties);
 			ListCell   *requestCell = NULL;
 
 			foreach(requestCell, restRequests)


### PR DESCRIPTION
## What

Add a way for callers to stamp custom key/value pairs into the **summary** of the Iceberg snapshot created for a relation at commit time, alongside the mandatory `operation` key.

- New `ApplyIcebergMetadataChangesExt(..., List *extraSummaryProperties)`. The existing `ApplyIcebergMetadataChanges()` becomes a thin wrapper that passes `NIL`, so **no existing callers change**.
- New per-relation setter `AddIcebergSnapshotSummaryProperties(Oid relationId, List *properties)` records extra summary properties on `TableMetadataOperationTracker` (allocated in `TopTransactionContext`). They are merged into the snapshot summary by the renamed/extended `SetSnapshotSummary()` when the snapshot is built at commit.
- The reserved `operation` key can never be overridden; properties with a NULL key or value are ignored.

## Why

The Iceberg spec allows arbitrary keys in a snapshot's `summary` map beyond the required `operation`. Downstream readers surface them verbatim — e.g. Snowflake's `SYSTEM$AUTO_REFRESH_STATUS()` returns `currentSnapshotSummary`, described as *"the Iceberg snapshot summary from the metadata.json file."* This lets producers annotate snapshots with things like a source LSN or data version that a reader can then observe with no reader-side changes.

First consumer: snowflake_cdc stamps the source commit LSN and data version of each change batch into the CDC table's snapshot summary.

## Notes

- The summary is built at transaction-commit time, downstream of the SQL write, so the properties are carried via the per-relation tracker side channel rather than as call arguments.
- `pgindent` was not run in this environment (the repo's pre-commit config is incompatible with the installed pre-commit version); code follows surrounding tab/style conventions.

## Verification

`metadata_operations.c` and `track_iceberg_metadata_changes.c` compile cleanly against PostgreSQL 18.3 server headers + the repo include tree. Full extension build/install (duckdb/vcpkg) not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)