### PR TITLE
[release-3.4] Backport #528: use pointer keys in the object storage path hashes

### DIFF
--- a/pg_lake_engine/include/pg_lake/util/path_hash.h
+++ b/pg_lake_engine/include/pg_lake/util/path_hash.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Hash tables keyed on an object storage path.
+ *
+ * The straightforward way to key a dynahash on a path is a
+ * char[MAX_S3_PATH_LENGTH] key with HASH_STRINGS, but that reserves 1095
+ * bytes per entry for paths that are ~120 bytes in practice. On the
+ * pre-commit path we build such a hash over every file in the table, so the
+ * padding, not the data, dominated the peak.
+ *
+ * These helpers key on a char * instead: the entry holds only the pointer and
+ * the hash and match functions dereference it. There is deliberately no
+ * HASH_KEYCOPY, so the string is not copied and must outlive the hash. That
+ * is what callers want in the common case, where the path was already
+ * pstrdup'd out of SPI or Avro into a context at least as long-lived as the
+ * hash. A caller whose path lives in a scratch context it resets (one
+ * manifest at a time, say) has to copy the path itself before inserting it.
+ */
+
+#pragma once
+
+#include "utils/hsearch.h"
+#include "utils/palloc.h"
+
+/*
+ * PathHashEntry is the entry type of a path hash that carries no payload,
+ * i.e. a set of paths. Entries with a payload declare their own struct with a
+ * char * path as its first member.
+ */
+typedef struct PathHashEntry
+{
+	char	   *path;
+}			PathHashEntry;
+
+extern PGDLLEXPORT HTAB *CreatePathHash(const char *name, Size entrySize,
+										long nelem, MemoryContext context);
+extern PGDLLEXPORT void *PathHashSearch(HTAB *pathHash, const char *path,
+										HASHACTION action, bool *foundPtr);

--- a/pg_lake_engine/include/pg_lake/util/path_hash.h
+++ b/pg_lake_engine/include/pg_lake/util/path_hash.h
@@ -31,6 +31,7 @@
  * pstrdup'd out of SPI or Avro into a context at least as long-lived as the
  * hash. A caller whose path lives in a scratch context it resets (one
  * manifest at a time, say) has to copy the path itself before inserting it.
+ * Dereferencing the key also means a path can never be NULL.
  */
 
 #pragma once

--- a/pg_lake_engine/src/utils/path_hash.c
+++ b/pg_lake_engine/src/utils/path_hash.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "postgres.h"
+
+#include "common/hashfn.h"
+#include "pg_lake/util/path_hash.h"
+
+static uint32 PathHashKeyHash(const void *key, Size keysize);
+static int	PathHashKeyCompare(const void *key1, const void *key2, Size keysize);
+
+
+/*
+ * CreatePathHash creates a hash table keyed on a char * path.
+ *
+ * entrySize is the size of the caller's entry struct, whose first member must
+ * be the char * path. nelem and context have the same meaning as in
+ * hash_create.
+ *
+ * The hash stores the pointer, not the string, so every path handed to
+ * PathHashSearch with HASH_ENTER has to outlive the hash.
+ */
+HTAB *
+CreatePathHash(const char *name, Size entrySize, long nelem, MemoryContext context)
+{
+	HASHCTL		hashCtl;
+
+	Assert(entrySize >= sizeof(PathHashEntry));
+
+	memset(&hashCtl, 0, sizeof(hashCtl));
+	hashCtl.keysize = sizeof(char *);
+	hashCtl.entrysize = entrySize;
+	hashCtl.hash = PathHashKeyHash;
+	hashCtl.match = PathHashKeyCompare;
+	hashCtl.hcxt = context;
+
+	return hash_create(name, nelem, &hashCtl,
+					   HASH_ELEM | HASH_FUNCTION | HASH_COMPARE | HASH_CONTEXT);
+}
+
+
+/*
+ * PathHashSearch is hash_search for a hash created by CreatePathHash.
+ *
+ * dynahash copies keysize bytes from the key argument, which for a pointer key
+ * means the pointer itself, so the key argument is the address of the pointer
+ * rather than the pointer. Passing a path straight to hash_search would copy
+ * the first 8 bytes of the string instead, which is why this wrapper exists.
+ */
+void *
+PathHashSearch(HTAB *pathHash, const char *path, HASHACTION action, bool *foundPtr)
+{
+	return hash_search(pathHash, &path, action, foundPtr);
+}
+
+
+/*
+ * PathHashKeyHash hashes the string behind a pointer key.
+ *
+ * Unlike dynahash's string_hash it hashes the whole string, since there is no
+ * fixed key size to truncate to.
+ */
+static uint32
+PathHashKeyHash(const void *key, Size keysize PG_USED_FOR_ASSERTS_ONLY)
+{
+	Assert(keysize == sizeof(char *));
+
+	const char *path = *(const char *const *) key;
+
+	return hash_bytes((const unsigned char *) path, strlen(path));
+}
+
+
+/*
+ * PathHashKeyCompare compares the strings behind two pointer keys.
+ */
+static int
+PathHashKeyCompare(const void *key1, const void *key2, Size keysize PG_USED_FOR_ASSERTS_ONLY)
+{
+	Assert(keysize == sizeof(char *));
+
+	const char *path1 = *(const char *const *) key1;
+	const char *path2 = *(const char *const *) key2;
+
+	return strcmp(path1, path2);
+}

