### PR TITLE
[release-3.4] Backport #511: bound memory used by the pre-commit data file diff

### DIFF
--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -399,6 +399,14 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 		dataFileEntry->dataFile = *dataFile;
 	}
 
+	/*
+	 * The by-id hash was only a staging area for grouping the SPI rows of one
+	 * file together, and every entry has been copied into filesByPath by now.
+	 * The path, partition and column stats each entry points to were
+	 * allocated in our own context, not in the hash's, so they survive.
+	 */
+	hash_destroy(filesById);
+
 	return filesByPath;
 }
 

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -93,7 +93,8 @@ static void InitRestCatalogRequestsHashIfNeeded(void);
 static bool ShouldRunCommitTimeAnalyze(HTAB *trackedRelations);
 static void EnsureFreshStatsForCommitTimeDiff(void);
 static HTAB *CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata);
-static void FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
+static void FindChangedFilesSinceMetadata(const TableMetadataOperationTracker * opTracker,
+										  HTAB *currentFilesMap,
 										  List **addedFiles, List **removedFilePaths);
 static HTAB *CreatePartitionSpecsHashForMetadata(IcebergTableMetadata * metadata);
 static List *FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTableMetadata * metadata);
@@ -1097,8 +1098,17 @@ EnsureFreshStatsForCommitTimeDiff(void)
 
 
 /*
- * CreateDataFilesHashForMetadata creates and populates a hash table of data files
- * from the given Iceberg table metadata.
+ * CreateDataFilesHashForMetadata creates and populates a hash table of data file
+ * paths from the given Iceberg table metadata.
+ *
+ * Only the paths end up in the hash, so the decoded manifest entries behind
+ * them are scratch. They are not cheap scratch: an entry carries a DataFile
+ * with a per-column stat and bound array each, so a snapshot with tens of
+ * thousands of entries decodes to hundreds of megabytes. Read one manifest at
+ * a time into a context we reset after each, the way
+ * IcebergSnapshotAddAllReferencedFiles does, so peak is one manifest rather
+ * than the whole snapshot. The path itself is copied by dynahash into the hash
+ * entry, so it survives the reset.
  */
 static HTAB *
 CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
@@ -1109,16 +1119,38 @@ CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
 		return dataFilesMap;
 
 	IcebergSnapshot *iceSnapshot = GetCurrentSnapshot(metadata, true);
-	List	   *dataFiles = FetchDataFilesFromSnapshot(iceSnapshot, NULL, IsManifestEntryStatusScannable, NULL);
+	List	   *manifests = FetchManifestsFromSnapshot(iceSnapshot, NULL);
 
-	ListCell   *fileCell = NULL;
+	MemoryContext manifestContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "FetchDataFilesFromManifest for CreateDataFilesHashForMetadata",
+							  ALLOCSET_DEFAULT_SIZES);
 
-	foreach(fileCell, dataFiles)
+	ListCell   *manifestCell = NULL;
+
+	foreach(manifestCell, manifests)
 	{
-		TableDataFile *dataFile = lfirst(fileCell);
+		IcebergManifest *manifest = lfirst(manifestCell);
+		MemoryContext oldContext = MemoryContextSwitchTo(manifestContext);
 
-		AppendFileToHash(dataFile->path, dataFilesMap);
+		bool		pathOnly = true;
+		List	   *dataFilePaths = FetchDataFilesFromManifest(manifest, pathOnly,
+															   IsManifestEntryStatusScannable,
+															   NULL);
+		ListCell   *pathCell = NULL;
+
+		foreach(pathCell, dataFilePaths)
+		{
+			char	   *dataFilePath = lfirst(pathCell);
+
+			AppendFileToHash(dataFilePath, dataFilesMap);
+		}
+
+		MemoryContextSwitchTo(oldContext);
+		MemoryContextReset(manifestContext);
 	}
+
+	MemoryContextDelete(manifestContext);
 
 	return dataFilesMap;
 }
