### PR TITLE
pg_extension_base: wait for a deregistered base worker to exit

### DIFF
--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -1862,7 +1862,19 @@ PgExtensionBaseWorkerMain(Datum arg)
 	 */
 	pqsignal(SIGTERM, die);
 
-	/* reset workerPid on exit */
+	/*
+	 * Reset workerPid on exit.
+	 *
+	 * This must stay registered before
+	 * BackgroundWorkerInitializeConnectionByOid below.  before_shmem_exit
+	 * callbacks fire in reverse registration order, so the connection's own
+	 * callbacks (ShutdownPostgres, ReplicationSlotShmemExit) run first and
+	 * clearing workerPid runs last.  That ordering is what lets
+	 * WaitForBaseWorkerExit treat a cleared workerPid as "locks released and
+	 * slot freed" rather than just "worker on its way out".  Moving this
+	 * below the connection setup, or switching it to on_shmem_exit, would
+	 * make that wait return too early.
+	 */
 	before_shmem_exit(PgExtensionBaseWorkerSharedMemoryExit, arg);
 
 	/*

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -2456,19 +2456,11 @@ WaitForBaseWorkerExit(int32 workerId, pid_t workerPid)
 	{
 		CHECK_FOR_INTERRUPTS();
 
-		bool		stillRunning;
-
-		LWLockAcquire(&BaseWorkerControl->lock, LW_SHARED);
-
-		bool		isFound = false;
-		BaseWorkerEntry *entry =
-			GetBaseWorkerEntry(MyDatabaseId, workerId, &isFound);
-
-		stillRunning = isFound && entry->workerPid == workerPid;
-
-		LWLockRelease(&BaseWorkerControl->lock);
-
-		if (!stillRunning)
+		/*
+		 * GetBaseWorkerPid returns 0 once the entry is gone, so an entry that
+		 * disappeared entirely also ends the wait.
+		 */
+		if (GetBaseWorkerPid(workerId) != workerPid)
 			return;
 
 		if (GetCurrentTimestamp() >= deadline)

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -2407,13 +2407,11 @@ DeregisterBaseWorker_internal(int32 workerId)
 	/*
 	 * Wait for a worker we just signalled to actually exit before returning.
 	 *
-	 * Callers deregister a worker precisely so they can drop the objects it
-	 * was using -- e.g. UnregisterCDCPublication drops the replication slot
-	 * and the publication's metalog/changelog Iceberg (foreign) tables right
-	 * after this returns.  If we returned while the worker were still alive,
-	 * those DROPs would block on -- or deadlock against -- locks the worker
-	 * still holds, which is exactly what stalls a PITR-fork recovery
-	 * finalize.
+	 * A caller typically deregisters a worker so it can then drop or alter
+	 * the resources the worker was using (a replication slot, a connection, a
+	 * table).  If we returned while the worker were still alive, that
+	 * follow-up work could block on -- or deadlock against -- locks the
+	 * worker still holds.
 	 *
 	 * SIGTERM is asynchronous, so signalling above does not guarantee the
 	 * worker is gone yet.  The worker clears its own workerPid under

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -340,6 +340,8 @@ static StartBaseWorkerResult StartBaseWorker(int workerId, Oid extensionId,
 static LockAcquireResult LockDatabaseStarter(Oid databaseId, LOCKMODE lockMode,
 											 bool waitForLock);
 
+static void WaitForBaseWorkerExit(int32 workerId, pid_t workerPid);
+
 /* functions called by base worker */
 static void PgExtensionBaseWorkerSharedMemoryExit(int code, Datum arg);
 
@@ -2370,6 +2372,7 @@ DeregisterBaseWorker_internal(int32 workerId)
 	/* lock the shared hash, because we might change it */
 	LWLockAcquire(&BaseWorkerControl->lock, LW_EXCLUSIVE);
 
+	pid_t		signalledPid = 0;
 	bool		isFound = false;
 	BaseWorkerEntry *baseWorkerEntry = GetBaseWorkerEntry(MyDatabaseId, workerId, &isFound);
 
@@ -2392,13 +2395,101 @@ DeregisterBaseWorker_internal(int32 workerId)
 			 * PgExtensionBaseWorkerMain when it sees needsRestart is true.
 			 */
 			if (baseWorkerEntry->workerPid > 0)
+			{
+				signalledPid = baseWorkerEntry->workerPid;
 				kill(baseWorkerEntry->workerPid, SIGTERM);
+			}
 		}
 	}
 
 	LWLockRelease(&BaseWorkerControl->lock);
 
