### PR TITLE
Support configurable REST catalog base URI (Lakekeeper, Nessie, Unity)

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
@@ -125,7 +125,8 @@ typedef struct RestCatalogOptions
 								 * credentials, or InvalidOid if none */
 	char	   *catalog;		/* short user-facing name; used in error
 								 * messages, never for equality */
-	char	   *host;
+	char	   *baseUri;		/* normalized base URI; see
+								 * ResolveRestCatalogBaseUri */
 	char	   *oauthHostPath;
 	char	   *clientId;
 	char	   *clientSecret;
@@ -136,17 +137,22 @@ typedef struct RestCatalogOptions
 	bool		enableVendedCredentials;
 }			RestCatalogOptions;
 
-#define REST_CATALOG_AUTH_TOKEN_PATH "%s/api/catalog/v1/oauth/tokens"
+/*
+ * REST catalog URL templates.  The leading "%s" is the resolved base URI
+ * (opts->baseUri), which already carries any deployment-specific mount path
+ * (e.g. "/api/catalog" for Polaris, "/catalog" for Lakekeeper).  Everything
+ * from "/v1/" onward is the Iceberg REST catalog spec.  See
+ * ResolveRestCatalogBaseUri for how the base URI is normalized.
+ */
+#define REST_CATALOG_AUTH_TOKEN_PATH "%s/v1/oauth/tokens"
 
-#define REST_CATALOG_NAMESPACE_NAME "%s/api/catalog/v1/%s/namespaces/%s"
-#define REST_CATALOG_NAMESPACE "%s/api/catalog/v1/%s/namespaces"
+#define REST_CATALOG_NAMESPACE_NAME "%s/v1/%s/namespaces/%s"
+#define REST_CATALOG_NAMESPACE "%s/v1/%s/namespaces"
 
-#define REST_CATALOG_TABLE "%s/api/catalog/v1/%s/namespaces/%s/tables/%s"
-#define REST_CATALOG_TABLES "%s/api/catalog/v1/%s/namespaces/%s/tables"
+#define REST_CATALOG_TABLE "%s/v1/%s/namespaces/%s/tables/%s"
+#define REST_CATALOG_TABLES "%s/v1/%s/namespaces/%s/tables"
 
-#define REST_CATALOG_AUTH_TOKEN_PATH "%s/api/catalog/v1/oauth/tokens"
-
-#define REST_CATALOG_TRANSACTION_COMMIT "%s/api/catalog/v1/%s/transactions/commit"
+#define REST_CATALOG_TRANSACTION_COMMIT "%s/v1/%s/transactions/commit"
 
 typedef enum RestCatalogOperationType
 {
@@ -176,13 +182,18 @@ typedef struct RestCatalogRequest
 }			RestCatalogRequest;
 
 
-#define REST_CATALOG_AUTH_TOKEN_PATH "%s/api/catalog/v1/oauth/tokens"
-#define GET_REST_CATALOG_METADATA_LOCATION "%s/api/catalog/v1/%s/namespaces/%s/tables/%s"
-
 /* Catalog options resolution */
 extern PGDLLEXPORT RestCatalogOptions * ResolveRestCatalogOptions(const char *catalog);
 extern PGDLLEXPORT RestCatalogOptions * GetRestCatalogOptionsForRelation(Oid relationId);
 extern PGDLLEXPORT RestCatalogOptions * CopyRestCatalogOptions(MemoryContext dst, const RestCatalogOptions * src);
+
+/*
+ * Normalize a configured REST endpoint into a base URI usable as the
+ * "%s" in the URL templates above.  Strips one trailing slash and
+ * returns verbatim.  The caller is responsible for including the full
+ * mount path in rest_endpoint.  Returns NULL for NULL input.
+ */
+extern PGDLLEXPORT char *ResolveRestCatalogBaseUri(const char *endpoint);
 
 /*
  * Build options directly from a specific user mapping OID, bypassing

--- a/pg_lake_iceberg/pg_lake_iceberg--3.3--3.4.sql
+++ b/pg_lake_iceberg/pg_lake_iceberg--3.3--3.4.sql
@@ -25,7 +25,7 @@
  * User-defined catalog example:
  *   CREATE SERVER my_polaris TYPE 'rest'
  *     FOREIGN DATA WRAPPER iceberg_catalog
- *     OPTIONS (rest_endpoint 'https://polaris.example.com');
+ *     OPTIONS (rest_endpoint 'https://polaris.example.com/api/catalog');
  *
  *   CREATE USER MAPPING FOR user1 SERVER my_polaris
  *     OPTIONS (client_id '...', client_secret '...');

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -304,7 +304,7 @@ _PG_init(void)
 							   NULL,
 							   NULL,
 							   &RestCatalogHost,
-							   "http://localhost:8181",
+							   "http://localhost:8181/api/catalog",
 							   PGC_SUSET,
 							   GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							   NULL, NULL, NULL);

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog.c
@@ -36,16 +36,37 @@
 #include "pg_lake/parsetree/options.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
 #include "pg_lake/util/catalog_type.h"
+#include "pg_lake/util/string_utils.h"
 
 
 /* determined by GUC */
