### PR TITLE
test_common: bump Apache Polaris REST catalog to 1.7.0

### DIFF
--- a/pg_lake_table/tests/pytests/test_polaris_catalog.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog.py
@@ -36,16 +36,19 @@ def test_polaris_catalog_running(pg_conn, s3, polaris_session, installcheck):
     assert resp.ok, f"Polaris is not running: {resp.status_code} {resp.text}"
 
 
-# Apache Polaris 1.4+ rejects '/' in entity names with HTTP 400
-# ("Entity name must not contain '/'"). Until pg_lake maps Postgres
-# schema names that contain '/' to multi-level Iceberg namespaces
-# (or otherwise encodes them server-acceptably), we cannot include '/'
-# in test data that goes through the REST catalog.
+# Apache Polaris tightened entity-name validation over releases and now
+# rejects a fixed set of characters with HTTP 400 ("Entity name must not
+# contain '<c>'"). As of 1.7 the forbidden set (see EntityNameValidator)
+# is: / \ : * ? " < > | # + ` (plus control chars and leading/trailing
+# whitespace). Until pg_lake maps such Postgres schema names to
+# server-acceptable Iceberg names, test data going through the REST
+# catalog must avoid these characters while still exercising the other
+# special characters our name encoding must handle.
 namespaces = [
     "regular_name",
-    "regular..!!**(())..;;..??::@@&&==++$$,,#name",
-    "Special-Table!_With.Multiple_Uses_Of@Chars#-Here~And*Here!name",
-    "!~*().?:@&=+$,#",
+    "regular..!!(())..;;..@@&&==$$,,name",
+    "Special-Table!_With.Multiple_Uses_Of@Chars-Here~AndHere!name",
+    "!~().@&=$,",
 ]
 
 
@@ -204,11 +207,11 @@ def test_create_namespace_rollback(
 
 existing_namespaces = [
     "regular_nsp_name",
-    "nonregular_nsp!~*()name:$Uses_Of@",
+    "nonregular_nsp!~()name$Uses_Of@",
 ]
 existing_table_names = [
     "regular_tbl_name",
-    "nonregular_tbl!~*()name:$Uses_Of@",
+    "nonregular_tbl!~()name$Uses_Of@",
 ]
 
 

--- a/test_common/rest_catalog/Makefile
+++ b/test_common/rest_catalog/Makefile
@@ -8,7 +8,7 @@ PG_SHAREDIR := $(shell $(PG_CONFIG) --sharedir)
 USE_PGXS=1
 include $(PGXS)
 
-JAR_VERSION=1.5.0
+JAR_VERSION=1.7.0
 
 # Polaris build and install
 all:


### PR DESCRIPTION
Move the Apache Polaris REST-catalog submodule from `apache-polaris-1.5.0` to `apache-polaris-1.7.0` (released 2026-08-02) so the REST-catalog integration is exercised against the current release. The 1.7 line includes several vended-credential fixes (e.g. propagating storage HTTP-client settings to `S3FileIO`, `allowedLocations` re-validation, stricter table-location validation) that are relevant to our vended-credentials work.

## Changes

- **`test_common/rest_catalog/polaris`** — submodule pointer bumped to `apache-polaris-1.7.0`.
- **`test_common/rest_catalog/Makefile`** — bump `JAR_VERSION` to `1.7.0`. The install paths are already `JAR_VERSION`-parameterized, so no path/name changes were needed (unlike the 1.2→1.5 `-incubating` drop).
- **`pg_lake_table/tests/pytests/test_polaris_catalog.py`** — sanitize the special-character namespace/table test data.

  Polaris 1.7 introduces `EntityNameValidator`, which rejects a fixed set of characters in entity names with HTTP 400 (`Entity name must not contain '<c>'`): `` / \ : * ? " < > | # + ` `` (plus control characters and leading/trailing whitespace). This is the 1.7 analog of the 1.4 `/` tightening handled in #344. The affected names used `* # + : ?`; they are replaced with variants that drop only the now-forbidden characters while keeping the rest of the special-character coverage (`! ( ) . ; @ & = $ , ~ - _`) intact. The explanatory comment is updated to describe the full 1.7 forbidden set.

The CI jar cache-key already includes `polaris/version.txt` (added in #344), so this submodule bump invalidates the cache and forces a real rebuild against 1.7. The existing `test_polaris_jar_matches_expected_version` guard also re-validates the pin: it reads `JAR_VERSION` from the Makefile and asserts `java -jar polaris-admin.jar --version` matches.

## Verification

Verified locally against Polaris 1.7.0 (pgduck_server + Moto), on a clean `main`-based build:

- `pg_lake_iceberg/tests/pytests/test_polaris_conn.py` — **5/5** pass (incl. `test_polaris_jar_matches_expected_version`, which confirms the installed jar reports `1.7.0`).
- `pg_lake_table/tests/pytests/test_polaris_catalog.py` — **48/48** pass.
- Sample of `pg_lake_table/tests/pytests/test_polaris_catalog_writable.py` (basic_flow, ddl, drop_table, complex_transaction, base_types, add_drop_columns) — **6/6** pass.

After `make install-rest_catalog`, the install step produces `polaris-{admin,server}-1.7.0-runner.jar` and `java -jar polaris-admin.jar --version` reports `1.7.0`.
