### PR TITLE
pg_lake_iceberg: skip dropped attributes in struct value serde

### DIFF
--- a/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_json_serde.c
@@ -241,31 +241,42 @@ PGStructIcebergJsonSerialize(Datum structDatum, Field * field, PGType pgType)
 
 	HeapTupleHeader tuple = DatumGetHeapTupleHeader(structDatum);
 
-	int			tupleFieldCount = tupleDesc->natts;
+	int			attributeCount = tupleDesc->natts;
 
 	/* build json string for struct by iterating each field */
 	StringInfo	jsonString = makeStringInfo();
 
 	appendStringInfoChar(jsonString, '{');
 
-	for (int fieldIndex = 0; fieldIndex < tupleFieldCount; fieldIndex++)
-	{
-		Form_pg_attribute attr = TupleDescAttr(tupleDesc, fieldIndex);
+	/*
+	 * Dropped attributes are still part of the tuple descriptor but are left
+	 * out of the Iceberg struct (see PostgresTypeToIcebergField), so skip
+	 * them here too and index field->field.structType.fields with a separate
+	 * live field counter.
+	 */
+	int			fieldIndex = 0;
 
-		FieldStructElement *structElementField = &field->field.structType.fields[fieldIndex];
+	for (int attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, attributeIndex);
+
+		if (attr->attisdropped)
+			continue;
+
+		FieldStructElement *structElementField = &field->field.structType.fields[fieldIndex++];
 
 		PGType		attrPGType = MakePGType(attr->atttypid, attr->atttypmod);
 
 		bool		isNull = false;
-		Datum		attrDatum = GetAttributeByNum(tuple, fieldIndex + 1, &isNull);
+		Datum		attrDatum = GetAttributeByNum(tuple, attr->attnum, &isNull);
 		const char *attrJsonString = PGIcebergJsonSerialize(attrDatum, structElementField->type, attrPGType, &isNull);
 
-		appendStringInfo(jsonString, "\"%d\": %s", structElementField->id, attrJsonString);
-
-		if (fieldIndex < tupleFieldCount - 1)
+		if (fieldIndex > 1)
 		{
 			appendStringInfo(jsonString, ", ");
 		}
+
+		appendStringInfo(jsonString, "\"%d\": %s", structElementField->id, attrJsonString);
 	}
 
 	appendStringInfoChar(jsonString, '}');
@@ -576,11 +587,34 @@ PGStructIcebergJsonDeserialize(const char *structJson, Field * field, PGType pgT
 
 	MemoryContext spiContext = MemoryContextSwitchTo(callerContext);
 
-	Datum	   *attrDatums = palloc0(sizeof(Datum) * fieldsLen);
-	bool	   *attrNulls = palloc0(sizeof(bool) * fieldsLen);
+	/*
+	 * heap_form_tuple indexes these arrays by physical attribute number, so
+	 * they must cover every attribute in the descriptor, including dropped
+	 * ones. Dropped attributes are not present in the serialized struct (see
+	 * PostgresTypeToIcebergField / PGStructIcebergJsonSerialize), so default
+	 * everything to null and only fill in the live attributes.
+	 */
+	int			attributeCount = tupleDesc->natts;
+	Datum	   *attrDatums = palloc0(sizeof(Datum) * attributeCount);
+	bool	   *attrNulls = palloc0(sizeof(bool) * attributeCount);
 
-	for (size_t fieldIdx = 0; fieldIdx < fieldsLen; fieldIdx++)
+	for (int attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++)
+		attrNulls[attributeIndex] = true;
+
+	/*
+	 * The serialized fields appear in the same order as the live attributes
+	 * (and as field->field.structType.fields), so walk the descriptor's live
+	 * attributes in lockstep with the json_each rows.
+	 */
+	size_t		fieldIdx = 0;
+
+	for (int attributeIndex = 0; attributeIndex < attributeCount && fieldIdx < fieldsLen; attributeIndex++)
 	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, attributeIndex);
