### PR TITLE
pg_lake_iceberg: one-sided primitives for the stored Iceberg representation of a type

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * iceberg_representation.h
+ *	 Primitives for answering "what does the Iceberg create path store for this
+ *	 Postgres type, and does it match what a table already stores?"
+ *
+ * A consumer that must decide whether a type change is invisible to an existing
+ * Iceberg table (e.g. ALTER COLUMN ... TYPE) derives the stored field for the
+ * NEW type only, and compares it against the field the table already persists
+ * in lake_table.field_id_mappings.  Deriving BOTH sides answers a different and
+ * weaker question -- "would a fresh create of old and new agree under today's
+ * settings" -- and fails in the unsafe direction: a transform this module does
+ * not model cancels out on both sides, yielding a spurious "equal".  Against a
+ * persisted field the same gap makes the two differ, so the caller blocks.
+ *
+ * That matters because the transform set is not closed.  pg_lake shapes storage
+ * with the unsupported-numeric rewrite and the compatibility mapping, but a
+ * caller may add its own before the table is created (snowflake_cdc stores enums
+ * and user-defined ranges as text, for one).  Only the persisted field reflects
+ * all of them.
+ */
+
+#pragma once
+
+#include "postgres.h"
+
+#include "pg_lake/iceberg/compatibility_mode.h"
+#include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/pgduck/type.h"
+
+/*
+ * IcebergStoredPostgresType - the Postgres type the create path actually stores
+ * for a declared column type, i.e. the declared type after the unsupported
+ * numeric -> float8 rewrite, gated on pg_lake_iceberg.unsupported_numeric_as_double
+ * exactly as MaybeConvertUnsupportedNumericColumnsToDouble gates it.  Returns
+ * `type` unchanged when nothing is rewritten (including when the GUC is off, in
+ * which case CREATE rejects such a column outright rather than storing it).
+ *
+ * Rewriting a nested leaf means rebuilding the enclosing composite or map, which
+ * materializes a type in lake_struct / the map schema -- the create path's own
+ * behaviour.  A caller that must not create catalog types should first reject
+ * the input with TypeHasUnsupportedNumericLeaf(type, true).
+ */
+extern PGDLLEXPORT PGType IcebergStoredPostgresType(PGType type);
+
+/*
+ * IcebergStorageFieldForColumnType - the Iceberg field tree the create path
+ * stores for a declared column type under a table's compatibility mode: the
+ * structural derivation followed by the compatibility storage mapping.
+ *
+ * This IS the create path's shaping, not a model of it: registration
+ * (CreatePostgresColumnMappingsForColumnDefs) calls this, so a comparison
+ * against a persisted field cannot drift from what produced that field.
+ *
+ * `declaredType` is expected to have been through IcebergStoredPostgresType
+ * already, as the create path's callers have.  `surfaceFieldOut`, when non-NULL,
+ * receives the pre-mapping tree, which registration needs to record the
+ * per-leaf surface->storage divergences.
+ */
+extern PGDLLEXPORT Field * IcebergStorageFieldForColumnType(PGType declaredType,
+															IcebergCompatibilityMode mode,
+															bool forAddColumn,
+															int *subFieldIndex,
+															Field * *surfaceFieldOut);
+
+/*
+ * IcebergFieldsEquivalent - true when two Iceberg field trees are the same
+ * stored representation, ignoring field ids and defaults (assigned per
+ * derivation, irrelevant to storage).  So varchar length / text-family members
+ * collapse to `string`, smallint and integer to `int`, and so on.
+ *
+ * Tolerates NULL on either side (NULL equals only NULL), so a caller can pass a
+ * persisted field it could not resolve without a separate check.
+ */
+extern PGDLLEXPORT bool IcebergFieldsEquivalent(Field * a, Field * b);
+
+/*
+ * TypeHasUnsupportedNumericLeaf - true when the type tree has a numeric leaf
+ * Iceberg cannot hold as a decimal (unbounded, or precision/scale beyond
+ * DUCKDB_MAX_NUMERIC_PRECISION).  `nestedOnly` restricts the answer to leaves
+ * below the top level, i.e. those whose rewrite would require materializing a
+ * new composite or map type.
+ *
+ * Shares ConvertTypeTree's traversal, so it cannot drift out of coverage from
+ * the rewrite it predicts, and creates no catalog types (see the leaf rule).
+ */
+extern PGDLLEXPORT bool TypeHasUnsupportedNumericLeaf(PGType type, bool nestedOnly);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -77,6 +77,17 @@ extern PGDLLEXPORT Field *IcebergStorageFieldForColumnType(
 	int *subFieldIndex, Field **surfaceFieldOut);
 
 /*
+ * IcebergFieldsEquivalent - true when two Iceberg field trees are the same
+ * stored representation, ignoring field ids and defaults (assigned per
+ * derivation, irrelevant to storage).  So varchar length / text-family members
+ * collapse to `string`, smallint and integer to `int`, and so on.
+ *
+ * Tolerates NULL on either side (NULL equals only NULL), so a caller can pass a
+ * persisted field it could not resolve without a separate check.
+ */
+extern PGDLLEXPORT bool IcebergFieldsEquivalent(Field *a, Field *b);
+
+/*
  * TypeHasUnrepresentableLeaf - true when the type tree has a leaf Iceberg
  * cannot hold natively (currently: a numeric that is unbounded or whose
  * precision/scale exceeds DUCKDB_MAX_NUMERIC_PRECISION).  `nestedOnly`

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -72,9 +72,9 @@ extern PGDLLEXPORT PGType IcebergStoredPostgresType(PGType type);
  * receives the pre-mapping tree, which registration needs to record the
  * per-leaf surface->storage divergences.
  */
-extern PGDLLEXPORT Field *IcebergStorageFieldForColumnType(
-	PGType declaredType, IcebergCompatibilityMode mode, bool forAddColumn,
-	int *subFieldIndex, Field **surfaceFieldOut);
+extern PGDLLEXPORT Field * IcebergStorageFieldForColumnType(
+															PGType declaredType, IcebergCompatibilityMode mode, bool forAddColumn,
+															int *subFieldIndex, Field * *surfaceFieldOut);
 
 /*
  * IcebergFieldsEquivalent - true when two Iceberg field trees are the same
@@ -85,7 +85,7 @@ extern PGDLLEXPORT Field *IcebergStorageFieldForColumnType(
  * Tolerates NULL on either side (NULL equals only NULL), so a caller can pass a
  * persisted field it could not resolve without a separate check.
  */
-extern PGDLLEXPORT bool IcebergFieldsEquivalent(Field *a, Field *b);
+extern PGDLLEXPORT bool IcebergFieldsEquivalent(Field * a, Field * b);
 
 /*
  * TypeHasUnrepresentableLeaf - true when the type tree has a leaf Iceberg

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -55,7 +55,7 @@
  * Rewriting a nested leaf means rebuilding the enclosing composite or map, which
  * materializes a type in lake_struct / the map schema -- the create path's own
  * behaviour.  A caller that must not create catalog types should first reject
- * the input with TypeHasUnsupportedNumericLeaf(type, true).
+ * the input with TypeHasUnrepresentableLeaf(type, true).
  */
 extern PGDLLEXPORT PGType IcebergStoredPostgresType(PGType type);
 
@@ -80,24 +80,13 @@ extern PGDLLEXPORT Field * IcebergStorageFieldForColumnType(PGType declaredType,
 															Field * *surfaceFieldOut);
 
 /*
- * IcebergFieldsEquivalent - true when two Iceberg field trees are the same
- * stored representation, ignoring field ids and defaults (assigned per
- * derivation, irrelevant to storage).  So varchar length / text-family members
- * collapse to `string`, smallint and integer to `int`, and so on.
- *
- * Tolerates NULL on either side (NULL equals only NULL), so a caller can pass a
- * persisted field it could not resolve without a separate check.
- */
-extern PGDLLEXPORT bool IcebergFieldsEquivalent(Field * a, Field * b);
-
-/*
- * TypeHasUnsupportedNumericLeaf - true when the type tree has a numeric leaf
- * Iceberg cannot hold as a decimal (unbounded, or precision/scale beyond
- * DUCKDB_MAX_NUMERIC_PRECISION).  `nestedOnly` restricts the answer to leaves
- * below the top level, i.e. those whose rewrite would require materializing a
- * new composite or map type.
+ * TypeHasUnrepresentableLeaf - true when the type tree has a leaf Iceberg
+ * cannot hold natively (currently: a numeric that is unbounded or whose
+ * precision/scale exceeds DUCKDB_MAX_NUMERIC_PRECISION).  `nestedOnly`
+ * restricts the answer to leaves below the top level, i.e. those whose rewrite
+ * would require materializing a new composite or map type.
  *
  * Shares ConvertTypeTree's traversal, so it cannot drift out of coverage from
  * the rewrite it predicts, and creates no catalog types (see the leaf rule).
  */
-extern PGDLLEXPORT bool TypeHasUnsupportedNumericLeaf(PGType type, bool nestedOnly);
+extern PGDLLEXPORT bool TypeHasUnrepresentableLeaf(PGType type, bool nestedOnly);

--- a/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/iceberg_representation.h
@@ -31,9 +31,8 @@
  *
  * That matters because the transform set is not closed.  pg_lake shapes storage
  * with the unsupported-numeric rewrite and the compatibility mapping, but a
