### PR TITLE
[release-3.4] Backport #527: use scratch memory contexts at commit time

### DIFF
--- a/pg_lake_engine/include/pg_lake/util/s3_writer_utils.h
+++ b/pg_lake_engine/include/pg_lake/util/s3_writer_utils.h
@@ -23,6 +23,7 @@
 /* pg_lake_engine.max_parallel_file_uploads */
 extern int32 MaxParallelFileUploads;
 
+extern PGDLLEXPORT char *GenerateTempFileNameForUpload(char *pattern);
 extern PGDLLEXPORT void ScheduleFileCopyToS3WithCleanup(char *localFilePath, char *s3Uri, bool autoDeleteRecord);
 extern PGDLLEXPORT void CopyLocalFileToS3(char *localFilePath, char *s3Uri);
 extern PGDLLEXPORT void FinishAllUploads(void);

--- a/pg_lake_engine/src/data_file/data_files.c
+++ b/pg_lake_engine/src/data_file/data_files.c
@@ -120,7 +120,12 @@ DeepCopyDataFileStats(const DataFileStats * stats)
 {
 	DataFileStats *copiedStats = palloc0(sizeof(DataFileStats));
 
-	copiedStats->dataFilePath = pstrdup(stats->dataFilePath);
+	/*
+	 * Files read from the files catalog carry their path in TableDataFile
+	 * rather than in the stats, so both string fields can be unset.
+	 */
+	copiedStats->dataFilePath = stats->dataFilePath ? pstrdup(stats->dataFilePath) : NULL;
+	copiedStats->partitionKeysText = stats->partitionKeysText ? pstrdup(stats->partitionKeysText) : NULL;
 	copiedStats->fileSize = stats->fileSize;
 	copiedStats->rowCount = stats->rowCount;
 	copiedStats->deletedRowCount = stats->deletedRowCount;

--- a/pg_lake_engine/src/utils/s3_writer_utils.c
+++ b/pg_lake_engine/src/utils/s3_writer_utils.c
@@ -23,6 +23,7 @@
 #include "pg_lake/cleanup/in_progress_files.h"
 #include "pg_lake/pgduck/client.h"
 #include "pg_lake/pgduck/parallel_command.h"
+#include "pg_lake/storage/local_storage.h"
 #include "pg_lake/util/path_hash.h"
 #include "pg_lake/util/s3_reader_utils.h"
 #include "pg_lake/util/s3_writer_utils.h"
@@ -55,6 +56,35 @@ static HTAB *PendingUploads = NULL;
 
 /* pg_lake_engine.max_parallel_file_uploads setting */
 int			MaxParallelFileUploads = DEFAULT_MAX_PARALLEL_FILE_UPLOADS;
+
+
+/*
+ * GenerateTempFileNameForUpload returns the path of a temporary file that is
+ * going to be scheduled for upload with ScheduleFileCopyToS3WithCleanup.
+ *
+ * Callers could use GenerateTempFileName directly, but that ties the deletion
+ * of the local file to the caller's memory context, while the upload itself
+ * only happens when FinishAllUploads is called. That makes it unsafe for a
+ * caller to run in a context that is reset before then, which is easy to get
+ * wrong. Register the deletion on the upload scheduling context instead, so
+ * the local file lives exactly as long as the upload that needs it: it is
+ * deleted once the uploads are done, or when the transaction ends without
+ * them happening.
+ */
+char *
+GenerateTempFileNameForUpload(char *pattern)
+{
+	InitUploadScheduling();
+
+	MemoryContext oldContext = MemoryContextSwitchTo(UploadSchedulingContext);
+
+	bool		ensureCleanup = true;
+	char	   *localFilePath = GenerateTempFileName(pattern, ensureCleanup);
+
+	MemoryContextSwitchTo(oldContext);
+
+	return localFilePath;
+}
 
 
 /*

--- a/pg_lake_iceberg/src/iceberg/api/manifest.c
+++ b/pg_lake_iceberg/src/iceberg/api/manifest.c
@@ -97,7 +97,7 @@ FetchManifestsFromSnapshot(IcebergSnapshot * snapshot, ManifestPredicateFn manif
 int64_t
 UploadIcebergManifestToURI(List *manifestEntries, char *manifestURI)
 {
-	char	   *localManifestPath = GenerateTempFileName(PG_LAKE_ICEBERG, true);
+	char	   *localManifestPath = GenerateTempFileNameForUpload(PG_LAKE_ICEBERG);
 
 	WriteIcebergManifest(localManifestPath, manifestEntries);
 

--- a/pg_lake_iceberg/src/iceberg/api/manifest_list.c
+++ b/pg_lake_iceberg/src/iceberg/api/manifest_list.c
@@ -35,7 +35,7 @@
 int64_t
 UploadIcebergManifestListToURI(List *manifestList, char *manifestListURI)
 {
-	char	   *localManifestListPath = GenerateTempFileName(PG_LAKE_ICEBERG, true);
+	char	   *localManifestListPath = GenerateTempFileNameForUpload(PG_LAKE_ICEBERG);
 
 	WriteIcebergManifestList(localManifestListPath, manifestList);
 

--- a/pg_lake_iceberg/src/iceberg/api/table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/api/table_metadata.c
@@ -405,7 +405,7 @@ WriteMetadataJsonToTemporaryFile(IcebergTableMetadata * metadata, FILE *file)
 void
 UploadTableMetadataToURI(IcebergTableMetadata * tableMetadata, char *metadataURI)
 {
-	char	   *localFilePath = GenerateTempFileName(PG_LAKE_ICEBERG, true);
+	char	   *localFilePath = GenerateTempFileNameForUpload(PG_LAKE_ICEBERG);
 
 	/* open the destination file for writing */
 	FILE	   *localFile = AllocateFile(localFilePath, PG_BINARY_W);

--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -1120,14 +1120,8 @@ CreateNewManifestsForDeletedEntries(List *allManifestEntries, List *deletedManif
  *     perManifestCtx, which is destroyed before returning.
  *
  *   - The WRITE phase (UploadIcebergManifestToURI, the new IcebergManifest
- *     headers) is run in callerCtx.  This is required, not just convenient:
- *     UploadIcebergManifestToURI -> GenerateTempFileName registers a
- *     callback on the current memory context that unlinks the local temp
- *     file when that context is reset.  The actual S3 upload is deferred
- *     until commit, so the callback must outlive this function.  Running
- *     the WRITE phase in callerCtx also means the resulting IcebergManifest
- *     headers are already in callerCtx and can be appended to the final
- *     lists directly.
+ *     headers) is run in callerCtx, so that the resulting IcebergManifest
+ *     headers can be appended to the final lists directly.
  *
  * Callers must not be in perManifestCtx when calling this function -- it
  * unconditionally restores CurrentMemoryContext to whatever it was on

--- a/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
+++ b/pg_lake_iceberg/src/iceberg/operations/manifest_merge.c
@@ -504,18 +504,14 @@ RemoveDeletedManifestEntriesInternal(IcebergManifest * *manifest, IcebergSnapsho
 	 *
 	 * Use two memory contexts:
 	 *
-	 * - callerCtx      : holds the new IcebergManifest header we hand back,
-	 * and the local temp file registered for upload at commit time.
+	 * - callerCtx      : holds the new IcebergManifest header we hand back.
 	 *
 	 * - perManifestCtx : holds the manifest entries we read and the filtered
 	 * list we build from them.  We free this before returning.
 	 *
 	 * The WRITE phase (GenerateRemoteManifestPath,
-	 * UploadIcebergManifestToURI, CreateNewIcebergManifest) must run in
-	 * callerCtx, because UploadIcebergManifestToURI -> GenerateTempFileName
-	 * registers a callback on the current memory context that unlinks the
-	 * local temp file when that context is reset.  The matching upload is
-	 * deferred until commit, so the callback has to outlive this function.
+	 * UploadIcebergManifestToURI, CreateNewIcebergManifest) runs in
+	 * callerCtx, so that the manifest header we return is already there.
 	 */
 	bool		modified = false;
 

--- a/pg_lake_table/src/fdw/data_files_catalog.c
+++ b/pg_lake_table/src/fdw/data_files_catalog.c
@@ -278,6 +278,14 @@ GetTableDataFilesHashFromCatalog(Oid relationId, bool dataOnly, bool newFilesOnl
 		 */
 		if (!fileFound)
 		{
+			/*
+			 * dynahash only fills in the key of a new entry, so clear the
+			 * rest before we start filling it in. Callers are allowed to copy
+			 * a TableDataFile out of the hash, and the fields this function
+			 * does not set (such as stats.dataFilePath) are pointers.
+			 */
+			memset(dataFile, 0, sizeof(TableDataFile));
+
 			dataFile->fileId = fileId;
 
 			bool		isPathNull = false;

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -31,6 +31,7 @@
 #include "pg_lake/iceberg/metadata_operations.h"
 #include "pg_lake/iceberg/operations/find_referenced_files.h"
 #include "pg_lake/iceberg/operations/manifest_merge.h"
+#include "pg_lake/iceberg/partitioning/partition.h"
 #include "pg_lake/iceberg/partitioning/spec_generation.h"
 #include "pg_lake/partitioning/partition_spec_catalog.h"
 #include "pg_lake/rest_catalog/rest_catalog.h"
@@ -101,6 +102,7 @@ static List *FindNewPartitionSpecsSinceMetadata(HTAB *currentSpecs, IcebergTable
 static IcebergTableMetadata * GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker);
 static List *GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 										   List *allTransforms);
+static TableMetadataOperation * CopyAddDataFileOperation(const TableDataFile * dataFile);
 static List *GetDDLMetadataOperations(const TableMetadataOperationTracker * opTracker);
 static void DeleteInProgressAddedFiles(Oid relationId, List *addedFiles);
 static bool AreSchemasEqual(IcebergTableSchema * existingSchema, DataFileSchema * newSchema);
@@ -910,6 +912,30 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 	HASH_SEQ_STATUS status;
 	TableMetadataOperationTracker *opTracker;
 
+	/*
+	 * Everything we do per relation below — the data file diff, the
+	 * metadata operations, the new Iceberg metadata and manifests — is only
+	 * needed while that relation is being processed. A transaction that
+	 * writes to many lake tables would otherwise pay the sum of the
+	 * per-relation peaks instead of the largest one, so reset a scratch
+	 * context between relations.
+	 *
+	 * What has to outlive an iteration already lives elsewhere: the files
+	 * staged for upload, and the local temp files holding their contents, are
+	 * held by the upload scheduling context, and REST catalog request bodies
+	 * are copied into TopTransactionContext by RecordRestCatalogRequestInTx.
+	 *
+	 * An error in the loop needs no handling of its own. The scratch context
+	 * is a child of the caller's context, which is the transaction context at
+	 * pre-commit and the subtransaction context under VACUUM, so it is
+	 * deleted along with its parent when the (sub)transaction aborts.
+	 */
+	MemoryContext outerContext = CurrentMemoryContext;
+	MemoryContext perRelationContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "pg_lake per-relation metadata changes",
+							  ALLOCSET_DEFAULT_SIZES);
+
 	hash_seq_init(&status, trackedRelations);
 	while ((opTracker = hash_seq_search(&status)) != NULL)
 	{
@@ -918,6 +944,8 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 		/* relation is dropped */
 		if (!RelationExistsInTheIcebergCatalog(relationId))
 			continue;
+
+		MemoryContextSwitchTo(perRelationContext);
 
 		List	   *allTransforms = AllPartitionTransformList(relationId);
 
@@ -1000,7 +1028,12 @@ ApplyTrackedIcebergMetadataChanges(bool isVerbose)
 			}
 
 		}