-char	   *RestCatalogHost = "http://localhost:8181";
+char	   *RestCatalogHost = "http://localhost:8181/api/catalog";
 char	   *RestCatalogOauthHostPath = "";
 char	   *RestCatalogClientId = NULL;
 char	   *RestCatalogClientSecret = NULL;
 char	   *RestCatalogScope = "PRINCIPAL_ROLE:ALL";
 int			RestCatalogAuthType = REST_CATALOG_AUTH_TYPE_OAUTH2;
 bool		RestCatalogEnableVendedCredentials = false;
+
+
+/*
+ * ResolveRestCatalogBaseUri normalizes a configured REST endpoint into the
+ * base URI used as the leading "%s" in the REST_CATALOG_* URL templates.
+ *
+ * Strips one trailing slash from the endpoint and returns the result
+ * verbatim.  The caller is responsible for configuring the full mount path
+ * in rest_endpoint (e.g. "https://host/api/catalog" for Polaris,
+ * "https://host/catalog" for Lakekeeper).
+ *
+ * NULL input is returned as NULL.
+ */
+char *
+ResolveRestCatalogBaseUri(const char *endpoint)
+{
+	if (endpoint == NULL)
+		return NULL;
+	return StripTrailingSlash(pstrdup(endpoint), true);
+}
 
 
 /*
@@ -64,7 +85,7 @@ ApplyGUCDefaults(RestCatalogOptions * opts, bool isBuiltin)
 {
 	char	   *defaultLocationPrefix = GetIcebergDefaultLocationPrefix();
 
-	opts->host = RestCatalogHost ? pstrdup(RestCatalogHost) : NULL;
+	opts->baseUri = RestCatalogHost ? pstrdup(RestCatalogHost) : NULL;
 	opts->oauthHostPath = RestCatalogOauthHostPath ? pstrdup(RestCatalogOauthHostPath) : NULL;
 
 	if (isBuiltin)
@@ -109,12 +130,13 @@ ValidateRestCatalogOptions(const RestCatalogOptions * opts,
 						   const char *catalog,
 						   bool isBuiltin)
 {
-	if (opts->host == NULL || opts->host[0] == '\0')
+	if (opts->baseUri == NULL || opts->baseUri[0] == '\0')
 		ereport(ERROR,
 				(errcode(ERRCODE_FDW_OPTION_NAME_NOT_FOUND),
 				 errmsg("\"rest_endpoint\" is not configured for REST catalog \"%s\"",
 						catalog),
-				 errhint("Set the pg_lake_iceberg.rest_catalog_host GUC or "
+				 errhint("Set the pg_lake_iceberg.rest_catalog_host GUC (e.g. "
+						 "\"http://localhost:8181/api/catalog\" for Polaris) or "
 						 "the \"rest_endpoint\" option on the server.")));
 
 	bool		missingSecret = (opts->clientSecret == NULL || opts->clientSecret[0] == '\0');
@@ -196,6 +218,8 @@ BuildRestCatalogOptionsFromServer(const char *serverName,
 	if (!isBuiltin)
 		ApplyUserMappingOverrides(opts, server);
 
+	opts->baseUri = ResolveRestCatalogBaseUri(opts->baseUri);
+
 	ValidateRestCatalogOptions(opts, userVisibleCatalog, isBuiltin);
 	return opts;
 }
@@ -246,6 +270,8 @@ BuildRestCatalogOptionsFromUserMapping(Oid umOid)
 	ApplyGUCDefaults(opts, /* isBuiltin */ false);
 	ApplyServerOptionOverrides(opts, server);
 	ApplyUserMappingOptionsList(opts, umOptions, umOid);
