### PR TITLE
pg_lake_table: bound memory used by the pre-commit data file diff

### DIFF
--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -399,6 +399,14 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 		dataFileEntry->dataFile = *dataFile;
 	}
 
+	/*
+	 * The by-id hash was only a staging area for grouping the SPI rows of one
+	 * file together, and every entry has been copied into filesByPath by now.
+	 * The path, partition and column stats each entry points to were
+	 * allocated in our own context, not in the hash's, so they survive.
+	 */
+	hash_destroy(filesById);
+
 	return filesByPath;
 }
 

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -93,7 +93,8 @@ static void InitRestCatalogRequestsHashIfNeeded(void);
 static bool ShouldRunCommitTimeAnalyze(HTAB *trackedRelations);
 static void EnsureFreshStatsForCommitTimeDiff(void);
 static HTAB *CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata);
-static void FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
+static void FindChangedFilesSinceMetadata(const TableMetadataOperationTracker * opTracker,
+										  HTAB *currentFilesMap,
 										  List **addedFiles, List **removedFilePaths);
 static HTAB *CreatePartitionSpecsHashForMetadata(IcebergTableMetadata * metadata);
 static List *FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTableMetadata * metadata);
@@ -1098,8 +1099,17 @@ EnsureFreshStatsForCommitTimeDiff(void)
 
 
 /*
- * CreateDataFilesHashForMetadata creates and populates a hash table of data files
- * from the given Iceberg table metadata.
+ * CreateDataFilesHashForMetadata creates and populates a hash table of data file
+ * paths from the given Iceberg table metadata.
+ *
+ * Only the paths end up in the hash, so the decoded manifest entries behind
+ * them are scratch. They are not cheap scratch: an entry carries a DataFile
+ * with a per-column stat and bound array each, so a snapshot with tens of
+ * thousands of entries decodes to hundreds of megabytes. Read one manifest at
+ * a time into a context we reset after each, the way
+ * IcebergSnapshotAddAllReferencedFiles does, so peak is one manifest rather
+ * than the whole snapshot. The path itself is copied by dynahash into the hash
+ * entry, so it survives the reset.
  */
 static HTAB *
 CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
@@ -1110,16 +1120,38 @@ CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
 		return dataFilesMap;
 
 	IcebergSnapshot *iceSnapshot = GetCurrentSnapshot(metadata, true);
-	List	   *dataFiles = FetchDataFilesFromSnapshot(iceSnapshot, NULL, IsManifestEntryStatusScannable, NULL);
+	List	   *manifests = FetchManifestsFromSnapshot(iceSnapshot, NULL);
 
-	ListCell   *fileCell = NULL;
+	MemoryContext manifestContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "FetchDataFilesFromManifest for CreateDataFilesHashForMetadata",
+							  ALLOCSET_DEFAULT_SIZES);
 
-	foreach(fileCell, dataFiles)
+	ListCell   *manifestCell = NULL;
+
+	foreach(manifestCell, manifests)
 	{
-		TableDataFile *dataFile = lfirst(fileCell);
+		IcebergManifest *manifest = lfirst(manifestCell);
+		MemoryContext oldContext = MemoryContextSwitchTo(manifestContext);
 
-		AppendFileToHash(dataFile->path, dataFilesMap);
+		bool		pathOnly = true;
+		List	   *dataFilePaths = FetchDataFilesFromManifest(manifest, pathOnly,
+															   IsManifestEntryStatusScannable,
+															   NULL);
+		ListCell   *pathCell = NULL;
+
+		foreach(pathCell, dataFilePaths)
+		{
+			char	   *dataFilePath = lfirst(pathCell);
+
+			AppendFileToHash(dataFilePath, dataFilesMap);
+		}
+
+		MemoryContextSwitchTo(oldContext);
+		MemoryContextReset(manifestContext);
 	}
+
+	MemoryContextDelete(manifestContext);
 
 	return dataFilesMap;
 }
