### PR TITLE
Use scratch memory contexts at commit time

### DIFF
--- a/pg_lake_engine/include/pg_lake/util/s3_writer_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/s3_writer_utils.h
@@ -23,6 +23,7 @@
 /* pg_lake_engine.max_parallel_file_uploads */
 extern int32 MaxParallelFileUploads;
 
+extern PGDLLEXPORT char *GenerateTempFileNameForUpload(char *pattern);
 extern PGDLLEXPORT void ScheduleFileCopyToS3WithCleanup(char *localFilePath, char *s3Uri, bool autoDeleteRecord);
 extern PGDLLEXPORT void CopyLocalFileToS3(char *localFilePath, char *s3Uri);
 extern PGDLLEXPORT void CopyLocalFileToS3NoCache(char *localFilePath, char *s3Uri);

--- a/pg_lake_engine/src/data_file/data_files.c
+++ b/pg_lake_engine/src/data_file/data_files.c
@@ -120,7 +120,12 @@ DeepCopyDataFileStats(const DataFileStats * stats)
 {
 	DataFileStats *copiedStats = palloc0(sizeof(DataFileStats));
 
-	copiedStats->dataFilePath = pstrdup(stats->dataFilePath);
+	/*
+	 * Files read from the files catalog carry their path in TableDataFile
+	 * rather than in the stats, so both string fields can be unset.
+	 */
+	copiedStats->dataFilePath = stats->dataFilePath ? pstrdup(stats->dataFilePath) : NULL;
+	copiedStats->partitionKeysText = stats->partitionKeysText ? pstrdup(stats->partitionKeysText) : NULL;
 	copiedStats->fileSize = stats->fileSize;
 	copiedStats->rowCount = stats->rowCount;
 	copiedStats->deletedRowCount = stats->deletedRowCount;

--- a/pg_lake_engine/src/utils/s3_writer_utils.c
+++ b/pg_lake_engine/src/utils/s3_writer_utils.c
@@ -23,6 +23,7 @@
 #include "pg_lake/cleanup/in_progress_files.h"
 #include "pg_lake/pgduck/client.h"
 #include "pg_lake/pgduck/parallel_command.h"
+#include "pg_lake/storage/local_storage.h"
 #include "pg_lake/util/path_hash.h"
 #include "pg_lake/util/s3_reader_utils.h"
 #include "pg_lake/util/s3_writer_utils.h"
@@ -55,6 +56,35 @@ static HTAB *PendingUploads = NULL;
 
 /* pg_lake_engine.max_parallel_file_uploads setting */
 int			MaxParallelFileUploads = DEFAULT_MAX_PARALLEL_FILE_UPLOADS;
+
+
+/*
+ * GenerateTempFileNameForUpload returns the path of a temporary file that is
+ * going to be scheduled for upload with ScheduleFileCopyToS3WithCleanup.
+ *
+ * Callers could use GenerateTempFileName directly, but that ties the deletion
+ * of the local file to the caller's memory context, while the upload itself
+ * only happens when FinishAllUploads is called. That makes it unsafe for a
+ * caller to run in a context that is reset before then, which is easy to get
+ * wrong. Register the deletion on the upload scheduling context instead, so
+ * the local file lives exactly as long as the upload that needs it: it is
+ * deleted once the uploads are done, or when the transaction ends without
+ * them happening.
+ */
+char *
+GenerateTempFileNameForUpload(char *pattern)
+{
+	InitUploadScheduling();
+
+	MemoryContext oldContext = MemoryContextSwitchTo(UploadSchedulingContext);
+
+	bool		ensureCleanup = true;
+	char	   *localFilePath = GenerateTempFileName(pattern, ensureCleanup);
+
+	MemoryContextSwitchTo(oldContext);
+
+	return localFilePath;
+}
 
 
 /*

--- a/pg_lake_iceberg/src/iceberg/api/manifest.c
+++ b/pg_lake_iceberg/src/iceberg/api/manifest.c
@@ -97,7 +97,7 @@ FetchManifestsFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manif
 int64_t
 UploadIcebergManifestToURI(List *manifestEntries, char *manifestURI)
 {
-	char	   *localManifestPath = GenerateTempFileName(PG_LAKE_ICEBERG, true);
+	char	   *localManifestPath = GenerateTempFileNameForUpload(PG_LAKE_ICEBERG);
 
 	WriteIcebergManifest(localManifestPath, manifestEntries);
 

--- a/pg_lake_iceberg/src/iceberg/api/manifest_list.c
+++ b/pg_lake_iceberg/src/iceberg/api/manifest_list.c
@@ -35,7 +35,7 @@
 int64_t
 UploadIcebergManifestListToURI(List *manifestList, char *manifestListURI)
 {
-	char	   *localManifestListPath = GenerateTempFileName(PG_LAKE_ICEBERG, true);
+	char	   *localManifestListPath = GenerateTempFileNameForUpload(PG_LAKE_ICEBERG);
 
 	WriteIcebergManifestList(localManifestListPath, manifestList);
 

--- a/pg_lake_iceberg/src/iceberg/api/table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/api/table_metadata.c
@@ -405,7 +405,7 @@ WriteMetadataJsonToTemporaryFile(IcebergTableMetadata * metadata, FILE *file)
 void
 UploadTableMetadataToURI(IcebergTableMetadata * tableMetadata, char *metadataURI)
 {
-	char	   *localFilePath = GenerateTempFileName(PG_LAKE_ICEBERG, true);
+	char	   *localFilePath = GenerateTempFileNameForUpload(PG_LAKE_ICEBERG);
 
 	/* open the destination file for writing */
 	FILE	   *localFile = AllocateFile(localFilePath, PG_BINARY_W);

--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -1120,14 +1120,8 @@ CreateNewManifestsForDeletedEntries(List *allManifestEntries, List *deletedManif
  *     perManifestCtx, which is destroyed before returning.
  *
  *   - The WRITE phase (UploadIcebergManifestToURI, the new IcebergManifest
- *     headers) is run in callerCtx.  This is required, not just convenient:
- *     UploadIcebergManifestToURI -> GenerateTempFileName registers a
- *     callback on the current memory context that unlinks the local temp
- *     file when that context is reset.  The actual S3 upload is deferred
- *     until commit, so the callback must outlive this function.  Running
- *     the WRITE phase in callerCtx also means the resulting IcebergManifest
- *     headers are already in callerCtx and can be appended to the final
- *     lists directly.
+ *     headers) is run in callerCtx, so that the resulting IcebergManifest
+ *     headers can be appended to the final lists directly.
  *
  * Callers must not be in perManifestCtx when calling this function -- it
  * unconditionally restores CurrentMemoryContext to whatever it was on

--- a/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
+++ b/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
@@ -504,18 +504,14 @@ RemoveDeletedManifestEntriesInternal(IcebergManifest * *manifest, IcebergSnapsho
 	 *
 	 * Use two memory contexts:
 	 *
-	 * - callerCtx      : holds the new IcebergManifest header we hand back,
-	 * and the local temp file registered for upload at commit time.
+	 * - callerCtx      : holds the new IcebergManifest header we hand back.
 	 *
 	 * - perManifestCtx : holds the manifest entries we read and the filtered
 	 * list we build from them.  We free this before returning.
 	 *
 	 * The WRITE phase (GenerateRemoteManifestPath,
-	 * UploadIcebergManifestToURI, CreateNewIcebergManifest) must run in
-	 * callerCtx, because UploadIcebergManifestToURI -> GenerateTempFileName
-	 * registers a callback on the current memory context that unlinks the
-	 * local temp file when that context is reset.  The matching upload is
-	 * deferred until commit, so the callback has to outlive this function.
+	 * UploadIcebergManifestToURI, CreateNewIcebergManifest) runs in
+	 * callerCtx, so that the manifest header we return is already there.
 	 */
 	bool		modified = false;
 

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -278,6 +278,14 @@ GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnl
 		 */
 		if (!fileFound)
 		{
+			/*
+			 * dynahash only fills in the key of a new entry, so clear the
+			 * rest before we start filling it in. Callers are allowed to copy
+			 * a TableDataFile out of the hash, and the fields this function
+			 * does not set (such as stats.dataFilePath) are pointers.
+			 */
+			memset(dataFile, 0, sizeof(TableDataFile));
+
 			dataFile->fileId = fileId;
 
 			bool		isPathNull = false;

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1544,7 +1544,6 @@ CopyAddDataFileOperation(const TableDataFile * dataFile)
 {
 	DataFileStats *copiedStats = DeepCopyDataFileStats(&dataFile->stats);
 
-	/* a NULL partition is valid, there is nothing to copy then */
 	Partition  *copiedPartition =
 		dataFile->partition != NULL ? CopyPartition(dataFile->partition) : NULL;
 

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -31,6 +31,7 @@
 #include "pg_lake/iceberg/metadata_operations.h"
 #include "pg_lake/iceberg/operations/find_referenced_files.h"
 #include "pg_lake/iceberg/operations/manifest_merge.h"
+#include "pg_lake/iceberg/partitioning/partition.h"
 #include "pg_lake/iceberg/partitioning/spec_generation.h"
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
@@ -101,6 +102,7 @@ static List *FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTable
 static IcebergTableMetadata * GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker);
 static List *GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 										   List *allTransforms);
+static TableMetadataOperation * CopyAddDataFileOperation(const TableDataFile * dataFile);
 static List *GetDDLMetadataOperations(const TableMetadataOperationTracker * opTracker);
 static void DeleteInProgressAddedFiles(Oid relationId, List *addedFiles);
 static bool AreSchemasEqual(IcebergTableSchema * existingSchema, DataFileSchema * newSchema);
@@ -911,6 +913,25 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 	HASH_SEQ_STATUS status;
 	TableMetadataOperationTracker *opTracker;
 
+	/*
+	 * Everything we do per relation below — the data file diff, the
+	 * metadata operations, the new Iceberg metadata and manifests — is only
+	 * needed while that relation is being processed. A transaction that
+	 * writes to many lake tables would otherwise pay the sum of the
+	 * per-relation peaks instead of the largest one, so reset a scratch
+	 * context between relations.
+	 *
+	 * What has to outlive an iteration already lives elsewhere: the files
+	 * staged for upload, and the local temp files holding their contents, are
+	 * held by the upload scheduling context, and REST catalog request bodies
+	 * are copied into TopTransactionContext by RecordRestCatalogRequestInTx.
+	 */
+	MemoryContext outerContext = CurrentMemoryContext;
+	MemoryContext perRelationContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "pg_lake per-relation metadata changes",
+							  ALLOCSET_DEFAULT_SIZES);
+
 	hash_seq_init(&status, trackedRelations);
 	while ((opTracker = hash_seq_search(&status)) != NULL)
 	{
@@ -919,6 +940,8 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 		/* relation is dropped */
 		if (!RelationExistsInTheIcebergCatalog(relationId))
 			continue;
+
+		MemoryContextSwitchTo(perRelationContext);
 
 		List	   *allTransforms = AllPartitionTransformList(relationId);
 
@@ -1001,7 +1024,12 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 			}
 
 		}