- * caller may add its own before the table is created (snowflake_cdc stores enums
- * and user-defined ranges as text, for one).  Only the persisted field reflects
- * all of them.
+ * caller may add its own before the table is created.  Only the persisted field
+ * reflects all of them.
  */
 
 #pragma once
@@ -73,11 +72,9 @@ extern PGDLLEXPORT PGType IcebergStoredPostgresType(PGType type);
  * receives the pre-mapping tree, which registration needs to record the
  * per-leaf surface->storage divergences.
  */
-extern PGDLLEXPORT Field * IcebergStorageFieldForColumnType(PGType declaredType,
-															IcebergCompatibilityMode mode,
-															bool forAddColumn,
-															int *subFieldIndex,
-															Field * *surfaceFieldOut);
+extern PGDLLEXPORT Field *IcebergStorageFieldForColumnType(
+	PGType declaredType, IcebergCompatibilityMode mode, bool forAddColumn,
+	int *subFieldIndex, Field **surfaceFieldOut);
 
 /*
  * TypeHasUnrepresentableLeaf - true when the type tree has a leaf Iceberg
@@ -89,4 +86,5 @@ extern PGDLLEXPORT Field * IcebergStorageFieldForColumnType(PGType declaredType,
  * Shares ConvertTypeTree's traversal, so it cannot drift out of coverage from
  * the rewrite it predicts, and creates no catalog types (see the leaf rule).
  */
-extern PGDLLEXPORT bool TypeHasUnrepresentableLeaf(PGType type, bool nestedOnly);
+extern PGDLLEXPORT bool TypeHasUnrepresentableLeaf(PGType type,
+												   bool nestedOnly);

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -71,6 +71,63 @@ IcebergStorageFieldForColumnType(PGType declaredType,
 	return storageField;
 }
 