@@ -1127,18 +1159,42 @@ CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
 
 /*
  * FindChangedFilesSinceMetadata identifies added and removed files by comparing
- * the current state of data files with the state recorded in the provided metadata.
- * It populates the addedFiles and removedFilePaths lists with the respective files.
+ * the current state of data files with the state recorded in the last pushed
+ * metadata for the relation. It populates the addedFiles and removedFilePaths
+ * lists with the respective files.
  *
  * addedFiles: file info, wrapped in `TableDataFile` struct, for the files that are added since the metadata
  * removedFilePaths: file paths, which are added before the current tx, that are removed since the metadata
+ *
+ * Reading the last pushed metadata means reading its whole file list: the
+ * metadata JSON, every manifest in the current snapshot, and every entry in
+ * those manifests. None of that is needed once we know which paths changed, so
+ * it is read into a scratch context that is deleted before returning. What
+ * survives is bounded by the number of files this transaction changed, not by
+ * the number of files the table has. That matters because pre-commit walks
+ * every relation in the transaction, and TopTransactionContext is not reset in
+ * between: without this the peak is the sum over all relations of their full
+ * file lists.
  */
 static void
-FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
+FindChangedFilesSinceMetadata(const TableMetadataOperationTracker * opTracker,
+							  HTAB *currentFilesMap,
 							  List **addedFiles, List **removedFilePaths)
 {
+	MemoryContext resultContext = CurrentMemoryContext;
+	MemoryContext metadataContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "pg_lake last pushed metadata file list",
+							  ALLOCSET_DEFAULT_SIZES);
+
+	MemoryContextSwitchTo(metadataContext);
+
 	/* create metadata's data files */
+	IcebergTableMetadata *metadata = GetLastPushedIcebergMetadata(opTracker);
 	HTAB	   *metadataDataFilesMap = CreateDataFilesHashForMetadata(metadata);
+
+	/* the result lists belong to the caller, not to the scratch context */
+	MemoryContextSwitchTo(resultContext);
 
 	/* find added files */
 	HASH_SEQ_STATUS currentFilesStatus;
@@ -1162,9 +1218,15 @@ FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * meta
 
 	while ((metadataDataFilePath = hash_seq_search(&metadataFilesStatus)) != NULL)
 	{
+		/*
+		 * The path is a key inside metadataDataFilesMap, which goes away with
+		 * the scratch context below, so hand out a copy.
+		 */
 		if (!hash_search(currentFilesMap, metadataDataFilePath, HASH_FIND, NULL))
-			*removedFilePaths = lappend(*removedFilePaths, metadataDataFilePath);
+			*removedFilePaths = lappend(*removedFilePaths, pstrdup(metadataDataFilePath));
 	}
+
+	MemoryContextDelete(metadataContext);
 }
 
 
@@ -1341,14 +1403,11 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 		return list_make1(removeAllOp);
 	}
 
-	/* get last pushed metadata */
-	IcebergTableMetadata *lastMetadata = GetLastPushedIcebergMetadata(opTracker);
-
-	/* find added and removed files since metadata */
+	/* find added and removed files since the last pushed metadata */
 	List	   *addedFiles = NIL;
 	List	   *removedFilePaths = NIL;
 
-	FindChangedFilesSinceMetadata(currentFilesMap, lastMetadata, &addedFiles, &removedFilePaths);
+	FindChangedFilesSinceMetadata(opTracker, currentFilesMap, &addedFiles, &removedFilePaths);
 
 	/*
 	 * Now that we know which files are newly added, load per-column stats
@@ -1395,6 +1454,18 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 
 		metadataOperations = lappend(metadataOperations, removedFileOp);
 	}
+
+	/*
+	 * The path index over the catalog file list is only needed for the diff
+	 * above. Its entries are the widest thing we allocate per file, because
+	 * the key is a fixed MAX_S3_PATH_LENGTH array, so drop it now rather than
+	 * leaving one per relation behind until the transaction ends. The
+	 * operations we return do not point into it: the path, partition and
+	 * column stats of each added file were allocated separately and outlive
+	 * it, and the removed paths are copies. addedFiles does point into it, so
+	 * it must not be used after this.
+	 */
+	hash_destroy(currentFilesMap);
 
 	return metadataOperations;
 }


