### PR TITLE
pg_lake_table: add fast drop that deletes an Iceberg table by prefix

### DIFF
--- a/docs/iceberg-tables.md
+++ b/docs/iceberg-tables.md
@@ -868,6 +868,8 @@ drop table measurements;
 
 When you drop an Iceberg table, the files that make up the Iceberg table will be added to the “deletion queue”, but are not immediately deleted. This allows for restoring a backup if you need to revert to a previous point in time (see Point-in-time recoveries). When you run `VACUUM (iceberg);`, any files that have been in the deletion queue for more than 10 days will be deleted.
 
+By default the drop enumerates every file the table references, so the deletion queue holds exact per-file entries. Setting `pg_lake_table.fast_drop_file_cleanup` instead queues the table's whole location prefix, which VACUUM removes in a single recursive pass. This reads no Iceberg metadata, so it is much faster for tables with many files. It applies only to managed-location tables; a table created with a custom `location` may share that prefix with other tables, so it always falls back to per-file enumeration.
+
 ## Backups
 
 When an Iceberg table is modified, the files that make up the previous version of the Iceberg table remain in object storage until they are explicitly deleted (by VACUUM). Our default policy is to keep files for at least 10 days to allow past versions to be restored.

--- a/pg_lake_table/include/pg_lake/ddl/drop_table.h
+++ b/pg_lake_table/include/pg_lake/ddl/drop_table.h
@@ -21,9 +21,11 @@
 
 extern bool SkipDropAccessHook;
 extern bool DeferDropFileCleanup;
+extern bool FastDropFileCleanup;
 
 extern void InitializeDropTableHandler(void);
 extern PGDLLEXPORT bool CheckIfTypeIsUsedInTables(Oid typeId, const char *tableSetSubquery);
 extern bool CheckIfTypeIsUsedInInternalIcebergTable(Oid typeId);
 extern bool ProcessDropPgLakeTable(ProcessUtilityParams * params, void *arg);
 extern void TryMarkAllReferencedFilesForDeletion(Oid relationId);
+extern bool TryMarkTablePrefixForDeletion(Oid relationId);

--- a/pg_lake_table/src/ddl/ddl_changes.c
+++ b/pg_lake_table/src/ddl/ddl_changes.c
@@ -166,20 +166,26 @@ ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 					IsIcebergTableCreatedInCurrentTransaction(relationId);
 
 				/*
-				 * When the caller enabled deferred cleanup (the
-				 * pg_lake_table.defer_drop_file_cleanup GUC), don't walk
-				 * object storage now: queue the table's metadata.json as a
-				 * single resolve_metadata row and let VACUUM resolve it into
-				 * the exact referenced files later. This stays file-accurate
-				 * (never a whole prefix), so it is safe for custom locations
-				 * too. A table created in this transaction has no persisted
-				 * metadata to resolve, so it takes the normal path.
+				 * Reclaim the dropped table's object storage. Fast drop
+				 * queues the whole location prefix and reads no metadata, but
+				 * is only safe for managed locations, so
+				 * TryMarkTablePrefixForDeletion may decline and fall through.
+				 * Deferred cleanup queues metadata.json for VACUUM to resolve
+				 * into exact files later, which is safe for custom locations
+				 * too. Otherwise, enumerate every file now.
 				 */
-				bool		deferMetadataResolution =
-					DeferDropFileCleanup &&
-					!createdInCurrentTx;
+				bool		fastDrop = false;
 
-				if (deferMetadataResolution)
+				if (createdInCurrentTx)
+				{
+					/* nothing persisted yet; handled elsewhere */
+				}
+				else if (FastDropFileCleanup &&
+						 TryMarkTablePrefixForDeletion(relationId))
+				{
+					fastDrop = true;
+				}
+				else if (DeferDropFileCleanup)
 				{
 					char	   *metadataLocation =
 						GetIcebergMetadataLocation(relationId, true);
@@ -187,7 +193,7 @@ ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 					InsertMetadataResolveRecord(metadataLocation, InvalidOid,
 												GetCurrentTransactionStartTimestamp());
 				}
-				else if (!createdInCurrentTx)
+				else
 				{
 					TryMarkAllReferencedFilesForDeletion(relationId);
 				}