+/*
+ * The required flags are compared even though the derivation currently produces
+ * false for every list element and map value: when one side is a persisted
+ * field, a difference we ignored here would be a difference we let through, and
+ * this predicate exists to gate changes that must not slip past.
+ */
+bool
+IcebergFieldsEquivalent(Field *a, Field *b)
+{
+	if (a == NULL || b == NULL)
+		return a == b;
+
+	if (a->type != b->type)
+		return false;
+
+	switch (a->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			return strcmp(a->field.scalar.typeName,
+						  b->field.scalar.typeName) == 0;
+
+		case FIELD_TYPE_LIST:
+			return a->field.list.elementRequired ==
+					   b->field.list.elementRequired &&
+				   IcebergFieldsEquivalent(a->field.list.element,
+										   b->field.list.element);
+
+		case FIELD_TYPE_MAP:
+			return a->field.map.valueRequired == b->field.map.valueRequired &&
+				   IcebergFieldsEquivalent(a->field.map.key,
+										   b->field.map.key) &&
+				   IcebergFieldsEquivalent(a->field.map.value,
+										   b->field.map.value);
+
+		case FIELD_TYPE_STRUCT:
+		{
+			if (a->field.structType.nfields != b->field.structType.nfields)
+				return false;
+
+			for (size_t i = 0; i < a->field.structType.nfields; i++)
+			{
+				FieldStructElement *elementA = &a->field.structType.fields[i];
+				FieldStructElement *elementB = &b->field.structType.fields[i];
+
+				if (elementA->required != elementB->required ||
+					strcmp(elementA->name, elementB->name) != 0 ||
+					!IcebergFieldsEquivalent(elementA->type, elementB->type))
+					return false;
+			}
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool
 TypeHasUnrepresentableLeaf(PGType type, bool nestedOnly)
 {

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -79,65 +79,10 @@ IcebergStorageFieldForColumnType(PGType declaredType, IcebergCompatibilityMode m
 
 
 /*
- * IcebergFieldsEquivalent - see iceberg_representation.h.
- *
- * The required flags are compared even though the derivation currently produces
- * `false` for every list element and map value: when one side is a persisted
- * field, a difference we ignored here would be a difference we let through, and
- * this predicate exists to gate changes that must not slip past.
+ * TypeHasUnrepresentableLeaf - see iceberg_representation.h.
  */
 bool
-IcebergFieldsEquivalent(Field * a, Field * b)
-{
-	if (a == NULL || b == NULL)
-		return a == b;
-
-	if (a->type != b->type)
-		return false;
-
-	switch (a->type)
-	{
-		case FIELD_TYPE_SCALAR:
-			return strcmp(a->field.scalar.typeName, b->field.scalar.typeName) == 0;
-
-		case FIELD_TYPE_LIST:
-			return a->field.list.elementRequired == b->field.list.elementRequired &&
-				IcebergFieldsEquivalent(a->field.list.element, b->field.list.element);
-
-		case FIELD_TYPE_MAP:
-			return a->field.map.valueRequired == b->field.map.valueRequired &&
-				IcebergFieldsEquivalent(a->field.map.key, b->field.map.key) &&
-				IcebergFieldsEquivalent(a->field.map.value, b->field.map.value);
-
-		case FIELD_TYPE_STRUCT:
-			{
-				if (a->field.structType.nfields != b->field.structType.nfields)
-					return false;
-
-				for (size_t i = 0; i < a->field.structType.nfields; i++)
-				{
-					FieldStructElement *elementA = &a->field.structType.fields[i];
-					FieldStructElement *elementB = &b->field.structType.fields[i];
-
-					if (elementA->required != elementB->required ||
-						strcmp(elementA->name, elementB->name) != 0 ||
-						!IcebergFieldsEquivalent(elementA->type, elementB->type))
-						return false;
-				}
-
-				return true;
-			}
-	}
-
-	return false;
-}
-
-
-/*
- * TypeHasUnsupportedNumericLeaf - see iceberg_representation.h.
- */
-bool
-TypeHasUnsupportedNumericLeaf(PGType type, bool nestedOnly)
+TypeHasUnrepresentableLeaf(PGType type, bool nestedOnly)
 {
 	UnsupportedNumericProbe probe = {.nestedOnly = nestedOnly,.found = false};
 	Oid			rewrittenOid;

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "postgres.h"
+
+#include "pg_lake/iceberg/compatibility_mode.h"
+#include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/iceberg/iceberg_representation.h"
+#include "pg_lake/pgduck/numeric.h"
+#include "pg_lake/util/rel_utils.h"
+
+
+/*
+ * State for the TypeHasUnsupportedNumericLeaf probe: what to look for, and
+ * whether it was seen.
+ */
+typedef struct UnsupportedNumericProbe
+{
+	bool		nestedOnly;
+	bool		found;
+}			UnsupportedNumericProbe;
+
+static bool UnsupportedNumericLeafProbe(Oid typeOid, int32 typeMod, int level,
+										void *context, Oid *outOid, int32 *outMod);
+
+
+/*
+ * IcebergStoredPostgresType - see iceberg_representation.h.
+ *
+ * The GUC check mirrors MaybeConvertUnsupportedNumericColumnsToDouble: with the
+ * GUC off no rewrite happens at any level, because CREATE rejects an unsupported
+ * numeric outright instead of storing it in some other shape.
+ */
+PGType
+IcebergStoredPostgresType(PGType type)
+{
+	if (!UnsupportedNumericAsDouble)
+		return type;
+
+	PGType		converted = MaybeConvertType(type, NULL);
+
+	return OidIsValid(converted.postgresTypeOid) ? converted : type;
+}
+
+
+/*
+ * IcebergStorageFieldForColumnType - see iceberg_representation.h.
+ */
+Field *
+IcebergStorageFieldForColumnType(PGType declaredType, IcebergCompatibilityMode mode,
+								 bool forAddColumn, int *subFieldIndex,
+								 Field * *surfaceFieldOut)
+{
+	Field	   *surfaceField = PostgresTypeToIcebergField(declaredType, forAddColumn,
+														  subFieldIndex);
+	Field	   *storageField = DeepCopyField(surfaceField);
+
+	ApplyCompatibilityStorageMapping(storageField, mode);
+
+	if (surfaceFieldOut != NULL)
+		*surfaceFieldOut = surfaceField;
+
+	return storageField;
+}
+
+
+/*
+ * IcebergFieldsEquivalent - see iceberg_representation.h.
+ *
+ * The required flags are compared even though the derivation currently produces
+ * `false` for every list element and map value: when one side is a persisted
+ * field, a difference we ignored here would be a difference we let through, and
+ * this predicate exists to gate changes that must not slip past.
+ */
+bool
+IcebergFieldsEquivalent(Field * a, Field * b)
+{
+	if (a == NULL || b == NULL)
+		return a == b;
+
+	if (a->type != b->type)
+		return false;
+
+	switch (a->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			return strcmp(a->field.scalar.typeName, b->field.scalar.typeName) == 0;
+
+		case FIELD_TYPE_LIST:
+			return a->field.list.elementRequired == b->field.list.elementRequired &&
+				IcebergFieldsEquivalent(a->field.list.element, b->field.list.element);
+
+		case FIELD_TYPE_MAP:
+			return a->field.map.valueRequired == b->field.map.valueRequired &&
+				IcebergFieldsEquivalent(a->field.map.key, b->field.map.key) &&
+				IcebergFieldsEquivalent(a->field.map.value, b->field.map.value);
+
+		case FIELD_TYPE_STRUCT:
+			{
+				if (a->field.structType.nfields != b->field.structType.nfields)
+					return false;
+
+				for (size_t i = 0; i < a->field.structType.nfields; i++)
+				{
+					FieldStructElement *elementA = &a->field.structType.fields[i];
+					FieldStructElement *elementB = &b->field.structType.fields[i];
+
+					if (elementA->required != elementB->required ||
+						strcmp(elementA->name, elementB->name) != 0 ||
+						!IcebergFieldsEquivalent(elementA->type, elementB->type))
+						return false;
+				}
+
+				return true;
+			}
+	}
+
+	return false;
+}
+
+
+/*
+ * TypeHasUnsupportedNumericLeaf - see iceberg_representation.h.
+ */
+bool
+TypeHasUnsupportedNumericLeaf(PGType type, bool nestedOnly)
+{
+	UnsupportedNumericProbe probe = {.nestedOnly = nestedOnly,.found = false};
+	Oid			rewrittenOid;
+	int32		rewrittenMod;
+
+	ConvertTypeTree(type.postgresTypeOid, type.postgresTypeMod, 0,
+					UnsupportedNumericLeafProbe, &probe,
+					&rewrittenOid, &rewrittenMod);
+
+	return probe.found;
+}
+
+
+/*
+ * UnsupportedNumericLeafProbe is the ConvertTypeTree leaf rule behind
+ * TypeHasUnsupportedNumericLeaf.  It records what it sees and always returns
+ * false, i.e. never requests a rewrite, which keeps ConvertTypeTree's composite
+ * and map branches short of FindOrCreateCompositeTypeFromColumnDefs and
+ * GetOrCreatePGMapType: the probe walks the same structure the real rewrite
+ * would, and materializes nothing.
+ */
+static bool
+UnsupportedNumericLeafProbe(Oid typeOid, int32 typeMod, int level, void *context,
+							Oid *outOid, int32 *outMod)
+{
+	UnsupportedNumericProbe *probe = (UnsupportedNumericProbe *) context;
+
+	if (IsUnsupportedNumericForIceberg(typeOid, typeMod) &&
+		(!probe->nestedOnly || level > 0))
+		probe->found = true;
+
+	return false;
+}

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -23,24 +23,21 @@
 #include "pg_lake/pgduck/numeric.h"
 #include "pg_lake/util/rel_utils.h"
 
-
 /*
- * State for the TypeHasUnsupportedNumericLeaf probe: what to look for, and
+ * State for the TypeHasUnrepresentableLeaf probe: what to look for, and
  * whether it was seen.
  */
 typedef struct UnsupportedNumericProbe
 {
-	bool		nestedOnly;
-	bool		found;
-}			UnsupportedNumericProbe;
+	bool nestedOnly;
+	bool found;
+} UnsupportedNumericProbe;
 
 static bool UnsupportedNumericLeafProbe(Oid typeOid, int32 typeMod, int level,
-										void *context, Oid *outOid, int32 *outMod);
-
+										void *context, Oid *outOid,
+										int32 *outMod);
 
 /*
- * IcebergStoredPostgresType - see iceberg_representation.h.
- *
  * The GUC check mirrors MaybeConvertUnsupportedNumericColumnsToDouble: with the
  * GUC off no rewrite happens at any level, because CREATE rejects an unsupported
  * numeric outright instead of storing it in some other shape.
@@ -51,23 +48,20 @@ IcebergStoredPostgresType(PGType type)
 	if (!UnsupportedNumericAsDouble)
 		return type;
 
-	PGType		converted = MaybeConvertType(type, NULL);
+	PGType converted = MaybeConvertType(type, NULL);
 
 	return OidIsValid(converted.postgresTypeOid) ? converted : type;
 }
 
-
-/*
- * IcebergStorageFieldForColumnType - see iceberg_representation.h.
- */
 Field *
-IcebergStorageFieldForColumnType(PGType declaredType, IcebergCompatibilityMode mode,
+IcebergStorageFieldForColumnType(PGType declaredType,
+								 IcebergCompatibilityMode mode,
 								 bool forAddColumn, int *subFieldIndex,
-								 Field * *surfaceFieldOut)
+								 Field **surfaceFieldOut)
 {
-	Field	   *surfaceField = PostgresTypeToIcebergField(declaredType, forAddColumn,
-														  subFieldIndex);
-	Field	   *storageField = DeepCopyField(surfaceField);
+	Field *surfaceField =
+		PostgresTypeToIcebergField(declaredType, forAddColumn, subFieldIndex);
+	Field *storageField = DeepCopyField(surfaceField);
 
 	ApplyCompatibilityStorageMapping(storageField, mode);
 
@@ -77,36 +71,32 @@ IcebergStorageFieldForColumnType(PGType declaredType, IcebergCompatibilityMode m
 	return storageField;
 }
 
-
-/*
- * TypeHasUnrepresentableLeaf - see iceberg_representation.h.
- */
 bool
 TypeHasUnrepresentableLeaf(PGType type, bool nestedOnly)
 {
-	UnsupportedNumericProbe probe = {.nestedOnly = nestedOnly,.found = false};
-	Oid			rewrittenOid;
-	int32		rewrittenMod;
+	UnsupportedNumericProbe probe = { .nestedOnly = nestedOnly,
+									  .found = false };
+	Oid rewrittenOid;
+	int32 rewrittenMod;
 
 	ConvertTypeTree(type.postgresTypeOid, type.postgresTypeMod, 0,
-					UnsupportedNumericLeafProbe, &probe,
-					&rewrittenOid, &rewrittenMod);
+					UnsupportedNumericLeafProbe, &probe, &rewrittenOid,
+					&rewrittenMod);
 
 	return probe.found;
 }
 
-
 /*
  * UnsupportedNumericLeafProbe is the ConvertTypeTree leaf rule behind
- * TypeHasUnsupportedNumericLeaf.  It records what it sees and always returns
+ * TypeHasUnrepresentableLeaf.  It records what it sees and always returns
  * false, i.e. never requests a rewrite, which keeps ConvertTypeTree's composite
  * and map branches short of FindOrCreateCompositeTypeFromColumnDefs and
  * GetOrCreatePGMapType: the probe walks the same structure the real rewrite
  * would, and materializes nothing.
  */
 static bool
-UnsupportedNumericLeafProbe(Oid typeOid, int32 typeMod, int level, void *context,
-							Oid *outOid, int32 *outMod)
+UnsupportedNumericLeafProbe(Oid typeOid, int32 typeMod, int level,
+							void *context, Oid *outOid, int32 *outMod)
 {
 	UnsupportedNumericProbe *probe = (UnsupportedNumericProbe *) context;
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_representation.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_representation.c
@@ -29,9 +29,9 @@
  */
 typedef struct UnsupportedNumericProbe
 {
-	bool nestedOnly;
-	bool found;
-} UnsupportedNumericProbe;
+	bool		nestedOnly;
+	bool		found;
+}			UnsupportedNumericProbe;
 
 static bool UnsupportedNumericLeafProbe(Oid typeOid, int32 typeMod, int level,
 										void *context, Oid *outOid,
@@ -48,7 +48,7 @@ IcebergStoredPostgresType(PGType type)
 	if (!UnsupportedNumericAsDouble)
 		return type;
 
-	PGType converted = MaybeConvertType(type, NULL);
+	PGType		converted = MaybeConvertType(type, NULL);
 
 	return OidIsValid(converted.postgresTypeOid) ? converted : type;
 }
@@ -57,11 +57,11 @@ Field *
 IcebergStorageFieldForColumnType(PGType declaredType,
 								 IcebergCompatibilityMode mode,
 								 bool forAddColumn, int *subFieldIndex,
-								 Field **surfaceFieldOut)
+								 Field * *surfaceFieldOut)
 {
-	Field *surfaceField =
+	Field	   *surfaceField =
 		PostgresTypeToIcebergField(declaredType, forAddColumn, subFieldIndex);
-	Field *storageField = DeepCopyField(surfaceField);
+	Field	   *storageField = DeepCopyField(surfaceField);
 
 	ApplyCompatibilityStorageMapping(storageField, mode);
 
@@ -78,7 +78,7 @@ IcebergStorageFieldForColumnType(PGType declaredType,
  * this predicate exists to gate changes that must not slip past.
  */
 bool
-IcebergFieldsEquivalent(Field *a, Field *b)
+IcebergFieldsEquivalent(Field * a, Field * b)
 {
 	if (a == NULL || b == NULL)
 		return a == b;
@@ -94,35 +94,35 @@ IcebergFieldsEquivalent(Field *a, Field *b)
 
 		case FIELD_TYPE_LIST:
 			return a->field.list.elementRequired ==
-					   b->field.list.elementRequired &&
-				   IcebergFieldsEquivalent(a->field.list.element,
-										   b->field.list.element);
+				b->field.list.elementRequired &&
+				IcebergFieldsEquivalent(a->field.list.element,
+										b->field.list.element);
 
 		case FIELD_TYPE_MAP:
 			return a->field.map.valueRequired == b->field.map.valueRequired &&
-				   IcebergFieldsEquivalent(a->field.map.key,
-										   b->field.map.key) &&
-				   IcebergFieldsEquivalent(a->field.map.value,
-										   b->field.map.value);
+				IcebergFieldsEquivalent(a->field.map.key,
+										b->field.map.key) &&
+				IcebergFieldsEquivalent(a->field.map.value,
+										b->field.map.value);
 
 		case FIELD_TYPE_STRUCT:
-		{
-			if (a->field.structType.nfields != b->field.structType.nfields)
-				return false;
-
-			for (size_t i = 0; i < a->field.structType.nfields; i++)
 			{
-				FieldStructElement *elementA = &a->field.structType.fields[i];
-				FieldStructElement *elementB = &b->field.structType.fields[i];
-
-				if (elementA->required != elementB->required ||
-					strcmp(elementA->name, elementB->name) != 0 ||
-					!IcebergFieldsEquivalent(elementA->type, elementB->type))
+				if (a->field.structType.nfields != b->field.structType.nfields)
 					return false;
-			}
 
-			return true;
-		}
+				for (size_t i = 0; i < a->field.structType.nfields; i++)
+				{
+					FieldStructElement *elementA = &a->field.structType.fields[i];
+					FieldStructElement *elementB = &b->field.structType.fields[i];
+
+					if (elementA->required != elementB->required ||
+						strcmp(elementA->name, elementB->name) != 0 ||
+						!IcebergFieldsEquivalent(elementA->type, elementB->type))
+						return false;
+				}
+
+				return true;
+			}
 	}
 
 	return false;
@@ -131,10 +131,10 @@ IcebergFieldsEquivalent(Field *a, Field *b)
 bool
 TypeHasUnrepresentableLeaf(PGType type, bool nestedOnly)
 {
-	UnsupportedNumericProbe probe = { .nestedOnly = nestedOnly,
-									  .found = false };
-	Oid rewrittenOid;
-	int32 rewrittenMod;
+	UnsupportedNumericProbe probe = {.nestedOnly = nestedOnly,
+	.found = false};
+	Oid			rewrittenOid;
+	int32		rewrittenMod;
 
 	ConvertTypeTree(type.postgresTypeOid, type.postgresTypeMod, 0,
 					UnsupportedNumericLeafProbe, &probe, &rewrittenOid,

--- a/pg_lake_iceberg/src/test/test_iceberg_representation.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_representation.c
@@ -31,6 +31,7 @@
 PG_FUNCTION_INFO_V1(pg_lake_iceberg_storage_type);
 PG_FUNCTION_INFO_V1(pg_lake_same_iceberg_representation);
 
+static bool IcebergFieldsEquivalent(Field * a, Field * b);
 static Field * StorageFieldForTypeString(const char *typeString,
 										 IcebergCompatibilityMode mode);
 static IcebergCompatibilityMode CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex);
@@ -101,14 +102,69 @@ pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
 	 * unsupported numeric.)
 	 */
 	if (!UnsupportedNumericAsDouble &&
-		(TypeHasUnsupportedNumericLeaf(MakePGType(oldTypeOid, oldTypeMod), false) ||
-		 TypeHasUnsupportedNumericLeaf(MakePGType(newTypeOid, newTypeMod), false)))
+		(TypeHasUnrepresentableLeaf(MakePGType(oldTypeOid, oldTypeMod), false) ||
+		 TypeHasUnrepresentableLeaf(MakePGType(newTypeOid, newTypeMod), false)))
 		PG_RETURN_BOOL(false);
 
 	Field	   *oldField = StorageFieldForTypeString(oldTypeString, mode);
 	Field	   *newField = StorageFieldForTypeString(newTypeString, mode);
 
 	PG_RETURN_BOOL(IcebergFieldsEquivalent(oldField, newField));
+}
+
+
+/*
+ * IcebergFieldsEquivalent - true when two field trees represent the same stored
+ * type, ignoring field ids and defaults.
+ *
+ * The required flags are compared even though derivation currently produces
+ * false for every list element and map value: any future divergence here is a
+ * real semantic difference, and this predicate exists to catch exactly that.
+ */
+static bool
+IcebergFieldsEquivalent(Field * a, Field * b)
+{
+	if (a == NULL || b == NULL)
+		return a == b;
+
+	if (a->type != b->type)
+		return false;
+
+	switch (a->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			return strcmp(a->field.scalar.typeName, b->field.scalar.typeName) == 0;
+
+		case FIELD_TYPE_LIST:
+			return a->field.list.elementRequired == b->field.list.elementRequired &&
+				IcebergFieldsEquivalent(a->field.list.element, b->field.list.element);
+
+		case FIELD_TYPE_MAP:
+			return a->field.map.valueRequired == b->field.map.valueRequired &&
+				IcebergFieldsEquivalent(a->field.map.key, b->field.map.key) &&
+				IcebergFieldsEquivalent(a->field.map.value, b->field.map.value);
+
+		case FIELD_TYPE_STRUCT:
+			{
+				if (a->field.structType.nfields != b->field.structType.nfields)
+					return false;
+
+				for (size_t i = 0; i < a->field.structType.nfields; i++)
+				{
+					FieldStructElement *elementA = &a->field.structType.fields[i];
+					FieldStructElement *elementB = &b->field.structType.fields[i];
+
+					if (elementA->required != elementB->required ||
+						strcmp(elementA->name, elementB->name) != 0 ||
+						!IcebergFieldsEquivalent(elementA->type, elementB->type))
+						return false;
+				}
+
+				return true;
+			}
+	}
+
+	return false;
 }
 
 

--- a/pg_lake_iceberg/src/test/test_iceberg_representation.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_representation.c
@@ -31,12 +31,11 @@
 PG_FUNCTION_INFO_V1(pg_lake_iceberg_storage_type);
 PG_FUNCTION_INFO_V1(pg_lake_same_iceberg_representation);
 
-static bool IcebergFieldsEquivalent(Field * a, Field * b);
-static Field * StorageFieldForTypeString(const char *typeString,
-										 IcebergCompatibilityMode mode);
-static IcebergCompatibilityMode CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex);
-static void AppendFieldTypeString(StringInfo buffer, Field * field);
-
+static Field *StorageFieldForTypeString(const char *typeString,
+										IcebergCompatibilityMode mode);
+static IcebergCompatibilityMode CompatibilityModeArg(FunctionCallInfo fcinfo,
+													 int argIndex);
+static void AppendFieldTypeString(StringInfo buffer, Field *field);
 
 /*
  * pg_lake_iceberg_storage_type(type text, compatibility_mode text) -> text
@@ -52,16 +51,16 @@ pg_lake_iceberg_storage_type(PG_FUNCTION_ARGS)
 	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL();
 
-	Field	   *field = StorageFieldForTypeString(text_to_cstring(PG_GETARG_TEXT_PP(0)),
-												  CompatibilityModeArg(fcinfo, 1));
+	Field *field =
+		StorageFieldForTypeString(text_to_cstring(PG_GETARG_TEXT_PP(0)),
+								  CompatibilityModeArg(fcinfo, 1));
 
-	StringInfo	buffer = makeStringInfo();
+	StringInfo buffer = makeStringInfo();
 
 	AppendFieldTypeString(buffer, field);
 
 	PG_RETURN_TEXT_P(cstring_to_text(buffer->data));
 }
-
 
 /*
  * pg_lake_same_iceberg_representation(old_type text, new_type text,
@@ -80,14 +79,14 @@ pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_NULL();
 
-	char	   *oldTypeString = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	char	   *newTypeString = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	char *oldTypeString = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char *newTypeString = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	IcebergCompatibilityMode mode = CompatibilityModeArg(fcinfo, 2);
 
-	Oid			oldTypeOid;
-	int32		oldTypeMod;
-	Oid			newTypeOid;
-	int32		newTypeMod;
+	Oid oldTypeOid;
+	int32 oldTypeMod;
+	Oid newTypeOid;
+	int32 newTypeMod;
 
 	parseTypeString(oldTypeString, &oldTypeOid, &oldTypeMod, NULL);
 	parseTypeString(newTypeString, &newTypeOid, &newTypeMod, NULL);
@@ -102,71 +101,17 @@ pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
 	 * unsupported numeric.)
 	 */
 	if (!UnsupportedNumericAsDouble &&
-		(TypeHasUnrepresentableLeaf(MakePGType(oldTypeOid, oldTypeMod), false) ||
-		 TypeHasUnrepresentableLeaf(MakePGType(newTypeOid, newTypeMod), false)))
+		(TypeHasUnrepresentableLeaf(MakePGType(oldTypeOid, oldTypeMod),
+									false) ||
+		 TypeHasUnrepresentableLeaf(MakePGType(newTypeOid, newTypeMod),
+									false)))
 		PG_RETURN_BOOL(false);
 
