### PR TITLE
pg_lake_table: fix preload order for the test hideable extension

### DIFF
--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
@@ -4,7 +4,4 @@ module_pathname = '$libdir/pg_lake_table_test_hideable'
 relocatable = false
 requires = 'pg_extension_base,pg_lake_table'
 schema = pg_catalog
-# RegisterHideableExtension lives in pg_lake_table, so its whole preload
-# chain must be loaded before this module.  The explicit list guarantees
-# that regardless of the order pg_extension_base scans control files in.
 #!shared_preload_libraries = '$libdir/pg_lake_engine,$libdir/pg_lake_iceberg,$libdir/pg_lake_table,$libdir/pg_lake_table_test_hideable'

--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
@@ -4,4 +4,7 @@ module_pathname = '$libdir/pg_lake_table_test_hideable'
 relocatable = false
 requires = 'pg_extension_base,pg_lake_table'
 schema = pg_catalog
-#!shared_preload_libraries
+# RegisterHideableExtension lives in pg_lake_table, so its whole preload
+# chain must be loaded before this module.  The explicit list guarantees
+# that regardless of the order pg_extension_base scans control files in.
+#!shared_preload_libraries = '$libdir/pg_lake_engine,$libdir/pg_lake_iceberg,$libdir/pg_lake_table,$libdir/pg_lake_table_test_hideable'


### PR DESCRIPTION
`pg_lake_table_test_hideable` is auto-preloaded through the `pg_extension_base` `#!shared_preload_libraries` directive, and its `_PG_init` calls `RegisterHideableExtension`. That symbol lives in `pg_lake_table`, but the test extension's control file used the bare directive form, which preloads only the extension's own module.

`pg_extension_base` scans installed control files in `readdir` order and preloads libraries in first-seen order. Whenever `pg_lake_table_test_hideable.control` happened to be read before `pg_lake_table.control`, the test module was `dlopen`ed before `pg_lake_table.so` and the server failed to start:

```
FATAL: could not load library ".../pg_lake_table_test_hideable.so": undefined symbol: RegisterHideableExtension
```

The order is filesystem-dependent, so this surfaced as an intermittent failure that took down server startup across otherwise-unrelated installcheck/check jobs (pg_map, pg_extension_base, spatial, benchmark, installcheck-postgres, and pg_lake_table's own checks).

The fix switches the control file to the explicit-list directive form, matching `pg_lake_table.control` itself, so the full `pg_lake_engine` / `pg_lake_iceberg` / `pg_lake_table` chain is preloaded before the test module regardless of scan order. `AddPreloadLibrary` already dedupes, so listing the chain here is a no-op when `pg_lake_table.control` is processed too.

Follow-up worth considering separately: the preloader's dependence on `readdir` order is a latent footgun for any future auto-preloaded extension that depends on another. Making the scan order deterministic (or dependency-aware via `requires`) would remove the need for each extension to restate its provider chain, but that is a broader change than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)