### PR TITLE
Preserve numeric precision and scale inside composite types

### DIFF
--- a/pg_lake_copy/tests/pytests/test_parquet_copy.py
+++ b/pg_lake_copy/tests/pytests/test_parquet_copy.py
@@ -961,8 +961,8 @@ def test_nested_unbounded_numeric(pg_conn, tmp_path, kind):
 
     # An oversized numeric leaf (30 integral digits) is rejected wherever it
     # sits in the nested structure. (The within-cap acceptance path is covered
-    # by test_nested_numeric_roundtrip; a nested numeric Parquet write is a
-    # separate concern from the digit-limit validation exercised here.)
+    # by test_nested_numeric_roundtrip for a top-level array and by
+    # test_nested_unbounded_numeric_at_limit_roundtrip for every other shape.)
     error = run_command(
         f"COPY ({_nested_numeric_select(kind, over, over)}) "
         f"TO '{parquet_path}' WITH (format 'parquet')",
@@ -1009,6 +1009,157 @@ def test_nested_numeric_roundtrip(pg_conn, tmp_path):
     )
     result = run_query("SELECT a FROM test_num_array", pg_conn)
     assert result[0]["a"] == [Decimal("500.00"), Decimal(NUMERIC_AT_LIMIT)]
+
+    pg_conn.rollback()
+
+
+# Where the round-trip leaves the value, per nested shape: the column type that
+# can hold what _nested_numeric_select() produces, and the expression that digs
+# the numeric leaf back out of it. Comparing the leaf rather than the whole
+# container keeps the assertion on the value: a numeric that went through
+# DECIMAL(38,9) comes back with nine fractional digits, which compares equal as
+# a Decimal but not as the composite's text output.
+_NESTED_NUMERIC_ROUNDTRIP = {
+    "array": ("numeric[]", "v[2]"),
+    "composite": ("lake_struct.cost_pair", "(v).amount"),
+    "map": ("map_type.key_int_val_numeric", "(v[2]).val"),
+    "domain_scalar": ("cost_scalar", "v"),
+    "array_of_composite": ("lake_struct.cost_pair[]", "(v[2]).amount"),
+}
+
+# "domain_array" is left out: writing a domain over an array is rejected before
+# any value is looked at ('Value "LIST" can not be converted to a DuckDB Type'),
+# for any element type, so there is no round-trip to observe. It stays in
+# test_nested_unbounded_numeric above, where the numeric validation rejects the
+# value before the write is attempted.
+_NESTED_NUMERIC_ROUNDTRIP_KINDS = [
+    kind for kind in NESTED_NUMERIC_KINDS if kind in _NESTED_NUMERIC_ROUNDTRIP
+]
+
+
+@pytest.mark.parametrize("kind", _NESTED_NUMERIC_ROUNDTRIP_KINDS)
+def test_nested_unbounded_numeric_at_limit_roundtrip(pg_conn, tmp_path, kind):
+    """A numeric leaf exactly at the digit cap survives the round-trip.
+
+    The cap the COPY TO validation enforces (29 integral digits) is derived from
+    DECIMAL(38,9), so a leaf that passes validation must also be written as
+    DECIMAL(38,9). A nested leaf used to lose its type modifier on the way to
+    DuckDB and be written as a bare DECIMAL -- DECIMAL(18,3) -- which cannot
+    hold a value the validation had just accepted.
+    """
+    parquet_path = tmp_path / "test.parquet"
+
+    _create_nested_numeric_types(pg_conn)
+
+    at_limit = str(NUMERIC_AT_LIMIT)
+    column_type, leaf = _NESTED_NUMERIC_ROUNDTRIP[kind]
+
+    run_command(
+        f"""
+        CREATE TABLE test_nested_at_limit (v {column_type});
+        COPY ({_nested_numeric_select(kind, at_limit, at_limit)})
+        TO '{parquet_path}' WITH (format 'parquet');
+        COPY test_nested_at_limit FROM '{parquet_path}' WITH (format 'parquet');
+        """,
+        pg_conn,
+    )
+
+    result = run_query(f"SELECT {leaf} AS leaf FROM test_nested_at_limit", pg_conn)
+    assert result[0]["leaf"] == Decimal(NUMERIC_AT_LIMIT), kind
+
+    pg_conn.rollback()
+
+
+# One composite carrying every numeric flavor that maps to a different DuckDB
+# type, so a single Parquet footer shows what each nesting position did with it.
+# Field names avoid DuckDB keywords (UNBOUNDED is one) to keep the expected
+# STRUCT strings free of quoting unrelated to what is being tested.
+_NUM_FLAVORS_ROW = (
+    "ROW(1.5, 1.2345, 123456789012345678901234.99, "
+    "ARRAY[1.2345::numeric(10,4)], ARRAY[1.5::numeric])::lake_struct.num_flavors"
+)
+
+_NUM_FLAVORS_STRUCT = (
+    "STRUCT(plain DECIMAL(38,9), bounded DECIMAL(10,4), wide VARCHAR, "
+    "bounded_arr DECIMAL(10,4)[], plain_arr DECIMAL(38,9)[])"
+)
+
+# Every leaf of the table below, so the values can be compared before and after
+# the round-trip without going through a composite's text output.
+_NUM_FLAVORS_LEAVES = """
+    SELECT (flavors).plain, (flavors).bounded, (flavors).wide,
+           (flavors).bounded_arr, (flavors).plain_arr,
+           ((wrapped).leaf).plain, ((wrapped).leaf).wide,
+           (flavor_arr[1]).bounded, (flavor_arr[1]).wide,
+           (num_map[1]).val
+    FROM %s
+"""
+
+
+def test_nested_numeric_parquet_types(pg_conn, duckdb_conn, tmp_path):
+    """A numeric leaf gets the same DuckDB type wherever it is nested.
+
+    That is the mapping test_types asserts for top-level columns: an unbounded
+    numeric becomes DECIMAL(38,9) (the configured default precision and scale),
+    numeric(P,S) becomes DECIMAL(P,S), and a numeric too wide for DuckDB falls
+    back to VARCHAR. Nested leaves used to be written as a bare DuckDB DECIMAL,
+    which both rounded the value to three fractional digits and disagreed with
+    the type the same numeric gets at the top level.
+    """
+    parquet_path = tmp_path / "nested_numeric_types.parquet"
+
+    _create_nested_numeric_types(pg_conn)
+    run_command(
+        f"""
+        CREATE TYPE lake_struct.num_flavors AS (
+            plain numeric,
+            bounded numeric(10,4),
+            wide numeric(39,2),
+            bounded_arr numeric(10,4)[],
+            plain_arr numeric[]
+        );
+        CREATE TYPE lake_struct.num_wrapper AS (leaf lake_struct.num_flavors);
+        CREATE TABLE test_num_flavors (
+            flavors lake_struct.num_flavors,
+            wrapped lake_struct.num_wrapper,
+            flavor_arr lake_struct.num_flavors[],
+            num_map map_type.key_int_val_numeric
+        );
+        INSERT INTO test_num_flavors VALUES (
+            {_NUM_FLAVORS_ROW},
+            ROW({_NUM_FLAVORS_ROW})::lake_struct.num_wrapper,
+            ARRAY[{_NUM_FLAVORS_ROW}],
+            '{{"(1,1.5)","(2,{NUMERIC_AT_LIMIT})"}}'::map_type.key_int_val_numeric
+        );
+        COPY test_num_flavors TO '{parquet_path}' WITH (format 'parquet');
+        """,
+        pg_conn,
+    )
+
+    duckdb_conn.execute("DESCRIBE SELECT * FROM read_parquet($1)", [str(parquet_path)])
+    written_types = {name: type_name for name, type_name, *_ in duckdb_conn.fetchall()}
+
+    assert written_types == {
+        "flavors": _NUM_FLAVORS_STRUCT,
+        "wrapped": f"STRUCT(leaf {_NUM_FLAVORS_STRUCT})",
+        "flavor_arr": f"{_NUM_FLAVORS_STRUCT}[]",
+        "num_map": "MAP(INTEGER, DECIMAL(38,9))",
+    }
+
+    # And the values themselves come back unrounded, including through the
+    # VARCHAR fallback for the leaf DuckDB cannot store as a DECIMAL.
+    before = run_query(_NUM_FLAVORS_LEAVES % "test_num_flavors", pg_conn)
+
+    run_command(
+        f"""
+        CREATE TABLE test_num_flavors_after (LIKE test_num_flavors);
+        COPY test_num_flavors_after FROM '{parquet_path}' WITH (format 'parquet');
+        """,
+        pg_conn,
+    )
+
+    after = run_query(_NUM_FLAVORS_LEAVES % "test_num_flavors_after", pg_conn)
+    assert after == before
 
     pg_conn.rollback()
 