+
+		if (attr->attisdropped)
+			continue;
+
 		bool		isNull = false;
 
 		FieldStructElement *structElementField = &field->field.structType.fields[fieldIdx];
@@ -588,20 +622,19 @@ PGStructIcebergJsonDeserialize(const char *structJson, Field * field, PGType pgT
 		/* we need only the value (key is unused) to build tuple */
 		const char *attrJsonString = GET_SPI_VALUE(JSONOID, fieldIdx, 2, &isNull);
 
+		fieldIdx++;
+
 		if (isNull)
 		{
-			attrNulls[fieldIdx] = true;
+			attrNulls[attributeIndex] = true;
 
 			continue;
 		}
 
-		/* find the attribute from tuple's descriptor */
-		Form_pg_attribute attr = TupleDescAttr(tupleDesc, fieldIdx);
-
 		PGType		attrPGType = MakePGType(attr->atttypid, attr->atttypmod);
 
-		attrDatums[fieldIdx] = PGIcebergJsonDeserialize(attrJsonString, structElementField->type, attrPGType, &isNull);
-		attrNulls[fieldIdx] = isNull;
+		attrDatums[attributeIndex] = PGIcebergJsonDeserialize(attrJsonString, structElementField->type, attrPGType, &isNull);
+		attrNulls[attributeIndex] = isNull;
 	}
 
 	MemoryContextSwitchTo(spiContext);

--- a/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
+++ b/pg_lake_table/src/fdw/schema_operations/field_id_mapping_catalog.c
@@ -1031,6 +1031,16 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 				TupleDesc	tupDesc = isComposite ?
 					lookup_rowtype_tupdesc(pgType.postgresTypeOid, pgType.postgresTypeMod) : NULL;
 