-	Field	   *oldField = StorageFieldForTypeString(oldTypeString, mode);
-	Field	   *newField = StorageFieldForTypeString(newTypeString, mode);
+	Field *oldField = StorageFieldForTypeString(oldTypeString, mode);
+	Field *newField = StorageFieldForTypeString(newTypeString, mode);
 
 	PG_RETURN_BOOL(IcebergFieldsEquivalent(oldField, newField));
 }
-
-
-/*
- * IcebergFieldsEquivalent - true when two field trees represent the same stored
- * type, ignoring field ids and defaults.
- *
- * The required flags are compared even though derivation currently produces
- * false for every list element and map value: any future divergence here is a
- * real semantic difference, and this predicate exists to catch exactly that.
- */
-static bool
-IcebergFieldsEquivalent(Field * a, Field * b)
-{
-	if (a == NULL || b == NULL)
-		return a == b;
-
-	if (a->type != b->type)
-		return false;
-
-	switch (a->type)
-	{
-		case FIELD_TYPE_SCALAR:
-			return strcmp(a->field.scalar.typeName, b->field.scalar.typeName) == 0;
-
-		case FIELD_TYPE_LIST:
-			return a->field.list.elementRequired == b->field.list.elementRequired &&
-				IcebergFieldsEquivalent(a->field.list.element, b->field.list.element);
-
-		case FIELD_TYPE_MAP:
-			return a->field.map.valueRequired == b->field.map.valueRequired &&
-				IcebergFieldsEquivalent(a->field.map.key, b->field.map.key) &&
-				IcebergFieldsEquivalent(a->field.map.value, b->field.map.value);
-
-		case FIELD_TYPE_STRUCT:
-			{
-				if (a->field.structType.nfields != b->field.structType.nfields)
-					return false;
-
-				for (size_t i = 0; i < a->field.structType.nfields; i++)
-				{
-					FieldStructElement *elementA = &a->field.structType.fields[i];
-					FieldStructElement *elementB = &b->field.structType.fields[i];
-
-					if (elementA->required != elementB->required ||
-						strcmp(elementA->name, elementB->name) != 0 ||
-						!IcebergFieldsEquivalent(elementA->type, elementB->type))
-						return false;
-				}
-
-				return true;
-			}
-	}
-
-	return false;
-}
-
 
 /*
  * StorageFieldForTypeString parses a Postgres type string (e.g. 'varchar(50)',
@@ -174,19 +119,21 @@ IcebergFieldsEquivalent(Field * a, Field * b)
  * it, applying the same two steps registration does.
  */
 static Field *
