### PR TITLE
pg_extension_base: find control files via extension_control_path

### DIFF
--- a/pg_extension_base/include/pg_extension_base/extension_control_file.h
+++ b/pg_extension_base/include/pg_extension_base/extension_control_file.h
@@ -20,6 +20,6 @@
 #include "nodes/pg_list.h"
 
 extern PGDLLEXPORT bool IsExtensionControlFilename(const char *filename);
-extern PGDLLEXPORT char *GetExtensionControlDirectory(void);
+extern PGDLLEXPORT List *GetExtensionControlDirectories(void);
 extern PGDLLEXPORT char *GetExtensionControlFilename(const char *extname);
 extern PGDLLEXPORT List *GetExtensionDependencyList(char *extensionName);

--- a/pg_extension_base/src/extension_control_file.c
+++ b/pg_extension_base/src/extension_control_file.c
@@ -21,6 +21,9 @@
 #include "postgres.h"
 #include "miscadmin.h"
 
+#include <sys/stat.h>
+
+#include "commands/extension.h"
 #include "pg_extension_base/extension_control_file.h"
 #include "storage/fd.h"
 #include "utils/conffiles.h"
@@ -42,45 +45,109 @@ IsExtensionControlFilename(const char *filename)
 
 
 /*
- * GetExtensionControlDirectory returns the directory containing
- * .control files for extensions.
+ * GetExtensionControlDirectories returns the list of directories that can
+ * contain .control files for extensions, in the order in which PostgreSQL
+ * searches them.
+ *
+ * On PostgreSQL 18 and above, the directories come from the
+ * extension_control_path setting, which we interpret the same way as
+ * get_extension_control_directories() in the PostgreSQL source: the special
+ * value $system refers to the extension directory in the installation's
+ * share directory, while every other entry gets /extension appended.
+ *
+ * Before PostgreSQL 18 there is no such setting and control files can only
+ * live in the share directory.
  */
-char *
-GetExtensionControlDirectory(void)
+List *
+GetExtensionControlDirectories(void)
 {
 	char		sharepath[MAXPGPATH];
-	char	   *result;
 
 	get_share_path(my_exec_path, sharepath);
-	result = (char *) palloc(MAXPGPATH);
-	snprintf(result, MAXPGPATH, "%s/extension", sharepath);
 
-	return result;
+	char	   *systemDirectory = psprintf("%s/extension", sharepath);
+
+#if PG_VERSION_NUM >= 180000
+	if (Extension_control_path == NULL || Extension_control_path[0] == '\0')
+	{
+		return list_make1(systemDirectory);
+	}
+
+	List	   *directories = NIL;
+	char	   *remainder = Extension_control_path;
+
+	for (;;)
+	{
+		char	   *separator = first_path_var_separator(remainder);
+		int			entryLength = separator != NULL ?
+			(int) (separator - remainder) : (int) strlen(remainder);
+		char	   *entry = pnstrdup(remainder, entryLength);
+		char	   *directory = NULL;
+
+		if (strcmp(entry, "$system") == 0)
+		{
+			directory = systemDirectory;
+		}
+		else
+		{
+			directory = psprintf("%s/extension", entry);
+		}
+
+		pfree(entry);
+
+		canonicalize_path(directory);
+		directories = lappend(directories, directory);
+
+		if (remainder[entryLength] == '\0')
+		{
+			break;
+		}
+
+		/* skip past the separator and continue with the next entry */
+		remainder += entryLength + 1;
+	}
+
+	return directories;
+#else
+	return list_make1(systemDirectory);
+#endif
 }
 
 
 /*
- * GetExtensionControlFilename returns the .control file path
- * for a given extension.
+ * GetExtensionControlFilename returns the .control file path for a given
+ * extension, or NULL if the extension does not have a control file in any
+ * of the directories that PostgreSQL searches.
  */
 char *
 GetExtensionControlFilename(const char *extname)
 {
-	char		sharepath[MAXPGPATH];
-	char	   *result;
+	ListCell   *directoryCell = NULL;
 
-	get_share_path(my_exec_path, sharepath);
-	result = (char *) palloc(MAXPGPATH);
-	snprintf(result, MAXPGPATH, "%s/extension/%s.control",
-			 sharepath, extname);
+	foreach(directoryCell, GetExtensionControlDirectories())
+	{
+		char	   *directory = lfirst(directoryCell);
+		char	   *filename = psprintf("%s/%s.control", directory, extname);
+		struct stat statBuffer;
 
-	return result;
+		if (stat(filename, &statBuffer) == 0)
+		{
+			return filename;
+		}
+
+		pfree(filename);
+	}
+
+	return NULL;
 }
 
 
 /*
  * GetExtensionDependencyList returns a list of extension names from
  * the requires line of the extension control file.
+ *
+ * Returns an empty list if the extension is not installed, in which case
+ * we leave it to PostgreSQL to report the error.
  */
 List *
 GetExtensionDependencyList(char *extensionName)