+
+		MemoryContextSwitchTo(outerContext);
+		MemoryContextReset(perRelationContext);
 	}
+
+	MemoryContextDelete(perRelationContext);
 
 	/* now write all the metadata files to object storage in parallel */
 	FinishAllUploads();
@@ -1360,6 +1388,23 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 							  List *allTransforms)
 {
 	/*
+	 * The catalog read below is proportional to the number of files in the
+	 * table, while the operations we return are proportional to the number of
+	 * files this transaction changed. Read into a scratch context so the
+	 * difference does not survive until the end of the transaction: the path,
+	 * partition values and column stats of every file in the table are
+	 * allocated per file, and until now they were allocated in the caller's
+	 * context and stayed there long after the diff was done.
+	 */
+	MemoryContext resultContext = CurrentMemoryContext;
+	MemoryContext catalogContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "pg_lake pre-commit data file diff",
+							  ALLOCSET_DEFAULT_SIZES);
+
+	MemoryContextSwitchTo(catalogContext);
+
+	/*
 	 * get current state of data files, which are not applied to metadata yet,
 	 * from catalog
 	 *
@@ -1399,6 +1444,9 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	if (opTracker->relationDataFilesRemoveAllSeen &&
 		hash_get_num_entries(currentFilesMap) == 0)
 	{
+		MemoryContextSwitchTo(resultContext);
+		MemoryContextDelete(catalogContext);
+
 		TableMetadataOperation *removeAllOp = palloc0(sizeof(TableMetadataOperation));
 
 		removeAllOp->type = DATA_FILE_REMOVE_ALL;
@@ -1430,6 +1478,14 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	 */
 	DeleteInProgressAddedFiles(opTracker->relationId, addedFiles);
 