### PR DESCRIPTION
## Problem

At pre-commit, `ApplyTrackedIcebergMetadataChanges` walks every relation that changed in the transaction and, for each one, reconstructs the metadata operations by diffing the data file catalog against the file list of the last pushed Iceberg snapshot.

Everything that diff allocates lands in `TopTransactionContext`, which is not reset between relations. So the peak is the sum over all relations of their *entire* file lists, even though all we need to keep is one operation per **changed** file. On a table with a large number of data files, a commit that adds a handful of files can hold hundreds of megabytes until the transaction ends. With several such tables in one transaction it adds up linearly.

Two things dominate:

1. **The manifest decode.** `CreateDataFilesHashForMetadata` decoded every manifest of the current snapshot up front and left the decoded entries alive for the rest of the transaction. Those entries are not cheap: a data file carries four per-column stat arrays and two per-column bound arrays, so for a wide table a decoded entry is a few KB — and all we take from it is the path.
2. **The path-keyed hashes.** `TableDataFileHashEntry` embeds the key as a fixed `char[MAX_S3_PATH_LENGTH]` (1095 bytes), making it the widest per-file allocation we make. One such hash per relation was left behind for the rest of the transaction after the diff had consumed it.

## Solution

Three changes, all in the pre-commit diff path, none of which change behaviour:

**Decode one manifest at a time.** `CreateDataFilesHashForMetadata` now iterates the snapshot's manifests and reads each into a scratch context that is reset after each one, asking for paths only — the same pattern `IcebergSnapshotAddAllReferencedFiles` already uses. Peak is now one manifest rather than the whole snapshot. The path is copied into the hash entry by dynahash, so it survives the reset.

This also removes a latent type confusion: the list returned by `FetchDataFilesFromSnapshot` holds `DataFile`, but it was read through a `TableDataFile *` to get at the path. The two happen to agree on the offset of the path field today (`int64 fileId` vs. a padded `IcebergDataFileContentType content`), so it worked by accident.

**Free the previous file list once the diff is done.** `FindChangedFilesSinceMetadata` now reads the last pushed metadata itself, into a scratch context it deletes before returning, and hands the caller copies of the removed paths. Nothing about the previous snapshot's file list needs to outlive the diff.

**Destroy the two file hashes once consumed.** The by-path index over the catalog is destroyed at the end of `GetDataFileMetadataOperations`, and the by-id staging hash in `GetTableDataFilesByPathHashFromCatalog` is destroyed once its entries have been copied into the by-path hash. In both cases the entries' paths, partitions and column stats were allocated in the caller's context, not in the hash's, so they survive; the returned operations do not point into either hash.

Net effect: what survives the pre-commit diff is bounded by the number of files the transaction changed, rather than by the number of files the tables have.

## Test plan

- Full `pg_lake_table` pytest suite.
- Targeted run over the tests that exercise this path (writable iceberg, iceberg DDL, partitioned/bucket/date/multi-expr/identity/truncate writes, partition evolution, manifest merge, in-tx and xact behaviour, referenced/unreferenced/in-progress files, vacuum, autovacuum compaction, update/delete, changelog, snapshot expiry, stats): 285 passed.

## Follow-ups, not in this PR

- `TableDataFileHashEntry`'s fixed 1095-byte key is still the per-file cost driver while the hash is live; a pointer key with the path allocated to its actual length would shrink it by roughly an order of magnitude for typical paths, but it changes a public struct.
- `MAX_S3_PATH_LENGTH` budgets 5 bytes for the URI scheme prefix (`s3://`). Longer schemes eat into the key budget, and since dynahash truncates the key with `strlcpy`, an over-long path is silently truncated rather than rejected — two paths that differ only past the cut would collide in the diff.
- The SPI catalog read still allocates a `path` string and a `Partition` per file in the caller's context, which survive for the rest of the transaction. Putting the catalog read behind a scratch context too would reclaim that as well.