@@ -89,19 +156,19 @@ GetExtensionDependencyList(char *extensionName)
 
 	char	   *filename = GetExtensionControlFilename(extensionName);
 
+	if (filename == NULL)
+	{
+		return NIL;
+	}
+
 	FILE	   *file;
 
 	if ((file = AllocateFile(filename, "r")) == NULL)
 	{
 		if (errno == ENOENT)
 		{
-			/* missing control file indicates extension is not installed */
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("extension \"%s\" is not available", extensionName),
-					 errdetail("Could not open extension control file \"%s\": %m.",
-							   filename),
-					 errhint("The extension must first be installed on the system where PostgreSQL is running.")));
+			/* control file disappeared after we found it */
+			return NIL;
 		}
 		ereport(ERROR,
 				(errcode_for_file_access(),

--- a/pg_extension_base/src/library_preloader.c
+++ b/pg_extension_base/src/library_preloader.c
@@ -47,9 +47,21 @@ typedef struct PreloadLibrary
 	char	   *libraryName;
 }			PreloadLibrary;
 
+/* ExtensionControlFileEntry represents the control file of one extension */
+typedef struct ExtensionControlFileEntry
+{
+	/* name of the extension */
+	char	   *extensionName;
+
+	/* path of the .control file of the extension */
+	char	   *filename;
+}			ExtensionControlFileEntry;
+
 /* internal functions */
 static List *FindAllPreloadLibraries(void);
-static List *FindExtensionPreloadLibraryNames(char *extensionName);
+static List *FindAllExtensionControlFiles(void);
+static bool HasExtensionControlFile(List *controlFiles, const char *extensionName);
+static List *FindExtensionPreloadLibraryNames(ExtensionControlFileEntry * controlFile);
 static List *AddPreloadLibrary(List *libraries, PreloadLibrary * preloadLibrary);
 
 /* SQL-callable functions */
@@ -86,39 +98,13 @@ static List *
 FindAllPreloadLibraries(void)
 {
 	List	   *libraries = NIL;
+	ListCell   *controlFileCell = NULL;
 
-	char	   *location = GetExtensionControlDirectory();
-	DIR		   *extensionDirectory = AllocateDir(location);
-	struct dirent *dirEntry;
-
-	if (extensionDirectory == NULL && errno == ENOENT)
+	foreach(controlFileCell, FindAllExtensionControlFiles())
 	{
-		/* extension directory does not exists (but we are in an extension?) */
-		return NIL;
-	}
+		ExtensionControlFileEntry *controlFile = lfirst(controlFileCell);
 
-	while ((dirEntry = ReadDir(extensionDirectory, location)) != NULL)
-	{
-		if (!IsExtensionControlFilename(dirEntry->d_name))
-		{
-			continue;
-		}
-
-		/* extract extension name from 'name.control' filename */
-		char	   *extensionName = pstrdup(dirEntry->d_name);
-
-		/* strip the file suffix */
-		char	   *dotPosition = strrchr(extensionName, '.');
-
-		*dotPosition = '\0';
-
-		if (strcmp(extensionName, "pg_extension_base") == 0)
-		{
-			/* we can skip ourselves, we're already being loaded */
-			continue;
-		}
-
-		List	   *libraryNames = FindExtensionPreloadLibraryNames(extensionName);
+		List	   *libraryNames = FindExtensionPreloadLibraryNames(controlFile);
 
 		if (libraryNames == NIL)
 		{
@@ -134,16 +120,106 @@ FindAllPreloadLibraries(void)
 
 			PreloadLibrary *preloadLibrary = palloc0(sizeof(PreloadLibrary));
 
-			preloadLibrary->extensionName = extensionName;
+			preloadLibrary->extensionName = controlFile->extensionName;
 			preloadLibrary->libraryName = libraryName;
 
 			libraries = AddPreloadLibrary(libraries, preloadLibrary);
 		}
 	}
 
-	FreeDir(extensionDirectory);
-
 	return libraries;
+}
+
+
+/*
+ * FindAllExtensionControlFiles returns the control file of every extension
+ * that is installed, except for pg_extension_base itself.
+ *
+ * Extensions can be installed in any of the directories that PostgreSQL
+ * searches for control files, and the same extension may appear in several
+ * of them. We only return the control file that PostgreSQL would use, which
+ * is the one in the first directory that has it.
+ */
+static List *
+FindAllExtensionControlFiles(void)
+{
+	List	   *controlFiles = NIL;
+	ListCell   *directoryCell = NULL;
+
+	foreach(directoryCell, GetExtensionControlDirectories())
+	{
+		char	   *location = lfirst(directoryCell);
+		DIR		   *extensionDirectory = AllocateDir(location);
+		struct dirent *dirEntry;
+
+		if (extensionDirectory == NULL && errno == ENOENT)
+		{
+			/* directory does not exist, so it has no extensions */
+			continue;
+		}
+
+		while ((dirEntry = ReadDir(extensionDirectory, location)) != NULL)
+		{
+			if (!IsExtensionControlFilename(dirEntry->d_name))
+			{
+				continue;
+			}
+
+			/* extract extension name from 'name.control' filename */
+			char	   *extensionName = pstrdup(dirEntry->d_name);
+
+			/* strip the file suffix */
+			char	   *dotPosition = strrchr(extensionName, '.');
+
+			*dotPosition = '\0';
+
+			if (strcmp(extensionName, "pg_extension_base") == 0)
+			{
+				/* we can skip ourselves, we're already being loaded */
+				continue;
+			}
+
+			if (HasExtensionControlFile(controlFiles, extensionName))
+			{
+				/* an earlier directory has this extension, which wins */
+				continue;
+			}
+
+			ExtensionControlFileEntry *controlFile = palloc0(sizeof(ExtensionControlFileEntry));
+
+			controlFile->extensionName = extensionName;
+			controlFile->filename = psprintf("%s/%s", location, dirEntry->d_name);
+
+			controlFiles = lappend(controlFiles, controlFile);
+		}
+
+		FreeDir(extensionDirectory);
+	}
+
+	return controlFiles;
+}
+
+
+/*
+ * HasExtensionControlFile returns whether the given list already contains a
+ * control file for the given extension.
+ */
+static bool
+HasExtensionControlFile(List *controlFiles, const char *extensionName)
+{
+	ListCell   *controlFileCell = NULL;
+
+	foreach(controlFileCell, controlFiles)
+	{
+		ExtensionControlFileEntry *controlFile = lfirst(controlFileCell);
+
+		if (strcmp(controlFile->extensionName, extensionName) == 0)
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 
@@ -163,9 +239,10 @@ FindAllPreloadLibraries(void)
  * module.
  */
 static List *
-FindExtensionPreloadLibraryNames(char *extensionName)
+FindExtensionPreloadLibraryNames(ExtensionControlFileEntry * controlFile)
 {
-	char	   *filename = GetExtensionControlFilename(extensionName);
+	char	   *extensionName = controlFile->extensionName;
+	char	   *filename = controlFile->filename;
 
 	FILE	   *file;
 
@@ -173,13 +250,8 @@ FindExtensionPreloadLibraryNames(char *extensionName)
 	{
 		if (errno == ENOENT)
 		{
-			/* missing control file indicates extension is not installed */
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("extension \"%s\" is not available", extensionName),
-					 errdetail("Could not open extension control file \"%s\": %m.",
-							   filename),
-					 errhint("The extension must first be installed on the system where PostgreSQL is running.")));
+			/* control file disappeared after we listed the directory */
+			return NIL;
 		}
 		ereport(ERROR,
 				(errcode_for_file_access(),

--- a/pg_extension_base/tests/pytests/test_extension_control_path.py
+++ b/pg_extension_base/tests/pytests/test_extension_control_path.py
@@ -1,0 +1,188 @@
+import os
+
+import pytest
+from utils_pytest import *
+
+# Names of the extensions we install outside of the share directory.
+# They deliberately do not start with pg_extension_base_test, because they
+# are not installed in the share directory like the other test extensions.
+CONTROL_PATH_EXT = "control_path_test_ext"
+CONTROL_PATH_DEP = "control_path_test_dep"
+CONTROL_PATH_PRELOAD = "control_path_test_preload"
+
+
+def write_extension(directory, name, control_lines, script=None):
+    with open(f"{directory}/{name}.control", "w") as control_file:
+        control_file.write("\n".join(control_lines) + "\n")
+
+    if script is not None:
+        with open(f"{directory}/{name}--1.0.sql", "w") as script_file:
+            script_file.write(script + "\n")
+
+
+@pytest.fixture(scope="module")
+def extension_control_directory(tmp_path_factory):
+    """
+    Installs SQL-only extensions in a directory that is not the share
+    directory, in the layout that PostgreSQL expects from an
+    extension_control_path entry: <entry>/extension/<name>.control.
+
+    Returns the path to add to extension_control_path.
+    """
+    base_directory = tmp_path_factory.mktemp("extension_control_path")
+    extension_directory = base_directory / "extension"
+    extension_directory.mkdir()
+
+    # PostgreSQL reads the files as the user that runs the server, which is
+    # the user that runs the tests, but the directories are traversed by
+    # every backend, so keep them readable.
+    os.chmod(base_directory, 0o755)
+    os.chmod(extension_directory, 0o755)
+
+    write_extension(
+        extension_directory,
+        CONTROL_PATH_DEP,
+        [
+            "comment = 'dependency installed via extension_control_path'",
+            "default_version = '1.0'",
+            "relocatable = true",
+        ],
+        f"CREATE FUNCTION {CONTROL_PATH_DEP}() RETURNS int LANGUAGE sql AS 'SELECT 1';",
+    )
+
+    write_extension(
+        extension_directory,
+        CONTROL_PATH_EXT,
+        [
+            "comment = 'extension installed via extension_control_path'",
+            "default_version = '1.0'",
+            "relocatable = true",
+            f"requires = '{CONTROL_PATH_DEP}'",
+        ],
+        f"CREATE FUNCTION {CONTROL_PATH_EXT}() RETURNS int LANGUAGE sql AS 'SELECT 2';",
+    )
+
+    # This one is never created, we only check that pg_extension_base finds
+    # its preload request when it scans the directories in the path.
+    write_extension(
+        extension_directory,
+        CONTROL_PATH_PRELOAD,
+        [
+            "comment = 'preloading extension installed via extension_control_path'",
+            "default_version = '1.0'",
+            "relocatable = true",
+            f"#!shared_preload_libraries = '$libdir/{CONTROL_PATH_PRELOAD}'",
+        ],
+    )
+
+    return str(base_directory)
+
+
+@pytest.fixture
+def control_path_conn(superuser_conn):
+    """
+    Connection that rolls back after the test, which also undoes the
+    extension_control_path setting.
+    """
+    if get_pg_version_num(superuser_conn) < 180000:
+        pytest.skip("extension_control_path was added in PostgreSQL 18")
+
+    yield superuser_conn
+
+    superuser_conn.rollback()
+
+
+# pg_extension_base intercepts every CREATE EXTENSION to install and update
+# dependencies, so it has to look for control files in the same directories as
+# PostgreSQL. Otherwise, extensions that are installed in a directory in
+# extension_control_path cannot be created at all.
+def test_create_extension_in_control_path(
+    control_path_conn, extension_control_directory
+):
+    run_command(
+        f"SET extension_control_path TO '{extension_control_directory}:$system'",
+        control_path_conn,
+    )
+
+    # the dependency lives in the same directory and is created via CASCADE
+    run_command(f"CREATE EXTENSION {CONTROL_PATH_EXT} CASCADE", control_path_conn)
+
+    result = run_query(
+        f"SELECT {CONTROL_PATH_EXT}() AS ext, {CONTROL_PATH_DEP}() AS dep",
+        control_path_conn,
+    )
+    assert result[0]["ext"] == 2
+    assert result[0]["dep"] == 1
+
+    # ALTER EXTENSION .. UPDATE goes through the dependency handling as well,
+    # which reads the requires line from the control file
+    run_command(f"ALTER EXTENSION {CONTROL_PATH_EXT} UPDATE", control_path_conn)
+
+
+# Extensions in the share directory keep working when the path has other
+# directories in front of it.
+def test_create_extension_in_share_directory(
+    control_path_conn, extension_control_directory
+):
+    run_command(
+        f"SET extension_control_path TO '{extension_control_directory}:$system'",
+        control_path_conn,
+    )
+
+    run_command(
+        "CREATE EXTENSION pg_extension_base_test_ext1 CASCADE", control_path_conn
+    )
+
+    result = run_query(
+        "SELECT extversion FROM pg_extension WHERE extname = 'pg_extension_base'",
+        control_path_conn,
+    )
+    assert len(result) == 1
+
+
+# Without the directory in the path, the extension is not available, and the
+# error should come from PostgreSQL rather than from pg_extension_base.
+def test_create_extension_outside_control_path(
+    control_path_conn, extension_control_directory
+):
+    error = run_command(
+        f"CREATE EXTENSION {CONTROL_PATH_EXT} CASCADE",
+        control_path_conn,
+        raise_error=False,
+    )
+    assert f'extension "{CONTROL_PATH_EXT}" is not available' in error
+
+    control_path_conn.rollback()
+
+    # nothing was created
+    result = run_query(
+        f"SELECT 1 FROM pg_extension WHERE extname = '{CONTROL_PATH_DEP}'",
+        control_path_conn,
+    )
+    assert len(result) == 0
+
+
+# The libraries that extensions ask to preload are collected from all the
+# directories in the path.
+def test_list_preload_libraries_in_control_path(
+    control_path_conn, extension_control_directory, pg_extension_base
+):
+    result = run_query(
+        f"SELECT library_name FROM extension_base.list_preload_libraries()"
+        f" WHERE extension_name = '{CONTROL_PATH_PRELOAD}'",
+        control_path_conn,
+    )
+    assert len(result) == 0
+
+    run_command(
+        f"SET extension_control_path TO '{extension_control_directory}:$system'",
+        control_path_conn,
+    )
+
+    result = run_query(
+        f"SELECT library_name FROM extension_base.list_preload_libraries()"
+        f" WHERE extension_name = '{CONTROL_PATH_PRELOAD}'",
+        control_path_conn,
+    )
+    assert len(result) == 1
+    assert result[0]["library_name"] == f"$libdir/{CONTROL_PATH_PRELOAD}"


### PR DESCRIPTION
## Problem

`pg_extension_base` resolves extension control files itself, but it only ever looked in the share directory. PostgreSQL 18 added the `extension_control_path` setting, which lets a control file live in any directory in that path. Since `pg_extension_base` installs a `ProcessUtility` hook that inspects the control file of every `CREATE EXTENSION`, and threw an error when it could not find one, no extension installed outside of the share directory could be created at all, including extensions that have nothing to do with pg_lake:

```
ERROR:  extension "vector" is not available
DETAIL:  Could not open extension control file "/usr/share/postgresql/18/extension/vector.control": No such file or directory.
```

That breaks packaging that gives every extension its own directory, such as [CloudNativePG extension image volumes](https://cloudnative-pg.io/docs/current/imagevolume_extensions/), on a PostgreSQL version pg_lake supports. 

Fixes #494.

## Solution

`GetExtensionControlDirectory` becomes `GetExtensionControlDirectories`, which returns every directory PostgreSQL searches, and the control file lookup walks that list. On PostgreSQL 18 the directories come from `extension_control_path`, interpreted the way PostgreSQL interprets it: `$system` is the extension directory under the share directory, and any other entry gets `/extension` appended. On PostgreSQL 16 and 17 there is only the share directory, so behavior there is unchanged.

```
# postgresql.conf, extension installed under /opt/ext
shared_preload_libraries = 'pg_extension_base'
extension_control_path   = '/opt/ext/share:$system'
dynamic_library_path     = '/opt/ext/lib:$libdir'
```

```sql
-- now resolves /opt/ext/share/extension/vector.control instead of failing
CREATE EXTENSION vector;
```

When an extension has no control file in any of the directories, `pg_extension_base` no longer raises its own error. It reports that the extension has no dependencies and lets PostgreSQL report the failure, which it does with the same message.

The library preloader walks the same directories, so an extension outside of the share directory can also request that its library is preloaded through `#!shared_preload_libraries`. An extension that appears in more than one directory is only considered once, matching the one PostgreSQL would use.

## Test plan

- [x] New `test_extension_control_path.py` installs SQL-only extensions in a directory outside of the share directory and checks that `CREATE EXTENSION` (with a dependency via `CASCADE`), `ALTER EXTENSION .. UPDATE`, and the preload-library listing all find them. Two of the four tests fail on `main` with the exact error from #494.
- [x] Existing pg_extension_base suite passes (63 tests), including the preloader and dependency tests.
- [x] `pgindent` and `black` clean.