+
+		MemoryContextSwitchTo(outerContext);
+		MemoryContextReset(perRelationContext);
 	}
+
+	MemoryContextDelete(perRelationContext);
 
 	/* now write all the metadata files to object storage in parallel */
 	FinishAllUploads();
@@ -1359,6 +1392,23 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 							  List *allTransforms)
 {
 	/*
+	 * The catalog read below is proportional to the number of files in the
+	 * table, while the operations we return are proportional to the number of
+	 * files this transaction changed. Read into a scratch context so the
+	 * difference does not survive until the end of the transaction: the path,
+	 * partition values and column stats of every file in the table are
+	 * allocated per file, and until now they were allocated in the caller's
+	 * context and stayed there long after the diff was done.
+	 */
+	MemoryContext resultContext = CurrentMemoryContext;
+	MemoryContext catalogContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "pg_lake pre-commit data file diff",
+							  ALLOCSET_DEFAULT_SIZES);
+
+	MemoryContextSwitchTo(catalogContext);
+
+	/*
 	 * get current state of data files, which are not applied to metadata yet,
 	 * from catalog
 	 *
@@ -1403,6 +1453,14 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	 */
 	DeleteInProgressAddedFiles(opTracker->relationId, addedFiles);
 
+	/*
+	 * Build the operations we return in the caller's context. Everything they
+	 * point to is copied out of the scratch context, so the memory we keep is
+	 * proportional to the files this transaction changed rather than to the
+	 * files in the table.
+	 */
+	MemoryContextSwitchTo(resultContext);
+
 	List	   *metadataOperations = NIL;
 
 	/* create operations for added files */
