### PR TITLE
[release-3.4] Backport #533: pg_lake_engine: fix unnest() of an array of a composite type

### DIFF
--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -39,13 +39,18 @@
 #include "nodes/nodeFuncs.h"
 #include "parser/parse_func.h"
 #include "parser/parse_oper.h"
+#include "rewrite/rewriteManip.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/syscache.h"
+#include "utils/typcache.h"
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+/* alias of the inner unnest(..) RTE that ExpandCompositeUnnestRte leaves behind */
+#define COMPOSITE_UNNEST_ALIAS "pg_lake_unnest"
 
 typedef Node *(*ExpressionRewriter) (Node *expression, void *context);
 
@@ -125,6 +130,9 @@ typedef struct OperatorRewriteRuleByName
 
 static void InitRewriteRules(void);
 static Node *RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext * context);
+static void ExpandCompositeUnnestRtes(List *rtable);
+static bool IsCompositeUnnestRte(RangeTblEntry *rte, Oid *elementTypeId);
+static void ExpandCompositeUnnestRte(RangeTblEntry *rte, Oid elementTypeId);
 static Node *ReplaceJsonbWithPgLakeInternalJsonbFunction(Node *inputNode, void *context);
 static bool IsJsonbCast(Node *node);
 static Node *WrapPgLakeInternalJsonbFunction(Node *data);
@@ -537,13 +545,21 @@ RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext * context)
 
 		context->level++;
 
-		node = (Node *) query_tree_mutator(query,
-										   RewriteQueryTreeForPGDuckMutator,
-										   context, 0);
+		Query	   *rewrittenQuery = query_tree_mutator(query,
+														RewriteQueryTreeForPGDuckMutator,
+														context, 0);
 
 		context->level--;
 