@@ -1126,18 +1158,42 @@ CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
 
 /*
  * FindChangedFilesSinceMetadata identifies added and removed files by comparing
- * the current state of data files with the state recorded in the provided metadata.
- * It populates the addedFiles and removedFilePaths lists with the respective files.
+ * the current state of data files with the state recorded in the last pushed
+ * metadata for the relation. It populates the addedFiles and removedFilePaths
+ * lists with the respective files.
  *
  * addedFiles: file info, wrapped in `TableDataFile` struct, for the files that are added since the metadata
  * removedFilePaths: file paths, which are added before the current tx, that are removed since the metadata
+ *
+ * Reading the last pushed metadata means reading its whole file list: the
+ * metadata JSON, every manifest in the current snapshot, and every entry in
+ * those manifests. None of that is needed once we know which paths changed, so
+ * it is read into a scratch context that is deleted before returning. What
+ * survives is bounded by the number of files this transaction changed, not by
+ * the number of files the table has. That matters because pre-commit walks
+ * every relation in the transaction, and TopTransactionContext is not reset in
+ * between: without this the peak is the sum over all relations of their full
+ * file lists.
  */
 static void
-FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * metadata,
+FindChangedFilesSinceMetadata(const TableMetadataOperationTracker * opTracker,
+							  HTAB *currentFilesMap,
 							  List **addedFiles, List **removedFilePaths)
 {
+	MemoryContext resultContext = CurrentMemoryContext;
+	MemoryContext metadataContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "pg_lake last pushed metadata file list",
+							  ALLOCSET_DEFAULT_SIZES);
+
+	MemoryContextSwitchTo(metadataContext);
+
 	/* create metadata's data files */
+	IcebergTableMetadata *metadata = GetLastPushedIcebergMetadata(opTracker);
 	HTAB	   *metadataDataFilesMap = CreateDataFilesHashForMetadata(metadata);
+
+	/* the result lists belong to the caller, not to the scratch context */
+	MemoryContextSwitchTo(resultContext);
 
 	/* find added files */
 	HASH_SEQ_STATUS currentFilesStatus;
@@ -1161,9 +1217,15 @@ FindChangedFilesSinceMetadata(HTAB *currentFilesMap, IcebergTableMetadata * meta
 
 	while ((metadataDataFilePath = hash_seq_search(&metadataFilesStatus)) != NULL)
 	{
+		/*
+		 * The path is a key inside metadataDataFilesMap, which goes away with
+		 * the scratch context below, so hand out a copy.
+		 */
 		if (!hash_search(currentFilesMap, metadataDataFilePath, HASH_FIND, NULL))
-			*removedFilePaths = lappend(*removedFilePaths, metadataDataFilePath);
+			*removedFilePaths = lappend(*removedFilePaths, pstrdup(metadataDataFilePath));
 	}
+
+	MemoryContextDelete(metadataContext);
 }
 
 
@@ -1314,14 +1376,11 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 																		 forUpdate, orderBy, snapshot, allTransforms,
 																		 true /* skipColumnStats */ );
 
-	/* get last pushed metadata */
-	IcebergTableMetadata *lastMetadata = GetLastPushedIcebergMetadata(opTracker);
-
-	/* find added and removed files since metadata */
+	/* find added and removed files since the last pushed metadata */
 	List	   *addedFiles = NIL;
 	List	   *removedFilePaths = NIL;
 
-	FindChangedFilesSinceMetadata(currentFilesMap, lastMetadata, &addedFiles, &removedFilePaths);
+	FindChangedFilesSinceMetadata(opTracker, currentFilesMap, &addedFiles, &removedFilePaths);
 
 	/*
 	 * Now that we know which files are newly added, load per-column stats
@@ -1368,6 +1427,18 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 
 		metadataOperations = lappend(metadataOperations, removedFileOp);
 	}
+
+	/*
+	 * The path index over the catalog file list is only needed for the diff
+	 * above. Its entries are the widest thing we allocate per file, because
+	 * the key is a fixed MAX_S3_PATH_LENGTH array, so drop it now rather than
+	 * leaving one per relation behind until the transaction ends. The
+	 * operations we return do not point into it: the path, partition and
+	 * column stats of each added file were allocated separately and outlive
+	 * it, and the removed paths are copies. addedFiles does point into it, so
+	 * it must not be used after this.
+	 */
+	hash_destroy(currentFilesMap);
 
 	return metadataOperations;
 }

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
@@ -4,4 +4,4 @@ module_pathname = '$libdir/pg_lake_table_test_hideable'
 relocatable = false
 requires = 'pg_extension_base,pg_lake_table'
 schema = pg_catalog