@@ -1412,11 +1470,8 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	{
 		TableDataFile *addedFile = lfirst(addedFileCell);
 
-		TableMetadataOperation *addFileOp =
-			AddDataFileOperation(addedFile->path, addedFile->content, &addedFile->stats,
-								 addedFile->partition, addedFile->partitionSpecId);
-
-		metadataOperations = lappend(metadataOperations, addFileOp);
+		metadataOperations = lappend(metadataOperations,
+									 CopyAddDataFileOperation(addedFile));
 	}
 
 	/* create operations for removed files */
@@ -1426,22 +1481,45 @@ GetDataFileMetadataOperations(const TableMetadataOperationTracker * opTracker,
 	{
 		char	   *removedFilePath = lfirst(removedFileCell);
 
-		TableMetadataOperation *removedFileOp = RemoveDataFileOperation(removedFilePath);
+		TableMetadataOperation *removedFileOp = RemoveDataFileOperation(pstrdup(removedFilePath));
 
 		metadataOperations = lappend(metadataOperations, removedFileOp);
 	}
 
 	/*
-	 * The path index over the catalog file list is only needed for the diff
-	 * above, so drop it now rather than leaving one per relation behind until
-	 * the transaction ends. The operations we return do not point into it:
-	 * the path, partition and column stats of each added file were allocated
-	 * separately and outlive it, and the removed paths are copies. addedFiles
-	 * does point into it, so it must not be used after this.
+	 * The catalog file list, the path index over it and the paths of the last
+	 * pushed metadata were only needed to compute the operations above, and
+	 * are the widest thing we allocate per file. Drop them now rather than
+	 * leaving one set per relation behind until the transaction ends. Nothing
+	 * we return points into them: the operations carry their own copies, and
+	 * addedFiles / removedFilePaths must not be used after this.
 	 */
-	hash_destroy(currentFilesMap);
+	MemoryContextDelete(catalogContext);
 
 	return metadataOperations;
+}
+
+
+/*
+ * CopyAddDataFileOperation creates a DATA_FILE_ADD operation for the given data
+ * file in the current memory context, deep copying everything the operation
+ * points to.
+ *
+ * The data file itself lives in the scratch context that GetDataFileMetadataOperations
+ * reads the catalog into, and that context is gone by the time the operation is
+ * applied, so the operation cannot alias the path, stats or partition of it.
+ */
+static TableMetadataOperation *
+CopyAddDataFileOperation(const TableDataFile * dataFile)
+{
+	DataFileStats *copiedStats = DeepCopyDataFileStats(&dataFile->stats);
+
+	Partition  *copiedPartition =
+		dataFile->partition != NULL ? CopyPartition(dataFile->partition) : NULL;
+
+	return AddDataFileOperation(pstrdup(dataFile->path), dataFile->content,
+								copiedStats, copiedPartition,
+								dataFile->partitionSpecId);
 }
 
 