+	/*
+	 * Build the operations we return in the caller's context. Everything they
+	 * point to is copied out of the scratch context, so the memory we keep is
+	 * proportional to the files this transaction changed rather than to the
+	 * files in the table.
+	 */
+	MemoryContextSwitchTo(resultContext);
+
 	List	   *metadataOperations = NIL;
 
 	/* create operations for added files */
@@ -1439,11 +1495,8 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	{
 		TableDataFile *addedFile = lfirst(addedFileCell);
 
-		TableMetadataOperation *addFileOp =
-			AddDataFileOperation(addedFile->path, addedFile->content, &addedFile->stats,
-								 addedFile->partition, addedFile->partitionSpecId);
-
-		metadataOperations = lappend(metadataOperations, addFileOp);
+		metadataOperations = lappend(metadataOperations,
+									 CopyAddDataFileOperation(addedFile));
 	}
 
 	/* create operations for removed files */
@@ -1453,22 +1506,49 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	{
 		char	   *removedFilePath = lfirst(removedFileCell);
 
-		TableMetadataOperation *removedFileOp = RemoveDataFileOperation(removedFilePath);
+		TableMetadataOperation *removedFileOp = RemoveDataFileOperation(pstrdup(removedFilePath));
 
 		metadataOperations = lappend(metadataOperations, removedFileOp);
 	}
 
 	/*
-	 * The path index over the catalog file list is only needed for the diff
-	 * above, so drop it now rather than leaving one per relation behind until
-	 * the transaction ends. The operations we return do not point into it:
-	 * the path, partition and column stats of each added file were allocated
-	 * separately and outlive it, and the removed paths are copies. addedFiles
-	 * does point into it, so it must not be used after this.
+	 * The catalog file list, the path index over it and the paths of the last
+	 * pushed metadata were only needed to compute the operations above, and
+	 * are the widest thing we allocate per file. Drop them now rather than
+	 * leaving one set per relation behind until the transaction ends. Nothing
+	 * we return points into them: the operations carry their own copies, and
+	 * addedFiles / removedFilePaths must not be used after this.
 	 */
