### PR TITLE
Make Azure append blob writes safe to retry

### DIFF
--- a/duckdb_pglake/Makefile
+++ b/duckdb_pglake/Makefile
@@ -142,11 +142,24 @@ patch_duckdb: $(shell find patches -type f -name '*.patch')
 			git apply --ignore-whitespace "$$patch"; \
 		done;) \
 	done
+	# Out-of-tree extensions are fetched by CMake, which applies the patches it
+	# finds in the DuckDB source tree, so copy ours there before building.
+	for extdir in patches/extensions/*/ ; do \
+		[ -d "$$extdir" ] || continue ; \
+		ext=$$(basename $$extdir) ; \
+		echo "staging patches for extension $$ext" ; \
+		mkdir -p duckdb/.github/patches/extensions/$$ext && \
+		cp $$extdir*.patch duckdb/.github/patches/extensions/$$ext/ ; \
+	done
 
 clean_patches:
 	for patchdir in duckdb duckdb-postgres ; do \
 		(cd $$patchdir && \
 		git checkout -f . ); \
+	done
+	for extdir in patches/extensions/*/ ; do \
+		[ -d "$$extdir" ] || continue ; \
+		rm -rf duckdb/.github/patches/extensions/$$(basename $$extdir) ; \
 	done
 
 format:

--- a/duckdb_pglake/extension_config.cmake
+++ b/duckdb_pglake/extension_config.cmake
@@ -3,7 +3,6 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 13f8a814d41a978c3f19eb1dc76069489652ea6f
     INCLUDE_DIR src/include