-		return node;
+		/*
+		 * Rewrite the range table entries that mean something else in DuckDB.
+		 * We do this after mutating the query, since the mutator hands back a
+		 * copy of the range table and we should not touch the range table of
+		 * the query we were given.
+		 */
+		ExpandCompositeUnnestRtes(rewrittenQuery->rtable);
+
+		return (Node *) rewrittenQuery;
 	}
 
 	/*
@@ -643,6 +659,206 @@ RewriteQueryTreeForPGDuckMutator(Node *node, RewriteQueryTreeContext * context)
 	}
 
 	return node;
+}
+
+
+/*
+ * ExpandCompositeUnnestRtes rewrites the unnest(..) calls over arrays of a
+ * composite type in the given range table into a form that means the same thing
+ * to DuckDB.
+ *
+ * PostgreSQL expands a function RTE that returns a composite type into one
+ * column per field, and ruleutils always emits the full column alias list:
+ *
+ *     unnest(t.arr) a("code", "charges", "is_waived")
+ *
+ * DuckDB's unnest() of an array of structs produces a single struct column, so
+ * it binds only the first alias: a reference to any other field fails to bind,
+ * and a reference to the first field silently returns the whole struct. We
+ * therefore select the fields out of that struct ourselves.
+ */
+static void
+ExpandCompositeUnnestRtes(List *rtable)
+{
+	ListCell   *lc;
+
+	foreach(lc, rtable)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+		Oid			elementTypeId = InvalidOid;
+
+		if (IsCompositeUnnestRte(rte, &elementTypeId))
+			ExpandCompositeUnnestRte(rte, elementTypeId);
+	}
+}
+
+
+/*
+ * IsCompositeUnnestRte returns whether the given RTE is an unnest(..) call over
+ * an array of a composite type that the rewrite below can handle, and if so also
+ * returns the composite type.
+ */
+static bool
+IsCompositeUnnestRte(RangeTblEntry *rte, Oid *elementTypeId)
+{
+	if (rte->rtekind != RTE_FUNCTION || list_length(rte->functions) != 1)
+		return false;
+
+	/* WITH ORDINALITY adds a column that the rewrite below cannot produce */
+	if (rte->funcordinality)
+		return false;
+
+	RangeTblFunction *rtfunc = (RangeTblFunction *) linitial(rte->functions);
+
+	/* a column definition list is deparsed with its own syntax */
+	if (rtfunc->funccolnames != NIL)
+		return false;
+
+	if (!IsA(rtfunc->funcexpr, FuncExpr) ||
+		((FuncExpr *) rtfunc->funcexpr)->funcid != F_UNNEST_ANYARRAY)
+		return false;
+
+	/*
+	 * A domain over a composite type is expanded per field just the same, so
+	 * look through the domain. The field references we build below need the
+	 * composite type itself in any case, since that is what carries the
+	 * fields.
+	 */
+	Oid			typeId = getBaseType(exprType(rtfunc->funcexpr));
+
+	if (get_typtype(typeId) != TYPTYPE_COMPOSITE)
+		return false;
+
+	/*
+	 * The rewrite below leaves behind an inner unnest(..) RTE whose single
+	 * column is the struct DuckDB returns, which is not something we can
+	 * expand again. It carries an alias of our own so that we recognize it
+	 * here, which keeps a second pass over the same tree from nesting another
+	 * subquery for a composite of any number of fields.
+	 */
+	if (strcmp(rte->eref->aliasname, COMPOSITE_UNNEST_ALIAS) == 0)
+		return false;
+
+	TupleDesc	tupleDesc = lookup_rowtype_tupdesc(typeId, -1);
+	bool		anyFieldDropped = false;
+
+	for (int fieldNumber = 0; fieldNumber < tupleDesc->natts; fieldNumber++)
+	{
+		if (TupleDescAttr(tupleDesc, fieldNumber)->attisdropped)
+		{
+			anyFieldDropped = true;
+			break;
+		}
+	}
+
+	ReleaseTupleDesc(tupleDesc);
+
+	/*
+	 * A dropped field still occupies a column of the RTE, but has no name we
+	 * could put in the alias list, so leave these RTEs alone and let the
+	 * query fail to bind in DuckDB as it does today.
+	 */
+	if (anyFieldDropped)
+		return false;
+
+	*elementTypeId = typeId;
+
+	return true;
+}
+
+
+/*
+ * ExpandCompositeUnnestRte replaces an unnest(..) RTE over an array of a
+ * composite type with an equivalent lateral subquery that selects the fields of
+ * the composite one by one:
+ *
+ *     (SELECT (u.u).code, (u.u).charges FROM unnest(t.arr) u(u)) a
+ *
+ * where u stands for COMPOSITE_UNNEST_ALIAS. The subquery has one column per
+ * field, in the same order, so the Vars that reference the RTE, and the aliases
+ * of any join above it, stay valid.
+ */
+static void
+ExpandCompositeUnnestRte(RangeTblEntry *rte, Oid elementTypeId)
+{
+	RangeTblFunction *rtfunc = (RangeTblFunction *) linitial(rte->functions);
+	TupleDesc	tupleDesc = lookup_rowtype_tupdesc(elementTypeId, -1);
+	List	   *colnames = rte->eref->colnames;
+
+	/* the unnest(..) call, and anything it references, moves a level down */
+	IncrementVarSublevelsUp(rtfunc->funcexpr, 1, 0);
+
+	/* to DuckDB, unnest(..) of an array of structs returns a single column */
+	rtfunc->funccolcount = 1;
+
+	RangeTblEntry *unnestRte = makeNode(RangeTblEntry);
+
+	unnestRte->rtekind = RTE_FUNCTION;
+	unnestRte->functions = rte->functions;
+
+	/*
+	 * The inner RTE is the only thing in its own FROM clause, so it never
+	 * needs the LATERAL keyword; the outer RTE keeps the flag that covers the
+	 * correlation.
+	 */
+	unnestRte->lateral = false;
+	unnestRte->inFromCl = true;
+
+	/*
+	 * Name it after ourselves rather than after the RTE we are replacing, so
+	 * that IsCompositeUnnestRte() recognizes it as already expanded. The name
+	 * is only visible to the field references we build below, since the inner
+	 * RTE is alone in the subquery.
+	 */
+	unnestRte->eref = makeAlias(COMPOSITE_UNNEST_ALIAS,
+								list_make1(makeString(COMPOSITE_UNNEST_ALIAS)));
+
+	List	   *targetList = NIL;
+
+	/* the parser names every column of a function RTE, dropped ones aside */
+	Assert(list_length(colnames) == tupleDesc->natts);
+
+	for (int fieldNumber = 1; fieldNumber <= tupleDesc->natts; fieldNumber++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDesc, fieldNumber - 1);
+		FieldSelect *fieldSelect = makeNode(FieldSelect);
+
+		fieldSelect->arg = (Expr *) makeVar(1, 1, elementTypeId, -1,
+											InvalidOid, 0);
+		fieldSelect->fieldnum = fieldNumber;
+		fieldSelect->resulttype = attr->atttypid;
+		fieldSelect->resulttypmod = attr->atttypmod;
+		fieldSelect->resultcollid = attr->attcollation;
+
+		/*
+		 * Name the column the way the RTE does, so that references to it keep
+		 * resolving once the subquery names its own columns.
+		 */
+		char	   *colname = strVal(list_nth(colnames, fieldNumber - 1));
+
+		targetList = lappend(targetList,
+							 makeTargetEntry((Expr *) fieldSelect, fieldNumber,
+											 pstrdup(colname), false));
+	}
+
+	ReleaseTupleDesc(tupleDesc);
+
+	RangeTblRef *rangeTableRef = makeNode(RangeTblRef);
+
+	rangeTableRef->rtindex = 1;
+
+	Query	   *subquery = makeNode(Query);
+
+	subquery->commandType = CMD_SELECT;
+	subquery->querySource = QSRC_ORIGINAL;
+	subquery->canSetTag = true;
+	subquery->rtable = list_make1(unnestRte);
+	subquery->jointree = makeFromExpr(list_make1(rangeTableRef), NULL);
+	subquery->targetList = targetList;
+
+	rte->rtekind = RTE_SUBQUERY;
+	rte->subquery = subquery;
+	rte->functions = NIL;
 }
 
 