--- a/pg_lake_engine/include/pg_lake/pgduck/parse_struct.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/parse_struct.h
@@ -42,6 +42,9 @@ typedef struct CompositeCol
 {
 	char	   *colName;		/* the column name */
 	Oid			colType;		/* our oid type, or 0 if not yet allocated  */
+	int32		colTypeMod;		/* typmod of colType, or -1 if none; for an
+								 * array field this is the element typmod, as
+								 * in pg_attribute.atttypmod */
 	char	   *colTypeName;	/* string version of the type */
 	CompositeType *subStruct;	/* for a non-composite type, NULL; for
 								 * composite, pointer to that type's struct */

--- a/pg_lake_engine/src/pgduck/parse_struct.c
+++ b/pg_lake_engine/src/pgduck/parse_struct.c
@@ -296,10 +296,14 @@ ParseStructColumn(StructParserState * parse)
 	/*
 	 * If we are not a supported builting type, this should be InvalidOid,
 	 * which will later be assigned in the createUncreatedTypes() routine
+	 *
+	 * GetPGTypeForDuckDBTypeNameBuiltin only assigns typeMod for types that
+	 * carry one, so seed it with "no modifier" first.
 	 */
-	int			typeMod;
+	int			typeMod = -1;
 
 	myCol->colType = GetPGTypeForDuckDBTypeNameBuiltin(fieldType, &typeMod, isArray);
+	myCol->colTypeMod = typeMod;
 	myCol->colTypeName = fieldType;
 	myCol->isArray = isArray;
 	myCol->colName = fieldName;
@@ -1091,10 +1095,13 @@ GetDuckDBStructDefinitionForCompositeType(CompositeType * type,
 		{
 			/*
 			 * Now add our simple type string -- array handling added later,
-			 * so use underlying element type.
+			 * so use underlying element type.  The typmod has to travel with
+			 * the oid, otherwise a numeric(p,s) field would render as a bare
+			 * DECIMAL and DuckDB would resolve it to its own default.
 			 */
 
-			PGType		baseColumnType = MakePGTypeOid(GetRelatedTypeOid(col->colType, false));
+			PGType		baseColumnType = MakePGType(GetRelatedTypeOid(col->colType, false),
+													col->colTypeMod);
 			DuckDBType	duckDBType = GetDuckDBTypeForPGType(baseColumnType);
 
 			if (duckDBType)
@@ -1215,6 +1222,12 @@ GetCompositeTypeForPGType(Oid postgresType)
 
 		col->colType = GetRelatedTypeOid(rawTypid, false);
 		col->isArray = rawTypid != col->colType;
+
+		/*
+		 * atttypmod already refers to the element type for an array
+		 * attribute, so it pairs with the unwrapped colType either way.
+		 */
+		col->colTypeMod = attr->atttypmod;
 
 		/*
 		 * We need more info about this type than just the name, so already

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -22,6 +22,7 @@
 #include "pg_lake/pgduck/parse_struct.h"
 #include "pg_lake/pgduck/type.h"
 #include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_extension_base/extension_ids.h"
 #include "pg_lake/extensions/pg_map.h"
 #include "pg_lake/extensions/postgis.h"
@@ -532,7 +533,14 @@ GetFullDuckDBTypeNameForPGType(PGType postgresType, CopyDataFormat format)
 		/* get the element type and return [] after */
 		Oid			elementType = get_element_type(postgresType.postgresTypeOid);
 
-		return psprintf("%s[]", GetFullDuckDBTypeNameForPGType(MakePGTypeOid(elementType), format));
+		/*
+		 * A typmod on an array type always describes its element (that is how
+		 * pg_attribute.atttypmod stores it), so hand it to the element.
+		 */
+		return psprintf("%s[]",
+						GetFullDuckDBTypeNameForPGType(MakePGType(elementType,
+																  postgresType.postgresTypeMod),
+													   format));
 	}
 
 	if (myType == DUCKDB_TYPE_STRUCT)
@@ -547,15 +555,30 @@ GetFullDuckDBTypeNameForPGType(PGType postgresType, CopyDataFormat format)
 
 	const char *typeName = GetDuckDBTypeName(myType);
 
-	if (myType == DUCKDB_TYPE_DECIMAL && postgresType.postgresTypeMod != -1)
+	if (myType == DUCKDB_TYPE_DECIMAL)
 	{
-		StringInfo	typeNameWithMod = makeStringInfo();
+		/*
+		 * Decide the DECIMAL width exactly as the top-level column path does
+		 * (see ChooseDuckDBEngineTypeForWrite), so a numeric nested in a
+		 * struct, list or map is stored the same way as the same numeric in a
+		 * table column, and matches the decimal type the Iceberg schema
+		 * declares for it.  Notably, an unbounded numeric gets the configured
+		 * default precision/scale rather than DuckDB's own DECIMAL default,
+		 * which is narrower than what the CSV writer already lets through.
+		 */
+		int			precision = -1;
+		int			scale = -1;
 
-		appendStringInfo(typeNameWithMod, "%s(%d,%d)", typeName,
-						 numeric_typmod_precision(postgresType.postgresTypeMod),
-						 numeric_typmod_scale(postgresType.postgresTypeMod));
+		GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(postgresType.postgresTypeMod,
+															 &precision, &scale);
 
-		return typeNameWithMod->data;
+		if (!CanPushdownNumericToDuckdb(precision, scale))
+		{
+			/* too wide for DuckDB; fall back to text, as we do elsewhere */
+			return GetDuckDBTypeName(DUCKDB_TYPE_VARCHAR);
+		}
+
+		return psprintf("%s(%d,%d)", typeName, precision, scale);
 	}
 
 	return typeName;

--- a/pg_lake_table/tests/pytests/test_complex_types.py
+++ b/pg_lake_table/tests/pytests/test_complex_types.py
@@ -444,3 +444,105 @@ def test_add_column_composite_with_dropped_attribute(
     pg_conn.rollback()
     run_command("DROP SCHEMA IF EXISTS dropped_attribute_add CASCADE;", pg_conn)
     pg_conn.commit()
+
+
+def _parquet_decimal_leaves(superuser_conn, pgduck_conn, qualified_table):
+    """
+    Return ``{leaf_name: (precision, scale)}`` for every DECIMAL leaf physically
+    present in the table's data files, read straight from the Parquet footer.
+    """
+    files = run_query(
+        f"SELECT path FROM lake_table.files "
+        f"WHERE table_name = '{qualified_table}'::regclass",
+        superuser_conn,
+    )
+    assert files, f"expected at least one data file for {qualified_table}"
+
+    leaves = {}
+    for (path,) in files:
+        rows = run_query(
+            "SELECT name, precision, scale FROM parquet_schema("
+            f"'{path}') WHERE converted_type = 'DECIMAL'",
+            pgduck_conn,
+        )
+        for name, precision, scale in rows:
+            leaves[name] = (precision, scale)
+
+    return leaves
+
+
+def test_numeric_typmod_inside_composite(
+    pg_conn, superuser_conn, pgduck_conn, extension, s3, with_default_location
+):
+    """
+    A numeric(p,s) field of a composite type must be written with its own
+    precision and scale, not DuckDB's default DECIMAL(18,3), which rounded the
+    value and disagreed with the decimal type declared in the Iceberg schema.
+    """
+    run_command(
+        """
+        CREATE SCHEMA numeric_typmod;
+        SET search_path TO numeric_typmod;
+        CREATE TYPE nested_slot AS (deep numeric(10,4));
+        CREATE TYPE slot AS (amount numeric(10,4),
+                             amounts numeric(10,4)[],
+                             sub nested_slot,
+                             label text);
+        CREATE TABLE slots (
+            id integer,
+            top numeric(10,4),
+            arr numeric(10,4)[],
+            nested slot,
+            nested_arr slot[]
+        ) USING iceberg;
+        INSERT INTO slots VALUES (
+            1,
+            1.2345,
+            ARRAY[1.2345::numeric(10,4)],
+            ROW(1.2345, ARRAY[1.2345::numeric(10,4)], ROW(1.2345)::nested_slot, 'x')::slot,
+            ARRAY[ROW(1.2345, ARRAY[1.2345::numeric(10,4)], ROW(1.2345)::nested_slot, 'y')::slot]
+        );
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Every numeric must keep all four fractional digits, wherever it is nested.
+    res = run_query(
+        """
+        SELECT top, arr,
+               (nested).amount, (nested).amounts, ((nested).sub).deep,
+               (nested_arr[1]).amount, (nested_arr[1]).amounts,
+               ((nested_arr[1]).sub).deep
+        FROM slots WHERE id = 1
+        """,
+        pg_conn,
+    )
+    expected = Decimal("1.2345")
+    assert res[0] == [
+        expected,
+        [expected],
+        expected,
+        [expected],
+        expected,
+        expected,
+        [expected],
+        expected,
+    ]
+
+    # The Parquet footer must agree with the numeric(10,4) declared in Postgres
+    # (and hence with the decimal(10,4) in the Iceberg schema) for every leaf.
+    leaves = _parquet_decimal_leaves(
+        superuser_conn, pgduck_conn, "numeric_typmod.slots"
+    )
+    assert leaves == {
+        "top": (10, 4),
+        "element": (10, 4),
+        "amount": (10, 4),
+        "deep": (10, 4),
+    }, leaves
+
+    pg_conn.rollback()
+    run_command("DROP SCHEMA IF EXISTS numeric_typmod CASCADE;", pg_conn)
+    run_command("RESET search_path;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
Fixes #524.

A `numeric(p,s)` field of a composite type was written to Parquet as DuckDB's default `DECIMAL(18,3)`, so values were silently rounded to three fractional digits and the data file disagreed with the `decimal(p,s)` the Iceberg schema declares for the same field:

```sql
CREATE TYPE slot AS (amount numeric(10,4));
CREATE TABLE slots (nested slot) USING iceberg;
INSERT INTO slots VALUES (ROW(1.2345)::slot);
SELECT (nested).amount FROM slots;   -- 1.2350 before, 1.2345 now
```

## Cause

The intermediate composite representation had nowhere to keep a field's typmod: `GetCompositeTypeForPGType()` discarded `pg_attribute.atttypmod`, so the STRUCT string built for the CSV-to-Parquet write handed DuckDB a bare `DECIMAL`, which DuckDB resolves to its own default width. `CompositeCol` now carries the typmod and it is passed along with the oid in both directions. The `LIST` branch of `GetFullDuckDBTypeNameForPGType()` dropped it the same way, which affected an array reached through a container.

The bug applied to a struct field, an array inside a struct, a nested struct, and all of those inside an array of structs. A top-level column or top-level array was already correct, because the top-level write path keeps the typmod when it unwraps the array.

## Also here

Nested `DECIMAL` widths are now rendered with the same rule the top-level column path uses (`GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod` plus `CanPushdownNumericToDuckdb`) rather than the raw typmod. This means an unbounded `numeric` nested in a composite gets the configured default precision/scale instead of DuckDB's narrower default — the CSV writer already permits 29 integral digits for an unbounded numeric at any nesting depth, which `DECIMAL(18,3)` cannot hold — and precision/scale combinations DuckDB rejects fall back to text, as the top-level path and the Iceberg metadata already do.

## Testing

New `test_numeric_typmod_inside_composite` covers every nesting position and asserts both the value round-trip and that the Parquet footer declares `decimal(10,4)` for each leaf, so it also catches a footer that silently disagrees with the Iceberg schema.

`pg_lake_table` numeric/complex-type/Iceberg-type/field-id/interval/timetz suites and the `pg_lake_iceberg` pytests pass. Twelve failures in `test_iceberg_read_only_table`, `test_iceberg_size_clamping_containers` and `test_recovery` on my machine reproduce identically without this change and are unrelated (a stale local `pgduck_server`).