-    ADD_PATCHES
 )
 
 duckdb_extension_load(aws
@@ -14,6 +13,7 @@ duckdb_extension_load(aws
 duckdb_extension_load(azure
     GIT_URL https://github.com/duckdb/duckdb-azure
     GIT_TAG 7e1ac3333d946a6bf5b4552722743e03f30a47cd
+    APPLY_PATCHES
 )
 
 # Extension from this repo

--- a/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
+++ b/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
@@ -1,8 +1,8 @@
 diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
-index 796d5a2..9838b66 100644
+index 796d5a2..beb5b4f 100644
 --- a/src/azure_blob_filesystem.cpp
 +++ b/src/azure_blob_filesystem.cpp
-@@ -402,9 +402,38 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
+@@ -402,9 +402,31 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
  	// real. Only with AppendBlobClient is each append committed (sync'd).
  	auto append_client = afh.blob_client.AsAppendBlobClient();
  	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
@@ -20,14 +20,7 @@ index 796d5a2..9838b66 100644
 +	try {
 +		auto res = append_client.AppendBlock(body_stream, options);
 +		afh.last_modified = ToTimestamp(res.Value.LastModified);
-+
-+		if (idx_t(res.Value.AppendOffset) != afh.file_offset) {
-+			// Cannot happen while the position condition holds, but if the service ever says it
-+			// appended somewhere else then the file is not what we think it is either.
-+			throw IOException("Appended %lld bytes at offset %lld of '%s', but expected offset %lld", nr_bytes,
-+			                  static_cast<int64_t>(res.Value.AppendOffset), afh.GetPath(),
-+			                  static_cast<int64_t>(afh.file_offset));
-+		}
++		D_ASSERT(idx_t(res.Value.AppendOffset) == afh.file_offset);
 +	} catch (const Azure::Storage::StorageException &e) {
 +		if (int(e.StatusCode) != 412) {
 +			throw;

--- a/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
+++ b/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
@@ -1,8 +1,16 @@
 diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
-index 796d5a2..de3fc77 100644
+index 796d5a2..6ff0274 100644
 --- a/src/azure_blob_filesystem.cpp
 +++ b/src/azure_blob_filesystem.cpp
-@@ -402,9 +402,48 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
+@@ -19,6 +19,7 @@
+ #include <azure/storage/blobs/blob_options.hpp>
+ 
+ #include <cstdlib>
++#include <cstring>
+ 
+ namespace duckdb {
+ 
+@@ -402,9 +403,67 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
  	// real. Only with AppendBlobClient is each append committed (sync'd).
  	auto append_client = afh.blob_client.AsAppendBlobClient();
  	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
@@ -28,16 +36,35 @@ index 796d5a2..de3fc77 100644
 +			throw;
 +		}
 +
-+		// The blob is not at the offset we expected. Either an earlier attempt at this very append
-+		// did reach the service and we are looking at a retry after a lost response, or someone
-+		// else is writing to the blob. Only in the former case is the blob exactly as long as this
-+		// append was supposed to make it, in which case the write did happen and we are done.
++		// The blob does not end at the offset we expected. Either an earlier attempt at this very
++		// append did reach the service and we are looking at a retry after a lost response, or
++		// someone else is writing to the blob. To tell the two apart, the blob has to be exactly as
++		// long as this append was supposed to make it, and it has to hold the bytes we are trying
++		// to write at the offset we are trying to write them, so check both.
 +		auto res_props = afh.blob_client.GetProperties();
 +		if (res_props.Value.BlobSize != static_cast<int64_t>(afh.file_offset) + nr_bytes) {
 +			throw IOException("Failed to append %lld bytes at offset %lld of '%s': blob is %lld "
 +			                  "bytes, it is most likely being written to concurrently",
 +			                  nr_bytes, static_cast<int64_t>(afh.file_offset), afh.GetPath(),
 +			                  static_cast<int64_t>(res_props.Value.BlobSize));
++		}
++
++		if (nr_bytes > 0) {
++			Azure::Core::Http::HttpRange range;
++			range.Offset = static_cast<int64_t>(afh.file_offset);
++			range.Length = nr_bytes;
++			Azure::Storage::Blobs::DownloadBlobToOptions download_options;
++			download_options.Range = range;
++
++			auto written = make_unsafe_uniq_array<uint8_t>(static_cast<idx_t>(nr_bytes));
++			afh.blob_client.DownloadTo(written.get(), nr_bytes, download_options);
++
++			if (memcmp(written.get(), buffer, nr_bytes) != 0) {
++				throw IOException("Failed to append %lld bytes at offset %lld of '%s': the blob "
++				                  "holds different bytes at that offset, it is most likely being "
++				                  "written to concurrently",
++				                  nr_bytes, static_cast<int64_t>(afh.file_offset), afh.GetPath());
++			}
 +		}
 +
 +		afh.last_modified = ToTimestamp(res_props.Value.LastModified);

--- a/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
+++ b/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
@@ -1,16 +1,8 @@
 diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
-index 796d5a2..6ff0274 100644
+index 796d5a2..beb5b4f 100644
 --- a/src/azure_blob_filesystem.cpp
 +++ b/src/azure_blob_filesystem.cpp
-@@ -19,6 +19,7 @@
- #include <azure/storage/blobs/blob_options.hpp>
- 
- #include <cstdlib>
-+#include <cstring>
- 
- namespace duckdb {
- 
-@@ -402,9 +403,67 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
+@@ -402,9 +402,31 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
  	// real. Only with AppendBlobClient is each append committed (sync'd).
  	auto append_client = afh.blob_client.AsAppendBlobClient();
  	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
@@ -25,57 +17,21 @@ index 796d5a2..6ff0274 100644
 +	Azure::Storage::Blobs::AppendBlockOptions options;
 +	options.AccessConditions.IfAppendPositionEqual = static_cast<int64_t>(afh.file_offset);
 +
-+	int64_t append_offset;
-+
 +	try {
 +		auto res = append_client.AppendBlock(body_stream, options);
 +		afh.last_modified = ToTimestamp(res.Value.LastModified);
-+		append_offset = res.Value.AppendOffset;
++		D_ASSERT(idx_t(res.Value.AppendOffset) == afh.file_offset);
 +	} catch (const Azure::Storage::StorageException &e) {
 +		if (int(e.StatusCode) != 412) {
 +			throw;
 +		}
 +
-+		// The blob does not end at the offset we expected. Either an earlier attempt at this very
-+		// append did reach the service and we are looking at a retry after a lost response, or
-+		// someone else is writing to the blob. To tell the two apart, the blob has to be exactly as
-+		// long as this append was supposed to make it, and it has to hold the bytes we are trying
-+		// to write at the offset we are trying to write them, so check both.
-+		auto res_props = afh.blob_client.GetProperties();
-+		if (res_props.Value.BlobSize != static_cast<int64_t>(afh.file_offset) + nr_bytes) {
-+			throw IOException("Failed to append %lld bytes at offset %lld of '%s': blob is %lld "
-+			                  "bytes, it is most likely being written to concurrently",
-+			                  nr_bytes, static_cast<int64_t>(afh.file_offset), afh.GetPath(),
-+			                  static_cast<int64_t>(res_props.Value.BlobSize));
-+		}
-+
-+		if (nr_bytes > 0) {
-+			Azure::Core::Http::HttpRange range;
-+			range.Offset = static_cast<int64_t>(afh.file_offset);
-+			range.Length = nr_bytes;
-+			Azure::Storage::Blobs::DownloadBlobToOptions download_options;
-+			download_options.Range = range;
-+
-+			auto written = make_unsafe_uniq_array<uint8_t>(static_cast<idx_t>(nr_bytes));
-+			afh.blob_client.DownloadTo(written.get(), nr_bytes, download_options);
-+
-+			if (memcmp(written.get(), buffer, nr_bytes) != 0) {
-+				throw IOException("Failed to append %lld bytes at offset %lld of '%s': the blob "
-+				                  "holds different bytes at that offset, it is most likely being "
-+				                  "written to concurrently",
-+				                  nr_bytes, static_cast<int64_t>(afh.file_offset), afh.GetPath());
-+			}
-+		}
-+
-+		afh.last_modified = ToTimestamp(res_props.Value.LastModified);
-+		append_offset = static_cast<int64_t>(afh.file_offset);
-+	}
-+
-+	if (append_offset != static_cast<int64_t>(afh.file_offset)) {
-+		// Should not happen, since we send the offset as a precondition, but if it ever does then
-+		// the file is not what we think it is and reporting success would corrupt it.
-+		throw IOException("Appended %lld bytes at offset %lld of '%s', but expected offset %lld", nr_bytes,
-+		                  append_offset, afh.GetPath(), static_cast<int64_t>(afh.file_offset));
++		// The blob does not end where we expect it to. Either this append is a retry of one that did
++		// reach the service, or someone else is writing to the blob. We cannot tell those apart
++		// here, and in both cases the file is not what we think it is, so fail the write.
++		throw IOException("Failed to append %lld bytes at offset %lld of '%s': the blob does not end "
++		                  "at that offset, it is most likely being written to concurrently",
++		                  nr_bytes, static_cast<int64_t>(afh.file_offset), afh.GetPath());
 +	}
 +
  	afh.file_offset += nr_bytes;

--- a/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
+++ b/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
@@ -1,0 +1,56 @@
+diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
+index 796d5a2..de3fc77 100644
+--- a/src/azure_blob_filesystem.cpp
++++ b/src/azure_blob_filesystem.cpp
+@@ -402,9 +402,48 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
+ 	// real. Only with AppendBlobClient is each append committed (sync'd).
+ 	auto append_client = afh.blob_client.AsAppendBlobClient();
+ 	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
+-	auto res = append_client.AppendBlock(body_stream);
+-	afh.last_modified = ToTimestamp(res.Value.LastModified);
+-	D_ASSERT(idx_t(res.Value.AppendOffset) == afh.file_offset);
++
++	// Appending a block is not idempotent by itself, while the SDK does retry transport errors and
++	// 408/5xx responses. An append that reached the service but whose response got lost would then
++	// be applied twice and still report success, silently duplicating a part of the file. Telling
++	// the service which offset we expect to append at makes such a retry fail with 412 instead.
++	Azure::Storage::Blobs::AppendBlockOptions options;
++	options.AccessConditions.IfAppendPositionEqual = static_cast<int64_t>(afh.file_offset);
++
++	int64_t append_offset;
++
++	try {
++		auto res = append_client.AppendBlock(body_stream, options);
++		afh.last_modified = ToTimestamp(res.Value.LastModified);
++		append_offset = res.Value.AppendOffset;
++	} catch (const Azure::Storage::StorageException &e) {
++		if (int(e.StatusCode) != 412) {
++			throw;
++		}
++
++		// The blob is not at the offset we expected. Either an earlier attempt at this very append
++		// did reach the service and we are looking at a retry after a lost response, or someone
++		// else is writing to the blob. Only in the former case is the blob exactly as long as this
++		// append was supposed to make it, in which case the write did happen and we are done.
++		auto res_props = afh.blob_client.GetProperties();
++		if (res_props.Value.BlobSize != static_cast<int64_t>(afh.file_offset) + nr_bytes) {
++			throw IOException("Failed to append %lld bytes at offset %lld of '%s': blob is %lld "
++			                  "bytes, it is most likely being written to concurrently",
++			                  nr_bytes, static_cast<int64_t>(afh.file_offset), afh.GetPath(),
++			                  static_cast<int64_t>(res_props.Value.BlobSize));
++		}
++
++		afh.last_modified = ToTimestamp(res_props.Value.LastModified);
++		append_offset = static_cast<int64_t>(afh.file_offset);
++	}
++
++	if (append_offset != static_cast<int64_t>(afh.file_offset)) {
++		// Should not happen, since we send the offset as a precondition, but if it ever does then
++		// the file is not what we think it is and reporting success would corrupt it.
++		throw IOException("Appended %lld bytes at offset %lld of '%s', but expected offset %lld", nr_bytes,
++		                  append_offset, afh.GetPath(), static_cast<int64_t>(afh.file_offset));
++	}
++
+ 	afh.file_offset += nr_bytes;
+ 	afh.length += nr_bytes;
+ 	DUCKDB_LOG_FILE_SYSTEM_WRITE(handle, nr_bytes, afh.file_offset);

--- a/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
+++ b/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
@@ -1,8 +1,8 @@
 diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
-index 796d5a2..beb5b4f 100644
+index 796d5a2..9838b66 100644
 --- a/src/azure_blob_filesystem.cpp
 +++ b/src/azure_blob_filesystem.cpp
-@@ -402,9 +402,31 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
+@@ -402,9 +402,38 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
  	// real. Only with AppendBlobClient is each append committed (sync'd).
  	auto append_client = afh.blob_client.AsAppendBlobClient();
  	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
@@ -20,7 +20,14 @@ index 796d5a2..beb5b4f 100644
 +	try {
 +		auto res = append_client.AppendBlock(body_stream, options);
 +		afh.last_modified = ToTimestamp(res.Value.LastModified);
-+		D_ASSERT(idx_t(res.Value.AppendOffset) == afh.file_offset);
++
++		if (idx_t(res.Value.AppendOffset) != afh.file_offset) {
++			// Cannot happen while the position condition holds, but if the service ever says it
++			// appended somewhere else then the file is not what we think it is either.
++			throw IOException("Appended %lld bytes at offset %lld of '%s', but expected offset %lld", nr_bytes,
++			                  static_cast<int64_t>(res.Value.AppendOffset), afh.GetPath(),
++			                  static_cast<int64_t>(afh.file_offset));
++		}
 +	} catch (const Azure::Storage::StorageException &e) {
 +		if (int(e.StatusCode) != 412) {
 +			throw;

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -125,6 +125,49 @@ def test_copy_to_parquet_azure_long_prefix(azure, pgduck_conn):
     pgduck_conn.rollback()
 
 
+def test_copy_to_azure_multiple_appends(azure, pgduck_conn, tmp_path):
+    """A file that does not fit in the write buffer is written as multiple appends,
+    and each append tells Azure the offset it expects to be written at, so check that
+    such a file still ends up with exactly the bytes we wrote."""
+    key = "test_copy_to_azure_multiple_appends/data.csv"
+    local_path = tmp_path / "data.csv"
+
+    perform_query(
+        f"""
+        CREATE TABLE bigtable AS
+        SELECT i, repeat('x', 100) padding FROM generate_series(1,20000) t(i);
+        COPY bigtable TO '{local_path}';
+        COPY bigtable TO 'az://{TEST_BUCKET}/{key}';
+    """,
+        pgduck_conn,
+    )
+
+    properties = azure.get_blob_client(key).get_blob_properties()
+
+    # more than one append went into this blob
+    assert properties.append_blob_committed_block_count > 1
+
+    # and the blob is exactly as long as the same data written locally
+    assert properties.size == os.path.getsize(local_path)
+
+    perform_query(
+        f"""
+        CREATE TABLE roundtrip (i int, padding text);
+        COPY roundtrip FROM 'az://{TEST_BUCKET}/{key}';
+    """,
+        pgduck_conn,
+    )
+
+    results = perform_query_on_cursor(
+        "SELECT count(*), sum(i) FROM roundtrip", pgduck_conn
+    )
+    assert len(results) == 1
+    assert results[0][0] == 20000
+    assert int(results[0][1]) == 200010000
+
+    pgduck_conn.rollback()
+
+
 def test_copy_from_non_existent(s3, pgduck_conn):
     perform_query("CREATE TABLE mytable (x int)", pgduck_conn)
 


### PR DESCRIPTION
## Problem

Writes to `azure://` and `az://` go through `AppendBlobClient::AppendBlock`, one call per buffer flush, with no condition attached. The Azure SDK retries transport errors and 408/500/502/503/504 responses up to three times, so an append that reached the service but whose response was lost is applied a second time and the write still reports success. The file then contains two identical copies of that block, concatenated. duckdb-azure does compare the offset the service reports back, but only in a `D_ASSERT`, which release builds compile out. Iceberg metadata files are written through this path, so one retried append is enough to leave behind a metadata file that no reader can parse, and nothing in the write path notices.

## Solution

Carry a patch against duckdb-azure that sends the offset we expect to append at (`IfAppendPositionEqual`) with every `AppendBlock`. A retried request then fails with 412 instead of appending the data twice, and any 412 becomes an `IOException` naming the blob and the offset. That does mean a lost response fails the write even though the append itself did land, but a failed write the caller can retry is better than a doubled block reported as success, and we cannot tell that case apart from a second writer on the same blob anyway.

Only `azure://` and `az://` are affected. `abfss://` appends carry an explicit offset and S3 multipart uploads carry a part number and upload id, so both are already safe to replay.

Patches for out-of-tree extensions have to live in the DuckDB source tree for CMake to find them when it fetches the extension, so `patch_duckdb` now copies `patches/extensions/<ext>/*.patch` into `duckdb/.github/patches/extensions/<ext>/`, and the azure extension is loaded with `APPLY_PATCHES`. httpfs carried `ADD_PATCHES`, which is not a keyword `duckdb_extension_load` understands and which has no patches behind it, so that is removed.

This belongs upstream in duckdb/duckdb-azure. Once it lands there we can drop the patch and bump `GIT_TAG`.

## Test plan

- [x] New `test_copy_to_azure_multiple_appends`: a file that takes more than one append comes out the same length as the same data written to a local file, with `append_blob_committed_block_count > 1`, and round-trips through `COPY FROM`.
- [x] Verified against a temporary build that duplicates every `AppendBlock` to simulate a lost response and retry. Without the patch the blob comes out at exactly twice the correct length and the write reports success. With the patch the duplicate is refused and the write fails with `IO Error: Failed to append 935 bytes at offset 0 of 'az://.../data.parquet': the blob does not end at that offset, it is most likely being written to concurrently`.
- [x] `pgduck_server` test_s3.py, test_caching.py and test_functions.py pass locally; `pg_lake_copy` and `pg_lake_table` suites pass in CI.
