### PR TITLE
pg_lake_iceberg: leave dropped attributes out of Iceberg structs

### DIFF
--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -208,17 +208,34 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 	else if (get_typtype(typeId) == TYPTYPE_COMPOSITE)
 	{
 		TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeId, typeMod);
-		int			fieldCount = tupleDesc->natts;
+		int			attributeCount = tupleDesc->natts;
+		int			fieldCount = 0;
+
+		/*
+		 * Dropped attributes are still part of the tuple descriptor, but they
+		 * have no name or type we can map to Iceberg, and the values we write
+		 * do not contain them, so we leave them out of the struct.
+		 */
+		for (int attributeIndex = 0; attributeIndex < attributeCount; ++attributeIndex)
+		{
+			if (!TupleDescAttr(tupleDesc, attributeIndex)->attisdropped)
+				fieldCount++;
+		}
 
 		field->type = FIELD_TYPE_STRUCT;
 		field->field.structType.nfields = fieldCount;
 		field->field.structType.fields = palloc0(sizeof(FieldStructElement) * fieldCount);
 
-		for (int fieldIndex = 0; fieldIndex < fieldCount; ++fieldIndex)
-		{
-			Form_pg_attribute attr = TupleDescAttr(tupleDesc, fieldIndex);
+		int			fieldIndex = 0;
 
-			FieldStructElement *structElementField = &field->field.structType.fields[fieldIndex];
+		for (int attributeIndex = 0; attributeIndex < attributeCount; ++attributeIndex)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupleDesc, attributeIndex);
+
+			if (attr->attisdropped)
+				continue;
+
+			FieldStructElement *structElementField = &field->field.structType.fields[fieldIndex++];
 
 			structElementField->id = *subFieldIndex + 1;
 			*subFieldIndex = structElementField->id;

--- a/pg_lake_table/tests/pytests/test_complex_types.py
+++ b/pg_lake_table/tests/pytests/test_complex_types.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import psycopg2
 import time
@@ -274,3 +275,42 @@ def test_map_escaping(pg_conn, superuser_conn, extension, s3, with_default_locat
     assert res[0][0] == ["[", "'", "]"]
 
     pg_conn.rollback()
+
+
+def test_struct_with_dropped_attribute(pg_conn, extension, s3, with_default_location):
+    """Attributes dropped from a composite type are not part of the Iceberg struct."""
+    run_command(
+        """
+        CREATE SCHEMA dropped_attribute;
+        SET search_path TO dropped_attribute;
+        CREATE TYPE slot AS (junk int, label text, n int);
+        ALTER TYPE slot DROP ATTRIBUTE junk;
+        CREATE TABLE slots (id int, s slot, l slot[]) USING iceberg;
+        INSERT INTO slots VALUES (1, ROW('open', 3)::slot, ARRAY[ROW('closed', 4)::slot]);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    res = run_query(
+        "SELECT (s).label, (s).n, (l[1]).label, (l[1]).n FROM slots WHERE id = 1",
+        pg_conn,
+    )
+    assert res[0][0] == "open"
+    assert res[0][1] == 3
+    assert res[0][2] == "closed"
+    assert res[0][3] == 4
+
+    results = run_query(
+        "SELECT metadata_location FROM lake_iceberg.tables"
+        " WHERE table_name = 'slots' AND table_namespace = 'dropped_attribute'",
+        pg_conn,
+    )
+    parsed = json.loads(read_s3_operations(s3, results[0][0]))
+    fields = {f["name"]: f["type"] for f in parsed["schemas"][0]["fields"]}
+    assert [f["name"] for f in fields["s"]["fields"]] == ["label", "n"]
+    assert [f["name"] for f in fields["l"]["element"]["fields"]] == ["label", "n"]
+
+    pg_conn.rollback()
+    run_command("DROP SCHEMA IF EXISTS dropped_attribute CASCADE;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
Fixes #499.

`INSERT` into an Iceberg table failed when a composite column's type had an attribute
removed with `ALTER TYPE ... DROP ATTRIBUTE`:

```
ERROR:  Binder Error: Column name "........pg.dropped.1........" specified in FIELD_IDS
not found. ... Available column names: [n, label]
```

`PostgresTypeToIcebergField` iterated over all `tupleDesc->natts` without checking
`attisdropped`, so PostgreSQL's dropped-attribute placeholder was registered as a
struct field, got a sub-field id, and ended up in the Iceberg schema and in the
`field_ids` map. Every other part of the write path does skip dropped attributes
(`TupleDescToColumnMapForWrite`, the CSV writer's struct output,
`TypeHasStorageDivergentLeaf`, `register_field_ids`), which is why the two sides
disagreed.

This counts the live attributes first so `nfields` and the sub-field id numbering
match, and skips dropped attributes when filling them in.

Adds `test_struct_with_dropped_attribute`, which round-trips both a bare composite
and an array of composites through a type with a dropped attribute and asserts the
struct field lists in the Iceberg metadata are exactly the live attributes.
