### PR TITLE
Resolve the type modifier when unwrapping a domain

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/map.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/map.h
@@ -25,5 +25,6 @@ char	   *GetDuckDBMapDefinitionForPGType(Oid postgresTypeId,
 
 extern PGDLLEXPORT bool IsMapTypeOid(Oid typeId);
 extern PGDLLEXPORT Oid ResolveDomainBaseType(Oid typeId);
+extern PGDLLEXPORT Oid ResolveDomainBaseTypeAndTypmod(Oid typeId, int32 *typeMod);
 extern PGDLLEXPORT PGType GetMapKeyType(Oid mapOid);
 extern PGDLLEXPORT PGType GetMapValueType(Oid mapOid);

--- a/pg_lake_engine/include/pg_lake/pgduck/map.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/map.h
@@ -24,7 +24,6 @@ char	   *GetDuckDBMapDefinitionForPGType(Oid postgresTypeId,
 											CopyDataFormat format);
 
 extern PGDLLEXPORT bool IsMapTypeOid(Oid typeId);
-extern PGDLLEXPORT Oid ResolveDomainBaseType(Oid typeId);
 extern PGDLLEXPORT Oid ResolveDomainBaseTypeAndTypmod(Oid typeId, int32 *typeMod);
 extern PGDLLEXPORT PGType GetMapKeyType(Oid mapOid);
 extern PGDLLEXPORT PGType GetMapValueType(Oid mapOid);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -1398,7 +1398,8 @@ bool
 ShouldUseDuckSerialization(CopyDataFormat targetFormat, PGType postgresType)
 {
 	/* unwrap domain to base type so per-type checks below see the real type */
-	postgresType.postgresTypeOid = ResolveDomainBaseType(postgresType.postgresTypeOid);
+	postgresType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(postgresType.postgresTypeOid,
+																  &postgresType.postgresTypeMod);
 
 	Oid			typeId = postgresType.postgresTypeOid;
 

--- a/pg_lake_engine/src/parquet/field.c
+++ b/pg_lake_engine/src/parquet/field.c
@@ -267,14 +267,18 @@ PGTypeRequiresConversionToIcebergString(Field * field, PGType pgType)
  * on the mapping without re-implementing it.
  *
  * Domains are unwrapped to their base type so a domain over e.g. bytea maps to
- * "binary" rather than falling through to the "string" default. The field
- * builder already resolves domains before reaching here, so this is a no-op for
- * that caller, but the codecs hand us raw attribute type ids and rely on it.
+ * "binary" rather than falling through to the "string" default. The type
+ * modifier is taken from the domain as well, because a domain column has
+ * atttypmod -1 and a domain over numeric(10,2) would otherwise look unbounded.
+ * The field builder already resolves domains before reaching here, so this is a
+ * no-op for that caller, but the codecs hand us raw attribute type ids and rely
+ * on it.
  */
 char *
 PostgresBaseTypeIdToIcebergTypeName(PGType pgType)
 {
-	pgType.postgresTypeOid = ResolveDomainBaseType(pgType.postgresTypeOid);
+	pgType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(pgType.postgresTypeOid,
+															&pgType.postgresTypeMod);
 
 	switch (pgType.postgresTypeOid)
 	{

--- a/pg_lake_engine/src/pgduck/map.c
+++ b/pg_lake_engine/src/pgduck/map.c
@@ -237,6 +237,38 @@ ResolveDomainBaseType(Oid typeId)
 
 
 /*
+ * ResolveDomainBaseTypeAndTypmod is ResolveDomainBaseType, but it also reports
+ * the type modifier that belongs to the base type.
+ *
+ * A column whose type is a domain has atttypmod -1, because the modifier is
+ * part of the domain and not of the column, so callers that need e.g. the
+ * precision and scale of a numeric cannot get it from the attribute.  Without
+ * this, a domain over numeric(10,2) looks like an unbounded numeric.
+ *
+ * *typeMod is only overwritten when the caller does not have a modifier of its
+ * own, so an outer modifier keeps precedence over a nested one.  Note that
+ * getBaseTypeAndTypmod expects to start from -1 and asserts as much when it
+ * walks a stack of domains.
+ */
+Oid
+ResolveDomainBaseTypeAndTypmod(Oid typeId, int32 *typeMod)
+{
+	if (!IsMapTypeOid(typeId) && get_typtype(typeId) == TYPTYPE_DOMAIN)
+	{
+		int32		baseTypeMod = -1;
+		Oid			baseTypeId = getBaseTypeAndTypmod(typeId, &baseTypeMod);
+
+		if (*typeMod == -1)
+			*typeMod = baseTypeMod;
+
+		return baseTypeId;
+	}
+
+	return typeId;
+}
+
+
+/*
  * GetDuckDBMapDefinitionForPGType returns a type definition string for a DuckDB map type.
  */
 char *

--- a/pg_lake_engine/src/pgduck/map.c
+++ b/pg_lake_engine/src/pgduck/map.c
@@ -222,23 +222,10 @@ GetMapCreateFunctionOid()
 
 
 /*
- * ResolveDomainBaseType returns the base type OID for a domain, or the OID
- * unchanged if it is not a domain.  Map types are domains with special
- * semantics and are left as-is.
- */
-Oid
-ResolveDomainBaseType(Oid typeId)
-{
-	if (!IsMapTypeOid(typeId) && get_typtype(typeId) == TYPTYPE_DOMAIN)
-		return getBaseType(typeId);
-
-	return typeId;
-}
-
-
-/*
- * ResolveDomainBaseTypeAndTypmod is ResolveDomainBaseType, but it also reports
- * the type modifier that belongs to the base type.
+ * ResolveDomainBaseTypeAndTypmod returns the base type OID for a domain, or the
+ * OID unchanged if it is not a domain, and also reports the type modifier that
+ * belongs to the base type.  Map types are domains with special semantics and
+ * are left as-is.
  *
  * A column whose type is a domain has atttypmod -1, because the modifier is
  * part of the domain and not of the column, so callers that need e.g. the

--- a/pg_lake_engine/src/pgduck/serialize.c
+++ b/pg_lake_engine/src/pgduck/serialize.c
@@ -129,9 +129,13 @@ PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 {
 	/*
 	 * Unwrap domain types so that e.g. a domain-over-bytea is serialized with
-	 * the bytea-specific path rather than the generic text output path.
+	 * the bytea-specific path rather than the generic text output path.  The
+	 * serialization here does not depend on the type modifier, so it is
+	 * discarded.
 	 */
-	columnType = ResolveDomainBaseType(columnType);
+	int32		columnTypeMod = -1;
+
+	columnType = ResolveDomainBaseTypeAndTypmod(columnType, &columnTypeMod);
 
 	if (flinfo->fn_oid == ARRAY_OUT_OID)
 	{

--- a/pg_lake_engine/src/pgduck/write_data.c
+++ b/pg_lake_engine/src/pgduck/write_data.c
@@ -703,9 +703,13 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 	 * This happens before we look for an array type, because a domain over an
 	 * array type (e.g. CREATE DOMAIN ints AS int[]) is an array itself, which
 	 * get_element_type would not see. Map types are domains too, but carry
-	 * special semantics and are left alone by ResolveDomainBaseType.
+	 * special semantics and are left alone by ResolveDomainBaseTypeAndTypmod.
+	 *
+	 * The type modifier comes along, because a domain column has atttypmod -1
+	 * and a domain over numeric(10,2) would otherwise look unbounded.
 	 */
-	postgresType.postgresTypeOid = ResolveDomainBaseType(postgresType.postgresTypeOid);
+	postgresType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(postgresType.postgresTypeOid,
+																  &postgresTypeMod);
 
 	Oid			elementTypeId = get_element_type(postgresType.postgresTypeOid);
 	bool		isArrayType = OidIsValid(elementTypeId);
@@ -716,7 +720,10 @@ ChooseDuckDBEngineTypeForWrite(PGType postgresType,
 	 * The element type can be a domain as well (e.g. a bytea domain).
 	 */
 	if (isArrayType)
-		postgresType.postgresTypeOid = ResolveDomainBaseType(elementTypeId);
+		postgresType.postgresTypeOid = ResolveDomainBaseTypeAndTypmod(elementTypeId,
+																	  &postgresTypeMod);
+
+	postgresType.postgresTypeMod = postgresTypeMod;
 
 	DuckDBType	duckTypeId = GetDuckDBTypeForPGType(postgresType);
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_field.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_field.c
@@ -182,15 +182,20 @@ PostgresTypeToIcebergField(PGType pgType, bool forAddColumn, int *subFieldIndex)
 	 * Unwrap domain types to their base type so that e.g. a domain over
 	 * integer maps to Iceberg "int" rather than falling through to the
 	 * default "string" case.  Map types are domains too but carry special
-	 * semantics; ResolveDomainBaseType leaves those unchanged.
+	 * semantics; ResolveDomainBaseTypeAndTypmod leaves those unchanged.
+	 *
+	 * The type modifier of the domain comes along, because a column whose
+	 * type is a domain has atttypmod -1, and a domain over numeric(10,2)
+	 * would otherwise be recorded as an unbounded decimal(38,9).
 	 */
 	{
-		Oid			baseTypeId = ResolveDomainBaseType(typeId);
+		Oid			baseTypeId = ResolveDomainBaseTypeAndTypmod(typeId, &typeMod);
 
 		if (baseTypeId != typeId)
 		{
 			typeId = baseTypeId;
 			pgType.postgresTypeOid = baseTypeId;
+			pgType.postgresTypeMod = typeMod;
 		}
 	}
 

--- a/pg_lake_table/tests/pytests/test_domain.py
+++ b/pg_lake_table/tests/pytests/test_domain.py
@@ -170,3 +170,76 @@ def test_domain_over_array(extension, pg_conn, s3, with_default_location):
     pg_conn.rollback()
     run_command("drop schema if exists test_domain_over_array cascade;", pg_conn)
     pg_conn.commit()
+
+
+def _array_text(value):
+    """Normalize an array column to PostgreSQL array text.
+
+    psycopg parses a domain over int[] into a list, but an array of a domain
+    has an unknown element OID and comes back as text, so tests that cover both
+    shapes need to compare them in the same form.
+    """
+    if isinstance(value, list):
+        return "{" + ",".join(str(element) for element in value) + "}"
+    return str(value)
+
+
+def test_domain_over_numeric(extension, pg_conn, s3, with_default_location):
+    """A numeric domain must keep its precision and scale.
+
+    A column whose type is a domain has atttypmod -1: the modifier belongs to
+    the domain, not to the column. Without resolving it, numeric(10,2) behind a
+    domain is written as an unbounded decimal(38,9), and for the array shapes
+    the Iceberg schema and the DuckDB write type disagree, which breaks reads.
+    """
+    run_command(
+        """
+        create schema test_domain_numeric;
+        set search_path to test_domain_numeric;
+        create domain price as numeric(10,2);
+        -- the modifier can sit above or below the array type
+        create domain price_array as numeric(10,2)[];
+        create domain price_list as price[];
+        -- stacked domains: getBaseTypeAndTypmod walks to the bottom
+        create domain price_again as price;
+        create table domain_numerics (
+            p price,
+            a price_array,
+            l price_list,
+            e price[],
+            s price_again
+        ) using iceberg;
+        insert into domain_numerics values (
+            1.25,
+            array[1.25, 2.5]::price_array,
+            array[1.25, 2.5]::price_list,
+            array[1.25, 2.5]::price[],
+            2.5
+        );
+    """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    results = run_query(
+        "SELECT metadata_location FROM lake_iceberg.tables"
+        " WHERE table_name = 'domain_numerics'"
+        " AND table_namespace = 'test_domain_numeric'",
+        pg_conn,
+    )
+    parsed = json.loads(read_s3_operations(s3, results[0][0]))
+    fields = {f["name"]: f["type"] for f in parsed["schemas"][0]["fields"]}
+    assert fields["p"] == "decimal(10,2)"
+    assert fields["s"] == "decimal(10,2)"
+    for name in ("a", "l", "e"):
+        assert fields[name]["element"] == "decimal(10,2)", f"column {name}"
+
+    result = run_query("SELECT p, a, l, e, s FROM domain_numerics", pg_conn)
+    assert str(result[0]["p"]) == "1.25"
+    assert str(result[0]["s"]) == "2.50"
+    for name in ("a", "l", "e"):
+        assert _array_text(result[0][name]) == "{1.25,2.50}", f"column {name}"
+
+    pg_conn.rollback()
+    run_command("drop schema if exists test_domain_numeric cascade;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
Fixes #517. Stacked on #500 — based on `marcoslot/write-domain-over-array`, because the array repro only reaches the decimal path once that PR lets a domain over an array be written as a list at all.

A column whose type is a domain has `atttypmod = -1`: the modifier belongs to the domain (`pg_type.typtypmod`), not to the column. `getBaseType()` returns only the base type OID and drops it, so every place that maps a Postgres type for writing saw a domain over `numeric(10,2)` as an unbounded numeric:

```sql
create domain price as numeric(10,2);
create table t (p price) using iceberg;  -- recorded as decimal(38,9)
```

For the array shapes it is worse than imprecise. `ChooseDuckDBEngineTypeForWrite` and `PostgresTypeToIcebergField` derive the DuckDB write type and the stored Iceberg schema independently, and they disagreed, so the value came back in DuckDB list syntax and the read failed:

```
malformed array literal: "[1.250000000, 2.500000000]"
```

This adds `ResolveDomainBaseTypeAndTypmod`, which reports the modifier along with the base type, and adopts it in both mappings plus the shared scalar name mapping in `parquet/field.c` (the codecs hand that one raw attribute type ids). A modifier the caller already has keeps precedence, so `numeric(10,2)[]` behaves the same whether the modifier sits above or below the array type.

`pytests/test_domain.py::test_domain_over_numeric` covers a scalar numeric domain, a stacked domain, a domain over `numeric(10,2)[]`, a domain over an array of a numeric domain, and a plain array of a numeric domain. It fails on the parent branch with `assert 'decimal(38,9)' == 'decimal(10,2)'`.

Unconstrained `numeric` is unaffected: `ConvertTypeTree` already unwraps domains with `getBaseTypeAndTypmod`, so those columns are converted to `double` before they get here. That is also why this stayed hidden.
