### PR TITLE
pg_lake_engine: write domain-over-array columns as lists

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/map.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/map.h
@@ -24,6 +24,6 @@ char	   *GetDuckDBMapDefinitionForPGType(Oid postgresTypeId,
 											CopyDataFormat format);
 
 extern PGDLLEXPORT bool IsMapTypeOid(Oid typeId);
-extern PGDLLEXPORT Oid ResolveDomainBaseType(Oid typeId);
+extern PGDLLEXPORT Oid ResolveDomainBaseTypeAndTypmod(Oid typeId, int32 *typeMod);
 extern PGDLLEXPORT PGType GetMapKeyType(Oid mapOid);
 extern PGDLLEXPORT PGType GetMapValueType(Oid mapOid);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -1398,7 +1398,8 @@ bool
 ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType)
 {
 	/* unwrap domain to base type so per-type checks below see the real type */
-	postgresType.postgresTypeOid = ResolveDomainBaseType(postgresType.postgresTypeOid);
+	postgresType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(postgresType.postgresTypeOid,
+																  &postgresType.postgresTypeMod);
 
 	Oid			typeId = postgresType.postgresTypeOid;
 

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -470,7 +470,7 @@ TypeHasStorageDivergentLeaf(Oid typeOid, int32 typmod, Field * storageField)
 	if (typtype == TYPTYPE_DOMAIN)
 	{
 		int32		baseTypmod = typmod;
-		Oid			baseType = getBaseTypeAndTypmod(typeOid, &baseTypmod);
+		Oid			baseType = ResolveDomainBaseTypeAndTypmod(typeOid, &baseTypmod);
 
 		return TypeHasStorageDivergentLeaf(baseType, baseTypmod, storageField);
 	}

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -469,8 +469,18 @@ TypeHasStorageDivergentLeaf(Oid typeOid, int32 typmod, Field * storageField)
 
 	if (typtype == TYPTYPE_DOMAIN)
 	{
-		int32		baseTypmod = typmod;
-		Oid			baseType = ResolveDomainBaseTypeAndTypmod(typeOid, &baseTypmod);
+		/*
+		 * Unwrap the domain and keep walking.  This deliberately uses
+		 * getBaseTypeAndTypmod rather than ResolveDomainBaseTypeAndTypmod: a
+		 * map type is a domain over an array of key/value structs, and the
+		 * storage tree has that array shape, so leaving the map type as-is
+		 * here would recurse on an unchanged type id and never terminate.
+		 */
+		int32		baseTypmod = -1;
+		Oid			baseType = getBaseTypeAndTypmod(typeOid, &baseTypmod);
+
+		if (baseTypmod == -1)
+			baseTypmod = typmod;
 
 		return TypeHasStorageDivergentLeaf(baseType, baseTypmod, storageField);
 	}

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -267,14 +267,18 @@ PGTypeRequiresConversionToIcebergString(Field * field, PGType pgType)
  * on the mapping without re-implementing it.
  *
  * Domains are unwrapped to their base type so a domain over e.g. bytea maps to
- * "binary" rather than falling through to the "string" default. The field
- * builder already resolves domains before reaching here, so this is a no-op for
- * that caller, but the codecs hand us raw attribute type ids and rely on it.
+ * "binary" rather than falling through to the "string" default. The type
+ * modifier is taken from the domain as well, because a domain column has
+ * atttypmod -1 and a domain over numeric(10,2) would otherwise look unbounded.
+ * The field builder already resolves domains before reaching here, so this is a
+ * no-op for that caller, but the codecs hand us raw attribute type ids and rely
+ * on it.
  */
 char *
 PostgresBaseTypeIdToIcebergTypeName(PGType pgType)
 {
-	pgType.postgresTypeOid = ResolveDomainBaseType(pgType.postgresTypeOid);
+	pgType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(pgType.postgresTypeOid,
+															&pgType.postgresTypeMod);
 
 	switch (pgType.postgresTypeOid)
 	{

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -1355,7 +1355,7 @@ AppendRewriteExpression(StringInfo buf, const char *expr,
 
 	if (typtype == TYPTYPE_DOMAIN)
 	{
-		Oid			baseType = getBaseTypeAndTypmod(typeOid, &typmod);
+		Oid			baseType = ResolveDomainBaseTypeAndTypmod(typeOid, &typmod);
 
 		return AppendRewriteExpression(buf, expr, baseType, typmod, depth,
 									   rewriteKinds, storageField);

--- a/pg_lake_engine/src/pgduck/map.c
+++ b/pg_lake_engine/src/pgduck/map.c
@@ -222,15 +222,34 @@ GetMapCreateFunctionOid()
 
 
 /*
- * ResolveDomainBaseType returns the base type OID for a domain, or the OID
- * unchanged if it is not a domain.  Map types are domains with special
- * semantics and are left as-is.
+ * ResolveDomainBaseTypeAndTypmod returns the base type OID for a domain, or the
+ * OID unchanged if it is not a domain, and also reports the type modifier that
+ * belongs to the base type.  Map types are domains with special semantics and
+ * are left as-is.
+ *
+ * A column whose type is a domain has atttypmod -1, because the modifier is
+ * part of the domain and not of the column, so callers that need e.g. the
+ * precision and scale of a numeric cannot get it from the attribute.  Without
+ * this, a domain over numeric(10,2) looks like an unbounded numeric.
+ *
+ * *typeMod is only overwritten when the caller does not have a modifier of its
+ * own, so an outer modifier keeps precedence over a nested one.  Note that
+ * getBaseTypeAndTypmod expects to start from -1 and asserts as much when it
+ * walks a stack of domains.
  */
 Oid
-ResolveDomainBaseType(Oid typeId)
+ResolveDomainBaseTypeAndTypmod(Oid typeId, int32 *typeMod)
 {
 	if (!IsMapTypeOid(typeId) && get_typtype(typeId) == TYPTYPE_DOMAIN)
-		return getBaseType(typeId);
+	{
+		int32		baseTypeMod = -1;
+		Oid			baseTypeId = getBaseTypeAndTypmod(typeId, &baseTypeMod);
+
+		if (*typeMod == -1)
+			*typeMod = baseTypeMod;
+
+		return baseTypeId;
+	}
 
 	return typeId;
 }

--- a/pg_lake_engine/src/pgduck/serialize.c
+++ b/pg_lake_engine/src/pgduck/serialize.c
@@ -129,9 +129,13 @@ PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 {
 	/*
 	 * Unwrap domain types so that e.g. a domain-over-bytea is serialized with
-	 * the bytea-specific path rather than the generic text output path.
+	 * the bytea-specific path rather than the generic text output path.  The
+	 * serialization here does not depend on the type modifier, so it is
+	 * discarded.
 	 */
-	columnType = ResolveDomainBaseType(columnType);
+	int32		columnTypeMod = -1;
+
+	columnType = ResolveDomainBaseTypeAndTypmod(columnType, &columnTypeMod);
 
 	if (flinfo->fn_oid == ARRAY_OUT_OID)
 	{

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -514,6 +514,17 @@ GetDuckDBTypeForPGType(PGType postgresType)
 const char *
 GetFullDuckDBTypeNameForPGType(PGType postgresType, CopyDataFormat format)
 {
+	/*
+	 * Resolve a domain to its base type and modifier before anything else,
+	 * for the same reason the write path does (see
+	 * ChooseDuckDBEngineTypeForWrite): a domain over an array is an array
+	 * itself, so the DUCKDB_TYPE_LIST branch below would not recognise it and
+	 * the whole column would be named VARCHAR.
+	 */
+	postgresType.postgresTypeOid =
+		ResolveDomainBaseTypeAndTypmod(postgresType.postgresTypeOid,
+									   &postgresType.postgresTypeMod);
+
 	DuckDBType	myType = GetDuckDBTypeForPGType(postgresType);
 
 	/*

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -694,22 +694,29 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 		return VARCHAR_TYPE;
 
 	int32		postgresTypeMod = postgresType.postgresTypeMod;
-	Oid			elementTypeId = get_element_type(postgresType.postgresTypeOid);
-	bool		isArrayType = OidIsValid(elementTypeId);
 	char	   *typeModifier = "";
-
-	/*
-	 * We can handle an array by treating the element type like the type that
-	 * was passed in from here on out an add [] to the type name in the end.
-	 */
-	if (isArrayType)
-		postgresType.postgresTypeOid = elementTypeId;
 
 	/*
 	 * Unwrap domain types so that e.g. a domain over bytea is written as BLOB
 	 * rather than falling through to VARCHAR.
+	 *
+	 * This happens before we look for an array type, because a domain over an
+	 * array type (e.g. CREATE DOMAIN ints AS int[]) is an array itself, which
+	 * get_element_type would not see. Map types are domains too, but carry
+	 * special semantics and are left alone by ResolveDomainBaseType.
 	 */
 	postgresType.postgresTypeOid = ResolveDomainBaseType(postgresType.postgresTypeOid);
+
+	Oid			elementTypeId = get_element_type(postgresType.postgresTypeOid);
+	bool		isArrayType = OidIsValid(elementTypeId);
+
+	/*
+	 * We can handle an array by treating the element type like the type that
+	 * was passed in from here on out an add [] to the type name in the end.
+	 * The element type can be a domain as well (e.g. a bytea domain).
+	 */
+	if (isArrayType)
+		postgresType.postgresTypeOid = ResolveDomainBaseType(elementTypeId);
 
 	DuckDBType	duckTypeId = GetDuckDBTypeForPGType(postgresType);
 

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -703,9 +703,13 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 	 * This happens before we look for an array type, because a domain over an
 	 * array type (e.g. CREATE DOMAIN ints AS int[]) is an array itself, which
 	 * get_element_type would not see. Map types are domains too, but carry
-	 * special semantics and are left alone by ResolveDomainBaseType.
+	 * special semantics and are left alone by ResolveDomainBaseTypeAndTypmod.
+	 *
+	 * The type modifier comes along, because a domain column has atttypmod -1
+	 * and a domain over numeric(10,2) would otherwise look unbounded.
 	 */
-	postgresType.postgresTypeOid = ResolveDomainBaseType(postgresType.postgresTypeOid);
+	postgresType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(postgresType.postgresTypeOid,
+																  &postgresTypeMod);
 
 	Oid			elementTypeId = get_element_type(postgresType.postgresTypeOid);
 	bool		isArrayType = OidIsValid(elementTypeId);
@@ -716,7 +720,10 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 	 * The element type can be a domain as well (e.g. a bytea domain).
 	 */
 	if (isArrayType)
-		postgresType.postgresTypeOid = ResolveDomainBaseType(elementTypeId);
+		postgresType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(elementTypeId,
+																	  &postgresTypeMod);
+
+	postgresType.postgresTypeMod = postgresTypeMod;
 
 	DuckDBType	duckTypeId = GetDuckDBTypeForPGType(postgresType);
 

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -702,8 +702,13 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 	 *
 	 * This happens before we look for an array type, because a domain over an
 	 * array type (e.g. CREATE DOMAIN ints AS int[]) is an array itself, which
-	 * get_element_type would not see. Map types are domains too, but carry
-	 * special semantics and are left alone by ResolveDomainBaseTypeAndTypmod.
+	 * get_element_type would not see.
+	 *
+	 * Map types are domains too, and ResolveDomainBaseTypeAndTypmod leaves
+	 * them alone only while the map type is the outermost type. A domain over
+	 * a map still resolves past it to the underlying key/value array, so it
+	 * is stored as a list of structs rather than an Iceberg map; see the note
+	 * on stepwise resolution in compatibility_mode.c.
 	 *
 	 * The type modifier comes along, because a domain column has atttypmod -1
 	 * and a domain over numeric(10,2) would otherwise look unbounded.

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -182,15 +182,20 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 	 * Unwrap domain types to their base type so that e.g. a domain over
 	 * integer maps to Iceberg "int" rather than falling through to the
 	 * default "string" case.  Map types are domains too but carry special
-	 * semantics; ResolveDomainBaseType leaves those unchanged.
+	 * semantics; ResolveDomainBaseTypeAndTypmod leaves those unchanged.
+	 *
+	 * The type modifier of the domain comes along, because a column whose
+	 * type is a domain has atttypmod -1, and a domain over numeric(10,2)
+	 * would otherwise be recorded as an unbounded decimal(38,9).
 	 */
 	{
-		Oid			baseTypeId = ResolveDomainBaseType(typeId);
+		Oid			baseTypeId = ResolveDomainBaseTypeAndTypmod(typeId, &typeMod);
 
 		if (baseTypeId != typeId)
 		{
 			typeId = baseTypeId;
 			pgType.postgresTypeOid = baseTypeId;
+			pgType.postgresTypeMod = typeMod;
 		}
 	}
 

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -116,19 +116,23 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
         -- domains can be stacked, both above and below the array type
         create domain nested_int_list as int_list;
         create domain still_positive as positive;
+        -- a domain over an array whose element type is itself a domain
+        create domain positive_list as positive[];
         create table domain_arrays (
             i int_list,
             t time_list,
             p positive[],
             n nested_int_list,
-            s still_positive[]
+            s still_positive[],
+            d positive_list
         ) using iceberg;
         insert into domain_arrays values (
             array[1, 2]::int_list,
             array['09:00:00+04'::timetz]::time_list,
             array[3, 4]::positive[],
             array[5, 6]::nested_int_list,
-            array[7, 8]::still_positive[]
+            array[7, 8]::still_positive[],
+            array[9, 10]::positive_list
         );
     """,
         pg_conn,
@@ -136,7 +140,8 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
     pg_conn.commit()
 
     result = run_query(
-        "SELECT i, t::text AS t, p::text AS p, n, s::text AS s FROM domain_arrays",
+        "SELECT i, t::text AS t, p::text AS p, n, s::text AS s, d::text AS d"
+        " FROM domain_arrays",
         pg_conn,
     )
     assert result[0]["i"] == [1, 2]
@@ -145,6 +150,7 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
     assert result[0]["t"] == "{05:00:00+00}"
     assert result[0]["n"] == [5, 6]
     assert result[0]["s"] == "{7,8}"
+    assert result[0]["d"] == "{9,10}"
 
     results = run_query(
         "SELECT metadata_location FROM lake_iceberg.tables"
@@ -159,6 +165,7 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
     assert fields["p"]["element"] == "int"
     assert fields["n"]["element"] == "int"
     assert fields["s"]["element"] == "int"
+    assert fields["d"]["element"] == "int"
 
     pg_conn.rollback()
     run_command("drop schema if exists test_domain_over_array cascade;", pg_conn)

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -101,7 +101,11 @@ def test_domain_iceberg_field_type(extension, pg_conn, s3, with_default_location
 
 
 def test_domain_over_array(extension, pg_conn, s3, with_default_location):
-    """A domain over an array type is an array itself and must be written as a list."""
+    """A domain over an array type is an array itself and must be written as a list.
+
+    Domains can be stacked arbitrarily deep, and getBaseType() walks the whole
+    stack, so nesting resolves to the same list type.
+    """
     run_command(
         """
         create schema test_domain_over_array;
@@ -109,15 +113,22 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
         create domain int_list as int[];
         create domain time_list as timetz[];
         create domain positive as int check (value > 0);
+        -- domains can be stacked, both above and below the array type
+        create domain nested_int_list as int_list;
+        create domain still_positive as positive;
         create table domain_arrays (
             i int_list,
             t time_list,
-            p positive[]
+            p positive[],
+            n nested_int_list,
+            s still_positive[]
         ) using iceberg;
         insert into domain_arrays values (
             array[1, 2]::int_list,
             array['09:00:00+04'::timetz]::time_list,
-            array[3, 4]::positive[]
+            array[3, 4]::positive[],
+            array[5, 6]::nested_int_list,
+            array[7, 8]::still_positive[]
         );
     """,
         pg_conn,
@@ -125,12 +136,15 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
     pg_conn.commit()
 
     result = run_query(
-        "SELECT i, t::text AS t, p::text AS p FROM domain_arrays", pg_conn
+        "SELECT i, t::text AS t, p::text AS p, n, s::text AS s FROM domain_arrays",
+        pg_conn,
     )
     assert result[0]["i"] == [1, 2]
     assert result[0]["p"] == "{3,4}"
     # timetz is stored UTC-normalized because Iceberg has no timetz type
     assert result[0]["t"] == "{05:00:00+00}"
+    assert result[0]["n"] == [5, 6]
+    assert result[0]["s"] == "{7,8}"
 
     results = run_query(
         "SELECT metadata_location FROM lake_iceberg.tables"
@@ -143,6 +157,8 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
     assert fields["i"]["element"] == "int"
     assert fields["t"]["element"] == "time"
     assert fields["p"]["element"] == "int"
+    assert fields["n"]["element"] == "int"
+    assert fields["s"]["element"] == "int"
 
     pg_conn.rollback()
     run_command("drop schema if exists test_domain_over_array cascade;", pg_conn)

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -98,3 +98,52 @@ def test_domain_iceberg_field_type(extension, pg_conn, s3, with_default_location
     pg_conn.rollback()
     run_command("drop schema if exists test_domain_field_type cascade;", pg_conn)
     pg_conn.commit()
+
+
+def test_domain_over_array(extension, pg_conn, s3, with_default_location):
+    """A domain over an array type is an array itself and must be written as a list."""
+    run_command(
+        """
+        create schema test_domain_over_array;
+        set search_path to test_domain_over_array;
+        create domain int_list as int[];
+        create domain time_list as timetz[];
+        create domain positive as int check (value > 0);
+        create table domain_arrays (
+            i int_list,
+            t time_list,
+            p positive[]
+        ) using iceberg;
+        insert into domain_arrays values (
+            array[1, 2]::int_list,
+            array['09:00:00+04'::timetz]::time_list,
+            array[3, 4]::positive[]
+        );
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    result = run_query(
+        "SELECT i, t::text AS t, p::text AS p FROM domain_arrays", pg_conn
+    )
+    assert result[0]["i"] == [1, 2]
+    assert result[0]["p"] == "{3,4}"
+    # timetz is stored UTC-normalized because Iceberg has no timetz type
+    assert result[0]["t"] == "{05:00:00+00}"
+
+    results = run_query(
+        "SELECT metadata_location FROM lake_iceberg.tables"
+        " WHERE table_name = 'domain_arrays'"
+        " AND table_namespace = 'test_domain_over_array'",
+        pg_conn,
+    )
+    parsed = json.loads(read_s3_operations(s3, results[0][0]))
+    fields = {f["name"]: f["type"] for f in parsed["schemas"][0]["fields"]}
+    assert fields["i"]["element"] == "int"
+    assert fields["t"]["element"] == "time"
+    assert fields["p"]["element"] == "int"
+
+    pg_conn.rollback()
+    run_command("drop schema if exists test_domain_over_array cascade;", pg_conn)
+    pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -170,3 +170,76 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
     pg_conn.rollback()
     run_command("drop schema if exists test_domain_over_array cascade;", pg_conn)
     pg_conn.commit()
+
+
+def _array_text(value):
+    """Normalize an array column to PostgreSQL array text.
+
+    psycopg parses a domain over int[] into a list, but an array of a domain
+    has an unknown element OID and comes back as text, so tests that cover both
+    shapes need to compare them in the same form.
+    """
+    if isinstance(value, list):
+        return "{" + ",".join(str(element) for element in value) + "}"
+    return str(value)
+
+
+def test_domain_over_numeric(extension, pg_conn, s3, with_default_location):
+    """A numeric domain must keep its precision and scale.
+
+    A column whose type is a domain has atttypmod -1: the modifier belongs to
+    the domain, not to the column. Without resolving it, numeric(10,2) behind a
+    domain is written as an unbounded decimal(38,9), and for the array shapes
+    the Iceberg schema and the DuckDB write type disagree, which breaks reads.
+    """
+    run_command(
+        """
+        create schema test_domain_numeric;
+        set search_path to test_domain_numeric;
+        create domain price as numeric(10,2);
+        -- the modifier can sit above or below the array type
+        create domain price_array as numeric(10,2)[];
+        create domain price_list as price[];
+        -- stacked domains: getBaseTypeAndTypmod walks to the bottom
+        create domain price_again as price;
+        create table domain_numerics (
+            p price,
+            a price_array,
+            l price_list,
+            e price[],
+            s price_again
+        ) using iceberg;
+        insert into domain_numerics values (
+            1.25,
+            array[1.25, 2.5]::price_array,
+            array[1.25, 2.5]::price_list,
+            array[1.25, 2.5]::price[],
+            2.5
+        );
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    results = run_query(
+        "SELECT metadata_location FROM lake_iceberg.tables"
+        " WHERE table_name = 'domain_numerics'"
+        " AND table_namespace = 'test_domain_numeric'",
+        pg_conn,
+    )
+    parsed = json.loads(read_s3_operations(s3, results[0][0]))
+    fields = {f["name"]: f["type"] for f in parsed["schemas"][0]["fields"]}
+    assert fields["p"] == "decimal(10,2)"
+    assert fields["s"] == "decimal(10,2)"
+    for name in ("a", "l", "e"):
+        assert fields[name]["element"] == "decimal(10,2)", f"column {name}"
+
+    result = run_query("SELECT p, a, l, e, s FROM domain_numerics", pg_conn)
+    assert str(result[0]["p"]) == "1.25"
+    assert str(result[0]["s"]) == "2.50"
+    for name in ("a", "l", "e"):
+        assert _array_text(result[0][name]) == "{1.25,2.50}", f"column {name}"
+
+    pg_conn.rollback()
+    run_command("drop schema if exists test_domain_numeric cascade;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
Fixes #498.

`INSERT` into an Iceberg table failed for a column whose type is a domain over an
array (`CREATE DOMAIN ints AS int[]`) with:

```
ERROR:  Invalid Input Error: Value "LIST" can not be converted to a DuckDB Type.
```

`ChooseDuckDBEngineTypeForWrite` looked for an array element type before unwrapping
domains, so `get_element_type()` on the domain OID returned `InvalidOid` and
`isArrayType` stayed false. The domain then resolved to `int[]`, `GetDuckDBTypeForPGType`
returned `DUCKDB_TYPE_LIST`, and since `isArrayType` was false the type name was
rendered without an element type or a `[]` suffix — the bare string `LIST` in the
`columns={...}` argument of the generated `read_csv()`.

This resolves the domain first, then looks for an array element type, then resolves a
domain on the element type as well so that arrays over domains (`positive[]`, `bytea`
domains) keep working. Map types are domains too, but `ResolveDomainBaseType` leaves
those alone by design, so MAP detection is unaffected.

Adds `test_domain_over_array`, which covers a domain over `int[]`, a domain over
`timetz[]` (checking the UTC normalization still happens for the element type) and an
array over a scalar domain, and asserts the element types recorded in the Iceberg
metadata.

Note that a composite type with a domain-over-array *attribute* still fails, at
`CREATE TABLE` time, with `internalLeafField and externalLeafField have different
types` — `GetDuckDBTypeForPGType` does not resolve domains at all, so a domain nested
inside a composite is rendered as `VARCHAR`. That is described in #498 and not
addressed here.