--- a/pg_lake_engine/src/utils/path_hash.c
+++ b/pg_lake_engine/src/utils/path_hash.c
@@ -87,6 +87,8 @@ PathHashKeyHash(const void *key, Size keysize PG_USED_FOR_ASSERTS_ONLY)
 
 	const char *path = *(const char *const *) key;
 
+	Assert(path != NULL);
+
 	return hash_bytes((const unsigned char *) path, strlen(path));
 }
 

--- a/pg_lake_engine/src/utils/path_hash.c
+++ b/pg_lake_engine/src/utils/path_hash.c
@@ -60,10 +60,16 @@ CreatePathHash(const char *name, Size entrySize, long nelem, MemoryContext conte
  * means the pointer itself, so the key argument is the address of the pointer
  * rather than the pointer. Passing a path straight to hash_search would copy
  * the first 8 bytes of the string instead, which is why this wrapper exists.
+ *
+ * The hash and match functions dereference the key, so path cannot be NULL.
+ * Every caller either takes the path from a catalog or manifest column that is
+ * NOT NULL, or filters nulls out before getting here.
  */
 void *
 PathHashSearch(HTAB *pathHash, const char *path, HASHACTION action, bool *foundPtr)
 {
+	Assert(path != NULL);
+
 	return hash_search(pathHash, &path, action, foundPtr);
 }
 

--- a/pg_lake_engine/src/utils/s3_writer_utils.c
+++ b/pg_lake_engine/src/utils/s3_writer_utils.c
@@ -23,6 +23,7 @@
 #include "pg_lake/cleanup/in_progress_files.h"
 #include "pg_lake/pgduck/client.h"
 #include "pg_lake/pgduck/parallel_command.h"
+#include "pg_lake/util/path_hash.h"
 #include "pg_lake/util/s3_reader_utils.h"
 #include "pg_lake/util/s3_writer_utils.h"
 #include "pg_lake/util/rel_utils.h"
@@ -33,10 +34,13 @@
 
 /*
  * ScheduledUpload represents an upload to be performed by FinishAllUpload.
+ *
+ * remoteUrl is the hash key and points into UploadSchedulingContext, which
+ * outlives the hash.
  */
 typedef struct ScheduledUpload
 {
-	char		remoteUrl[MAX_S3_PATH_LENGTH];
+	char	   *remoteUrl;
 	char		localFile[MAXPGPATH];
 }			ScheduledUpload;
 
@@ -108,7 +112,14 @@ ScheduleFileUpload(char *localFile, char *remoteUrl)
 	InitUploadScheduling();
 
 	bool		found = false;
-	ScheduledUpload *upload = hash_search(PendingUploads, remoteUrl, HASH_ENTER, &found);
+
+	/*
+	 * The hash keys on the pointer, so keep the URL in the scheduling context
+	 * rather than relying on the caller's, which can be a per-tuple context.
+	 */
+	char	   *scheduledUrl = MemoryContextStrdup(UploadSchedulingContext, remoteUrl);
+	ScheduledUpload *upload = PathHashSearch(PendingUploads, scheduledUrl,
+											 HASH_ENTER, &found);
 
 	if (found)
 		elog(ERROR, "%s scheduled for upload twice", remoteUrl);
@@ -142,15 +153,8 @@ InitUploadScheduling(void)
 	MemoryContextRegisterResetCallback(UploadSchedulingContext, cb);
 
 	/* create a URL -> local file hash */
-	HASHCTL		hashCtl;
-
-	memset(&hashCtl, 0, sizeof(hashCtl));
-	hashCtl.keysize = MAX_S3_PATH_LENGTH;
-	hashCtl.entrysize = sizeof(ScheduledUpload);
-	hashCtl.hcxt = UploadSchedulingContext;
-
-	PendingUploads = hash_create("scheduled uploads", 32, &hashCtl,
-								 HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
+	PendingUploads = CreatePathHash("scheduled uploads", sizeof(ScheduledUpload),
+									32, UploadSchedulingContext);
 }
 
 
@@ -215,7 +219,7 @@ GetPendingUploadLocalPath(const char *remoteUrl)
 	bool		found = false;
 
 	ScheduledUpload *upload =
-		hash_search(PendingUploads, remoteUrl, HASH_FIND, &found);
+		PathHashSearch(PendingUploads, remoteUrl, HASH_FIND, &found);
 
 	if (found)
 		localFile = upload->localFile;

--- a/pg_lake_iceberg/include/pg_lake/iceberg/operations/find_referenced_files.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/operations/find_referenced_files.h
@@ -20,10 +20,18 @@
 #include "postgres.h"
 
 #include "pg_lake/iceberg/api/table_metadata.h"
+#include "pg_lake/util/path_hash.h"
 
 extern PGDLLEXPORT List *FindUnreferencedFilesForSnapshots(IcebergSnapshot * prevSnapshots, int prevSnapshotCount,
 														   IcebergSnapshot * currentSnapshots, int currentSnapshotCount);
 extern PGDLLEXPORT List *IcebergFindAllReferencedFiles(char *metadataPath);
+
+/*
+ * A files hash is a path hash of PathHashEntry, so its entries are read as
+ * PathHashEntry * rather than as the path itself. AppendFileToHash copies the
+ * path into the caller's memory context, which therefore has to outlive the
+ * hash.
+ */
 extern PGDLLEXPORT bool AppendFileToHash(const char *path, HTAB *referencedFilesHash);
 extern PGDLLEXPORT HTAB *CreateFilesHash(void);
 extern PGDLLEXPORT List *FindUnreferencedFilesAmongHTABs(HTAB *prevReferencedFileHash, HTAB *currentReferencedFileHash);

--- a/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
+++ b/pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c
@@ -38,12 +38,8 @@
 #include "pg_lake/iceberg/operations/find_referenced_files.h"
 #include "pg_lake/util/array_utils.h"
 #include "pg_lake/util/injection_points.h"
+#include "pg_lake/util/path_hash.h"
 #include "pg_lake/util/s3_reader_utils.h"
-
-typedef struct FileHashEntry
-{
-	char		path[MAX_S3_PATH_LENGTH];
-}			FileHashEntry;
 
 PG_FUNCTION_INFO_V1(find_all_referenced_files);
 PG_FUNCTION_INFO_V1(find_unreferenced_files);
@@ -87,7 +83,7 @@ find_all_referenced_files(PG_FUNCTION_ARGS)
 
 	hash_seq_init(&status, fileHash);
 
-	FileHashEntry *entry = NULL;
+	PathHashEntry *entry = NULL;
 
 	while ((entry = hash_seq_search(&status)) != NULL)
 	{
@@ -140,7 +136,7 @@ find_all_referenced_files_via_snapshot_ids(PG_FUNCTION_ARGS)
 
 	hash_seq_init(&status, fileHash);
 
-	FileHashEntry *entry = NULL;
+	PathHashEntry *entry = NULL;
 
 	while ((entry = hash_seq_search(&status)) != NULL)
 	{
@@ -346,13 +342,13 @@ FindUnreferencedFilesAmongHTABs(HTAB *prevReferencedFileHash, HTAB *currentRefer
 	HASH_SEQ_STATUS status;
 
 	hash_seq_init(&status, prevReferencedFileHash);
-	FileHashEntry *entry = NULL;
+	PathHashEntry *entry = NULL;
 
 	while ((entry = hash_seq_search(&status)) != NULL)
 	{
 		bool		found = false;
 
-		hash_search(currentReferencedFileHash, entry->path, HASH_FIND, &found);
+		PathHashSearch(currentReferencedFileHash, entry->path, HASH_FIND, &found);
 
 		if (!found)
 		{
@@ -391,7 +387,7 @@ IcebergFindAllReferencedFiles(char *metadataPath)
 	HASH_SEQ_STATUS status;
 
 	hash_seq_init(&status, fileHash);
-	FileHashEntry *entry = NULL;
+	PathHashEntry *entry = NULL;
 
 	while ((entry = hash_seq_search(&status)) != NULL)
 	{
@@ -478,6 +474,13 @@ IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot * snapshot, HTAB *fileHash)
 		List	   *manifestDataFiles = FetchDataFilesFromManifest(manifest, NULL, IsManifestEntryStatusScannable, NULL);
 		ListCell   *dataFileCell = NULL;
 
+		/*
+		 * Add the paths from our own context: AppendFileToHash copies each
+		 * path into the current context, and the context above is about to be
+		 * reset.
+		 */
+		MemoryContextSwitchTo(oldContext);
+
 		foreach(dataFileCell, manifestDataFiles)
 		{
 			DataFile   *dataFile = lfirst(dataFileCell);
@@ -485,7 +488,6 @@ IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot * snapshot, HTAB *fileHash)
 			AppendFileToHash(dataFile->file_path, fileHash);
 		}
 
-		MemoryContextSwitchTo(oldContext);
 		MemoryContextReset(manifestDataFileFetchContext);
 	}
 
@@ -495,36 +497,43 @@ IcebergSnapshotAddAllReferencedFiles(IcebergSnapshot * snapshot, HTAB *fileHash)
 /*
 * CreateFilesHash creates a hash table that is suitable for storing
 * file paths.
+*
+* The hash keys on the path pointer, and AppendFileToHash copies the path into
+* the memory context that is current when it is called, so callers have to
+* append from a context that outlives the hash (not from a scratch context
+* they reset).
 */
 HTAB *
 CreateFilesHash(void)
 {
-	HASHCTL		hashCtl;
-
-	memset(&hashCtl, 0, sizeof(hashCtl));
-	hashCtl.keysize = MAX_S3_PATH_LENGTH;
-	hashCtl.entrysize = sizeof(FileHashEntry);
-	hashCtl.hcxt = CurrentMemoryContext;
-
-	HTAB	   *referencedFilesHash = hash_create("Referenced Files Hash",
-												  1024,
-												  &hashCtl,
-												  HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
-
-	return referencedFilesHash;
+	return CreatePathHash("Referenced Files Hash", sizeof(PathHashEntry),
+						  1024, CurrentMemoryContext);
 }
 
 
 /*
 * AppendFileToHash appends the file to the hash table, and
 * returns true if the file already exists in the hash table.
+*
+* The hash keeps a copy of the path, allocated in the caller's memory context,
+* so the caller has to append from a context that outlives the hash.
 */
 bool
 AppendFileToHash(const char *path, HTAB *referencedFilesHash)
 {
 	bool		found = false;
 
-	hash_search(referencedFilesHash, path, HASH_ENTER, &found);
+	PathHashSearch(referencedFilesHash, path, HASH_FIND, &found);
 
-	return found;
+	if (found)
+		return true;
+
+	/*
+	 * Only the pointer is stored, so the hash needs a copy of the path it can
+	 * keep. Callers hand us paths decoded from a manifest, which they discard
+	 * per manifest.
+	 */
+	PathHashSearch(referencedFilesHash, pstrdup(path), HASH_ENTER, NULL);
+
+	return false;
 }

--- a/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
+++ b/pg_lake_table/include/pg_lake/fdw/data_files_catalog.h
@@ -19,6 +19,7 @@
 
 #include "pg_lake/data_file/data_files.h"
 #include "pg_lake/iceberg/manifest_spec.h"
+#include "pg_lake/util/path_hash.h"
 #include "pg_lake/util/s3_reader_utils.h"
 
 #include "nodes/pg_list.h"
@@ -27,9 +28,10 @@
 #define DATA_FILES_TABLE_QUALIFIED \
 	PG_LAKE_TABLE_SCHEMA "." PG_LAKE_TABLE_FILES_TABLE_NAME
 
+/* filePath is the hash key; it points to the same string as dataFile.path */
 typedef struct TableDataFileHashEntry
 {
-	char		filePath[MAX_S3_PATH_LENGTH];
+	char	   *filePath;
 	TableDataFile dataFile;
 }			TableDataFileHashEntry;
 

--- a/pg_lake_table/src/fdw/data_file_pruning.c
+++ b/pg_lake_table/src/fdw/data_file_pruning.c
@@ -66,6 +66,7 @@
 #include "pg_lake/pgduck/map.h"
 #include "pg_lake/pgduck/type.h"
 #include "pg_lake/util/rel_utils.h"
+#include "pg_lake/util/path_hash.h"
 #include "pg_lake/util/s3_reader_utils.h"
 
 bool		EnableDataFilePruning = true;
@@ -1662,7 +1663,7 @@ PruneByFilename(List *paths, Oid relationId, List *baseRestrictInfoList)
 			/* we have a _filename = any(...) condition */
 			bool		isFound = false;
 
-			hash_search(batchFilterHash, path, HASH_ENTER, &isFound);
+			PathHashSearch(batchFilterHash, path, HASH_FIND, &isFound);
 
 			if (!isFound)
 				/* not in any(..), so prune */
@@ -1726,16 +1727,14 @@ TryCreateBatchFilterHash(List *baseRestrictInfoList, Var *filenameCol)
 		deconstruct_array_builtin(filenameArray, TEXTOID,
 								  &filenames, &filenameIsNull, &filenameCount);
 
-		int			hashFlags = HASH_ELEM | HASH_STRINGS | HASH_CONTEXT;
-		HASHCTL		hashCtl;
-
-		memset(&hashCtl, 0, sizeof(hashCtl));
-		hashCtl.keysize = MAX_S3_PATH_LENGTH;
-		hashCtl.entrysize = MAX_S3_PATH_LENGTH;
-		hashCtl.hcxt = CurrentMemoryContext;
-
+		/*
+		 * The hash keys on the path pointer, and TextDatumGetCString below
+		 * allocates in the context we create the hash in, so the keys outlive
+		 * it.
+		 */
 		HTAB	   *batchFilterHash =
-			hash_create("batch filter hash", filenameCount, &hashCtl, hashFlags);
+			CreatePathHash("batch filter hash", sizeof(PathHashEntry),
+						   filenameCount, CurrentMemoryContext);
 
 		for (int filenameIndex = 0; filenameIndex < filenameCount; filenameIndex++)
 		{
@@ -1744,11 +1743,9 @@ TryCreateBatchFilterHash(List *baseRestrictInfoList, Var *filenameCol)
 				continue;
 
 			char	   *path = TextDatumGetCString(filenames[filenameIndex]);
-			bool		isFound = false;
 
-			hash_search(batchFilterHash, path, HASH_ENTER, &isFound);
+			PathHashSearch(batchFilterHash, path, HASH_ENTER, NULL);
 		}
-
 		return batchFilterHash;
 	}
 

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -53,6 +53,7 @@
 #include "pg_lake/pgduck/remote_storage.h"
 #include "pg_lake/pgduck/write_data.h"
 #include "pg_lake/util/array_utils.h"
+#include "pg_lake/util/path_hash.h"
 #include "pg_lake/util/plan_cache.h"
 #include "pg_lake/util/s3_reader_utils.h"
 #include "pg_extension_base/spi_helpers.h"
@@ -391,7 +392,7 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 
 	while ((dataFile = hash_seq_search(&status)) != NULL)
 	{
-		TableDataFileHashEntry *dataFileEntry = hash_search(filesByPath, dataFile->path, HASH_ENTER, &found);
+		TableDataFileHashEntry *dataFileEntry = PathHashSearch(filesByPath, dataFile->path, HASH_ENTER, &found);
 
 		if (found)
 			elog(ERROR, "duplicate data file path found in catalog: %s", dataFile->path);
@@ -403,7 +404,8 @@ GetTableDataFilesByPathHashFromCatalog(Oid relationId, bool dataOnly, bool newFi
 	 * The by-id hash was only a staging area for grouping the SPI rows of one
 	 * file together, and every entry has been copied into filesByPath by now.
 	 * The path, partition and column stats each entry points to were
-	 * allocated in our own context, not in the hash's, so they survive.
+	 * allocated in our own context, not in the hash's, so they survive. That
+	 * includes the path each filesByPath entry keys on.
 	 */
 	hash_destroy(filesById);
 
@@ -488,8 +490,8 @@ LoadColumnStatsForFiles(Oid relationId, HTAB *filesByPath, List *dataFiles)
 		}
 
 		TableDataFileHashEntry *entry =
-			(TableDataFileHashEntry *) hash_search(filesByPath, path,
-												   HASH_FIND, NULL);
+			(TableDataFileHashEntry *) PathHashSearch(filesByPath, path,
+													  HASH_FIND, NULL);
 
 		if (entry == NULL)
 		{
@@ -701,23 +703,17 @@ CreateDataFilesHash(void)
 
 /*
  * CreateDataFilesByPathHash creates a hash table of path => TableDataFileHashEntry.
+ *
+ * The entries key on the path pointer, not on a copy of the path, so every
+ * path added to the hash has to outlive it. Callers add paths they read from
+ * the catalog into the current context, which is also the context of the hash.
  */
 static HTAB *
 CreateDataFilesByPathHash(void)
 {
-	HASHCTL		hashCtl;
-
-	memset(&hashCtl, 0, sizeof(hashCtl));
-	hashCtl.keysize = MAX_S3_PATH_LENGTH;
-	hashCtl.entrysize = sizeof(TableDataFileHashEntry);
-	hashCtl.hcxt = CurrentMemoryContext;
-
-	HTAB	   *dataFilesHash = hash_create("data files by path hash",
-											1024,
-											&hashCtl,
-											HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
-
-	return dataFilesHash;
+	return CreatePathHash("data files by path hash",
+						  sizeof(TableDataFileHashEntry),
+						  1024, CurrentMemoryContext);
 }
 
 

--- a/pg_lake_table/src/fdw/data_files_catalog_batch.c
+++ b/pg_lake_table/src/fdw/data_files_catalog_batch.c
@@ -39,6 +39,7 @@
 #include "pg_lake/iceberg/partitioning/spec_generation.h"
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_lake/util/array_utils.h"
+#include "pg_lake/util/path_hash.h"
 
 #include "executor/spi.h"
 #include "utils/builtins.h"
@@ -47,14 +48,14 @@
 /* path -> int64 file id, built from RETURNING output of ExecInsertDataFiles */
 typedef struct FileIdHashEntry
 {
-	char		path[MAX_S3_PATH_LENGTH];
+	char	   *path;
 	int64		fileId;
 }			FileIdHashEntry;
 
 /* caller-above-callee forward decls for the statics below */
 static void FlushDataFileAddBatch(Oid relationId, List *addOps);
 static HTAB *BulkInsertDataFiles(Oid relationId, List *addOps);
-static HTAB *ExecInsertDataFiles(Oid relationId, int fileCount,
+static HTAB *ExecInsertDataFiles(Oid relationId, List *addOps,
 								 ArrayType *pathArray, ArrayType *rowCountArray,
 								 ArrayType *fileSizeArray, ArrayType *contentArray,
 								 ArrayType *firstRowIdArray);
@@ -204,23 +205,24 @@ BulkInsertDataFiles(Oid relationId, List *addOps)
 	ArrayType  *firstRowIdArray = MakeArrayFromDatums(firstRowIdDatums, firstRowIdNulls,
 													  fileCount, INT8OID);
 
-	return ExecInsertDataFiles(relationId, fileCount, pathArray, rowCountArray,
+	return ExecInsertDataFiles(relationId, addOps, pathArray, rowCountArray,
 							   fileSizeArray, contentArray, firstRowIdArray);
 }
 
 
 /*
  * INSERT into lake_table.files via unnest and return a path->id HTAB built
- * from the RETURNING clause. fileCount is the number of rows inserted.
+ * from the RETURNING clause. The hash has one entry per op in addOps.
  * Must be called outside any SPI session.
  * Caller must hash_destroy() the returned table when done.
  */
 static HTAB *
-ExecInsertDataFiles(Oid relationId, int fileCount, ArrayType *pathArray,
+ExecInsertDataFiles(Oid relationId, List *addOps, ArrayType *pathArray,
 					ArrayType *rowCountArray, ArrayType *fileSizeArray,
 					ArrayType *contentArray, ArrayType *firstRowIdArray)
 {
 	MemoryContext callerCxt = CurrentMemoryContext;
+	int			fileCount = list_length(addOps);
 
 	/*
 	 * RETURNING id, path captures sequence-assigned ids so downstream helpers
@@ -248,20 +250,34 @@ ExecInsertDataFiles(Oid relationId, int fileCount, ArrayType *pathArray,
 	SPI_ARG_VALUE(5, INT4ARRAYOID, contentArray, false);
 	SPI_ARG_VALUE(6, INT8ARRAYOID, firstRowIdArray, false);
 
+	/*
+	 * The hash keys on the path pointer, so key it on the paths of the ops
+	 * themselves, which outlive the hash. That also saves copying the paths
+	 * out of SPI: the RETURNING rows below only have to find their entry and
+	 * fill in the id.
+	 */
+	HTAB	   *pathToFileId = CreatePathHash("inserted file ids by path",
+											  sizeof(FileIdHashEntry),
+											  fileCount * 2, callerCxt);
+	ListCell   *operationCell = NULL;
+
+	foreach(operationCell, addOps)
+	{
+		TableMetadataOperation *operation = lfirst(operationCell);
+		bool		found = false;
+		FileIdHashEntry *entry = (FileIdHashEntry *)
+			PathHashSearch(pathToFileId, operation->path, HASH_ENTER, &found);
+
+		Assert(!found);			/* each path is unique in lake_table.files */
+
+		/* lake_table.files.id is a bigserial, so 0 means "not filled in yet" */
+		entry->fileId = 0;
+	}
+
 	SPI_START_EXTENSION_OWNER(PgLakeTable);
 	SPI_EXECUTE(query, /* readOnly = */ false);
 
-	HASHCTL		hashCtl;
-
-	memset(&hashCtl, 0, sizeof(hashCtl));
-	hashCtl.keysize = MAX_S3_PATH_LENGTH;
-	hashCtl.entrysize = sizeof(FileIdHashEntry);
-	hashCtl.hcxt = callerCxt;
-
-	HTAB	   *pathToFileId = hash_create("inserted file ids by path",
-										   fileCount * 2,
-										   &hashCtl,
-										   HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
+	Assert(SPI_processed == (uint64) fileCount);
 
 	for (int fileIndex = 0; fileIndex < fileCount; fileIndex++)
 	{
@@ -274,11 +290,11 @@ ExecInsertDataFiles(Oid relationId, int fileCount, ArrayType *pathArray,
 
 		Assert(!idIsNull && !pathIsNull);
 
-		bool		found;
 		FileIdHashEntry *entry = (FileIdHashEntry *)
-			hash_search(pathToFileId, path, HASH_ENTER, &found);
+			PathHashSearch(pathToFileId, path, HASH_FIND, NULL);
 
-		Assert(!found);			/* each path is unique in lake_table.files */
+		/* we inserted the paths of addOps, so RETURNING can only give those */
+		Assert(entry != NULL);
 		entry->fileId = fileId;
 	}
 
@@ -465,7 +481,7 @@ BulkInsertDataFilePartitionValues(Oid relationId, List *addOps, HTAB *pathToFile
 		Assert(operation->partitionSpecId != DEFAULT_SPEC_ID);
 
 		FileIdHashEntry *entry = (FileIdHashEntry *)
-			hash_search(pathToFileId, operation->path, HASH_FIND, NULL);
+			PathHashSearch(pathToFileId, operation->path, HASH_FIND, NULL);
 
 		Assert(entry != NULL);
 
@@ -615,7 +631,7 @@ BulkInsertTrackedFileIds(List *addOps, HTAB *pathToFileId)
 			fileIdDatums = palloc(sizeof(Datum) * fileCount);
 
 		FileIdHashEntry *entry = (FileIdHashEntry *)
-			hash_search(pathToFileId, operation->path, HASH_FIND, NULL);
+			PathHashSearch(pathToFileId, operation->path, HASH_FIND, NULL);
 
 		Assert(entry != NULL);
 		fileIdDatums[trackedFileCount++] = Int64GetDatum(entry->fileId);

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1107,8 +1107,8 @@ EnsureFreshStatsForCommitTimeDiff(void)
  * thousands of entries decodes to hundreds of megabytes. Read one manifest at
  * a time into a context we reset after each, the way
  * IcebergSnapshotAddAllReferencedFiles does, so peak is one manifest rather
- * than the whole snapshot. The path itself is copied by dynahash into the hash
- * entry, so it survives the reset.
+ * than the whole snapshot. AppendFileToHash copies the path into the context
+ * that is current when we call it, which is our own, so it survives the reset.
  */
 static HTAB *
 CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
@@ -1139,6 +1139,8 @@ CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
 															   NULL);
 		ListCell   *pathCell = NULL;
 
+		MemoryContextSwitchTo(oldContext);
+
 		foreach(pathCell, dataFilePaths)
 		{
 			char	   *dataFilePath = lfirst(pathCell);
@@ -1146,7 +1148,6 @@ CreateDataFilesHashForMetadata(IcebergTableMetadata * metadata)
 			AppendFileToHash(dataFilePath, dataFilesMap);
 		}
 
-		MemoryContextSwitchTo(oldContext);
 		MemoryContextReset(manifestContext);
 	}
 
@@ -1204,7 +1205,8 @@ FindChangedFilesSinceMetadata(const TableMetadataOperationTracker * opTracker,
 
 	while ((currentDataFile = hash_seq_search(&currentFilesStatus)) != NULL)
 	{
-		if (!hash_search(metadataDataFilesMap, currentDataFile->filePath, HASH_FIND, NULL))
+		if (!PathHashSearch(metadataDataFilesMap, currentDataFile->filePath,
+							HASH_FIND, NULL))
 			*addedFiles = lappend(*addedFiles, &currentDataFile->dataFile);
 	}
 
@@ -1213,16 +1215,17 @@ FindChangedFilesSinceMetadata(const TableMetadataOperationTracker * opTracker,
 
 	hash_seq_init(&metadataFilesStatus, metadataDataFilesMap);
 
-	char	   *metadataDataFilePath = NULL;
+	PathHashEntry *metadataDataFile = NULL;
 
-	while ((metadataDataFilePath = hash_seq_search(&metadataFilesStatus)) != NULL)
+	while ((metadataDataFile = hash_seq_search(&metadataFilesStatus)) != NULL)
 	{
 		/*
 		 * The path is a key inside metadataDataFilesMap, which goes away with
 		 * the scratch context below, so hand out a copy.
 		 */
-		if (!hash_search(currentFilesMap, metadataDataFilePath, HASH_FIND, NULL))
-			*removedFilePaths = lappend(*removedFilePaths, pstrdup(metadataDataFilePath));
+		if (!PathHashSearch(currentFilesMap, metadataDataFile->path, HASH_FIND, NULL))
+			*removedFilePaths = lappend(*removedFilePaths,
+										pstrdup(metadataDataFile->path));
 	}
 
 	MemoryContextDelete(metadataContext);
@@ -1430,13 +1433,11 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 
 	/*
 	 * The path index over the catalog file list is only needed for the diff
-	 * above. Its entries are the widest thing we allocate per file, because
-	 * the key is a fixed MAX_S3_PATH_LENGTH array, so drop it now rather than
-	 * leaving one per relation behind until the transaction ends. The
-	 * operations we return do not point into it: the path, partition and
-	 * column stats of each added file were allocated separately and outlive
-	 * it, and the removed paths are copies. addedFiles does point into it, so
-	 * it must not be used after this.
+	 * above, so drop it now rather than leaving one per relation behind until
+	 * the transaction ends. The operations we return do not point into it:
+	 * the path, partition and column stats of each added file were allocated
+	 * separately and outlive it, and the removed paths are copies. addedFiles
+	 * does point into it, so it must not be used after this.
 	 */
 	hash_destroy(currentFilesMap);
 


### PR DESCRIPTION
Backport of #528 to `release-3.4`.

## Why backport

Five hash tables key on an object storage path, and on 3.4 each one still does it with a `char[MAX_S3_PATH_LENGTH]` key plus `HASH_STRINGS`:

| hash | where |
| --- | --- |
| files-by-path index for the commit-time diff | `pg_lake_table/src/fdw/data_files_catalog.c` |
| referenced-files hash (Iceberg vacuum, commit-time diff) | `pg_lake_iceberg/src/iceberg/operations/find_referenced_files.c` |
| path -> file id from `RETURNING` | `pg_lake_table/src/fdw/data_files_catalog_batch.c` |
| pending uploads | `pg_lake_engine/src/utils/s3_writer_utils.c` |
| `_filename = any(...)` pruning filter | `pg_lake_table/src/fdw/data_file_pruning.c` |

That reserves 1095 bytes per entry for paths that are ~120 bytes in practice, and the hashes with the widest entries are the ones built over every file in the table. Keying on a `char *` instead makes an entry cost the pointer plus the string: on the commit path the per-file cost goes from ~2.4 KB to ~0.4 KB, i.e. -38 MB for a 20k-file table and -220 MB for a 117k-file one.

This is the same class of problem as #511, which is already on `release-3.4` as 939bd3d. #511 bounded what the pre-commit diff *decodes*; the fixed-width keys are what is left, and they are the widest per-file allocation the diff still makes. Any 3.4 workload that appends to a table without compacting it reaches this, and a host with `vm.overcommit_memory = 2` has no reclaim to absorb the peak. See #528 for the full analysis.

The drive-by in #528 is also worth having on 3.4: the pruning filter's probe went from `HASH_ENTER` to `HASH_FIND`. It only ever wanted to test membership, so inserting every probed path grew the filter to the size of the file list.

## Conflict resolution

None. Both commits of #528 cherry-picked onto `release-3.4` cleanly, squashed into one commit here. The added and removed lines are identical to `main`'s `f4d5e40..6f76262`, verified line for line.

Three of the ten touched files still differ from `main` after the pick, all from pre-existing divergence that this patch does not interact with:

- `s3_writer_utils.c` — `main` has `CopyLocalFileToS3NoCache()`, which 3.4 does not.
- `data_file_pruning.c` — `main` hoisted the per-file stats lookup into `GetDataFileStatsAndPartition()`; 3.4 still has it inline in the loop. The hash build and probe sites are the same on both.
- `track_iceberg_metadata_changes.c` — `main` has the TRUNCATE remove-all shortcut from #457, which 3.4 does not. Same divergence called out in #519.

The other seven files, including both new ones (`pg_lake_engine/{include/pg_lake/util,src/utils}/path_hash.{h,c}`), are byte-identical to `main`. One review follow-up has since been added on top: an `Assert(path != NULL)` in `PathHashSearch` plus two comment lines, requested by @sfc-gh-dachristensen. #531 puts the same commit on `main`, so the two files stay identical there. `AppendFileToHash` has exactly the same six call sites on both branches, so the memory-context requirement #528 documents holds here unchanged.

## Diff

Ten files across `pg_lake_engine`, `pg_lake_iceberg` and `pg_lake_table`, two of them new. No SQL migration files, no schema or catalog change, version stays at 3.4. `pg_lake_engine/Makefile` globs `src/*/*.c`, so the new translation unit needs no build change.

## Test plan

- Clean build of `pg_lake_engine`, `pg_lake_iceberg` and `pg_lake_table` on this branch, no new warnings.
- `make check-indent` passes the C half (`pgindent` reports no diff). It then dies at `black`, which is not installed on this workspace; there are no Python changes here.
- Behaviour is unchanged and the code is identical to `main`, where #528 ran 326 tests over the write/DDL/vacuum/manifest/pruning paths in a cassert build.
- 306 pytests re-run against this branch in an `--enable-cassert` PG 18 build, all passing: 103 in `pg_lake_iceberg` (iceberg functions, metadata json, data file stats, parallel uploads) and 203 in `pg_lake_table` (data file pruning, `_filename` filter, referenced / unreferenced / remove-unreferenced files, xacts, writable iceberg, insert / update / delete, vacuum, merge manifest, partitioned files, partition evolution, row ids, autovacuum compaction).
- [x] CI green on `release-3.4`: all 64 checks pass on run 31680310498.

Two jobs needed a re-run, neither related to this change:

- `test-check-pg_lake_table (18, shard 3)` — `test_writable_rest_iceberg_table[rest-...]` errored in its fixture with `no credentials found for REST catalog "rest"`. The `set_polaris_gucs` fixture sets the client id/secret with `ALTER SYSTEM` + `pg_reload_conf()`, and the `CREATE TABLE` runs on a different connection that had not processed the SIGHUP yet. The `user_server` variant of the same test, which does not need the GUCs, passed, as did the same shard on 16 and 17.
- `test-installcheck (16, installcheck-pg_lake_benchmark)` — `pgduck_server` aborted (core dumped) partway through the job, during the TPC-DS 0.01 generate. 13 tests had already passed; the remaining 15 plus 3 fixtures then failed with `Connection refused` on its socket. `pgduck_server` is a separate binary that this patch does not touch, the same job passes on `release-3.4`, and it passed on #528 with this code on `main`.

Both passed on re-run.



