### PR TITLE
pg_lake_table: preload pg_lake_table before its hideable test module

### DIFF
--- a/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
+++ b/pg_lake_table/tests/sample_extensions/pg_lake_table_test_hideable/pg_lake_table_test_hideable.control
@@ -4,4 +4,4 @@ module_pathname = '$libdir/pg_lake_table_test_hideable'
 relocatable = false
 requires = 'pg_extension_base,pg_lake_table'
 schema = pg_catalog
-#!shared_preload_libraries
+#!shared_preload_libraries = '$libdir/pg_lake_engine,$libdir/pg_lake_iceberg,$libdir/pg_lake_table,$libdir/pg_lake_table_test_hideable'


### PR DESCRIPTION
## Problem

`pg_lake_table_test_hideable.so` calls `RegisterHideableExtension()`, which is defined in `pg_lake_table.so`. `dlopen()` of the test module therefore only resolves once `pg_lake_table.so` has been loaded.

Its control file asks for the bare form:

```
#!shared_preload_libraries
```

which tells `pg_extension_base` to preload that extension's own `module_pathname` and nothing else. `FindAllPreloadLibraries()` builds the preload list by walking the extension control directory with `readdir()`, so whether `pg_lake_table` happens to be loaded first depends entirely on where the filesystem places `pg_lake_table_test_hideable.control` relative to some other control file that does pull `pg_lake_table` in (`pg_lake_table.control`, `pg_lake_copy.control`).

That order is not stable across containers. When it comes out the wrong way, postmaster start-up dies:

```
LOG:  pg_extension_base: preloading $libdir/pg_lake_table_test_hideable
FATAL:  could not load library ".../pg_lake_table_test_hideable.so": undefined symbol: RegisterHideableExtension
```

postgres never starts, so the pytest `postgres` fixture fails on `open("/tmp/pg_lake_tests/logfile")` and every test in the job reports `ERROR at setup`, with nothing in the output pointing at the real cause.

This is currently firing across the repo, not on one branch. On 2026-08-11 it took out 11 jobs on https://github.com/Snowflake-Labs/pg_lake/pull/519 (release-3.4), and it also hit the `main` push run for #511 (`test-installcheck-pg_lake_table (16, 1)`) and https://github.com/Snowflake-Labs/pg_lake/pull/505 (`installcheck-pg_lake_spatial (16)` and others). Which jobs fail varies run to run, which is what you would expect from a `readdir()` order that is only accidentally correct.

## Solution

List the dependency libraries explicitly, the same way `pg_lake_copy.control` and the `pg_extension_base` test extensions already do:

```
#!shared_preload_libraries = '$libdir/pg_lake_engine,$libdir/pg_lake_iceberg,$libdir/pg_lake_table,$libdir/pg_lake_table_test_hideable'
```

`FindAllPreloadLibraries()` walks one control file's list in order, and `AddPreloadLibrary()` dedupes by library name and keeps the first position, so `pg_lake_table` is loaded before the test module whichever control file `readdir()` returns first, and each library is still loaded exactly once.

The list mirrors `pg_lake_table.control`, so `pg_lake_engine` and `pg_lake_iceberg` come along for the same reason they do there.

## Test plan

Reproduced and verified against a local PG 18 install of these extensions, where `readdir()` already returns `pg_lake_table_test_hideable.control` before `pg_lake_table.control`:

- Baseline: start-up succeeds only because `snowflake_cdc.control` (which lists `$libdir/pg_lake_table`) is read earlier. Moving that control file aside reproduces the CI failure exactly — `FATAL: ... undefined symbol: RegisterHideableExtension`, postgres does not start.
- With this change and `snowflake_cdc.control` still moved aside, the preload log shows `pg_lake_engine`, `pg_lake_iceberg`, `pg_lake_table`, then `pg_lake_table_test_hideable`, each once, and the cluster reaches "database system is ready to accept connections".
- CI on this branch.
