### PR TITLE
Assert that a path hash key is not NULL

### DIFF
--- a/pg_lake_engine/include/pg_lake/util/path_hash.h
+++ b/pg_lake_engine/include/pg_lake/util/path_hash.h
@@ -31,6 +31,7 @@
  * pstrdup'd out of SPI or Avro into a context at least as long-lived as the
  * hash. A caller whose path lives in a scratch context it resets (one
  * manifest at a time, say) has to copy the path itself before inserting it.
+ * Dereferencing the key also means a path can never be NULL.
  */
 
 #pragma once

--- a/pg_lake_engine/src/utils/path_hash.c
+++ b/pg_lake_engine/src/utils/path_hash.c
@@ -87,6 +87,8 @@ PathHashKeyHash(const void *key, Size keysize PG_USED_FOR_ASSERTS_ONLY)
 
 	const char *path = *(const char *const *) key;
 
+	Assert(path != NULL);
+
 	return hash_bytes((const unsigned char *) path, strlen(path));
 }
 

--- a/pg_lake_engine/src/utils/path_hash.c
+++ b/pg_lake_engine/src/utils/path_hash.c
@@ -60,10 +60,16 @@ CreatePathHash(const char *name, Size entrySize, long nelem, MemoryContext conte
  * means the pointer itself, so the key argument is the address of the pointer
  * rather than the pointer. Passing a path straight to hash_search would copy
  * the first 8 bytes of the string instead, which is why this wrapper exists.
+ *
+ * The hash and match functions dereference the key, so path cannot be NULL.
+ * Every caller either takes the path from a catalog or manifest column that is
+ * NOT NULL, or filters nulls out before getting here.
  */
 void *
 PathHashSearch(HTAB *pathHash, const char *path, HASHACTION action, bool *foundPtr)
 {
+	Assert(path != NULL);
+
 	return hash_search(pathHash, &path, action, foundPtr);
 }
 


### PR DESCRIPTION
Review follow-up from @sfc-gh-dachristensen on #529, the `release-3.4` backport of #528: should `PathHashKeyHash` assert its key is non-NULL, or is that a contract?

It is a contract, and a NULL path already crashed one line later in `strlen()`, so the assert does not change what happens, only where. Putting it in `PathHashSearch` instead of the dynahash callback points at the caller that passed the NULL.

Non-NULL holds at all six call sites today. Five take the path from a catalog or manifest column that is NOT NULL. The sixth is the `_filename = any(...)` pruning filter, which skips null array elements before inserting.

The same commit is on #529 so `path_hash.{c,h}` stay identical on both branches.

## Test plan

- Clean build of `pg_lake_engine`, no new warnings. `--enable-cassert` build, so the assert is live.
- No behaviour change outside a cassert build.
- CI.