-StorageFieldForTypeString(const char *typeString, IcebergCompatibilityMode mode)
+StorageFieldForTypeString(const char *typeString,
+						  IcebergCompatibilityMode mode)
 {
-	Oid			typeOid;
-	int32		typeMod;
-	int			subFieldIndex = 0;
+	Oid typeOid;
+	int32 typeMod;
+	int subFieldIndex = 0;
 
 	parseTypeString(typeString, &typeOid, &typeMod, NULL);
 
-	PGType		storedType = IcebergStoredPostgresType(MakePGType(typeOid, typeMod));
+	PGType storedType =
+		IcebergStoredPostgresType(MakePGType(typeOid, typeMod));
 
-	return IcebergStorageFieldForColumnType(storedType, mode, false, &subFieldIndex, NULL);
+	return IcebergStorageFieldForColumnType(storedType, mode, false,
+											&subFieldIndex, NULL);
 }
-
 
 /*
  * CompatibilityModeArg reads an optional compatibility_mode text argument; a
@@ -198,9 +145,9 @@ CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex)
 	if (PG_ARGISNULL(argIndex))
 		return ICEBERG_COMPAT_AUTO;
 
-	return ParseIcebergCompatibilityMode(text_to_cstring(PG_GETARG_TEXT_PP(argIndex)));
+	return ParseIcebergCompatibilityMode(
+		text_to_cstring(PG_GETARG_TEXT_PP(argIndex)));
 }
-
 
 /*
  * AppendFieldTypeString renders a Field tree in a compact Iceberg-ish notation.
@@ -208,7 +155,7 @@ CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex)
  * them would make every expected value in a test depend on id allocation.
  */
 static void