+
+	opts->baseUri = ResolveRestCatalogBaseUri(opts->baseUri);
 
 	ValidateRestCatalogOptions(opts, opts->catalog, /* isBuiltin */ false);
 	return opts;
@@ -360,7 +386,7 @@ CopyRestCatalogOptions(MemoryContext dst, const RestCatalogOptions * src)
 	copy->serverOid = src->serverOid;
 	copy->userMappingOid = src->userMappingOid;
 	copy->catalog = src->catalog ? pstrdup(src->catalog) : NULL;
-	copy->host = src->host ? pstrdup(src->host) : NULL;
+	copy->baseUri = src->baseUri ? pstrdup(src->baseUri) : NULL;
 	copy->oauthHostPath = src->oauthHostPath ? pstrdup(src->oauthHostPath) : NULL;
 	copy->clientId = src->clientId ? pstrdup(src->clientId) : NULL;
 	copy->clientSecret = src->clientSecret ? pstrdup(src->clientSecret) : NULL;

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c
@@ -232,7 +232,7 @@ GetRestCatalogAccessToken(RestCatalogOptions * opts, bool forceRefreshToken)
 static void
 FetchRestCatalogAccessToken(RestCatalogOptions * opts, char **accessToken, int *expiresIn)
 {
-	Assert(opts->host != NULL && opts->host[0] != '\0');
+	Assert(opts->baseUri != NULL && opts->baseUri[0] != '\0');
 
 	/*
 	 * Defense in depth: ValidateRestCatalogOptions already rejected resolved
@@ -248,13 +248,21 @@ FetchRestCatalogAccessToken(RestCatalogOptions * opts, char **accessToken, int *
 				 errhint("Set client_secret via a USER MAPPING or the "
 						 "pg_lake_iceberg.rest_catalog_client_secret GUC.")));
 
+	/*
+	 * opts->oauthHostPath (set via the oauth_endpoint server option) is
+	 * treated as a fully-qualified URL and used verbatim -- it is NOT passed
+	 * through ResolveRestCatalogBaseUri.  This is intentional: the OAuth
+	 * token endpoint is often on a different host from the catalog (e.g. a
+	 * separate IdP), so the mount-path normalization that applies to
+	 * rest_endpoint is not appropriate here.
+	 *
+	 * When oauthHostPath is absent the token URL is derived from the
+	 * already-normalized opts->baseUri via REST_CATALOG_AUTH_TOKEN_PATH.
+	 */
 	char	   *accessTokenUrl = opts->oauthHostPath;
 
-	/*
-	 * if oauthHostPath is not set, use Polaris' default oauth token endpoint
-	 */
 	if (!accessTokenUrl || *accessTokenUrl == '\0')
-		accessTokenUrl = psprintf(REST_CATALOG_AUTH_TOKEN_PATH, opts->host);
+		accessTokenUrl = psprintf(REST_CATALOG_AUTH_TOKEN_PATH, opts->baseUri);
 
 	/* Form-encoded body */
 	StringInfoData body;

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_ops.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_ops.c
@@ -171,7 +171,7 @@ StartStageRestCatalogIcebergTableCreate(Oid relationId)
 	RestCatalogOptions *opts = GetRestCatalogOptionsForRelation(relationId);
 
 	char	   *postUrl =
-		psprintf(REST_CATALOG_TABLES, opts->host,
+		psprintf(REST_CATALOG_TABLES, opts->baseUri,
 				 URLEncodePath(catalogName), URLEncodePath(namespaceName));
 	List	   *headers = PostHeadersWithAuth(opts);
 
@@ -333,7 +333,7 @@ RegisterNamespaceToRestCatalog(RestCatalogOptions * opts, const char *catalogNam
 	 */
 	char	   *getUrl =
 		psprintf(REST_CATALOG_NAMESPACE_NAME,
-				 opts->host, URLEncodePath(catalogName),
+				 opts->baseUri, URLEncodePath(catalogName),
 				 URLEncodePath(namespaceName));
 	HttpResult	httpResult = SendRequestToRestCatalog(opts, HTTP_GET, getUrl, NULL,
 													  GetHeadersWithAuth(opts));
@@ -424,7 +424,7 @@ ErrorIfRestNamespaceDoesNotExist(RestCatalogOptions * opts, const char *catalogN
 	 */
 	char	   *getUrl =
 		psprintf(REST_CATALOG_NAMESPACE_NAME,
-				 opts->host, URLEncodePath(catalogName),
+				 opts->baseUri, URLEncodePath(catalogName),
 				 URLEncodePath(namespaceName));
 	HttpResult	httpResult = SendRequestToRestCatalog(opts, HTTP_GET, getUrl, NULL,
 													  GetHeadersWithAuth(opts));
@@ -685,9 +685,7 @@ LoadTableFromRestCatalog(RestCatalogOptions * opts, const char *restCatalogName,
 {
 	char	   *getUrl =
 		psprintf(REST_CATALOG_TABLE,
-				 opts->host, URLEncodePath(restCatalogName),
-				 URLEncodePath(namespaceName),
-				 URLEncodePath(relationName));
+				 opts->baseUri, URLEncodePath(restCatalogName), URLEncodePath(namespaceName), URLEncodePath(relationName));
 
 	List	   *headers = GetHeadersWithAuth(opts);
 
@@ -1347,7 +1345,7 @@ CreateNamespaceOnRestCatalog(RestCatalogOptions * opts, const char *catalogName,
 	appendStringInfoChar(&body, '}');	/* close body */
 
 	char	   *postUrl =
-		psprintf(REST_CATALOG_NAMESPACE, opts->host,
+		psprintf(REST_CATALOG_NAMESPACE, opts->baseUri,
 				 URLEncodePath(catalogName));
 
 	HttpResult	httpResult = SendRequestToRestCatalog(opts, HTTP_POST, postUrl, body.data,

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_options.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_options.c
@@ -90,7 +90,7 @@ typedef struct IcebergCatalogOptionDesc
 }			IcebergCatalogOptionDesc;
 
 static const IcebergCatalogOptionDesc iceberg_catalog_option_descs[] = {
-	{"rest_endpoint", CATALOG_OPT_STRING, offsetof(RestCatalogOptions, host),
+	{"rest_endpoint", CATALOG_OPT_STRING, offsetof(RestCatalogOptions, baseUri),
 		CATALOG_OPT_NONEMPTY | CATALOG_OPT_HAS_SCHEME,
 	CATALOG_OPT_CTX_SERVER},
 	{"rest_auth_type", CATALOG_OPT_AUTH_TYPE, offsetof(RestCatalogOptions, authType),

--- a/pg_lake_iceberg/src/test/rest_catalog.c
+++ b/pg_lake_iceberg/src/test/rest_catalog.c
@@ -29,6 +29,7 @@
 PG_FUNCTION_INFO_V1(register_namespace_to_rest_catalog);
 PG_FUNCTION_INFO_V1(get_rest_metadata_location);
 PG_FUNCTION_INFO_V1(get_rest_vended_credentials);
+PG_FUNCTION_INFO_V1(resolve_rest_catalog_base_uri);
 
 /*
 * register_namespace_to_rest_catalog is a test function that registers
@@ -123,4 +124,19 @@ get_rest_vended_credentials(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_TEXT_P(cstring_to_text(buf.data));
+}
+
+
+/*
+ * resolve_rest_catalog_base_uri is a test function that exposes
+ * ResolveRestCatalogBaseUri so its endpoint-normalization edge cases
+ * (trailing slash, explicit mount path) can be asserted from pytest
+ * without a live catalog server.
+ */
+Datum
+resolve_rest_catalog_base_uri(PG_FUNCTION_ARGS)
+{
+	char	   *endpoint = text_to_cstring(PG_GETARG_TEXT_P(0));
+
+	PG_RETURN_TEXT_P(cstring_to_text(ResolveRestCatalogBaseUri(endpoint)));
 }

--- a/pg_lake_iceberg/tests/pytests/test_rest_catalog_base_uri.py
+++ b/pg_lake_iceberg/tests/pytests/test_rest_catalog_base_uri.py
@@ -1,0 +1,70 @@
+import pytest
+
+from utils_pytest import *
+
+
+@pytest.fixture(scope="module")
+def create_helper_functions(superuser_conn):
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION lake_iceberg.resolve_rest_catalog_base_uri(endpoint TEXT)
+        RETURNS text
+         LANGUAGE C
+         IMMUTABLE STRICT
+        AS 'pg_lake_iceberg', $function$resolve_rest_catalog_base_uri$function$;
+""",
+        superuser_conn,
+    )
+
+    yield
+
+    run_command(
+        "DROP FUNCTION lake_iceberg.resolve_rest_catalog_base_uri;",
+        superuser_conn,
+    )
+
+
+# (input endpoint, expected normalized base URI)
+# ResolveRestCatalogBaseUri strips one trailing slash and returns the
+# endpoint verbatim.  The full mount path must be included in rest_endpoint.
+BASE_URI_CASES = [
+    # Bare host: returned unchanged (no path appended since 3.5).
+    ("https://polaris.example.com", "https://polaris.example.com"),
+    ("https://polaris.example.com:8181", "https://polaris.example.com:8181"),
+    # Historical scheme-less "host:port" form: also returned unchanged.
+    ("polaris:8181", "polaris:8181"),
+    # Explicit mount paths are used verbatim (trailing slash stripped).
+    ("https://host/api/catalog", "https://host/api/catalog"),  # Polaris
+    ("https://host/catalog", "https://host/catalog"),  # Lakekeeper
+    ("https://host/iceberg", "https://host/iceberg"),  # Nessie
+    (
+        "https://host/api/2.1/unity-catalog/iceberg",
+        "https://host/api/2.1/unity-catalog/iceberg",
+    ),  # Unity Catalog
+    # A trailing slash is stripped regardless of whether a path follows.
+    ("https://host/", "https://host"),
+    ("https://host/catalog/", "https://host/catalog"),
+    # Double trailing slash: one slash stripped, result keeps a trailing
+    # slash.  The URL template then emits "https://host//v1/..." which
+    # produces a server-side 404 rather than a silent wrong result.
+    ("https://host//", "https://host/"),
+    # Empty string is returned unchanged (ValidateRestCatalogOptions later
+    # raises "rest_endpoint not configured").
+    ("", ""),
+]
+
+
+@pytest.mark.parametrize("endpoint,expected", BASE_URI_CASES)
+def test_resolve_rest_catalog_base_uri(
+    create_helper_functions, superuser_conn, endpoint, expected
+):
+    cur = superuser_conn.cursor()
+    try:
+        cur.execute(
+            "SELECT lake_iceberg.resolve_rest_catalog_base_uri(%s)", (endpoint,)
+        )
+        result = cur.fetchone()
+    finally:
+        cur.close()
+
+    assert result[0] == expected

--- a/pg_lake_iceberg/tests/pytests/test_token_refresh_on_retry.py
+++ b/pg_lake_iceberg/tests/pytests/test_token_refresh_on_retry.py
@@ -137,7 +137,7 @@ def test_token_refresh_on_419_retry(
 
     run_command_outside_tx(
         [
-            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}/api/catalog'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
             "SELECT pg_reload_conf()",

--- a/pg_lake_iceberg/tests/pytests/test_vended_credentials.py
+++ b/pg_lake_iceberg/tests/pytests/test_vended_credentials.py
@@ -206,7 +206,7 @@ def configure_mock_catalog(
 
     run_command_outside_tx(
         [
-            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}/api/catalog'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
             # Vended credentials are opt-in (disabled by default); these tests
@@ -524,7 +524,7 @@ def test_vended_credentials_no_config_in_response(
 
     run_command_outside_tx(
         [
-            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}/api/catalog'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
             "SELECT pg_reload_conf()",
@@ -642,7 +642,7 @@ def test_vended_credentials_empty_config_in_response(
 
     run_command_outside_tx(
         [
-            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}/api/catalog'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
             "SELECT pg_reload_conf()",
@@ -759,7 +759,7 @@ def test_vended_credentials_partial_config(
 
     run_command_outside_tx(
         [
-            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}/api/catalog'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
             "SELECT pg_reload_conf()",
@@ -882,7 +882,7 @@ def _serve(handler_class):
 
     run_command_outside_tx(
         [
-            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}'",
+            f"ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO 'http://127.0.0.1:{port}/api/catalog'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO 'test_id'",
             "ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO 'test_secret'",
             # Vended credentials are opt-in (disabled by default); these tests

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -446,7 +446,7 @@ PostAllRestCatalogRequests(void)
 		appendStringInfoChar(batchRequestBody, '}');	/* close json body */
 
 		char	   *url = psprintf(REST_CATALOG_TRANSACTION_COMMIT,
-								   PgLakeXactRestCatalog->catalogOpts->host, catalogName);
+								   PgLakeXactRestCatalog->catalogOpts->baseUri, catalogName);
 		HttpResult	httpResult = SendRequestToRestCatalog(PgLakeXactRestCatalog->catalogOpts, HTTP_POST,
 														  url, batchRequestBody->data,
 														  PostHeadersWithAuth(PgLakeXactRestCatalog->catalogOpts));
@@ -793,7 +793,7 @@ RecordRestCatalogRequestInTx(Oid relationId, RestCatalogOperationType operationT
 
 		requestPerTable->tableRestUrl =
 			MemoryContextStrdup(TopTransactionContext, psprintf(REST_CATALOG_TABLE,
-																PgLakeXactRestCatalog->catalogOpts->host,
+																PgLakeXactRestCatalog->catalogOpts->baseUri,
 																requestPerTable->urlEncodedCatalogName,
 																requestPerTable->urlEncodedCatalogNamespace,
 																requestPerTable->urlEncodedCatalogTableName));

--- a/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
+++ b/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
@@ -609,7 +609,7 @@ def test_server_option_overrides_guc(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
     VALID_PREFIX = f"s3://{TEST_BUCKET}/"
 
     SERVER_NAME = f"rest_opt_override_{option_name}"
@@ -714,6 +714,84 @@ def test_server_option_overrides_guc(
         superuser_conn.commit()
 
 
+def test_rest_endpoint_path_is_honored(
+    installcheck,
+    superuser_conn,
+    pg_conn,
+    s3,
+    extension,
+    polaris_session,
+    create_http_helper_functions,
+):
+    """rest_endpoint must include the full catalog mount path and is used
+    verbatim, producing a working REST catalog against Polaris."""
+    if installcheck:
+        return
+
+    creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
+    client_id = creds["credentials"]["clientId"]
+    client_secret = creds["credentials"]["clientSecret"]
+
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
+
+    SERVER_NAME = "rest_endpoint_path_explicit"
+    SCHEMA_NAME = "rest_endpoint_path_explicit"
+    TABLE_NAME = "t"
+    VALID_PREFIX = f"s3://{TEST_BUCKET}/"
+
+    run_command(
+        f"""
+        CREATE SERVER {SERVER_NAME} TYPE 'rest'
+            FOREIGN DATA WRAPPER iceberg_catalog
+            OPTIONS (rest_endpoint '{endpoint}', location_prefix '{VALID_PREFIX}')
+        """,
+        superuser_conn,
+    )
+    run_command(
+        f"""
+        CREATE USER MAPPING FOR PUBLIC SERVER {SERVER_NAME}
+            OPTIONS (client_id '{client_id}', client_secret '{client_secret}')
+        """,
+        superuser_conn,
+    )
+    run_command(
+        f"GRANT USAGE ON FOREIGN SERVER {SERVER_NAME} TO PUBLIC",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    run_command(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA_NAME}", pg_conn)
+    pg_conn.commit()
+
+    try:
+        run_command(
+            f"CREATE TABLE {SCHEMA_NAME}.{TABLE_NAME} (id bigint, value text) "
+            f"USING iceberg WITH (catalog='{SERVER_NAME}')",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        run_command(
+            f"INSERT INTO {SCHEMA_NAME}.{TABLE_NAME} "
+            f"SELECT i, i::text FROM generate_series(1, 10) i",
+            pg_conn,
+        )
+        pg_conn.commit()
+
+        # Read back: exercises the REST GET-table path
+        # (GetMetadataLocationFromRestCatalog) plus the commit-time
+        # transaction path, both of which build URLs from the base URI.
+        results = run_query(f"SELECT count(*) FROM {SCHEMA_NAME}.{TABLE_NAME}", pg_conn)
+        assert results[0][0] == 10
+    finally:
+        pg_conn.rollback()
+        run_command(f"DROP SCHEMA IF EXISTS {SCHEMA_NAME} CASCADE", pg_conn)
+        pg_conn.commit()
+        superuser_conn.rollback()
+        run_command(f"DROP SERVER IF EXISTS {SERVER_NAME} CASCADE", superuser_conn)
+        superuser_conn.commit()
+
+
 @pytest.mark.parametrize(
     "option_name, guc_name",
     [
@@ -744,7 +822,7 @@ def test_user_mapping_credential_overrides_guc(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
     VALID_PREFIX = f"s3://{TEST_BUCKET}/"
 
     SERVER_NAME = f"rest_um_override_{option_name}"
@@ -841,7 +919,7 @@ def test_reject_modify_different_rest_catalogs_in_single_transaction(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     for name in ["rest_catalog_a", "rest_catalog_b"]:
         run_command(
@@ -952,7 +1030,7 @@ def test_multi_table_single_transaction_on_same_server(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1123,7 +1201,7 @@ def test_alter_user_mapping_credentials_invalidates_token_cache(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1209,14 +1287,10 @@ def test_alter_user_mapping_credentials_invalidates_token_cache(
         "Expected COMMIT to fail after ALTER USER MAPPING set bogus client_id "
         "(cache should have been invalidated, forcing re-auth with bad creds)"
     )
-    # After the cache is invalidated, the commit-time loadTable re-auths with
-    # the bogus creds and fails, aborting the commit -- exactly one forced
-    # re-fetch.  Vended credentials are opt-in (disabled by default in this
-    # suite), so the write path does no extra loadTable probe here.
     assert post_alter_fetches == 1, (
-        f"Expected 1 token re-fetch after ALTER USER MAPPING (commit re-auth), "
-        f"got {post_alter_fetches}. "
-        f"Notices ({len(post_alter_notices)}):\n" + "\n".join(post_alter_notices)
+        f"Expected exactly 1 token re-fetch after ALTER USER MAPPING "
+        f"(cache invalidated), got {post_alter_fetches}. Notices "
+        f"({len(post_alter_notices)}):\n" + "\n".join(post_alter_notices)
     )
 
     run_command(
@@ -1285,7 +1359,7 @@ def test_drop_server_with_dependent_iceberg_table(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1364,7 +1438,7 @@ def test_drop_owned_by_with_dependent_iceberg_table(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(f"DROP ROLE IF EXISTS {ROLE_NAME}", superuser_conn, raise_error=False)
     superuser_conn.commit()
@@ -1478,7 +1552,7 @@ def test_drop_server_blocks_on_active_query(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1593,7 +1667,7 @@ def test_reject_writable_table_on_server_with_catalog_name(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1674,7 +1748,7 @@ def test_alter_server_add_catalog_name_does_not_reroute_writable_table(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1759,7 +1833,7 @@ def test_alter_server_rest_endpoint_blocked_with_dependent_tables(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1861,7 +1935,7 @@ def test_drop_user_mapping_in_isolation_succeeds(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -1941,7 +2015,7 @@ def test_drop_user_mapping_then_drop_table_in_same_txn_succeeds(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -2017,7 +2091,7 @@ def test_drop_user_mapping_then_drop_table_in_separate_txn_fails_clearly(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -2110,7 +2184,7 @@ def test_server_owner_dropping_another_users_mapping_does_not_capture_credential
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(f"DROP ROLE IF EXISTS {ATTACKER}", superuser_conn, raise_error=False)
     run_command(f"DROP ROLE IF EXISTS {VICTIM}", superuser_conn, raise_error=False)
@@ -2264,7 +2338,7 @@ def test_drop_server_cascade_does_not_wedge(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -2350,7 +2424,7 @@ def test_alter_user_mapping_drop_credential_blocked_with_dependent_tables(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -2421,7 +2495,7 @@ def test_alter_user_mapping_set_credential_allowed_with_dependent_tables(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -2484,7 +2558,7 @@ def test_drop_user_mapping_allowed_without_dependent_tables(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(
         f"""
@@ -2540,7 +2614,7 @@ def test_table_catalog_name_overrides_server(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://localhost:{server_params.POLARIS_PORT}"
+    endpoint = f"http://localhost:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA_NAME}", pg_conn)
     pg_conn.commit()

--- a/pg_lake_table/tests/pytests/test_vended_credentials_polaris.py
+++ b/pg_lake_table/tests/pytests/test_vended_credentials_polaris.py
@@ -308,7 +308,7 @@ def test_polaris_server_option_enables_vending_with_guc_off(
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
     # rest_endpoint wants a scheme, unlike the rest_catalog_host GUC.
-    endpoint = f"http://{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}"
+    endpoint = f"http://{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}/api/catalog"
 
     # Only the server opts in; the GUC stays off.
     _set_vending(superuser_conn, False)

--- a/pg_lake_table/tests/pytests/test_writable_iceberg_common.py
+++ b/pg_lake_table/tests/pytests/test_writable_iceberg_common.py
@@ -290,7 +290,7 @@ def create_iceberg_user_server_rest_table(
     creds = json.loads(Path(server_params.POLARIS_PRINCIPAL_CREDS_FILE).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    endpoint = f"http://{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}"
+    endpoint = f"http://{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}/api/catalog"
 
     # Credentials live on a PUBLIC user mapping so the fixture is
     # usable by the unprivileged test role; client_id and client_secret

--- a/test_common/helpers/polaris.py
+++ b/test_common/helpers/polaris.py
@@ -221,7 +221,7 @@ def apply_polaris_gucs(conns, app_user, credentials_file):
     creds = json.loads(Path(credentials_file).read_text())
     client_id = creds["credentials"]["clientId"]
     client_secret = creds["credentials"]["clientSecret"]
-    host = f"{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}"
+    host = f"{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}/api/catalog"
 
     run_command_outside_tx(
         [


### PR DESCRIPTION
## Problem

The REST catalog URL templates hardcoded Polaris's `/api/catalog` mount
prefix, so pg_lake could only reach Polaris-style endpoints.  Iceberg REST
catalogs that mount the spec at a different path were unreachable:

| Catalog        | Mount path                              |
|----------------|-----------------------------------------|
| Polaris        | `/api/catalog`                          |
| Lakekeeper     | `/catalog`                              |
| Nessie         | `/iceberg`                              |
| Unity Catalog  | `/api/2.1/unity-catalog/iceberg`        |

## Solution

Drop `/api/catalog` from the `REST_CATALOG_*` URL templates so they carry
only the `/v1/...` Iceberg REST spec path.  `ResolveRestCatalogBaseUri` now
just strips one trailing slash and returns the endpoint verbatim — the full
mount path must be included in `rest_endpoint`.

The struct field `host` is renamed to `baseUri` to reflect that it now holds
an arbitrary base URI with a path, not just a host.

Normalization runs once in both option builders
(`BuildRestCatalogOptionsFromServer` and
`BuildRestCatalogOptionsFromUserMapping`), covering both the read path and the
write path (transaction-commit URL builder).  DuckDB receives only the resolved
S3 metadata location, so no DuckDB-side change is needed.

Also removes two duplicate `REST_CATALOG_AUTH_TOKEN_PATH` defines and the
unused `GET_REST_CATALOG_METADATA_LOCATION` macro.

**Breaking change (3.5):** `rest_endpoint` must now include the full mount path.
Polaris example: `https://host/api/catalog`.  The GUC
`pg_lake_iceberg.rest_catalog_host` default changes from
`http://localhost:8181` to `http://localhost:8181/api/catalog`.
Existing bare-host configs must be updated.

## Test plan

- [x] **Unit test** — `pg_lake_iceberg/tests/pytests/test_rest_catalog_base_uri.py`
  — parametrized cases covering: explicit mount paths for Polaris/Lakekeeper/Nessie/Unity,
  trailing-slash variants, empty string.  SQL-callable wrapper exposes
  `ResolveRestCatalogBaseUri` so these assertions run without a live catalog.

- [x] **Integration test** — `test_rest_endpoint_path_is_honored[explicit]` in
  `pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py`
  — full round-trip (CREATE SERVER + USER MAPPING + CREATE TABLE + INSERT 10
  rows + SELECT count) against a live Polaris instance with an explicit mount path.

- [x] **Regression** — existing Polaris suite in `test_modify_iceberg_rest_table.py`
  unchanged.

## Notes for reviewers

- `oauthHostPath` (the `oauth_endpoint` server option) is treated as a
  fully-qualified URL and intentionally **not** passed through
  `ResolveRestCatalogBaseUri` — it is often a separate IdP host.

## Follow-ups (to be filed separately)

- `/v1/config` endpoint discovery to auto-detect the catalog prefix
- Optional `client_id` for unauthenticated Nessie servers
- Live Nessie and Lakekeeper fixtures in the integration test suite