+	/*
+	 * Wait for a worker we just signalled to actually exit before returning.
+	 *
+	 * Callers deregister a worker precisely so they can drop the objects it
+	 * was using -- e.g. UnregisterCDCPublication drops the replication slot
+	 * and the publication's metalog/changelog Iceberg (foreign) tables right
+	 * after this returns.  If we returned while the worker were still alive,
+	 * those DROPs would block on -- or deadlock against -- locks the worker
+	 * still holds, which is exactly what stalls a PITR-fork recovery
+	 * finalize.
+	 *
+	 * SIGTERM is asynchronous, so signalling above does not guarantee the
+	 * worker is gone yet.  The worker clears its own workerPid under
+	 * BaseWorkerControl->lock in PgExtensionBaseWorkerSharedMemoryExit as it
+	 * exits, so waiting for that is race-free.  We do it after releasing the
+	 * lock so we do not block the worker's own shmem-exit cleanup.
+	 */
+	if (signalledPid > 0)
+		WaitForBaseWorkerExit(workerId, signalledPid);
+
 	PG_RETURN_VOID();
+}
+
+
+/*
+ * Bound on how long DeregisterBaseWorker_internal waits for a signalled
+ * worker to exit, and how often it re-checks.  The wait is best-effort: on
+ * timeout we log and proceed rather than error, matching the launcher's
+ * tolerant handling elsewhere.
+ */
+#define BASE_WORKER_EXIT_TIMEOUT_MS 30000
+#define BASE_WORKER_EXIT_POLL_MS 50
+
+/*
+ * WaitForBaseWorkerExit waits for the base worker (workerId, workerPid) to
+ * clear its workerPid in shared memory -- the signal, set under
+ * BaseWorkerControl->lock by PgExtensionBaseWorkerSharedMemoryExit, that the
+ * process has exited.  Comparing against the specific pid we signalled means
+ * a restart that reuses the entry with a fresh pid also ends the wait: our
+ * worker is gone either way.  Bounded by BASE_WORKER_EXIT_TIMEOUT_MS.
+ */
+static void
+WaitForBaseWorkerExit(int32 workerId, pid_t workerPid)
+{
+	TimestampTz deadline =
+		TimestampTzPlusMilliseconds(GetCurrentTimestamp(),
+									BASE_WORKER_EXIT_TIMEOUT_MS);
+
+	for (;;)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		bool		stillRunning;
+
+		LWLockAcquire(&BaseWorkerControl->lock, LW_SHARED);
+
+		bool		isFound = false;
+		BaseWorkerEntry *entry =
+			GetBaseWorkerEntry(MyDatabaseId, workerId, &isFound);
+
+		stillRunning = isFound && entry->workerPid == workerPid;
+
+		LWLockRelease(&BaseWorkerControl->lock);
+
+		if (!stillRunning)
+			return;
+
+		if (GetCurrentTimestamp() >= deadline)
+		{
+			ereport(WARNING,
+					(errmsg("base worker %d (pid %d) did not exit within %d ms "
+							"of SIGTERM; proceeding without waiting",
+							workerId, (int) workerPid,
+							BASE_WORKER_EXIT_TIMEOUT_MS)));
+			return;
+		}
+
+		int			waitResult =
+			WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					  BASE_WORKER_EXIT_POLL_MS, WAIT_EVENT_PG_SLEEP);
+
+		if (waitResult & WL_POSTMASTER_DEATH)
+			proc_exit(1);
+
+		ResetLatch(MyLatch);
+	}
 }
 
 


### PR DESCRIPTION
## Summary

`DeregisterBaseWorker_internal` SIGTERMs a running base worker but returns immediately, without waiting for the process to actually exit. SIGTERM is asynchronous, so a caller that deregisters a worker *in order to drop the objects it was using* can race a still-live worker.


## Fix

After signalling the worker, wait for it to clear its `workerPid` in shared memory — which it does under `BaseWorkerControl->lock` in `PgExtensionBaseWorkerSharedMemoryExit` as it exits — before returning. The wait:

- happens **after** releasing `BaseWorkerControl->lock`, so it never blocks the worker's own shmem-exit cleanup;
- compares against the specific pid we signalled, so a restart that reuses the entry with a fresh pid also ends the wait (our worker is gone either way);
- is **bounded** (30s) and **best-effort**: on timeout it logs a `WARNING` and proceeds, matching the launcher's tolerant handling elsewhere;
- reacts to interrupts and postmaster death while sleeping.