--- a/pg_lake_table/tests/pytests/test_composite_unnest.py
+++ b/pg_lake_table/tests/pytests/test_composite_unnest.py
@@ -1,0 +1,246 @@
+import pytest
+import psycopg2
+from utils_pytest import *
+
+
+# unnest(..) over an array of a composite type, see issues/530.
+# Each case: test id, query, whether we expect the query to be pushed down.
+test_cases = [
+    (
+        "left_join_all_fields",
+        """SELECT a.code, a.charges, a.is_waived, a.is_shiplify
+           FROM composite_unnest.tbl t
+           LEFT JOIN unnest(t.accessorials) a ON true
+           WHERE pro_number = 34342342""",
+        True,
+    ),
+    (
+        "first_field_only",
+        """SELECT a.code FROM composite_unnest.tbl t, unnest(t.accessorials) a""",
+        True,
+    ),
+    (
+        "qualification_and_aggregate",
+        """SELECT count(*), max(a.charges)
+           FROM composite_unnest.tbl t, unnest(t.accessorials) a
+           WHERE a.is_waived""",
+        True,
+    ),
+    (
+        "join_qualification",
+        """SELECT t.pro_number, a.charges
+           FROM composite_unnest.tbl t
+           LEFT JOIN unnest(t.accessorials) a ON a.code = 'LIMIT'""",
+        True,
+    ),
+    (
+        "column_alias_list",
+        """SELECT b.c, b.w
+           FROM composite_unnest.tbl t, unnest(t.accessorials) AS b(c, ch, w, s, n)""",
+        True,
+    ),
+    (
+        "nested_composite_field",
+        """SELECT a.code, (a.nested).x, (a.nested).y
+           FROM composite_unnest.tbl t, unnest(t.accessorials) a""",
+        True,
+    ),
+    (
+        "unnest_star",
+        """SELECT t.pro_number, a.* FROM composite_unnest.tbl t, unnest(t.accessorials) a""",
+        True,
+    ),
+    (
+        "two_unnests",
+        """SELECT a.code, b.charges
+           FROM composite_unnest.tbl t,
+                unnest(t.accessorials) a,
+                unnest(t.accessorials) b""",
+        True,
+    ),
+    (
+        "in_cte",
+        """WITH s AS (
+             SELECT a.code, a.charges FROM composite_unnest.tbl t, unnest(t.accessorials) a
+           )
+           SELECT code, sum(charges) FROM s GROUP BY code""",
+        True,
+    ),
+    (
+        "in_subquery",
+        """SELECT s.code FROM (
+             SELECT a.code FROM composite_unnest.tbl t, unnest(t.accessorials) a
+           ) s WHERE s.code LIKE 'LI%'""",
+        True,
+    ),
+    (
+        "correlated_reference",
+        """SELECT t.pro_number, (SELECT a.charges WHERE a.is_waived)
+           FROM composite_unnest.tbl t, unnest(t.accessorials) a""",
+        True,
+    ),
+    # The two cases below are controls: IsCompositeUnnestRte() rejects both, so
+    # they pass with and without the rewrite and only pin that it stays away.
+    (
+        "scalar_array_unnest",
+        """SELECT t.pro_number, x
+           FROM composite_unnest.tbl t, unnest(array[1, 2]) x""",
+        True,
+    ),
+    # DuckDB has no WITH ORDINALITY, so this one runs in PostgreSQL
+    (
+        "with_ordinality",
+        """SELECT a.code, a.ord
+           FROM composite_unnest.tbl t,
+                unnest(t.accessorials) WITH ORDINALITY
+                AS a(code, charges, is_waived, is_shiplify, nested, ord)""",
+        False,
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def rollback_after_test(pg_conn):
+    """Keep a failing case from aborting the transaction the next one inherits.
+
+    ``pg_conn`` is module scoped, so without this a single failure cascades into
+    ``current transaction is aborted`` for every case after it.
+    """
+    yield
+    pg_conn.rollback()
+
+
+@pytest.mark.parametrize(
+    "test_id, query, assert_pushdown",
+    test_cases,
+    ids=[test_case[0] for test_case in test_cases],
+)
+def test_composite_unnest(
+    create_composite_unnest_tables, pg_conn, test_id, query, assert_pushdown
+):
+    if assert_pushdown:
+        assert_query_pushdownable(query, pg_conn)
+    else:
+        assert_query_not_pushdownable(query, pg_conn)
+
+    assert_query_results_on_tables(
+        query, pg_conn, ["composite_unnest.tbl"], ["composite_unnest.heap_tbl"]
+    )
+
+
+def test_composite_unnest_field_values(create_composite_unnest_tables, pg_conn):
+    """The query from issues/530, which used to fail to bind in DuckDB."""
+
+    query = """
+    SELECT a.code, a.charges, a.is_waived, a.is_shiplify
+    FROM composite_unnest.tbl t
+    LEFT JOIN unnest(t.accessorials) a ON true
+    WHERE pro_number = 34342342
+    ORDER BY 1
+    """
+
+    # the fields are selected out of the single struct column DuckDB returns
+    assert_remote_query_contains_expression(query, '."code"', pg_conn)
+
+    assert run_query(query, pg_conn) == [
+        ["LIFTPU", 25, False, False],
+        ["LIMIT", 50, False, True],
+    ]
+
+
+def test_composite_unnest_single_field(create_composite_unnest_tables, pg_conn):
+    """A composite with a single field is expanded like any other.
+
+    Worth its own case because the rewritten RTE has as many columns as the
+    original one here, so it is only the alias that tells them apart.
+    """
+
+    query = """SELECT s.amount
+               FROM composite_unnest.single_tbl t, unnest(t.vals) s
+               ORDER BY 1"""
+
+    assert_query_pushdownable(query, pg_conn)
+
+    # the field is selected out of the single struct column DuckDB returns
+    assert_remote_query_contains_expression(query, '."amount"', pg_conn)
+
+    assert run_query(query, pg_conn) == [[10], [20]]
+
+
+def test_composite_unnest_dropped_field(create_composite_unnest_tables, pg_conn):
+    """A composite with a dropped field is left alone, and so still fails.
+
+    The dropped field occupies a column of the RTE but has no name to put in the
+    column alias list, so IsCompositeUnnestRte() rejects it and DuckDB is left
+    with the alias list PostgreSQL emits, which is one name short.
+    """
+
+    query = """SELECT d.keep1, d.keep2
+               FROM composite_unnest.dropped_tbl t, unnest(t.vals) d"""
+
+    with pytest.raises(
+        psycopg2.DatabaseError, match="Binder Error.*does not have a column named"
+    ):
+        run_query(query, pg_conn)
+
+
+@pytest.fixture(scope="module")
+def create_composite_unnest_tables(pg_conn, s3, request, extension):
+    url = f"s3://{TEST_BUCKET}/{request.node.name}/"
+
+    run_command(
+        f"""
+        CREATE SCHEMA composite_unnest;
+        SET search_path TO composite_unnest;
+
+        CREATE TYPE nested AS (x int, y text);
+        CREATE TYPE accessorial AS (
+            code text,
+            charges numeric,
+            is_waived boolean,
+            is_shiplify boolean,
+            nested nested
+        );
+
+        CREATE TYPE withdropped AS (keep1 int, goner text, keep2 int);
+        ALTER TYPE withdropped DROP ATTRIBUTE goner;
+
+        CREATE TYPE single AS (amount int);
+
+        CREATE FOREIGN TABLE tbl (pro_number bigint, accessorials accessorial[])
+            SERVER pg_lake OPTIONS (location '{url}', writable 'true', format 'parquet');
+        CREATE TABLE heap_tbl (pro_number bigint, accessorials accessorial[]);
+
+        CREATE FOREIGN TABLE dropped_tbl (id int, vals withdropped[])
+            SERVER pg_lake OPTIONS (location '{url}dropped/', writable 'true', format 'parquet');
+
+        CREATE FOREIGN TABLE single_tbl (id int, vals single[])
+            SERVER pg_lake OPTIONS (location '{url}single/', writable 'true', format 'parquet');
+        """,
+        pg_conn,
+    )
+
+    rows = """
+        VALUES (34342342, array[
+                    row('LIFTPU', 25.00, false, false, row(1, 'a'))::accessorial,
+                    row('LIMIT', 50.00, false, true, row(2, 'b'))::accessorial]),
+               (1, NULL),
+               (2, array[]::accessorial[]),
+               (3, array[row('DETENTION', 75.00, true, false, row(3, 'c'))::accessorial])
+    """
+
+    run_command(f"INSERT INTO tbl {rows};", pg_conn)
+    run_command(f"INSERT INTO heap_tbl {rows};", pg_conn)
+    run_command(
+        "INSERT INTO dropped_tbl VALUES (1, array[row(1, 2)::withdropped]);", pg_conn
+    )
+    run_command(
+        "INSERT INTO single_tbl VALUES (1, array[row(10)::single, row(20)::single]);",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    yield
+
+    run_command("DROP SCHEMA composite_unnest CASCADE;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
Backport of #533 to `release-3.4`. Fixes #530 there.

`unnest()` of an array of a composite type, in the FROM clause, could not
be pushed down correctly:

```sql
SELECT a.code, a.is_waived
FROM accessorial_test t
LEFT JOIN unnest(t.accessorials) a ON true;
ERROR:  Binder Error: Table "a" does not have a column named "is_waived"
```

PostgreSQL expands a function RTE that returns a composite type into one
column per field, and ruleutils always emits the full column alias list:

```sql
unnest(t.accessorials) a("code", "charges", "is_waived", "is_shiplify")
```

DuckDB's `unnest()` of an array of structs returns a single struct column, so
it binds only the first alias. Referencing any other field fails to bind, and
referencing the first field silently returns the whole struct rather than the
field, e.g. `a.code` came back as `(LIMIT,50.000000000,f,t)`.

"`unnest()` over an array of structs means something else in DuckDB" is the
same kind of thing as the jsonb and map rewrites, so `RewriteQueryTreeForPGDuck`
now rewrites such an RTE into an equivalent lateral subquery that selects the
fields out of the struct one by one:

```sql
LEFT JOIN LATERAL ( SELECT ("pg_lake_unnest"."pg_lake_unnest")."code" AS "code",
                           ("pg_lake_unnest"."pg_lake_unnest")."charges" AS "charges",
                           ("pg_lake_unnest"."pg_lake_unnest")."is_waived" AS "is_waived",
                           ("pg_lake_unnest"."pg_lake_unnest")."is_shiplify" AS "is_shiplify"
                    FROM "unnest"("t"."accessorials") "pg_lake_unnest"("pg_lake_unnest")
                  ) "a"("code", "charges", "is_waived", "is_shiplify") ON true
```

The subquery has one column per field, in the same order, so the Vars that
reference the RTE and the column aliases of any join above it stay valid, and
the query is still pushed down in full. A domain over a composite is expanded
per field as well, so the rewrite looks through the domain, though `unnest()`
over one is not pushed down today.

Both entry points already go through `RewriteQueryTreeForPGDuck` — the FDW path
in `GetForeignPlan` and query pushdown in `GeneratePushdownScan` — so the
deparser is left to print the tree it is handed. For pushdown, the expansion
happens once per plan rather than once per execution, and the mutator hands
back a copy, so the tree the caller owns is untouched. The RTE the expansion
leaves behind has a single struct column and carries the alias
`pg_lake_unnest`, which is how it is recognized as already expanded rather than
expanded again.

Left alone:

- `WITH ORDINALITY` and a `ROWS FROM`-style multi-function RTE, neither of
  which is pushed down today.
- a composite with a dropped attribute. The dropped field still occupies a
  column of the RTE but PostgreSQL has no name for it, and an alias list with
  a missing name is worse than the bind error above: ruleutils drops
  empty-named entries when it prints the list, so a list one name short over a
  subquery that projects every column returns the wrong field rather than
  failing. These RTEs keep today's bind error, and a test pins it.

The new pytest covers the reported query plus field references from a join
qualification, a WHERE clause, an aggregate, a user-supplied column alias
list, a nested composite, `a.*`, two unnests of the same column, a CTE, a
subquery, a correlated reference and a single-field composite, comparing each
against the same query on a heap table. A scalar-array unnest and a
`WITH ORDINALITY` case are controls: the rewrite skips both, so they pass
either way. Without the fix the other 12 cases fail.

Cherry-picked from 62a168c2 with no changes; 34 tests across the
composite-unnest, complex-types, fieldselect, join-alias and CTE/subquery
suites pass locally on this branch.
