### PR TITLE
pg_extension_base: let attached workers inherit caller writability

### DIFF
--- a/pg_extension_base/src/attached_worker.c
+++ b/pg_extension_base/src/attached_worker.c
@@ -53,6 +53,7 @@
 #include "utils/acl.h"
 #include "utils/backend_status.h"
 #include "utils/builtins.h"
+#include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/portal.h"
 #include "utils/ps_status.h"
@@ -73,6 +74,7 @@
 #define ATTACHED_WORKER_NKEYS			6
 
 #define ATTACHED_WORKER_FLAG_RETURN_RESULTS	0x01
+#define ATTACHED_WORKER_FLAG_CALLER_WRITABLE	0x02
 
 /* SQL-callable functions */
 PG_FUNCTION_INFO_V1(pg_extension_base_run_attached_worker);
@@ -309,6 +311,31 @@ StartAttachedWorkerInternal(char *command, char *databaseName, char *userName,
 {
 	/* store the worker state */
 	AttachedWorker *attachedWorker = (AttachedWorker *) palloc0(sizeof(AttachedWorker));
+
+	/*
+	 * An attached worker acts on behalf of the calling session, so it should
+	 * not be held back by a read-only restriction the caller itself is not
+	 * subject to.  Because it is a background worker it takes
+	 * default_transaction_read_only from the configuration files, so it would
+	 * refuse writes whenever the server is configured read-only -- as
+	 * Snowflake Postgres does when the disk runs low -- even for a caller
+	 * that is writing happily.  Pass the caller's state along so the worker
+	 * can match it.
+	 *
+	 * Key this on XactReadOnly rather than DefaultXactReadOnly: what matters
+	 * is whether the caller can write *now*, which is what the worker is
+	 * acting on its behalf to do.  The two differ in both directions -- a
+	 * caller that cleared the GUC inside an already read-only transaction
+	 * still cannot write in it, and a caller that ran SET TRANSACTION READ
+	 * WRITE can write even though the configured default says otherwise.
+	 *
+	 * The worker is only ever made less restrictive than its configuration,
+	 * never more: a read-only caller leaves the flag unset and the worker
+	 * keeps whatever the configuration gives it, exactly as before this flag
+	 * existed.
+	 */
+	if (!XactReadOnly)
+		flags |= ATTACHED_WORKER_FLAG_CALLER_WRITABLE;
 
 	/* estimate size of the background worker input */
 	shm_toc_estimator sharedMemoryEstimator;
@@ -734,6 +761,8 @@ AttachedWorkerMain(Datum mainArg)
 	uint32	   *flagsPtr = shm_toc_lookup(toc, ATTACHED_WORKER_KEY_FLAGS, true);
 	bool		returnResults = (flagsPtr != NULL &&
 								 (*flagsPtr & ATTACHED_WORKER_FLAG_RETURN_RESULTS) != 0);
+	bool		callerWritable = (flagsPtr != NULL &&
+								  (*flagsPtr & ATTACHED_WORKER_FLAG_CALLER_WRITABLE) != 0);
 
 	/* Attach to the response queue (protocol messages: errors, command tags) */
 	shm_mq_set_sender(messageQueue, MyProc);
@@ -762,6 +791,15 @@ AttachedWorkerMain(Datum mainArg)
 	/* Report status as running */
 	SetCurrentStatementStartTimestamp();
 	pgstat_report_activity(STATE_RUNNING, command);
+
+	/*
+	 * Match the caller's read-only setting when the caller was writable (see
+	 * StartAttachedWorkerInternal).  Do this before starting the transaction,
+	 * which is where default_transaction_read_only takes effect.
+	 */
+	if (callerWritable)
+		SetConfigOption("default_transaction_read_only", "off",
+						PGC_USERSET, PGC_S_SESSION);
 
 	/* Start the transaction */
 	StartTransactionCommand();

--- a/pg_extension_base/tests/pytests/test_attached_workers.py
+++ b/pg_extension_base/tests/pytests/test_attached_workers.py
@@ -58,6 +58,162 @@ def test_write(superuser_conn, pg_extension_base):
     superuser_conn.rollback()
 
 
+def test_write_while_server_configured_read_only(superuser_conn, pg_extension_base):
+    """
+    An attached worker must inherit the caller's writability.
+
+    A background worker takes default_transaction_read_only from the
+    configuration files, so without inheriting the caller's state it would
+    refuse writes whenever the server is configured read-only -- even for a
+    caller that deliberately turned the setting off, which is how a background
+    worker keeps making progress while the server is held read-only (e.g. to
+    protect a nearly-full disk).
+
+    The opt-out has to happen outside a transaction to have any effect, since a
+    transaction takes its read-only state at start; that is also exactly what
+    such a worker does.
+    """
+    run_command("CREATE TABLE test_read_only_write (x int)", superuser_conn)
+    superuser_conn.commit()
+
+    try:
+        set_read_only(superuser_conn, "on")
+        set_session_read_only(superuser_conn, "off")
+
+        run_command(
+            "SELECT * FROM extension_base.run_attached("
+            "$$INSERT INTO test_read_only_write VALUES (1)$$)",
+            superuser_conn,
+        )
+
+        result = run_query("SELECT count(*) FROM test_read_only_write", superuser_conn)
+        assert result[0]["count"] == 1
+        superuser_conn.commit()
+    finally:
+        superuser_conn.rollback()
+        set_session_read_only(superuser_conn, None)
+        set_read_only(superuser_conn, None)
+
+    run_command("DROP TABLE test_read_only_write", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_write_when_caller_set_transaction_read_write(
+    superuser_conn, pg_extension_base
+):
+    """
+    A caller can also make just its own transaction writable.
+
+    SET TRANSACTION READ WRITE (first statement of the transaction) leaves the
+    configured default read-only, so the worker has to look at the caller's
+    transaction state rather than at the configuration to get this right.
+    """
+    run_command("CREATE TABLE test_read_write_xact (x int)", superuser_conn)
+    superuser_conn.commit()
+
+    try:
+        set_read_only(superuser_conn, "on")
+        run_command("SET TRANSACTION READ WRITE", superuser_conn)
+
+        run_command(
+            "SELECT * FROM extension_base.run_attached("
+            "$$INSERT INTO test_read_write_xact VALUES (1)$$)",
+            superuser_conn,
+        )
+
+        result = run_query("SELECT count(*) FROM test_read_write_xact", superuser_conn)
+        assert result[0]["count"] == 1
+        superuser_conn.commit()
+    finally:
+        superuser_conn.rollback()
+        set_read_only(superuser_conn, None)
+
+    run_command("DROP TABLE test_read_write_xact", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_no_write_when_the_caller_itself_is_read_only(
+    superuser_conn, pg_extension_base
+):
+    """
+    The worker must not outrun a caller that cannot write.
+
+    Clearing default_transaction_read_only inside a transaction does not lift
+    the restriction on that transaction, so the caller still cannot write and
+    neither may the worker -- inheriting writability must not turn
+    run_attached() into a way around the caller's own read-only state.
+    """
+    run_command("CREATE TABLE test_read_only_caller (x int)", superuser_conn)
+    superuser_conn.commit()
+
+    try:
+        set_read_only(superuser_conn, "on")
+        run_command("SET default_transaction_read_only = off", superuser_conn)
+
+        error = run_command(
+            "SELECT * FROM extension_base.run_attached("
+            "$$INSERT INTO test_read_only_caller VALUES (1)$$)",
+            superuser_conn,
+            raise_error=False,
+        )
+        assert error is not None
+        assert "read-only transaction" in error
+    finally:
+        superuser_conn.rollback()
+        set_read_only(superuser_conn, None)
+
+    run_command("DROP TABLE test_read_only_caller", superuser_conn)
+    superuser_conn.commit()
+
+
+def set_session_read_only(conn, value):
+    """
+    Set (or reset, value None) default_transaction_read_only for this session,
+    outside a transaction so that the transactions which follow pick it up.
+    """
+    conn.rollback()
+    conn.autocommit = True
+    try:
+        if value is None:
+            run_command("RESET default_transaction_read_only", conn)
+        else:
+            run_command(f"SET default_transaction_read_only = {value}", conn)
+    finally:
+        conn.autocommit = False
+
+
+def set_read_only(conn, value):
+    """
+    Configure default_transaction_read_only server-wide, or reset it (value
+    None), and wait until this backend has applied the change.  pg_reload_conf()
+    only signals the backends, so without the wait the next transaction may
+    still run with the previous setting.
+    """
+    conn.rollback()
+    conn.autocommit = True
+    try:
+        if value is None:
+            run_command("ALTER SYSTEM RESET default_transaction_read_only", conn)
+        else:
+            run_command(
+                f"ALTER SYSTEM SET default_transaction_read_only = {value}", conn
+            )
+        run_command("SELECT pg_reload_conf()", conn)
+
+        expected = "off" if value is None else value
+        deadline = time.time() + 10
+        while True:
+            applied = run_query("SHOW default_transaction_read_only", conn)[0][0]
+            if applied == expected:
+                break
+            assert (
+                time.time() < deadline
+            ), f"default_transaction_read_only stayed {applied} after reload"
+            time.sleep(0.1)
+    finally:
+        conn.autocommit = False
+
+
 def test_error_in_worker(superuser_conn, pg_extension_base):
     # Test error handling
     error = run_command(

--- a/pg_lake_copy/tests/pytests/test_duckdb_reserved_keyword_copy.py
+++ b/pg_lake_copy/tests/pytests/test_duckdb_reserved_keyword_copy.py
@@ -144,8 +144,6 @@ def test_copy_roundtrip_composite_with_embedded_quote(pg_conn, s3):
     COPY TO/FROM must handle composite types whose field names contain
     double-quote characters.  The STRUCT type definition sent to DuckDB must
     properly escape the embedded quotes.
-
-    Reproduces: https://github.com/snowflake-eng/sfpg-extension-pg_lake_replication/issues/361
     """
     url = f"s3://{TEST_BUCKET}/test_kw_copy_composite_quote/data.parquet"
 
@@ -208,8 +206,6 @@ def test_copy_roundtrip_csv_composite_with_embedded_quote(pg_conn, s3):
     """
     COPY TO/FROM CSV with composite types containing double-quote field names.
     This exercises the read_csv columns= type string path.
-
-    Reproduces: https://github.com/snowflake-eng/sfpg-extension-pg_lake_replication/issues/361
     """
     url = f"s3://{TEST_BUCKET}/test_kw_copy_csv_composite_quote/data.csv"
 

--- a/pg_lake_engine/src/pgduck/iceberg_query_validation.c
+++ b/pg_lake_engine/src/pgduck/iceberg_query_validation.c
@@ -981,9 +981,9 @@ AppendIcebergSizeClampExpression(StringInfo buf, const char *expr,
  * unchanged.
  *
  * Both the INSERT..SELECT pushdown path (via WriteQueryResultTo) and the
- * snowflake_cdc snapshot path (via AddQueryResultToTable) flow through
- * this wrapper, so they share the same policy-driven behavior as the
- * per-tuple IcebergSizeCheckOrClampSlotInPlace path.
+ * bulk-load path (via AddQueryResultToTable) flow through this wrapper, so
+ * they share the same policy-driven behavior as the per-tuple
+ * IcebergSizeCheckOrClampSlotInPlace path.
  */
 char *
 IcebergWrapQueryWithSizeClampChecks(char *query, TupleDesc tupleDesc,

--- a/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/compatibility_mode.h
@@ -72,6 +72,6 @@ extern PGDLLEXPORT void ApplyCompatibilityStorageMapping(Field * field,
 /*
  * True iff typeOid is, or contains at any depth, a pg_map type. Used to reject
  * map columns under compatibility_mode='snowflake' (Snowflake cannot represent
- * them, mirroring snowflake_cdc's restriction).
+ * them).
  */
 extern PGDLLEXPORT bool TypeContainsMap(Oid typeOid);

--- a/pg_lake_table/include/pg_lake/recovery/recover.h
+++ b/pg_lake_table/include/pg_lake/recovery/recover.h
@@ -22,8 +22,7 @@
 /*
  * Hook invoked at the end of pg_lake_finish_postgres_recovery, after the
  * per-database lake_table recovery has run and committed. Other extensions
- * (such as pg_lake_replication) can set this to perform their own recovery
- * steps.
+ * can set this to perform their own recovery steps.
  */
 typedef void (*PgLakeFinishPostgresRecoveryHookType) (void);
 extern PGDLLEXPORT PgLakeFinishPostgresRecoveryHookType PgLakeFinishPostgresRecoveryHook;

--- a/pg_lake_table/pg_lake_table--2.4-1--3.0.sql
+++ b/pg_lake_table/pg_lake_table--2.4-1--3.0.sql
@@ -1,4 +1,4 @@
--- Cleanup things that now belong to pg_lake_replication.
+-- Cleanup objects that now belong to the replication extension.
 --
 -- If we do not need a migration path forward, we can just drop these objects
 -- here and not care about existing tables in a replication set.

--- a/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
+++ b/pg_lake_table/tests/pytests/test_data_file_hook_temp_table.py
@@ -1,11 +1,10 @@
 """
 Regression tests for ALLOW_TEMP_OBJECTS_BEGIN / ALLOW_TEMP_OBJECTS_END.
 
-PgLakeAddDataFileHook is an extension point used by sfpg-extension-pg_lake_replication
-(and any other module that needs to know which data file IDs were added in
-the current transaction). When the hook is set and returns true, pg_lake_table
-records each new data file ID in a per-transaction temp table created lazily
-inside SPI_START_EXTENSION_OWNER.
+PgLakeAddDataFileHook is an extension point used by modules that need to know
+which data file IDs were added in the current transaction. When the hook is set
+and returns true, pg_lake_table records each new data file ID in a
+per-transaction temp table created lazily inside SPI_START_EXTENSION_OWNER.
 
 Before ALLOW_TEMP_OBJECTS_BEGIN/END existed, the temp-table create ran under
 SECURITY_RESTRICTED_OPERATION, which PostgreSQL forbids: the temp namespace
@@ -103,8 +102,8 @@ def test_iceberg_dml_under_extension_owner(
 
     Downstream extensions that wrap their own SPI calls in
     SPI_START_EXTENSION_OWNER and then issue Iceberg DML hit this -- the
-    motivating example was sfpg-extension-pg_lake_replication's expiry path
-    running DELETE on the change-log Iceberg table.
+    motivating example was an extension's expiry path running DELETE on a
+    change-log Iceberg table.
     """
     # pg_conn is module-scoped, so each parametrization needs a distinct
     # table to avoid "relation already exists" on the second run.

--- a/pg_lake_table/tests/pytests/test_duckdb_reserved_keywords.py
+++ b/pg_lake_table/tests/pytests/test_duckdb_reserved_keywords.py
@@ -726,8 +726,6 @@ def test_iceberg_composite_field_with_embedded_double_quote(pg_conn, s3, extensi
     DuckDB's type parser requires identifier quoting in STRUCT(...) type
     strings.  A field name like  has"quote  must be emitted as "has""quote"
     (standard SQL identifier escaping) rather than being passed through raw.
-
-    Reproduces: https://github.com/snowflake-eng/sfpg-extension-pg_lake_replication/issues/361
     """
     schema = "test_duckdb_kw_struct_quote"
     location = f"s3://{TEST_BUCKET}/{schema}/"
@@ -792,8 +790,6 @@ def test_iceberg_composite_field_with_special_characters(pg_conn, s3, extension)
 
     Exercises the STRUCT(...) type string path in read_data.c:GetSchemaType()
     and GetDuckDBStructDefinitionForCompositeType() in parse_struct.c.
-
-    Reproduces: https://github.com/snowflake-eng/sfpg-extension-pg_lake_replication/issues/361
     """
     schema = "test_duckdb_kw_struct_special"
     location = f"s3://{TEST_BUCKET}/{schema}/"


### PR DESCRIPTION
## Problem

An attached worker runs SQL on behalf of the calling session, but it is a background worker, so it reads `default_transaction_read_only` from the configuration files rather than from its caller. Whenever the server is configured read-only — Snowflake Postgres does exactly this to protect a nearly-full disk — the worker refuses writes even for a caller that deliberately turned the setting off for its own session.

That is not hypothetical: `pg_lake_engine`'s in-progress-file bookkeeping goes through `extension_base.run_attached()`, so a background worker that must keep making progress under a read-only server hits

```
ERROR:  cannot execute INSERT in a read-only transaction
CONTEXT:  SQL statement "select * from extension_base.run_attached($1)"
```

with nothing it can do about it — the caller already opted itself out, and the setting is not reachable from inside `run_attached`.

## Change

Pass the caller's `default_transaction_read_only` to the worker (new `ATTACHED_WORKER_FLAG_CALLER_WRITABLE`) and have the worker match it before `StartTransactionCommand()`, which is where the setting takes effect. The worker then ends up exactly as writable as its caller.

The flag is derived from `XactReadOnly`, not `DefaultXactReadOnly`: what the worker acts on behalf of is the caller's ability to write *now*, and the two differ in both directions.

* Clearing the GUC inside an already read-only transaction does not make that transaction writable (`SET default_transaction_read_only = off` mid-transaction leaves `transaction_read_only = on`), so keying on the GUC would hand a writable worker to a caller that cannot write itself.
* `SET TRANSACTION READ WRITE` makes a transaction writable against a read-only configured default, so keying on the GUC would leave the worker read-only while its caller writes.

The worker is never made *more* restrictive than the configuration asks for: when the caller is read-only the flag is absent and the worker keeps its configured value, exactly as before this flag existed.

## Testing

Three new tests in `pg_extension_base/tests/pytests/test_attached_workers.py`, all under `ALTER SYSTEM SET default_transaction_read_only = on`:

* `test_write_while_server_configured_read_only` — the caller opts its session out (outside a transaction, as a background worker does) and writes through `run_attached`. Fails without the C change (`psycopg2.errors.ReadOnlySqlTransaction: cannot execute INSERT in a read-only transaction`).
* `test_write_when_caller_set_transaction_read_write` — the caller makes only its own transaction writable. Fails if the flag is keyed on the GUC instead of the transaction state.
* `test_no_write_when_the_caller_itself_is_read_only` — the caller clears the GUC *inside* its transaction, so it stays read-only; the worker must refuse the write too. Fails if the flag is keyed on the GUC.

Full suite: 31 passed.

Note the helper waits for the reload to be observed via `SHOW default_transaction_read_only` — `pg_reload_conf()` only signals backends, and without the wait both the set and the reset race the test body (a leaked read-only setting poisons the session-scoped connection and cascades into later tests).

## Related

Prerequisite for the snowflake_cdc change that keeps the CDC worker applying changes while the instance is held read-only on low disk; without this, the applied change still fails on pg_lake's bookkeeping INSERT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