-AppendFieldTypeString(StringInfo buffer, Field * field)
+AppendFieldTypeString(StringInfo buffer, Field *field)
 {
 	if (field == NULL)
 	{
@@ -241,7 +188,8 @@ AppendFieldTypeString(StringInfo buffer, Field * field)
 
 			for (size_t i = 0; i < field->field.structType.nfields; i++)
 			{
-				FieldStructElement *element = &field->field.structType.fields[i];
+				FieldStructElement *element =
+					&field->field.structType.fields[i];
 
 				if (i > 0)
 					appendStringInfoChar(buffer, ',');

--- a/pg_lake_iceberg/src/test/test_iceberg_representation.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_representation.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+
+#include "lib/stringinfo.h"
+#include "parser/parse_type.h"
+#include "utils/builtins.h"
+
+#include "pg_lake/iceberg/compatibility_mode.h"
+#include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/iceberg/iceberg_representation.h"
+#include "pg_lake/pgduck/numeric.h"
+#include "pg_lake/pgduck/type.h"
+
+PG_FUNCTION_INFO_V1(pg_lake_iceberg_storage_type);
+PG_FUNCTION_INFO_V1(pg_lake_same_iceberg_representation);
+
+static Field * StorageFieldForTypeString(const char *typeString,
+										 IcebergCompatibilityMode mode);
+static IcebergCompatibilityMode CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex);
+static void AppendFieldTypeString(StringInfo buffer, Field * field);
+
+
+/*
+ * pg_lake_iceberg_storage_type(type text, compatibility_mode text) -> text
+ *
+ * Renders the Iceberg type the create path stores for `type`, e.g. 'string',
+ * 'list<double>', 'struct<a:double,b:int>'.  Tests assert on this directly so a
+ * derivation that is wrong in the same way on both sides of a comparison cannot
+ * hide behind an "equal" verdict.
+ */
+Datum
+pg_lake_iceberg_storage_type(PG_FUNCTION_ARGS)
+{
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	Field	   *field = StorageFieldForTypeString(text_to_cstring(PG_GETARG_TEXT_PP(0)),
+												  CompatibilityModeArg(fcinfo, 1));
+
+	StringInfo	buffer = makeStringInfo();
+
+	AppendFieldTypeString(buffer, field);
+
+	PG_RETURN_TEXT_P(cstring_to_text(buffer->data));
+}
+
+
+/*
+ * pg_lake_same_iceberg_representation(old_type text, new_type text,
+ *									   compatibility_mode text) -> bool
+ *
+ * Composes the exported primitives the way a consumer with no persisted field to
+ * compare against would (see iceberg_representation.h on why that is the weaker
+ * question), so the type-pair expectations can be pinned without a real table.
+ *
+ * pg_lake_iceberg.unsupported_numeric_as_double is read live, so a test pins it
+ * with SET rather than passing it in.
+ */
+Datum
+pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
+{
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+
+	char	   *oldTypeString = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *newTypeString = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	IcebergCompatibilityMode mode = CompatibilityModeArg(fcinfo, 2);
+
+	Oid			oldTypeOid;
+	int32		oldTypeMod;
+	Oid			newTypeOid;
+	int32		newTypeMod;
+
+	parseTypeString(oldTypeString, &oldTypeOid, &oldTypeMod, NULL);
+	parseTypeString(newTypeString, &newTypeOid, &newTypeMod, NULL);
+
+	/*
+	 * Caller policy, not a property of the primitives: with
+	 * unsupported_numeric_as_double off, CREATE rejects such a numeric at any
+	 * level instead of storing it, so it has no stored form to compare.
+	 * Report "not the same" rather than letting both sides fall through to
+	 * the `string` default and match.  (A caller comparing against a
+	 * persisted field does not need this: a persisted field can never be an
+	 * unsupported numeric.)
+	 */
+	if (!UnsupportedNumericAsDouble &&
+		(TypeHasUnsupportedNumericLeaf(MakePGType(oldTypeOid, oldTypeMod), false) ||
+		 TypeHasUnsupportedNumericLeaf(MakePGType(newTypeOid, newTypeMod), false)))
+		PG_RETURN_BOOL(false);
+
+	Field	   *oldField = StorageFieldForTypeString(oldTypeString, mode);
+	Field	   *newField = StorageFieldForTypeString(newTypeString, mode);
+
+	PG_RETURN_BOOL(IcebergFieldsEquivalent(oldField, newField));
+}
+
+
+/*
+ * StorageFieldForTypeString parses a Postgres type string (e.g. 'varchar(50)',
+ * 'numeric(50,2)[]', 'uuid[]') and returns the field the create path stores for
+ * it, applying the same two steps registration does.
+ */
+static Field *
+StorageFieldForTypeString(const char *typeString, IcebergCompatibilityMode mode)
+{
+	Oid			typeOid;
+	int32		typeMod;
+	int			subFieldIndex = 0;
+
+	parseTypeString(typeString, &typeOid, &typeMod, NULL);
+
+	PGType		storedType = IcebergStoredPostgresType(MakePGType(typeOid, typeMod));
+
+	return IcebergStorageFieldForColumnType(storedType, mode, false, &subFieldIndex, NULL);
+}
+
+
+/*
+ * CompatibilityModeArg reads an optional compatibility_mode text argument; a
+ * NULL argument means AUTO, i.e. no compatibility storage mapping.
+ */
+static IcebergCompatibilityMode
+CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex)
+{
+	if (PG_ARGISNULL(argIndex))
+		return ICEBERG_COMPAT_AUTO;
+
+	return ParseIcebergCompatibilityMode(text_to_cstring(PG_GETARG_TEXT_PP(argIndex)));
+}
+
+
+/*
+ * AppendFieldTypeString renders a Field tree in a compact Iceberg-ish notation.
+ * Field ids and defaults are omitted: they are per-derivation, and including
+ * them would make every expected value in a test depend on id allocation.
+ */
+static void
+AppendFieldTypeString(StringInfo buffer, Field * field)
+{
+	if (field == NULL)
+	{
+		appendStringInfoString(buffer, "<none>");
+		return;
+	}
+
+	switch (field->type)
+	{
+		case FIELD_TYPE_SCALAR:
+			appendStringInfoString(buffer, field->field.scalar.typeName);
+			break;
+
+		case FIELD_TYPE_LIST:
+			appendStringInfoString(buffer, "list<");
+			AppendFieldTypeString(buffer, field->field.list.element);
+			appendStringInfoChar(buffer, '>');
+			break;
+
+		case FIELD_TYPE_MAP:
+			appendStringInfoString(buffer, "map<");
+			AppendFieldTypeString(buffer, field->field.map.key);
+			appendStringInfoChar(buffer, ',');
+			AppendFieldTypeString(buffer, field->field.map.value);
+			appendStringInfoChar(buffer, '>');
+			break;
+
+		case FIELD_TYPE_STRUCT:
+			appendStringInfoString(buffer, "struct<");
+
+			for (size_t i = 0; i < field->field.structType.nfields; i++)
+			{
+				FieldStructElement *element = &field->field.structType.fields[i];
+
+				if (i > 0)
+					appendStringInfoChar(buffer, ',');
+
+				appendStringInfo(buffer, "%s:", element->name);
+				AppendFieldTypeString(buffer, element->type);
+			}
+
+			appendStringInfoChar(buffer, '>');
+			break;
+	}
+}

--- a/pg_lake_iceberg/src/test/test_iceberg_representation.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_representation.c
@@ -31,11 +31,11 @@
 PG_FUNCTION_INFO_V1(pg_lake_iceberg_storage_type);
 PG_FUNCTION_INFO_V1(pg_lake_same_iceberg_representation);
 
-static Field *StorageFieldForTypeString(const char *typeString,
-										IcebergCompatibilityMode mode);
+static Field * StorageFieldForTypeString(const char *typeString,
+										 IcebergCompatibilityMode mode);
 static IcebergCompatibilityMode CompatibilityModeArg(FunctionCallInfo fcinfo,
 													 int argIndex);
-static void AppendFieldTypeString(StringInfo buffer, Field *field);
+static void AppendFieldTypeString(StringInfo buffer, Field * field);
 
 /*
  * pg_lake_iceberg_storage_type(type text, compatibility_mode text) -> text
@@ -51,11 +51,11 @@ pg_lake_iceberg_storage_type(PG_FUNCTION_ARGS)
 	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL();
 
-	Field *field =
+	Field	   *field =
 		StorageFieldForTypeString(text_to_cstring(PG_GETARG_TEXT_PP(0)),
 								  CompatibilityModeArg(fcinfo, 1));
 
-	StringInfo buffer = makeStringInfo();
+	StringInfo	buffer = makeStringInfo();
 
 	AppendFieldTypeString(buffer, field);
 
@@ -79,14 +79,14 @@ pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_NULL();
 
-	char *oldTypeString = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	char *newTypeString = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	char	   *oldTypeString = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *newTypeString = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	IcebergCompatibilityMode mode = CompatibilityModeArg(fcinfo, 2);
 
-	Oid oldTypeOid;
-	int32 oldTypeMod;
-	Oid newTypeOid;
-	int32 newTypeMod;
+	Oid			oldTypeOid;
+	int32		oldTypeMod;
+	Oid			newTypeOid;
+	int32		newTypeMod;
 
 	parseTypeString(oldTypeString, &oldTypeOid, &oldTypeMod, NULL);
 	parseTypeString(newTypeString, &newTypeOid, &newTypeMod, NULL);
@@ -107,8 +107,8 @@ pg_lake_same_iceberg_representation(PG_FUNCTION_ARGS)
 									false)))
 		PG_RETURN_BOOL(false);
 
-	Field *oldField = StorageFieldForTypeString(oldTypeString, mode);
-	Field *newField = StorageFieldForTypeString(newTypeString, mode);
+	Field	   *oldField = StorageFieldForTypeString(oldTypeString, mode);
+	Field	   *newField = StorageFieldForTypeString(newTypeString, mode);
 
 	PG_RETURN_BOOL(IcebergFieldsEquivalent(oldField, newField));
 }
@@ -122,13 +122,13 @@ static Field *
 StorageFieldForTypeString(const char *typeString,
 						  IcebergCompatibilityMode mode)
 {
-	Oid typeOid;
-	int32 typeMod;
-	int subFieldIndex = 0;
+	Oid			typeOid;
+	int32		typeMod;
+	int			subFieldIndex = 0;
 
 	parseTypeString(typeString, &typeOid, &typeMod, NULL);
 
-	PGType storedType =
+	PGType		storedType =
 		IcebergStoredPostgresType(MakePGType(typeOid, typeMod));
 
 	return IcebergStorageFieldForColumnType(storedType, mode, false,
@@ -146,7 +146,7 @@ CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex)
 		return ICEBERG_COMPAT_AUTO;
 
 	return ParseIcebergCompatibilityMode(
-		text_to_cstring(PG_GETARG_TEXT_PP(argIndex)));
+										 text_to_cstring(PG_GETARG_TEXT_PP(argIndex)));
 }
 
 /*
@@ -155,7 +155,7 @@ CompatibilityModeArg(FunctionCallInfo fcinfo, int argIndex)
  * them would make every expected value in a test depend on id allocation.
  */
 static void
-AppendFieldTypeString(StringInfo buffer, Field *field)
+AppendFieldTypeString(StringInfo buffer, Field * field)
 {
 	if (field == NULL)
 	{

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_representation.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_representation.py
@@ -1,0 +1,386 @@
+"""
+Tests for the Iceberg stored-representation primitives (iceberg_representation.h).
+
+Two layers:
+
+1. ``test_storage_type_*`` pin the *actual* Iceberg type the create path stores
+   for a Postgres type, e.g. ``numeric(50,2)[]`` -> ``list<double>``.  Pairwise
+   same/different assertions alone cannot catch a derivation that is wrong the
+   same way on both sides -- the failure mode that made a nested unsupported
+   numeric compare equal to ``text[]`` -- so the exact shape is asserted.
+
+2. ``test_*_representation*`` pin type pairs, composing the primitives the way a
+   caller with no persisted field to compare against would.  A caller that has
+   the persisted field (from ``lake_table.field_id_mappings``) should derive only
+   the new type and compare against that instead; see iceberg_representation.h.
+
+The extraction that lets a comparison run the same code that produced the
+persisted field is covered by the existing create-path suites
+(``pg_lake_table/tests/pytests/test_compatibility_mode.py``,
+``test_iceberg_uuid_compat.py``), which assert the resulting Iceberg schema
+end-to-end.
+"""
+
+import pytest
+from utils_pytest import *
+
+
+@pytest.fixture(scope="module")
+def iceberg_representation_fns(superuser_conn, iceberg_extension):
+    """Register SQL wrappers over the exported representation primitives."""
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION lake_iceberg.iceberg_storage_type(
+            type text, compatibility_mode text DEFAULT NULL)
+        RETURNS text
+        LANGUAGE C
+        AS 'pg_lake_iceberg', $$pg_lake_iceberg_storage_type$$;
+
+        CREATE OR REPLACE FUNCTION lake_iceberg.same_iceberg_representation(
+            old_type text, new_type text, compatibility_mode text DEFAULT NULL)
+        RETURNS bool
+        LANGUAGE C
+        AS 'pg_lake_iceberg', $$pg_lake_same_iceberg_representation$$;
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command(
+        "DROP FUNCTION IF EXISTS lake_iceberg.iceberg_storage_type(text, text);"
+        "DROP FUNCTION IF EXISTS lake_iceberg.same_iceberg_representation(text, text, text);",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
+def _storage_type(
+    conn, pg_type, unsupported_numeric_as_double=None, compatibility_mode=None
+):
+    """The Iceberg type the create path stores for pg_type.
+
+    unsupported_numeric_as_double is pinned with SET rather than passed in: the
+    primitives read the live GUC, exactly as the create path does.  The trailing
+    rollback reverts the SET along with the query.
+    """
+    if unsupported_numeric_as_double is not None:
+        run_command(
+            "SET pg_lake_iceberg.unsupported_numeric_as_double TO "
+            f"{str(unsupported_numeric_as_double).lower()}",
+            conn,
+        )
+
+    mode = "NULL" if compatibility_mode is None else f"'{compatibility_mode}'"
+    got = run_query(
+        f"SELECT lake_iceberg.iceberg_storage_type('{pg_type}', {mode})", conn
+    )[0][0]
+    conn.rollback()
+    return got
+
+
+def _same(
+    conn,
+    old_type,
+    new_type,
+    unsupported_numeric_as_double=None,
+    compatibility_mode=None,
+):
+    """Whether two Postgres types are stored with the same Iceberg representation."""
+    if unsupported_numeric_as_double is not None:
+        run_command(
+            "SET pg_lake_iceberg.unsupported_numeric_as_double TO "
+            f"{str(unsupported_numeric_as_double).lower()}",
+            conn,
+        )
+
+    mode = "NULL" if compatibility_mode is None else f"'{compatibility_mode}'"
+    got = run_query(
+        "SELECT lake_iceberg.same_iceberg_representation"
+        f"('{old_type}', '{new_type}', {mode})",
+        conn,
+    )[0][0]
+    conn.rollback()
+    return got
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: the exact stored representation
+# ---------------------------------------------------------------------------
+
+# (postgres type, expected iceberg storage type) with the default GUC state
+# (unsupported_numeric_as_double on) and no compatibility mode.
+STORAGE_TYPES = [
+    # text family: Iceberg models neither length nor which member
+    ("varchar(50)", "string"),
+    ("varchar(100)", "string"),
+    ("char(10)", "string"),
+    ("text", "string"),
+    ("json", "string"),
+    ("jsonb", "string"),
+    # integers and floats
+    ("smallint", "int"),
+    ("integer", "int"),
+    ("bigint", "long"),
+    ("real", "float"),
+    ("double precision", "double"),
+    ("boolean", "boolean"),
+    ("bytea", "binary"),
+    ("uuid", "uuid"),
+    # date/time: time and timetz collapse, timestamp and timestamptz do not
+    ("date", "date"),
+    ("time", "time"),
+    ("timetz", "time"),
+    ("timestamp", "timestamp"),
+    ("timestamptz", "timestamptz"),
+    # a numeric Iceberg can hold stays an exact decimal
+    ("numeric(10,2)", "decimal(10,2)"),
+    ("numeric(38,9)", "decimal(38,9)"),
+    # one Iceberg cannot is stored as double (GUC on)
+    ("numeric(50,2)", "double"),
+    ("numeric(60,3)", "double"),
+    ("numeric", "double"),
+    # containers: the rules apply at every level
+    ("text[]", "list<string>"),
+    ("varchar(10)[]", "list<string>"),
+    ("integer[]", "list<int>"),
+    ("bigint[]", "list<long>"),
+    ("uuid[]", "list<uuid>"),
+    ("numeric(10,2)[]", "list<decimal(10,2)>"),
+    # the case a top-level-only conversion got wrong: not list<string>
+    ("numeric(50,2)[]", "list<double>"),
+    ("numeric[]", "list<double>"),
+    ("text[][]", "list<string>"),
+]
+
+
+@pytest.mark.parametrize("pg_type,expected", STORAGE_TYPES)
+def test_storage_type(pg_type, expected, superuser_conn, iceberg_representation_fns):
+    got = _storage_type(superuser_conn, pg_type)
+    assert got == expected, f"{pg_type}: expected {expected}, got {got}"
+
+
+def test_storage_type_unsupported_numeric_guc_off(
+    superuser_conn, iceberg_representation_fns
+):
+    """With unsupported_numeric_as_double off there is no double rewrite, so an
+    oversized numeric falls through to the `string` default -- a shape CREATE
+    never actually stores, because it rejects such a column instead.  Pinned here
+    because it is precisely why a caller must not read a `string` match as "same
+    representation" (see test_unsupported_numeric_not_representable_when_disabled).
+    """
+    assert _storage_type(superuser_conn, "numeric(50,2)", False) == "string"
+    assert _storage_type(superuser_conn, "numeric(50,2)[]", False) == "list<string>"
+    # a bounded numeric is a genuine Iceberg decimal either way
+    assert _storage_type(superuser_conn, "numeric(10,2)", False) == "decimal(10,2)"
+
+
+def test_storage_type_compatibility_mode_is_depth_dependent(
+    superuser_conn, iceberg_representation_fns
+):
+    """Under compatibility_mode='snowflake' a uuid nested in a container is stored
+    as `string`, while a top-level uuid stays native.  Pinning both depths is what
+    makes the uuid vs text comparisons below unambiguous.
+    """
+    assert (
+        _storage_type(superuser_conn, "uuid", compatibility_mode="snowflake") == "uuid"
+    )
+    assert (
+        _storage_type(superuser_conn, "uuid[]", compatibility_mode="snowflake")
+        == "list<string>"
+    )
+    # auto applies no mapping at any depth
+    assert (
+        _storage_type(superuser_conn, "uuid[]", compatibility_mode="auto")
+        == "list<uuid>"
+    )
+
+
+def test_storage_type_composite_and_interval(
+    superuser_conn, iceberg_representation_fns
+):
+    """Composites derive to a struct and the rules apply to their fields; interval
+    has no native Iceberg type and is modelled as a struct of longs.
+    """
+    run_command("DROP TYPE IF EXISTS rep_num, rep_dbl, rep_txt;", superuser_conn)
+    run_command("CREATE TYPE rep_num AS (a numeric(50,2), b int);", superuser_conn)
+    run_command("CREATE TYPE rep_dbl AS (a double precision, b int);", superuser_conn)
+    run_command("CREATE TYPE rep_txt AS (a text, b int);", superuser_conn)
+    superuser_conn.commit()
+
+    try:
+        assert _storage_type(superuser_conn, "rep_num") == "struct<a:double,b:int>"
+        assert _storage_type(superuser_conn, "rep_dbl") == "struct<a:double,b:int>"
+        assert _storage_type(superuser_conn, "rep_txt") == "struct<a:string,b:int>"
+        assert (
+            _storage_type(superuser_conn, "interval")
+            == "struct<months:long,days:long,microseconds:long>"
+        )
+    finally:
+        run_command("DROP TYPE IF EXISTS rep_num, rep_dbl, rep_txt;", superuser_conn)
+        superuser_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: type-pair comparisons
+# ---------------------------------------------------------------------------
+
+# Type pairs whose Iceberg representation is identical (ignoring anything
+# Iceberg does not model: text length, which text-family member, etc.).
+SAME_REPRESENTATION = [
+    ("varchar(50)", "varchar(100)"),  # both Iceberg `string`
+    ("varchar(100)", "varchar(20)"),  # narrowing is still `string`
+    ("varchar(50)", "text"),
+    ("char(10)", "varchar(30)"),  # bpchar and varchar are both `string`
+    ("char(10)", "text"),
+    ("smallint", "integer"),  # both `int`
+    ("time", "timetz"),  # both `time`
+    ("json", "text"),  # json falls back to `string`, same as text
+    ("jsonb", "text"),
+    ("numeric", "numeric(50,2)"),  # both unsupported -> normalized to `double`
+]
+
+# Type pairs whose Iceberg representation differs.
+DIFFERENT_REPRESENTATION = [
+    ("integer", "bigint"),  # `int` vs `long`
+    ("integer", "text"),  # `int` vs `string`
+    ("numeric(10,2)", "text"),  # `decimal(10,2)` vs `string`
+    ("numeric(10,2)", "numeric(12,4)"),  # `decimal(10,2)` vs `decimal(12,4)`
+    ("timestamp", "timestamptz"),  # `timestamp` vs `timestamptz`
+    ("real", "double precision"),  # `float` vs `double`
+]
+
+
+@pytest.mark.parametrize("old_type,new_type", SAME_REPRESENTATION)
+def test_same_iceberg_representation_true(
+    old_type, new_type, superuser_conn, iceberg_representation_fns
+):
+    assert (
+        _same(superuser_conn, old_type, new_type) is True
+    ), f"{old_type} -> {new_type}: expected same representation"
+
+
+@pytest.mark.parametrize("old_type,new_type", DIFFERENT_REPRESENTATION)
+def test_same_iceberg_representation_false(
+    old_type, new_type, superuser_conn, iceberg_representation_fns
+):
+    assert (
+        _same(superuser_conn, old_type, new_type) is False
+    ), f"{old_type} -> {new_type}: expected different representation"
+
+
+# Nested type pairs, evaluated with the default GUC
+# (unsupported_numeric_as_double on).  These exercise the recursive derivation:
+# an unsupported numeric is stored as double at every level, so it must not be
+# conflated with the `string` fallback that a genuine text type maps to.
+NESTED_SAME = [
+    ("numeric(50,2)[]", "numeric(60,3)[]"),  # both list<double>
+    ("numeric[]", "numeric(50,2)[]"),  # both unsupported -> list<double>
+    ("varchar(10)[]", "text[]"),  # both list<string>
+]
+
+NESTED_DIFFERENT = [
+    # The false match a top-level-only conversion produces: a nested unsupported
+    # numeric is stored as list<double>, not list<string>, so it differs from text[].
+    ("numeric(50,2)[]", "text[]"),
+    ("numeric(50,2)[]", "numeric(10,2)[]"),  # list<double> vs list<decimal(10,2)>
+    ("integer[]", "bigint[]"),  # list<int> vs list<long>
+]
+
+
+@pytest.mark.parametrize("old_type,new_type", NESTED_SAME)
+def test_nested_same_representation(
+    old_type, new_type, superuser_conn, iceberg_representation_fns
+):
+    assert (
+        _same(superuser_conn, old_type, new_type) is True
+    ), f"{old_type} -> {new_type}: expected same representation"
+
+
+@pytest.mark.parametrize("old_type,new_type", NESTED_DIFFERENT)
+def test_nested_different_representation(
+    old_type, new_type, superuser_conn, iceberg_representation_fns
+):
+    assert (
+        _same(superuser_conn, old_type, new_type) is False
+    ), f"{old_type} -> {new_type}: expected different representation"
+
+
+def test_unsupported_numeric_double_when_enabled(
+    superuser_conn, iceberg_representation_fns
+):
+    """With unsupported_numeric_as_double on, an unsupported numeric is stored
+    as double at every nesting level, so it matches another unsupported numeric
+    -- and an actual double, the type the create path converts it to -- but not
+    text."""
+    assert _same(superuser_conn, "numeric(50,2)[]", "text[]", True) is False
+    assert _same(superuser_conn, "numeric(50,2)[]", "numeric(60,3)[]", True) is True
+    assert _same(superuser_conn, "numeric(50,2)", "numeric(60,3)", True) is True
+    # the converted leaf really is `double`, so it matches a genuine float8
+    assert _same(superuser_conn, "numeric(50,2)[]", "double precision[]", True) is True
+    assert _same(superuser_conn, "numeric[]", "double precision[]", True) is True
+
+
+def test_unsupported_numeric_not_representable_when_disabled(
+    superuser_conn, iceberg_representation_fns
+):
+    """With unsupported_numeric_as_double off, CREATE errors on an unsupported
+    numeric at any level, so it has no stored representation: the comparison is
+    conservatively false even for identical types.  Bounded numerics, which are
+    genuine Iceberg decimals, are unaffected."""
+    assert _same(superuser_conn, "numeric(50,2)", "numeric(50,2)", False) is False
+    assert _same(superuser_conn, "numeric(50,2)[]", "numeric(50,2)[]", False) is False
+    assert _same(superuser_conn, "numeric", "numeric", False) is False
+    # bounded numerics remain comparable when the GUC is off
+    assert _same(superuser_conn, "numeric(10,2)", "numeric(10,2)", False) is True
+    assert _same(superuser_conn, "numeric(10,2)[]", "numeric(10,2)[]", False) is True
+
+
+def test_compatibility_uuid_is_depth_dependent(
+    superuser_conn, iceberg_representation_fns
+):
+    """Under the snowflake compatibility mode a uuid nested inside a container is
+    stored as string, while a top-level uuid stays native.  So the same uuid vs
+    text comparison flips with nesting -- the case that requires the comparison
+    to be position-aware."""
+    # nested: uuid[] and text[] are both stored as list<string> -> same
+    assert (
+        _same(superuser_conn, "uuid[]", "text[]", compatibility_mode="snowflake")
+        is True
+    )
+    # top-level: uuid stays native `uuid`, text is `string` -> different
+    assert (
+        _same(superuser_conn, "uuid", "text", compatibility_mode="snowflake") is False
+    )
+
+
+def test_compatibility_auto_keeps_uuid_native(
+    superuser_conn, iceberg_representation_fns
+):
+    """With no compatibility mode (auto), a nested uuid stays native `uuid`, so a
+    nested uuid and a nested text differ."""
+    assert _same(superuser_conn, "uuid[]", "text[]") is False
+    assert _same(superuser_conn, "uuid[]", "uuid[]") is True
+
+
+def test_composite_unsupported_numeric_matches_float8_composite(
+    superuser_conn, iceberg_representation_fns
+):
+    """The recursion also descends into composites: a composite whose field is an
+    unsupported numeric is stored as the same struct<double, ...> the create path
+    produces for a float8 field, so it matches a float8 composite but not a text
+    one."""
+    run_command("DROP TYPE IF EXISTS rep_num, rep_dbl, rep_txt;", superuser_conn)
+    run_command("CREATE TYPE rep_num AS (a numeric(50,2), b int);", superuser_conn)
+    run_command("CREATE TYPE rep_dbl AS (a double precision, b int);", superuser_conn)
+    run_command("CREATE TYPE rep_txt AS (a text, b int);", superuser_conn)
+    superuser_conn.commit()
+    try:
+        # numeric field -> double, matches a genuine float8 composite
+        assert _same(superuser_conn, "rep_num", "rep_dbl", True) is True
+        # but not a composite whose field is text (`string`)
+        assert _same(superuser_conn, "rep_num", "rep_txt", True) is False
+    finally:
+        run_command("DROP TYPE IF EXISTS rep_num, rep_dbl, rep_txt;", superuser_conn)
+        superuser_conn.commit()

--- a/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
+++ b/pg_lake_table/src/fdw/schema_operations/register_field_ids.c
@@ -45,6 +45,7 @@
 #include "pg_lake/iceberg/catalog.h"
 #include "pg_lake/iceberg/compatibility_mode.h"
 #include "pg_lake/iceberg/iceberg_field.h"
+#include "pg_lake/iceberg/iceberg_representation.h"
 #include "pg_lake/iceberg/iceberg_type_json_serde.h"
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/object_store_catalog/object_store_catalog.h"
@@ -243,12 +244,16 @@ CreatePostgresColumnMappingsForColumnDefs(Oid relationId, List *columnDefList, b
 		 * metadata and writes); the per-leaf surface->storage divergence is
 		 * collected here and persisted by RegisterPostgresColumnMappings. The
 		 * PostgreSQL column type is never touched.
+		 *
+		 * The shaping itself lives in IcebergStorageFieldForColumnType so
+		 * that a consumer asking "would this type still be stored the same
+		 * way" (see iceberg_representation.h) runs the code that produced the
+		 * persisted field, rather than a second copy of it.
 		 */
-		Field	   *surfaceFieldTree =
-			PostgresTypeToIcebergField(pgType, forAddColumn, &subFieldIndex);
+		Field	   *surfaceFieldTree = NULL;
 
-		field->type = DeepCopyField(surfaceFieldTree);
-		ApplyCompatibilityStorageMapping(field->type, compatMode);
+		field->type = IcebergStorageFieldForColumnType(pgType, compatMode, forAddColumn,
+													   &subFieldIndex, &surfaceFieldTree);
 
 		List	   *storageOverrides =
 			CollectStorageDivergences(surfaceFieldTree, field->type, fieldId);


### PR DESCRIPTION
An alternative shape for #488. Same base commit, so the diffs compare directly.

The derivation rework in #488 is right. This PR differs only in what gets exported.

## One code path, exercised by every caller

`register_field_ids.c:247-254` is already `PostgresTypeToIcebergField` + `DeepCopyField` + `ApplyCompatibilityStorageMapping` — exactly the shaping a consumer needs to reproduce. This extracts it into `IcebergStorageFieldForColumnType` and has registration call it, so there is one implementation rather than a second copy beside the original.

That matters more than DRY usually does here, because this whole area is edge cases. A duplicated model is only as correct as the tests that pin it, and for nested oversized numerics, nested `uuid` under compat, or `interval`-as-struct, those tests don't get written — which is how the top-level-only bug survived in the first place. With one path, every `CREATE TABLE` in the suite drives the same function, so a divergence surfaces as a broken create-path test instead of a wrong `true` in a guard nobody is watching.

The numeric rule is likewise not re-implemented. `ConvertTypeTree` is, by its own comment, "the single place that knows how pg_lake types nest ... so independent passes cannot drift out of coverage"; `IcebergStoredPostgresType` wraps the existing `MaybeConvertType`, and `TypeHasUnsupportedNumericLeaf` reuses that same traversal with a leaf rule that records instead of rewriting (so it walks the structure the real rewrite would and materializes nothing).

## Only the new side should be derived

Deriving both sides answers the weaker "would a fresh create of old and new agree under today's settings", and fails in the unsafe direction: a transform not modelled here cancels out on both sides and yields a spurious match. Against a persisted field from `field_id_mappings`, the same gap makes them differ, so the caller blocks.

This is load-bearing because the transform set is not closed — snowflake_cdc stores enums and user-defined ranges as text before the table is created, outside pg_lake entirely. Only the persisted field reflects all of the transforms. The header says so.

Consequently there is no `IcebergCreatePathContext`: compatibility mode comes from the relation, and the GUC is read where pg_lake already reads it. The historical GUC value is already baked into the persisted field, so there is nothing to capture.

## What this avoids

No leaf-conversion callback, no `NULL` `Field`, no `PostgresTypeToIcebergFieldInternal` split. `iceberg_field.c` is untouched and its 11 call sites keep a single postcondition. Note the other two storage transforms are already post-derivation `Field`-tree passes (`ApplyCompatibilityStorageMapping`, `CollectStorageDivergences`), and the read/write codecs already walk surface and storage trees in parallel — threading a callback into the derivation is the odd one out.

Roughly 23% less production code than #488.

## Tests

`pg_lake_iceberg/tests/pytests/test_iceberg_representation.py` carries over #488's type-pair cases essentially unchanged (the GUC is pinned with `SET` rather than a 4th wrapper argument), and adds a layer that pins the **exact** stored type per Postgres type — `numeric(50,2)[]` is `list<double>`, not `list<string>`. Pairwise same/different verdicts can agree for the wrong reason when a derivation is wrong identically on both sides, which is the original bug.

The extraction itself is covered end to end by the existing create-path suites (`pg_lake_table` `test_compatibility_mode.py`, `test_iceberg_uuid_compat.py`).

CI green: 63/63 jobs.

The consumer side is the alternative to snowflake-eng/sfpg-extension-pg_lake_replication#704, one commit on top of that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)