+				/*
+				 * Dropped attributes are left out of the Iceberg struct (see
+				 * PostgresTypeToIcebergField), so structType.fields only
+				 * holds the live attributes. Walk the tuple descriptor's live
+				 * attributes in lockstep rather than indexing it by the live
+				 * field position, which would pair each field with the wrong
+				 * attribute once a dropped attribute precedes it.
+				 */
+				int			attributeIndex = 0;
+
 				for (size_t fieldIndex = 0; fieldIndex < nfields; fieldIndex++)
 				{
 					FieldStructElement *structElementField = &field->field.structType.fields[fieldIndex];
@@ -1039,7 +1049,13 @@ RegisterIcebergColumnMapping(Oid relationId, Field * field,
 
 					if (isComposite)
 					{
-						Form_pg_attribute attr = TupleDescAttr(tupDesc, fieldIndex);
+						while (attributeIndex < tupDesc->natts &&
+							   TupleDescAttr(tupDesc, attributeIndex)->attisdropped)
+							attributeIndex++;
+
+						Form_pg_attribute attr = TupleDescAttr(tupDesc, attributeIndex);
+
+						attributeIndex++;
 
 						subFieldPGType = MakePGType(attr->atttypid, attr->atttypmod);
 					}

--- a/pg_lake_table/src/fdw/snapshot.c
+++ b/pg_lake_table/src/fdw/snapshot.c
@@ -485,24 +485,45 @@ TypesAreCompatible(PGType pgType, PGType icebergType)
 		TupleDesc	pgTupleDesc = lookup_rowtype_tupdesc(pgType.postgresTypeOid, pgType.postgresTypeMod);
 		TupleDesc	icebergTupleDesc = lookup_rowtype_tupdesc(icebergType.postgresTypeOid, icebergType.postgresTypeMod);
 		bool		compatible = true;
+		int			pgIndex = 0;
+		int			icebergIndex = 0;
 
-		if (pgTupleDesc->natts != icebergTupleDesc->natts)
-			compatible = false;
-		else
+		/*
+		 * Dropped attributes are part of the tuple descriptor but are not
+		 * represented in the Iceberg schema, so compare only the live
+		 * attributes on each side, in order.
+		 */
+		while (compatible)
 		{
-			for (int i = 0; i < pgTupleDesc->natts; i++)
-			{
-				Form_pg_attribute pgAttr = TupleDescAttr(pgTupleDesc, i);
-				Form_pg_attribute icebergAttr = TupleDescAttr(icebergTupleDesc, i);
-				PGType		pgAttrType = MakePGType(pgAttr->atttypid, pgAttr->atttypmod);
-				PGType		icebergAttrType = MakePGType(icebergAttr->atttypid, icebergAttr->atttypmod);
+			while (pgIndex < pgTupleDesc->natts &&
+				   TupleDescAttr(pgTupleDesc, pgIndex)->attisdropped)
+				pgIndex++;
 
-				if (!TypesAreCompatible(pgAttrType, icebergAttrType))
-				{
+			while (icebergIndex < icebergTupleDesc->natts &&
+				   TupleDescAttr(icebergTupleDesc, icebergIndex)->attisdropped)
+				icebergIndex++;
+
+			bool		pgDone = pgIndex >= pgTupleDesc->natts;
+			bool		icebergDone = icebergIndex >= icebergTupleDesc->natts;
+
+			if (pgDone || icebergDone)
+			{
+				/* compatible only if both sides ran out of live attributes */
+				if (pgDone != icebergDone)
 					compatible = false;
-					break;
-				}
+				break;
 			}
+
+			Form_pg_attribute pgAttr = TupleDescAttr(pgTupleDesc, pgIndex);
+			Form_pg_attribute icebergAttr = TupleDescAttr(icebergTupleDesc, icebergIndex);
+			PGType		pgAttrType = MakePGType(pgAttr->atttypid, pgAttr->atttypmod);
+			PGType		icebergAttrType = MakePGType(icebergAttr->atttypid, icebergAttr->atttypmod);
+
+			if (!TypesAreCompatible(pgAttrType, icebergAttrType))
+				compatible = false;
+
+			pgIndex++;
+			icebergIndex++;
 		}
 
 		ReleaseTupleDesc(pgTupleDesc);

--- a/pg_lake_table/tests/pytests/test_complex_types.py
+++ b/pg_lake_table/tests/pytests/test_complex_types.py
@@ -314,3 +314,133 @@ def test_struct_with_dropped_attribute(pg_conn, extension, s3, with_default_loca
     pg_conn.rollback()
     run_command("DROP SCHEMA IF EXISTS dropped_attribute CASCADE;", pg_conn)
     pg_conn.commit()
+
+
+def test_struct_default_with_dropped_attribute(
+    pg_conn, extension, s3, with_default_location
+):
+    """A composite-typed default whose type has a dropped attribute round-trips
+    through Iceberg initial-default serialization and deserialization.
+
+    Serializing the default runs PGStructIcebergJsonSerialize and reading it
+    back for a pre-existing row runs PGStructIcebergJsonDeserialize.  Both walk
+    the type's tuple descriptor, which still contains the dropped attribute even
+    though the Iceberg struct only has the live fields.
+    """
+    run_command(
+        """
+        CREATE SCHEMA dropped_attribute_default;
+        SET search_path TO dropped_attribute_default;
+        CREATE TYPE slot AS (junk int, label text, n int);
+        ALTER TYPE slot DROP ATTRIBUTE junk;
+        CREATE TABLE slots (id int) USING iceberg;
+        INSERT INTO slots VALUES (1);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Adding the columns serializes the composite (and array-of-composite)
+    # defaults into the Iceberg initial-default.
+    run_command(
+        """
+        ALTER TABLE slots
+            ADD COLUMN s slot DEFAULT ROW('open', 3)::slot,
+            ADD COLUMN l slot[] DEFAULT ARRAY[ROW('closed', 4)::slot];
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # The pre-existing row (id = 1) has no stored value, so it is filled from
+    # the initial-default, exercising deserialization.
+    res = run_query(
+        "SELECT (s).label, (s).n, (l[1]).label, (l[1]).n FROM slots WHERE id = 1",
+        pg_conn,
+    )
+    assert res[0][0] == "open"
+    assert res[0][1] == 3
+    assert res[0][2] == "closed"
+    assert res[0][3] == 4
+
+    # A row inserted after the columns exist must round-trip identically.
+    run_command("INSERT INTO slots (id) VALUES (2);", pg_conn)
+    pg_conn.commit()
+    res = run_query(
+        "SELECT (s).label, (s).n, (l[1]).label, (l[1]).n FROM slots WHERE id = 2",
+        pg_conn,
+    )
+    assert res[0][0] == "open"
+    assert res[0][1] == 3
+    assert res[0][2] == "closed"
+    assert res[0][3] == 4
+
+    # The serialized initial-default must contain only the live sub-fields.
+    results = run_query(
+        "SELECT metadata_location FROM lake_iceberg.tables"
+        " WHERE table_name = 'slots' AND table_namespace = 'dropped_attribute_default'",
+        pg_conn,
+    )
+    parsed = json.loads(read_s3_operations(s3, results[0][0]))
+    schema = next(
+        s for s in parsed["schemas"] if s["schema-id"] == parsed["current-schema-id"]
+    )
+    fields = {f["name"]: f for f in schema["fields"]}
+    assert [sf["name"] for sf in fields["s"]["type"]["fields"]] == ["label", "n"]
+    assert sorted(fields["s"]["initial-default"].values(), key=str) == sorted(
+        ["open", 3], key=str
+    )
+
+    pg_conn.rollback()
+    run_command("DROP SCHEMA IF EXISTS dropped_attribute_default CASCADE;", pg_conn)
+    pg_conn.commit()
+
+
+def test_add_column_composite_with_dropped_attribute(
+    pg_conn, extension, s3, with_default_location
+):
+    """ALTER TABLE ADD COLUMN of a composite (and array-of-composite) column whose
+    type has a dropped attribute must register field ids that stay consistent with
+    the Iceberg metadata.
+
+    RegisterIcebergColumnMapping reads each struct sub-field's PostgreSQL type from
+    the tuple descriptor; pairing the live fields with the wrong attributes (because
+    of a preceding dropped attribute) made the internal field-id catalog disagree
+    with the written metadata, which trips the internal/external consistency assert
+    with "internalLeafField and externalLeafField have different types".  No default
+    is involved here, unlike test_struct_default_with_dropped_attribute.
+    """
+    run_command(
+        """
+        CREATE SCHEMA dropped_attribute_add;
+        SET search_path TO dropped_attribute_add;
+        CREATE TYPE slot AS (junk int, label text, n int);
+        ALTER TYPE slot DROP ATTRIBUTE junk;
+        CREATE TABLE slots (id int) USING iceberg;
+        INSERT INTO slots VALUES (1);
+        ALTER TABLE slots ADD COLUMN s slot;
+        ALTER TABLE slots ADD COLUMN l slot[];
+        INSERT INTO slots
+            VALUES (2, ROW('open', 3)::slot, ARRAY[ROW('closed', 4)::slot]);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    res = run_query(
+        "SELECT (s).label, (s).n, (l[1]).label, (l[1]).n FROM slots WHERE id = 2",
+        pg_conn,
+    )
+    assert res[0][0] == "open"
+    assert res[0][1] == 3
+    assert res[0][2] == "closed"
+    assert res[0][3] == 4
+
+    # The row inserted before the columns existed reads back as null.
+    res = run_query("SELECT s, l FROM slots WHERE id = 1", pg_conn)
+    assert res[0][0] is None
+    assert res[0][1] is None
+
+    pg_conn.rollback()
+    run_command("DROP SCHEMA IF EXISTS dropped_attribute_add CASCADE;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
Fixes #503. Follow-up to #501.

#501 fixed `PostgresTypeToIcebergField` so a composite type's Iceberg struct (`field->field.structType.fields`) contains only the **live** attributes, with `nfields` equal to the live count. Three consumers were still walking the full `tupleDesc->natts` while indexing structures that now hold only the live attributes, so any composite type carrying an attribute dropped with `ALTER TYPE ... DROP ATTRIBUTE` was mishandled.

## Changes

- **`PGStructIcebergJsonSerialize` / `PGStructIcebergJsonDeserialize`** (`iceberg_type_json_serde.c`) — the JSON value serde indexed `structType.fields` by the raw tuple offset, so a dropped attribute caused misaligned reads and an out-of-bounds read past the end of the array. The deserializer also sized its value arrays to the live-field count while `heap_form_tuple` indexes them by physical attribute number. Both now skip dropped attributes, index the field list with a separate live-field counter, and place deserialized values at their physical attribute position (dropped attributes left null).

- **`RegisterIcebergColumnMapping`** (`field_id_mapping_catalog.c`) — read each struct sub-field's PostgreSQL type from `TupleDescAttr(tupDesc, fieldIndex)`, pairing every live field after a dropped attribute with the wrong attribute's type. The persisted `field_id_mappings` then disagreed with the Iceberg metadata, so **`ALTER TABLE ADD COLUMN` of a composite column whose type has a dropped attribute failed under heavy asserts** with `internalLeafField and externalLeafField have different types`. Now walks the descriptor's live attributes in lockstep with the field list.

- **`TypesAreCompatible`** (`snapshot.c`) — compared two composite tuple descriptors by raw index and `natts`, so a dropped attribute on the Postgres side made an otherwise-compatible struct look incompatible. Now compares only the live attributes on each side, in order.

## Tests

Adds two tests over a composite type with a dropped attribute:
- `test_struct_default_with_dropped_attribute` — a composite and an array-of-composite column, each with a default, added to a table with a pre-existing row; asserts both the back-filled pre-existing row and a newly-inserted row round-trip, and that the serialized Iceberg `initial-default` contains only the live sub-fields. Exercises the serde and (via the default) the field-id registration path.
- `test_add_column_composite_with_dropped_attribute` — plain `ALTER TABLE ADD COLUMN` (no default) of a composite and array-of-composite column, then reads the values back. This is the minimal reproducer for the `field_id_mapping_catalog.c` bug.

The `snapshot.c` (`TypesAreCompatible`) change is not covered by a dedicated test: reaching it requires an external, read-only Iceberg table whose Postgres column is an explicitly-declared composite type that has a dropped attribute. Read-only tables created with an inferred schema synthesize fresh types (no dropped attribute), and a `location`-based foreign table starts empty, so neither drives the composite branch — verified empirically (the fix reverted still returns an empty read, not the schema-mismatch error). The change is a straightforward same-class hardening; I left it in rather than write a test that doesn't actually exercise it.

## Verification

Built the affected extensions and ran the pytest suite locally with heavy asserts enabled (`pg_lake_engine.enable_heavy_asserts=on`):
- `test_complex_types.py`: 10 passed (including both new tests). `test_add_column_composite_with_dropped_attribute` reproduces the `internalLeafField ... have different types` failure when the `field_id_mapping_catalog.c` fix is reverted.
- `test_iceberg_types.py`: passed. `test_iceberg_ddl.py` + `test_iceberg_field_ids.py` + `test_iceberg_uuid_compat.py`: 60 passed (2 Spark-dependent tests errored only because Java/PySpark is unavailable in the local sandbox).

## Not changed

- `BuildColumnDefListForTupleDesc` (`columns.c`) shares the pattern but its only caller (CREATE TABLE AS SELECT) passes a query result descriptor, which never carries dropped attributes.
- The map key/value accessors (`map.c`, `map_conversion.c`, `pg_map/map.c`) are guarded by `natts != 2` and operate on pg_lake-internal pair types that are not user-alterable.