-	hash_destroy(currentFilesMap);
+	MemoryContextDelete(catalogContext);
 
 	return metadataOperations;
+}
+
+
+/*
+ * CopyAddDataFileOperation creates a DATA_FILE_ADD operation for the given data
+ * file in the current memory context, deep copying everything the operation
+ * points to.
+ *
+ * The data file itself lives in the scratch context that GetDataFileMetadataOperations
+ * reads the catalog into, and that context is gone by the time the operation is
+ * applied, so the operation cannot alias the path, stats or partition of it.
+ */
+static TableMetadataOperation *
+CopyAddDataFileOperation(const TableDataFile * dataFile)
+{
+	DataFileStats *copiedStats = DeepCopyDataFileStats(&dataFile->stats);
+
+	/*
+	 * The catalog read always gives a data file a Partition, empty for an
+	 * unpartitioned table, but do not rely on that here.
+	 */
+	Partition  *copiedPartition =
+		dataFile->partition != NULL ? CopyPartition(dataFile->partition) : NULL;
+
+	return AddDataFileOperation(pstrdup(dataFile->path), dataFile->content,
+								copiedStats, copiedPartition,
+								dataFile->partitionSpecId);
 }
 
 

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -925,6 +925,11 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 	 * staged for upload, and the local temp files holding their contents, are
 	 * held by the upload scheduling context, and REST catalog request bodies
 	 * are copied into TopTransactionContext by RecordRestCatalogRequestInTx.