-#!shared_preload_libraries
+#!shared_preload_libraries = '$libdir/pg_lake_engine,$libdir/pg_lake_iceberg,$libdir/pg_lake_table,$libdir/pg_lake_table_test_hideable'


### PR DESCRIPTION
Backport of #511 to `release-3.4`.

## Why backport

At pre-commit, `ApplyTrackedIcebergMetadataChanges` reconstructs the metadata operations for every relation that changed in the transaction by diffing the data file catalog against the file list of the last pushed Iceberg snapshot. Everything that diff allocates lands in `TopTransactionContext`, which is not reset between relations, so the peak is the sum over all relations of their *entire* file lists — even though all that is needed is one operation per **changed** file. On a table with a large number of data files, a commit that adds a handful of files holds hundreds of megabytes until the transaction ends.

This is reachable on 3.4 by any workload that keeps appending to a table without compacting it, and it is worst exactly where it hurts most: a host with `vm.overcommit_memory = 2` has no reclaim to fall back on, so the transient peak has to fit under `CommitLimit`.

The fix decodes one manifest at a time into a scratch context, reads the last pushed file list into a context it deletes before returning, and destroys the two path-keyed file hashes once the diff has consumed them. See #511 for the full analysis.

## Measured on `main`

Peak RSS (`VmHWM`) of a backend doing one small commit against a snapshot that already has many files. Same on-disk data measured under both builds by swapping `pg_lake_table.so`; the two "patched" numbers are repeat measurements, so their spread is the run-to-run noise.

| `enable_manifest_merge_on_write` | manifests | data files | before | after | saved |
|---|---|---|---|---|---|
| off | 60 | 12,000 | 339 MB | 271 / 253 MB | 68–86 MB |
| off | 120 | 60,000 | 1446 MB | 1039 / 1032 MB | 407–414 MB |
| on (default) | 21 | 30,000 | 763 MB | 570 / 552 MB | 193–211 MB |

≈6.7 KB of peak per data file in the snapshot, consistent across scales, and no change in commit latency (4.6 s vs 4.6 / 4.8 s at 60k files).

## Conflict resolution

One conflict, in `GetDataFileMetadataOperations()`. `main` has the TRUNCATE remove-all shortcut from #457, which `release-3.4` does not, so the two branches disagree on the lines right where #511 drops the now-unused `lastMetadata` local. Resolved by keeping `release-3.4`'s shape — the shortcut is not backported here — and applying only #511's change: `GetLastPushedIcebergMetadata()` moves inside `FindChangedFilesSinceMetadata()`, which now takes the tracker.

Diffing this commit's patch against `558600e`'s shows the added and removed lines are identical; only hunk offsets and surrounding context differ.

## Second commit: CI unblock

The first CI run on this branch lost 11 jobs to a preload-order problem that has nothing to do with this backport: `pg_lake_table_test_hideable.control` asks for the bare `#!shared_preload_libraries`, so `RegisterHideableExtension` resolves only when `readdir()` happens to place a control file that pulls in `pg_lake_table` earlier in the extension directory. When it does not, the postmaster dies with `undefined symbol: RegisterHideableExtension` and every test in the job errors in the fixture. The same failure hit the `main` push run for #511 and #505 on the same day.

The second commit here lists the dependency libraries explicitly, the way `pg_lake_copy.control` already does. It is up against `main` as #521 and can be dropped from this branch if that one is backported to `release-3.4` first.

## Diff

Two files in `pg_lake_table`: `src/transaction/track_iceberg_metadata_changes.c` and `src/fdw/data_files_catalog.c`. No SQL migration files, no schema or catalog change, version stays at 3.4. `FetchManifestsFromSnapshot()` and `FetchDataFilesFromManifest(manifest, pathOnly, …)` already exist on 3.4 with the signatures the patch needs, and `GetLastPushedIcebergMetadata()` is identical on both branches.

## Test plan

- `make` in `pg_lake_table` on this branch: clean build, no new warnings.
- The behaviour is unchanged and the code is identical to `main`, where it ran the full `pg_lake_table` pytest suite plus a 285-test targeted run over the write/DDL/vacuum/manifest paths (see #511).
- [x] CI green on `release-3.4`: all 64 checks pass on run 31520456525 (needed the preload-order commit above; see #521).