### PR DESCRIPTION
Backport of #527 to `release-3.4`.

## Why backport

Pre-commit processing of a lake table allocates in `TopTransactionContext`, so everything it reads stays until the transaction ends. #511, on `release-3.4` as 939bd3d, bounded what the diff *decodes*, and #528, merged as c50863e while this branch was in CI, shrank the per-entry cost of the path-keyed hashes. Two things neither of them reaches are still on 3.4:

- `GetDataFileMetadataOperations` reads the path, partition values and column statistics of *every* file in the files catalog into the caller's context, only to work out which files this transaction changed. Roughly 280 B per file already in the catalog survives to the end of the transaction whether the transaction added one file or all of them — 16.8 MB at 60 000 files, per commit — which is also why RSS stays elevated after the commit returns.
- `ApplyTrackedIcebergMetadataChanges` leaves everything it produces per relation in the transaction context, so a transaction writing to N lake tables pays the *sum* of the per-relation peaks rather than the largest one.

Measured on `main` in #527: four tables of 15 000 new files each took peak RSS from 356 MB to 239 MB, and the steady-state hold per commit on a 60 000-file table from 16.8 MB to 0.04 MB. Any 3.4 workload that appends to large tables, or writes to several lake tables in one transaction, reaches this, and a host with `vm.overcommit_memory = 2` has no reclaim to absorb the peak.