@@ -201,13 +207,17 @@ ApplyDDLCatalogChanges(Oid relationId, List *ddlOperations,
 				 * to create another metadata file, the table is dropped. So,
 				 * this could be the only chance to delete the previous
 				 * metadata file. It is not covered by metadata resolution
-				 * either, so enqueue it directly on both paths.
+				 * either, so enqueue it directly, unless the prefix delete
+				 * already covers it.
 				 */
-				char	   *previousMetadataPath =
-					GetIcebergCatalogPreviousMetadataLocation(relationId, false);
+				if (!fastDrop)
+				{
+					char	   *previousMetadataPath =
+						GetIcebergCatalogPreviousMetadataLocation(relationId, false);
 
-				if (previousMetadataPath)
-					InsertDeletionQueueRecord(previousMetadataPath, InvalidOid, GetCurrentTimestamp());
+					if (previousMetadataPath)
+						InsertDeletionQueueRecord(previousMetadataPath, InvalidOid, GetCurrentTimestamp());
+				}
 			}
 
 			RemoveAllDataFilesFromPgLakeCatalogFromTable(relationId);

--- a/pg_lake_table/src/ddl/drop_table.c
+++ b/pg_lake_table/src/ddl/drop_table.c
@@ -73,6 +73,15 @@ bool		SkipDropAccessHook = false;
  */
 bool		DeferDropFileCleanup = false;
 
+/*
+ * pg_lake_table.fast_drop_file_cleanup GUC. When set, dropping a writable,
+ * default-location Iceberg table queues its whole location prefix for VACUUM
+ * to remove instead of reading Iceberg metadata to enumerate files.
+ * Custom-location tables fall back to per-file cleanup; see
+ * TryMarkTablePrefixForDeletion.
+ */
+bool		FastDropFileCleanup = false;
+
 #define INTERNAL_ICEBERG_TABLES_SUBQUERY \
 	"SELECT c.oid AS relid " \
 	"FROM lake_iceberg.tables_internal tbl " \
@@ -455,6 +464,31 @@ CheckIfTypeIsUsedInInternalIcebergTable(Oid typeId)
 		return false;
 
 	return CheckIfTypeIsUsedInTables(typeId, INTERNAL_ICEBERG_TABLES_SUBQUERY);
+}
+
+
+/*
+* TryMarkTablePrefixForDeletion queues the table's whole location prefix for
+* deletion, skipping the metadata.json -> manifest list -> manifest -> data
+* file walk that dominates the cost of dropping a table with many files.
+*
+* Managed tables live under a unique per-table prefix
+* (.../<table>/<relationId>), so deleting the prefix is exact. A custom
+* location may be shared with other tables, so we decline it and leave the
+* caller to fall back to per-file cleanup.
+*/
+bool
+TryMarkTablePrefixForDeletion(Oid relationId)
+{
+	if (HasCustomLocation(relationId))
+		return false;
+
+	char	   *queryArguments = "";
+	char	   *tableLocation = GetWritableTableLocation(relationId, &queryArguments);
+
+	InsertPrefixDeletionRecord(tableLocation, GetCurrentTransactionStartTimestamp());
+
+	return true;
 }
 
 

