### PR TITLE
[release-3.4] Backport #492: cap the CSV read buffer DuckDB allocates

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/client.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/client.h
@@ -25,6 +25,8 @@
 #define DEFAULT_PGDUCK_SERVER_CONNINFO "host=/tmp port=5332"
 
 #define DEFAULT_DUCKDB_MAX_LINE_SIZE (2097152)
+#define DEFAULT_DUCKDB_CSV_BUFFER_SIZE (32000000)
+#define PGLAKE_CSV_BUFFER_LINE_MULTIPLE (4)
 
 /* settings */
 extern char *PgduckServerConninfo;

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -1752,7 +1752,38 @@ AppendReadCSVTail(StringInfo buf, int maxLineSize, const char *columnsMap,
 	if (maxLineSize > 0)
 	{
 		/* use maxLineSize + 1 to include end-of-line */
-		appendStringInfo(buf, ", max_line_size=%d", maxLineSize + 1);
+		int64		lineSizeLimit = (int64) maxLineSize + 1;
+
+		/*
+		 * Pin buffer_size as well as max_line_size.
+		 *
+		 * DuckDB reads a CSV in chunks and, given only max_line_size, sizes
+		 * each chunk to hold 16 lines of that length -- allocated in one
+		 * piece, regardless of how large the file really is.  A file holding
+		 * a few very wide rows therefore costs the same up-front allocation
+		 * as one holding thousands.  Since we serialize bytea as four bytes
+		 * per input byte, a single 10MB bytea makes a 40MB line and DuckDB
+		 * asks for 640MB to read a file that may only hold 76MB, which is
+		 * enough to OOM the query engine outright.
+		 *
+		 * Setting buffer_size suppresses that rule, since DuckDB only derives
+		 * it when buffer_size was left alone.  We ask for a few lines' worth
+		 * and never less than DuckDB's own default, so ordinary row widths
+		 * read exactly as before and only the wide-line case gets a smaller
+		 * request.  It has to be a multiple of the line size rather than the
+		 * line size itself: a value spanning a buffer boundary cannot be
+		 * referenced in place and is copied into the vector's string heap, so
+		 * a buffer only as large as one line makes every wide value pay for a
+		 * copy.
+		 */
+		int64		bufferSize = Max(DEFAULT_DUCKDB_CSV_BUFFER_SIZE,
+									 PGLAKE_CSV_BUFFER_LINE_MULTIPLE *
+									 lineSizeLimit);
+
+		appendStringInfo(buf,
+						 ", max_line_size=" INT64_FORMAT
+						 ", buffer_size=" INT64_FORMAT,
+						 lineSizeLimit, bufferSize);
 	}
 
 	/*


### PR DESCRIPTION
Backport of #492 to `release-3.4`.

Cherry-picked from `597c573` on `main` with `git cherry-pick -x --signoff`. No conflicts, and the resulting diff is byte-identical to the commit on `main`. Original authorship (@sfc-gh-okalaci) is preserved.

## Why backport

`pgduck_server` treats a DuckDB allocation failure as unrecoverable and exits, dropping every connection. This is reachable on 3.4 with a single large `bytea`: we serialize `bytea` as `\xNN` (four bytes per input byte), so a 10MB value makes a 40MB line, and DuckDB sizes its CSV read buffer to hold 16 lines of the declared maximum regardless of how large the file actually is. That asks for 640MB to read a file holding four rows and 76MB of data.

The fix pins `buffer_size` to 4 lines' worth, floored at DuckDB's own 32MB default, which suppresses the 16x rule. Tables with ordinary row widths ask for exactly what DuckDB would have picked anyway, and large batches are unaffected because buffers are reused as the scan walks the file.

See #492 for the full analysis and the measurements behind the multiple of 4.

## Diff

Two files, both in `pg_lake_engine`: two new macros in `pgduck/client.h` and the `buffer_size` computation in `AppendReadCSVTail()`. No SQL migration files, no schema change, version stays at 3.4.

## Test plan

- `make` in `pg_lake_engine` on this branch: clean build, no new warnings.
- No test fixture on `release-3.4` asserts on the generated CSV read query, so nothing needed adjusting.
- [ ] CI green on `release-3.4`.