+	 *
+	 * An error in the loop needs no handling of its own. The scratch context
+	 * is a child of the caller's context, which is the transaction context at
+	 * pre-commit and the subtransaction context under VACUUM, so it is
+	 * deleted along with its parent when the (sub)transaction aborts.
 	 */
 	MemoryContext outerContext = CurrentMemoryContext;
 	MemoryContext perRelationContext =
@@ -1539,10 +1544,7 @@ CopyAddDataFileOperation(const TableDataFile * dataFile)
 {
 	DataFileStats *copiedStats = DeepCopyDataFileStats(&dataFile->stats);
 
-	/*
-	 * The catalog read always gives a data file a Partition, empty for an
-	 * unpartitioned table, but do not rely on that here.
-	 */
+	/* a NULL partition is valid, there is nothing to copy then */
 	Partition  *copiedPartition =
 		dataFile->partition != NULL ? CopyPartition(dataFile->partition) : NULL;
 


### PR DESCRIPTION
Implements items 2 and 3 of #522, on top of #511.

### 2. Build the catalog read in a scratch context

`GetDataFileMetadataOperations` reads the full set of data files currently in the files catalog into a hash table and walks the Iceberg metadata, only to work out which files this transaction added and removed. Everything it reads — the path, partition values and column statistics of *every* file in the table — was allocated in the caller's context, so it survived to the end of the transaction even though only the added files are needed downstream. #511 dropped the hash table itself; this drops the ~800 B per file that was left behind, which is also why RSS stayed elevated after the commit returned.

The read now happens in a scratch context that is deleted before returning, and the operations that are returned deep-copy what they need into the caller's context.

Two latent bugs on that copy path had to be fixed first:

- `GetTableDataFilesHashFromCatalog` left the parts of a new hash entry that it does not set uninitialized, because `hash_search(HASH_ENTER)` only fills in the key. Some of those fields are pointers (e.g. `stats.dataFilePath`), so a caller copying a `TableDataFile` out of the hash would follow garbage. It now `memset`s the entry first.
- `DeepCopyDataFileStats` dereferenced both string fields unconditionally, and both are unset for files read from the files catalog, which carries the path in `TableDataFile` instead. It also silently dropped `partitionKeysText`.

### 3. Reset a per-relation context inside the pre-commit loop

`ApplyTrackedIcebergMetadataChanges` loops over every lake table written to in the transaction and left everything in `TopTransactionContext`, so a transaction touching N lake tables paid the *sum* of the per-table peaks rather than the largest one. Each iteration now runs in a scratch context that is reset between relations.

As #522 predicted, what has to outlive an iteration already lives elsewhere — the staged uploads and the REST catalog request bodies — with one exception the issue did not anticipate, which is the first commit here.

### Temp file lifetime (prerequisite for 3)

Manifests, manifest lists and table metadata are written to a local temp file whose name comes from `GenerateTempFileName(pattern, true)`, and are then handed to `ScheduleFileCopyToS3WithCleanup`, which only performs the copy when `FinishAllUploads` runs at the end of pre-commit. `GenerateTempFileName` with `ensureCleanup` registers the *unlink* of that local file on `CurrentMemoryContext` — so resetting the writer's context deletes the file out from under an upload that has not happened yet. Item 3 does exactly that, and the test suite duly failed with `IO Error: Cannot open file ".../pgsql_tmp.pg_lake_iceberg_283880.4"` on commit.

The constraint existed before this PR; it is just invisible at the call site, and two functions in the write path already carried comments explaining that they must not run in a context that gets reset. The first commit adds `GenerateTempFileNameForUpload`, which registers the cleanup on the upload scheduling context, so the local file lives exactly as long as the upload that reads it — deleted once the uploads are done, or when the transaction ends without them happening. The three deferred uploads use it, and those two comments lose a paragraph each. The immediate `CopyLocalFileToS3*` callers keep `GenerateTempFileName`, since for them the file is already gone before their context is reset.

### Measurements

Item 3 needs a transaction that writes to more than one lake table, which the single-table benchmark in #522 cannot show. Four partitioned Iceberg tables, 2 500 data files and 10 manifests each, `enable_manifest_merge_on_write = off`, then one small `INSERT` into every one of them in a single transaction, measuring `VmHWM` of that backend:

| variant | peak RSS | peak over pre-commit RSS | commit |
|---|---|---|---|
| main | 60.7 MB | 13.1 MB | 0.5 s |
| this PR | 40.9 MB | 4.5 MB | 0.5 s |

The delta over pre-commit RSS is the part this PR moves — 13.1 MB → 4.5 MB, i.e. the transaction now pays roughly one relation's peak instead of four. The absolute peaks are lower than #522's table because each table here is an eighth of the size.

Both variants are the same build differing only by the second commit, swapped as `pg_lake_table.so` with a restart in between, so the comparison isolates these changes.

#### At 60 000 data files

The same four table shape scaled up, plus the two single table cases, measuring `MemoryContextMemAllocated(TopTransactionContext)` at three points in `ApplyTrackedIcebergMetadataChanges` (before the loop, after a relation's metadata is built, after `FinishAllUploads`) as well as the backend's peak RSS. The data files here are registered as `lake_table.files` and `lake_table.data_file_column_stats` rows in the same transaction as a real `INSERT`, rather than written for real, which keeps the pre-commit path identical and gets a 60 000 file transaction down to a few seconds to set up.

| variant | one table, 60 000 new files | 4 tables, 15 000 new files each | small `INSERT` into a table that already has 60 000 files |
|---|---|---|---|
| main | 213.4 MB peak, 213.3 MB still held after the uploads | 53 / 107 / 160 / 213 MB after each relation, peak RSS 356 MB | 16.8 MB held per commit |
| this PR | 195.7 MB peak, 0.1 MB held | 51 MB after every relation, peak RSS 239 MB | 0.04 MB held |

Three separate effects:

- The single table column is item 2 on its own. It takes 8% off the peak, because the catalog read no longer overlaps the operations built from it, and it releases the 213 MB before the manifests are uploaded instead of at the end of the transaction. Peak RSS for that case is unchanged (347 MB against 359 MB), since the freed memory goes back to the context free lists rather than to the OS. It matters for what runs after, not for the high water mark.
- The four table column is item 3. The transaction pays one relation's peak instead of four, and that does show in peak RSS, 356 MB down to 239 MB.
- The last column is the steady state for a large table. On main every commit leaves behind roughly 280 B per data file already in the catalog, 16.8 MB at 60 000 files, whether the transaction added one file or all of them. That is the part of item 2 that #511 could not reach.

Transient cost during the diff and apply is about 3.3 KB per added file either way; what changes is which context it lives in. Swapped the same way as the table above, and re-running main afterwards reproduced its numbers exactly.

### Testing

Green on CI. The temp file lifetime problem above was caught by the existing `pg_lake_table` pytest suite rather than by inspection, so it is worth noting that the suite does cover the failure mode.