--- a/pg_lake_table/src/init.c
+++ b/pg_lake_table/src/init.c
@@ -362,6 +362,19 @@ _PG_init(void)
 							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("pg_lake_table.fast_drop_file_cleanup",
+							 "When dropping a writable, default-location Iceberg "
+							 "table, queue its whole location prefix for VACUUM to "
+							 "remove, instead of reading Iceberg metadata to "
+							 "enumerate every referenced file. Custom-location "
+							 "tables fall back to per-file cleanup.",
+							 NULL,
+							 &FastDropFileCleanup,
+							 false,
+							 PGC_USERSET,
+							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
+
 	DefineCustomIntVariable("pg_lake_table.unbounded_numeric_default_precision",
 							"Determines the default precision for unbounded numeric types "
 							"in pg_lake tables.",

--- a/pg_lake_table/tests/pytests/test_drop_table.py
+++ b/pg_lake_table/tests/pytests/test_drop_table.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from utils_pytest import *
 
@@ -1074,6 +1076,194 @@ def test_custom_location_is_also_deferred(
 
     run_command("DROP SCHEMA IF EXISTS defer_drop_custom CASCADE", pg_conn)
     pg_conn.commit()
+
+
+FAST_GUC = "pg_lake_table.fast_drop_file_cleanup"
+
+
+def _drop_fast(conn, drop_sql, commit=True):
+    """Run drop_sql with fast file cleanup enabled. SET LOCAL scopes the GUC to
+    this transaction, so it never leaks to later tests."""
+    run_command(f"SET LOCAL {FAST_GUC} = on", conn)
+    run_command(drop_sql, conn)
+    if commit:
+        conn.commit()
+
+
+def test_fast_drop_queues_prefix(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    """Dropping a default-location table queues one is_prefix row for the whole
+    location, with no per-file or resolve_metadata rows, and VACUUM then removes
+    the prefix."""
+    run_command("CREATE SCHEMA IF NOT EXISTS fast_drop_prefix", pg_conn)
+    run_command(
+        """
+        CREATE TABLE fast_drop_prefix.t USING iceberg
+        WITH (autovacuum_enabled='false')
+        AS SELECT i AS id, 'pg_lake' AS name FROM generate_series(1, 10) i
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # a second snapshot, so a metadata walk would be real work if reached
+    run_command(
+        "INSERT INTO fast_drop_prefix.t SELECT i, 'pg_lake' FROM generate_series(11, 20) i",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    location = _writable_location(pg_conn, "fast_drop_prefix.t")
+
+    files_before = run_query(
+        f"SELECT count(*) FROM lake_file.list('{location}/**')", pg_conn
+    )[0][0]
+    assert files_before > 0
+
+    _drop_fast(pg_conn, "DROP TABLE fast_drop_prefix.t")
+
+    # table is gone
+    assert (
+        run_query(
+            "SELECT count(*) FROM pg_class "
+            "WHERE relname = 't' AND relnamespace = 'fast_drop_prefix'::regnamespace",
+            superuser_conn,
+        )[0][0]
+        == 0
+    )
+
+    assert _count_prefix_records(superuser_conn, location) == 1
+    assert _count_data_file_records(superuser_conn, location) == 0
+    assert _count_resolve_records(superuser_conn, location) == 0
+
+    # the drop itself deletes nothing; VACUUM does the removal
+    assert (
+        run_query(f"SELECT count(*) FROM lake_file.list('{location}/**')", pg_conn)[0][
+            0
+        ]
+        > 0
+    )
+
+    _assert_vacuum_drains(superuser_conn, location)
+
+    run_command("DROP SCHEMA IF EXISTS fast_drop_prefix CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_fast_drop_custom_location_falls_back(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    """A custom location may be shared with other tables, so the prefix path is
+    declined even with fast drop enabled: per-file rows, no prefix row."""
+    custom_location = f"s3://{TEST_BUCKET}/fast_custom_location/mytable"
+
+    run_command("CREATE SCHEMA IF NOT EXISTS fast_drop_custom", pg_conn)
+    run_command(
+        f"""
+        CREATE TABLE fast_drop_custom.t USING iceberg
+        WITH (autovacuum_enabled='false', location='{custom_location}')
+        AS SELECT i AS id, 'pg_lake' AS name FROM generate_series(1, 10) i
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    location = _writable_location(pg_conn, "fast_drop_custom.t")
+
+    _drop_fast(pg_conn, "DROP TABLE fast_drop_custom.t")
+
+    # fell back to per-file enumeration
+    assert _count_prefix_records(superuser_conn, location) == 0
+    assert _count_data_file_records(superuser_conn, location) > 0
+    assert _count_resolve_records(superuser_conn, location) == 0
+
+    _assert_vacuum_drains(superuser_conn, location)
+
+    run_command("DROP SCHEMA IF EXISTS fast_drop_custom CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_fast_drop_prefix_reclaimed_by_autovacuum(
+    s3, pg_conn, superuser_conn, extension, installcheck, with_default_location
+):
+    """The autovacuum worker reclaims a fast drop's prefix on its own.
+
+    InsertPrefixDeletionRecord stores table_name = 0, so no per-table pass ever
+    claims the row -- only the dropped-table pass does. That pass has to run in
+    the worker for the storage to come back without someone issuing
+    VACUUM (ICEBERG) by hand.
+    """
+    if installcheck:
+        return
+
+    naptime_seconds = 2
+    deadline_seconds = 60
+
+    run_command("CREATE SCHEMA IF NOT EXISTS fast_drop_autovacuum", pg_conn)
+    run_command(
+        """
+        CREATE TABLE fast_drop_autovacuum.t USING iceberg
+        WITH (autovacuum_enabled='false')
+        AS SELECT i AS id, 'pg_lake' AS name FROM generate_series(1, 10) i
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    location = _writable_location(pg_conn, "fast_drop_autovacuum.t")
+
+    files_before = run_query(
+        f"SELECT count(*) FROM lake_file.list('{location}/**')", pg_conn
+    )[0][0]
+    assert files_before > 0
+
+    # the drop stamps orphaned_at, so the row is not eligible until the
+    # retention period passes. Both GUCs have to be set at the system level
+    # because the worker is a separate backend.
+    run_command_outside_tx(
+        [
+            f"ALTER SYSTEM SET pg_lake_iceberg.autovacuum_naptime TO '{naptime_seconds}s'",
+            "ALTER SYSTEM SET pg_lake_engine.orphaned_file_retention_period TO 0",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    try:
+        _drop_fast(pg_conn, "DROP TABLE fast_drop_autovacuum.t")
+
+        remaining = 1
+        files_left = None
+        deadline = time.monotonic() + deadline_seconds
+
+        while time.monotonic() < deadline:
+            remaining = _count_prefix_records(superuser_conn, location)
+            files_left = run_query(
+                f"SELECT count(*) FROM lake_file.list('{location}/**')",
+                superuser_conn,
+            )[0][0]
+            superuser_conn.commit()
+
+            if remaining == 0 and files_left == 0:
+                break
+
+            time.sleep(0.5)
+
+        assert remaining == 0, (
+            f"prefix row still queued after {deadline_seconds}s; "
+            "the worker is not running the dropped-table pass"
+        )
+        assert files_left == 0, f"{files_left} files still under the prefix"
+    finally:
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_iceberg.autovacuum_naptime",
+                "ALTER SYSTEM RESET pg_lake_engine.orphaned_file_retention_period",
+                "SELECT pg_reload_conf()",
+            ]
+        )
+        run_command("DROP SCHEMA IF EXISTS fast_drop_autovacuum CASCADE", pg_conn)
+        pg_conn.commit()
 
 
 def test_flush_deletion_queue_drains_dropped_table_files(


### PR DESCRIPTION
## What

Adds a `pg_lake_table.fast_drop_file_cleanup` GUC (off by default). When enabled, dropping a writable, **default-location** Iceberg table queues the table's **entire location prefix** as a single `is_prefix` deletion-queue row, instead of reading the table's Iceberg metadata and enumerating every referenced file. `VACUUM` then removes everything under that prefix in one recursive pass.

> #539 has merged, so this now sits directly on `main`. The dependency on it is real rather than textual — see [Interaction with #539](#interaction-with-539).

## Why

The normal drop path walks `metadata.json → manifest lists → manifests → data files` in object storage and inserts one deletion-queue row per file. For tables made up of many files, that walk — and the per-file rows it produces — dominate the cost of the drop.

Managed tables already live under a unique per-table prefix (`…/<table>/<relationId>`), so their storage can be reclaimed by deleting that one prefix without touching any Iceberg metadata. This is the "fast delete" the prefix layout already makes safe.

#509 (merged) made the *removal* of individual objects much cheaper by batching S3 `DeleteObjects`. What remains expensive, and what this PR avoids, is the metadata walk itself plus inserting and later draining one queue row per file — so the two changes address different halves of the cost.

## Behavior / safety

- **Off by default**, so nothing changes unless a caller opts in.
- **Managed (default-location) tables only.** A custom `location` may be shared with other tables, so `TryMarkTablePrefixForDeletion` declines for those and the drop falls back to the existing per-file enumeration — nothing outside the table is ever deleted.
- Ordering of the drop's cleanup strategies is now: fast (prefix) → deferred (`defer_drop_file_cleanup`, metadata-resolve) → eager per-file. A table created in the current transaction takes none of these (its in-progress files are cleaned up separately).
- `previous_metadata` is skipped on the fast path since the prefix delete already covers it.
- The existing whole-prefix fallback (used when the metadata walk fails for a managed table) is unchanged; this reuses the same `InsertPrefixDeletionRecord` / `is_prefix` machinery, now as a first-class opt-in.

## Interaction with #539

`InsertPrefixDeletionRecord` queues the row with `table_name = 0`, so no per-table vacuum pass ever claims it — only the dropped-table pass (`VacuumRemoveDeletionQueueRecords(InvalidOid, …)`) does. Before #539 that pass ran only from a manual `VACUUM (ICEBERG)`, so a fast drop left the prefix queued until someone vacuumed by hand. #539 added `VacuumRemoveDroppedTableFiles()` to `PgLakeIcebergVacuumForTables` and to its catch-up pass, which is what makes the autovacuum worker reclaim it.

One caveat worth recording: #539 charges the per-vacuum budget by files *removed* rather than rows claimed, and a prefix row appends exactly one entry to the deleted-path list however many objects it removes. So a prefix delete costs 1 unit of `max_file_removals_per_vacuum` regardless of size. That is pre-existing behavior for prefix rows — this PR just makes them common — and bounding prefix deletes is explicitly deferred to #538.

No file overlap between the two branches; the code touched here is entirely in `pg_lake_table/src/ddl/`.

## Measured impact

Benchmarked against the eager (default) and `defer_drop_file_cleanup` paths on the test-suite moto server, counting object-store requests alongside wall time since local latency understates real S3. Medians of 3 reps.

The win is driven by **snapshot count**, not file count: the eager walk costs `1 + 2 × snapshots` sequential round trips. For a table written by many small commits (the mirror/CDC/streaming shape) at 512 commits:

| mode | drop s | drop reqs | vacuum s | vacuum reqs | total s | total reqs |
|:-----|-------:|----------:|---------:|------------:|--------:|-----------:|
| eager | 6.743 | 1025 | 0.314 | 4 | 7.057 | 1029 |
| defer | 0.027 | 0 | 7.109 | 1029 | 7.135 | 1029 |
| fast | 0.026 | 0 | 0.569 | 9 | **0.595** | **9** |

- The DROP itself: 6.74 s → 26 ms, and flat in the file count rather than linear.
- End to end, including the VACUUM passes that actually reclaim the storage: ~12× faster and ~114× fewer object-store requests.
- Deferral is not a substitute — it relocates the identical walk into VACUUM.
- Countervailing cost: the prefix VACUUM is slightly more expensive than draining known keys (0.569 s vs 0.314 s) because it has to LIST the prefix. That is 0.26 s against 6.7 s saved.
- A table bulk-loaded in a single commit sees no measurable end-to-end gain (0.094 s vs 0.093 s at 256 files): one snapshot is only 3 requests to walk, so there is nothing to save.
- Every mode left 0 objects under the prefix, so the fast path is not trading correctness for speed.

## Tests

Three tests in `test_drop_table.py`:
- `test_fast_drop_queues_prefix` — default-location drop queues exactly one prefix row, no per-file or resolve rows; files survive the drop; `VACUUM` removes the whole prefix and drains the queue.
- `test_fast_drop_custom_location_falls_back` — with the GUC on, a custom-location table declines the prefix path and falls back to per-file enumeration (no prefix row).
- `test_fast_drop_prefix_reclaimed_by_autovacuum` — the autovacuum worker reclaims the prefix with no manual `VACUUM`, covering the #539 dependency above. This test fails on `main` without #539.

These sit alongside the existing control tests (`test_normal_drop_enumerates_control`, `test_deferred_drop_skips_enumeration`, `test_custom_location_is_also_deferred`).

Ran locally on the rebased branch: `test_drop_table.py` (25 passed) and `test_deletion_queue_batching.py` (6 passed). CI is green.

Docs: added a note to the "Dropping an Iceberg table" section of `docs/iceberg-tables.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