The two latent bugs #527 fixes on the copy path are worth having on 3.4 independently of the memory work: `GetTableDataFilesHashFromCatalog` left the fields of a new hash entry that it does not set uninitialized, some of which are pointers, so a caller copying a `TableDataFile` out of the hash could follow garbage; and `DeepCopyDataFileStats` dereferenced both string fields unconditionally when both are unset for files read from the files catalog, and silently dropped `partitionKeysText`.

## Conflict resolution

One conflict, in `pg_lake_table/src/transaction/track_iceberg_metadata_changes.c`, from pre-existing divergence and not in code this patch changes the behaviour of. `release-3.4` does not have the TRUNCATE remove-all shortcut from #457, so the three lines #527 adds inside it — switching back to the result context and deleting the scratch context before that early return — are dropped with the block. There is no other early return out of `GetDataFileMetadataOperations`.

That is the only difference from `main`'s `d9d5839..83993f1`; the added and removed lines are otherwise identical, verified line for line. Seven of the ten touched files are byte-identical to `main` after the pick. The three that differ do so only where the branches already diverged:

- `s3_writer_utils.c` and `include/pg_lake/util/s3_writer_utils.h` — `main` has `CopyLocalFileToS3NoCache()` from #480, which 3.4 does not.
- `track_iceberg_metadata_changes.c` — the TRUNCATE shortcut above.

This branch was first cut before #529 landed, which needed two more resolutions (the `path_hash.h` include, and the comment above the scratch context delete, whose starting text was #511's). It has since been re-cut on top of c50863e, so those are gone and the patch is now the same shape as on `main`. Worth noting for that ordering: on `main` the files-by-path hash keys on the path *pointer*, so deleting the scratch context the catalog read allocates into is what frees the keys too. With #528 on the branch that now holds here identically.

## Diff

Ten files across `pg_lake_engine`, `pg_lake_iceberg` and `pg_lake_table`, no new files. No SQL migration files, no schema or catalog change, version stays at 3.4. `GenerateTempFileNameForUpload` is a new exported function in `pg_lake_engine`, used by the three deferred uploads (manifest, manifest list, table metadata); the immediate `CopyLocalFileToS3*` callers keep `GenerateTempFileName`.

The two review-feedback commits of #527 are folded into the single commit here.

## Test plan

- Clean build of `pg_lake_engine`, `pg_lake_iceberg` and `pg_lake_table` against PG 18, no compiler warnings, before and after the re-cut onto c50863e.
- `make check-indent` passes the C half (`pgindent` reports no diff). It then dies at `black`, which is not installed on this workspace; there are no Python changes here.
- Behaviour is unchanged from #527, where the temp file lifetime problem that item 3 exposes was caught by the existing `pg_lake_table` pytest suite rather than by inspection, and CI was green on `main`.
- CI green on `release-3.4`, twice: all 65 checks passed on run 31738539088 (pre-#529 version of this branch) and on run 31742718584 (the re-cut onto c50863e, commit 9d76bd9).

Two CI notes, neither about this patch:

- The re-cut run first came back 64/65 with `test-check-pg-lake-table (18, check-pg_lake_table, 4)` failing on `test_polaris_catalog_writable.py::test_sequences_serial_and_generated_columns[rest]`. It is a race in the test, already carrying `@pytest.mark.flaky(reruns=2)`: the shard sets `vacuum_compact_min_input_files = 1` and `autovacuum_naptime = 1s`, and the autovacuum worker expired `seq_demo/manual_seq_table/.../00001-*.metadata.json` at 21:08:19.253 while the test read that same file through `data_file_stats()` at 21:08:19.149. No `ERROR` is logged before that point. The first attempt's teardown then left the table in the REST catalog, so both reruns failed early at `CREATE TABLE` with `409 AlreadyExistsException` — which is the error that surfaces in the summary and hides the actual first failure. The shard passed on rerun, and the same shard passed on 31738539088 with the same patch.
- The very first run on this branch, 31737659797, ended in `startup_failure` before any job started, and GitHub does not allow retrying those. #529's branch hit the same thing within the same two minutes, so it was transient on the repo rather than anything about this ref.
