### PR TITLE
Hoist per-value type resolution out of PGDuckSerialize

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/serialize.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/serialize.h
@@ -25,6 +25,36 @@
 
 #define BYTEA_OUT_OID 31
 
+/*
+ * PGDuckSerializeKind identifies which serialization path a value takes in
+ * PGDuckSerialize.  It is derived from the type OID, its output function and
+ * the target format, all of which are constant for a given column, so callers
+ * that serialize many values of the same type can resolve it once with
+ * GetPGDuckSerializeKind and then call PGDuckSerializeWithKind per value.
+ * Resolving it costs several syscache probes, which is significant next to the
+ * type's output function call.
+ */
+typedef enum PGDuckSerializeKind
+{
+	/* no override; call the type's own output function */
+	PGDUCK_SERIALIZE_OUTPUT_FUNCTION = 0,
+	PGDUCK_SERIALIZE_MAP,
+	PGDUCK_SERIALIZE_ARRAY,
+	PGDUCK_SERIALIZE_STRUCT,
+	PGDUCK_SERIALIZE_INTERVAL,
+	PGDUCK_SERIALIZE_BYTEA,
+	PGDUCK_SERIALIZE_TIMETZ,
+	PGDUCK_SERIALIZE_GEOMETRY,
+
+	/* output function call plus BC-era year conversion */
+	PGDUCK_SERIALIZE_DATE_TIMESTAMP
+}			PGDuckSerializeKind;
+
+extern PGDLLEXPORT PGDuckSerializeKind GetPGDuckSerializeKind(FmgrInfo *flinfo, Oid typeOid,
+															  CopyDataFormat format);
+extern PGDLLEXPORT char *PGDuckSerializeWithKind(FmgrInfo *flinfo,
+												 PGDuckSerializeKind serializeKind,
+												 Datum value, CopyDataFormat format);
 extern PGDLLEXPORT char *PGDuckSerialize(FmgrInfo *flinfo, Oid typeOid, Datum value,
 										 CopyDataFormat format);
 extern PGDLLEXPORT char *PGDuckOnlySerialize(Oid typeOid, Datum value);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -119,6 +119,14 @@ typedef struct CopyToStateData
 	 * and looking it up per value costs several syscache probes.
 	 */
 	bool	   *useDuckSerialization;
+
+	/*
+	 * Per-column serialization kind for the columns that use DuckDB
+	 * serialization, precomputed for the same reason: PGDuckSerialize would
+	 * otherwise re-resolve the column's domain base type, and for arrays also
+	 * re-check whether it is a map type, for every value.
+	 */
+	PGDuckSerializeKind *duckSerializeKind;
 	MemoryContext rowcontext;	/* per-row evaluation context */
 	uint64		bytes_processed;	/* number of bytes processed so far */
 
@@ -475,6 +483,8 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 	cstate->out_functions = (FmgrInfo *) palloc(num_phys_attrs * sizeof(FmgrInfo));
 	cstate->needsNumericLeafCheck = (bool *) palloc0(num_phys_attrs * sizeof(bool));
 	cstate->useDuckSerialization = (bool *) palloc0(num_phys_attrs * sizeof(bool));
+	cstate->duckSerializeKind = (PGDuckSerializeKind *)
+		palloc0(num_phys_attrs * sizeof(PGDuckSerializeKind));
 	foreach(cur, cstate->attnumlist)
 	{
 		int			attnum = lfirst_int(cur);
@@ -499,6 +509,12 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 			ShouldUseDuckSerialization(cstate->targetFormat,
 									   MakePGType(attr->atttypid,
 												  attr->atttypmod));
+
+		if (cstate->useDuckSerialization[attnum - 1])
+			cstate->duckSerializeKind[attnum - 1] =
+				GetPGDuckSerializeKind(&cstate->out_functions[attnum - 1],
+									   attr->atttypid,
+									   cstate->targetFormat);
 	}
 
 	/*
@@ -936,24 +952,20 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 		{
 			if (!cstate->opts.binary)
 			{
-				/*
-				 * Lookup the underlying tuple's attribute so we can pass in
-				 * the typid
-				 */
-				Form_pg_attribute attr = TupleDescAttr(slot->tts_tupleDescriptor, attnum - 1);
-
 				if (cstate->useDuckSerialization[attnum - 1])
 				{
 					/*
 					 * Since we are at the top-level when emitting an
 					 * attribute in CopyOneRowTo(), we are not inside a
 					 * composite type.
+					 *
+					 * The serialization kind was resolved from the column's
+					 * type in StartCopyTo().
 					 */
-
-					string = PGDuckSerialize(&out_functions[attnum - 1],
-											 attr->atttypid,
-											 value,
-											 cstate->targetFormat);
+					string = PGDuckSerializeWithKind(&out_functions[attnum - 1],
+													 cstate->duckSerializeKind[attnum - 1],
+													 value,
+													 cstate->targetFormat);
 				}
 				else
 					string = OutputFunctionCall(&out_functions[attnum - 1],
@@ -971,9 +983,14 @@ CopyOneRowTo(CopyToState cstate, TupleTableSlot *slot)
 				 */
 				if (cstate->targetFormat != DATA_FORMAT_ICEBERG &&
 					cstate->needsNumericLeafCheck[attnum - 1])
+				{
+					Form_pg_attribute attr =
+						TupleDescAttr(slot->tts_tupleDescriptor, attnum - 1);
+
 					ErrorIfCopyToExceedsNumericLimitsInDatum(value,
 															 attr->atttypid,
 															 attr->atttypmod);
+				}
 
 
 				if (cstate->opts.csv_mode)

--- a/pg_lake_engine/src/pgduck/array_conversion.c
+++ b/pg_lake_engine/src/pgduck/array_conversion.c
@@ -102,6 +102,10 @@ ArrayOutForPGDuck(ArrayType *array, CopyDataFormat format)
 	/* whether elements need quotes only depends on the element type */
 	bool		elementIsContainer = IsSerializedAsContainer(element_type, format);
 
+	/* all elements have the same type, so they serialize the same way */
+	PGDuckSerializeKind elementSerializeKind =
+		GetPGDuckSerializeKind(&my_extra->proc, element_type, format);
+
 	for (i = 0; i < nitems && array_iterate(iter, &itemvalue, &isnull); i++)
 	{
 		bool		needquote;
@@ -115,8 +119,9 @@ ArrayOutForPGDuck(ArrayType *array, CopyDataFormat format)
 		}
 		else
 		{
-			values[i] = PGDuckSerialize(&my_extra->proc, element_type, itemvalue,
-										format);
+			values[i] = PGDuckSerializeWithKind(&my_extra->proc,
+												elementSerializeKind,
+												itemvalue, format);
 
 			/* count data plus backslashes; detect chars needing quotes */
 			needquote = !elementIsContainer;

--- a/pg_lake_engine/src/pgduck/map_conversion.c
+++ b/pg_lake_engine/src/pgduck/map_conversion.c
@@ -93,6 +93,12 @@ MapOutForPGDuck(Datum myMap, CopyDataFormat format)
 	bool		keyIsContainer = IsSerializedAsContainer(keysElementType, format);
 	bool		valIsContainer = IsSerializedAsContainer(valuesElementType, format);
 
+	/* all keys and all values have the same type, so resolve once */
+	PGDuckSerializeKind keySerializeKind =
+		GetPGDuckSerializeKind(&keysExtra->proc, keysElementType, format);
+	PGDuckSerializeKind valueSerializeKind =
+		GetPGDuckSerializeKind(&valuesExtra->proc, valuesElementType, format);
+
 	StringInfoData outputBuffer;
 
 	initStringInfo(&outputBuffer);
@@ -126,8 +132,8 @@ MapOutForPGDuck(Datum myMap, CopyDataFormat format)
 		if (nulls[0])
 			ereport(ERROR, (errmsg("cannot have NULL for map key entry")));;
 
-		serializedKey = PGDuckSerialize(&keysExtra->proc, keysElementType, pairValues[0],
-										format);
+		serializedKey = PGDuckSerializeWithKind(&keysExtra->proc, keySerializeKind,
+												pairValues[0], format);
 		if (!keyIsContainer)
 			serializedKey = (char *) quote_literal_cstr(serializedKey);
 
@@ -135,8 +141,9 @@ MapOutForPGDuck(Datum myMap, CopyDataFormat format)
 			serializedValue = "NULL";
 		else
 		{
-			serializedValue = PGDuckSerialize(&valuesExtra->proc, valuesElementType, pairValues[1],
-											  format);
+			serializedValue = PGDuckSerializeWithKind(&valuesExtra->proc,
+													  valueSerializeKind,
+													  pairValues[1], format);
 			if (!valIsContainer)
 				serializedValue = (char *) quote_literal_cstr(serializedValue);
 		}

--- a/pg_lake_engine/src/pgduck/serialize.c
+++ b/pg_lake_engine/src/pgduck/serialize.c
@@ -115,17 +115,17 @@ ConvertISOYearToBCIfNeeded(const char *dateTimestampString)
 
 
 /*
- * Serialize a Datum in a PGDuck-compatible way; a central hook for
- * special-purpose conversion of PG datatypes in preparation for PGDuck.
+ * GetPGDuckSerializeKind determines how a value of the given type is
+ * serialized for PGDuck, based on the type, its output function and the target
+ * format.
  *
- * By default, we call the supplied OutputFunction as provided, however we want
- * the ability to override this serialization on a type-by-type basis, in
- * particular for arrays and records, which get special handling to convert to
- * DuckDB-compatible text format.
+ * The answer is the same for every value of a column, but deriving it costs
+ * several syscache lookups (domain resolution, and the map check on top of
+ * that for arrays), so callers that serialize many values of the same type
+ * should resolve the kind once and pass it to PGDuckSerializeWithKind.
  */
-char *
-PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
-				CopyDataFormat format)
+PGDuckSerializeKind
+GetPGDuckSerializeKind(FmgrInfo *flinfo, Oid columnType, CopyDataFormat format)
 {
 	/*
 	 * Unwrap domain types so that e.g. a domain-over-bytea is serialized with
@@ -137,13 +137,13 @@ PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 	{
 		/* maps are a type of array */
 		if (IsMapTypeOid(columnType))
-			return MapOutForPGDuck(value, format);
+			return PGDUCK_SERIALIZE_MAP;
 
-		return ArrayOutForPGDuck(DatumGetArrayTypeP(value), format);
+		return PGDUCK_SERIALIZE_ARRAY;
 	}
 
 	if (flinfo->fn_oid == RECORD_OUT_OID)
-		return StructOutForPGDuck(value, format);
+		return PGDUCK_SERIALIZE_STRUCT;
 
 	/*
 	 * For Iceberg, intervals are serialized as struct(months, days,
@@ -151,44 +151,115 @@ PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
 	 * interval formatting is different from postgres interval formatting.
 	 */
 	if (columnType == INTERVALOID && format == DATA_FORMAT_ICEBERG)
-		return IntervalOutForPGDuck(value);
+		return PGDUCK_SERIALIZE_INTERVAL;
 
 	if (columnType == BYTEAOID)
-		return ByteAOutForPGDuck(value);
+		return PGDUCK_SERIALIZE_BYTEA;
 
 	/*
 	 * TimeTZ is stored as TIME (UTC-normalized) in Iceberg. We convert to UTC
 	 * in PGDuckSerialize, so DuckDB should parse as TIME.
 	 */
 	if (columnType == TIMETZOID && format == DATA_FORMAT_ICEBERG)
-		return TimeTzOutForPGDuck(value);
+		return PGDUCK_SERIALIZE_TIMETZ;
 
 	if (IsGeometryOutFunctionId(flinfo->fn_oid))
-	{
-		/*
-		 * Postgis emits HEX WKB by default, which DuckDB does not accept.
-		 * Hence, we emit as WKT.
-		 */
-		Datum		geomAsText = OidFunctionCall1(ST_AsTextFunctionId(), value);
+		return PGDUCK_SERIALIZE_GEOMETRY;
 
-		return TextDatumGetCString(geomAsText);
-	}
-
-	/*
-	 * PostgreSQL outputs BC dates/timestamps with a " BC" suffix (e.g.
-	 * "4712-01-01 BC"), but DuckDB expects ISO 8601 negative-year format
-	 * (e.g. "-4711-01-01").  Without this conversion, DuckDB silently drops
-	 * the BC era indicator and treats the value as AD.
-	 */
 	if (columnType == DATEOID || columnType == TIMESTAMPOID ||
 		columnType == TIMESTAMPTZOID)
-	{
-		char	   *result = OutputFunctionCall(flinfo, value);
+		return PGDUCK_SERIALIZE_DATE_TIMESTAMP;
 
-		return (char *) ConvertBCToISOYearIfNeeded(result);
+	return PGDUCK_SERIALIZE_OUTPUT_FUNCTION;
+}
+
+
+/*
+ * PGDuckSerializeWithKind serializes a Datum in a PGDuck-compatible way using
+ * a serialization kind that the caller already resolved via
+ * GetPGDuckSerializeKind.
+ *
+ * The kind must have been resolved for the type of the value being passed in,
+ * with the same target format.
+ */
+char *
+PGDuckSerializeWithKind(FmgrInfo *flinfo, PGDuckSerializeKind serializeKind,
+						Datum value, CopyDataFormat format)
+{
+	switch (serializeKind)
+	{
+		case PGDUCK_SERIALIZE_MAP:
+			return MapOutForPGDuck(value, format);
+
+		case PGDUCK_SERIALIZE_ARRAY:
+			return ArrayOutForPGDuck(DatumGetArrayTypeP(value), format);
+
+		case PGDUCK_SERIALIZE_STRUCT:
+			return StructOutForPGDuck(value, format);
+
+		case PGDUCK_SERIALIZE_INTERVAL:
+			return IntervalOutForPGDuck(value);
+
+		case PGDUCK_SERIALIZE_BYTEA:
+			return ByteAOutForPGDuck(value);
+
+		case PGDUCK_SERIALIZE_TIMETZ:
+			return TimeTzOutForPGDuck(value);
+
+		case PGDUCK_SERIALIZE_GEOMETRY:
+			{
+				/*
+				 * Postgis emits HEX WKB by default, which DuckDB does not
+				 * accept. Hence, we emit as WKT.
+				 */
+				Datum		geomAsText = OidFunctionCall1(ST_AsTextFunctionId(), value);
+
+				return TextDatumGetCString(geomAsText);
+			}
+
+		case PGDUCK_SERIALIZE_DATE_TIMESTAMP:
+			{
+				/*
+				 * PostgreSQL outputs BC dates/timestamps with a " BC" suffix
+				 * (e.g. "4712-01-01 BC"), but DuckDB expects ISO 8601
+				 * negative-year format (e.g. "-4711-01-01").  Without this
+				 * conversion, DuckDB silently drops the BC era indicator and
+				 * treats the value as AD.
+				 */
+				char	   *result = OutputFunctionCall(flinfo, value);
+
+				return (char *) ConvertBCToISOYearIfNeeded(result);
+			}
+
+		case PGDUCK_SERIALIZE_OUTPUT_FUNCTION:
+			return OutputFunctionCall(flinfo, value);
 	}
 
+	/* keep the compiler happy; all kinds are handled above */
 	return OutputFunctionCall(flinfo, value);
+}
+
+
+/*
+ * Serialize a Datum in a PGDuck-compatible way; a central hook for
+ * special-purpose conversion of PG datatypes in preparation for PGDuck.
+ *
+ * By default, we call the supplied OutputFunction as provided, however we want
+ * the ability to override this serialization on a type-by-type basis, in
+ * particular for arrays and records, which get special handling to convert to
+ * DuckDB-compatible text format.
+ *
+ * Callers in a per-value loop should hoist the GetPGDuckSerializeKind call out
+ * of the loop and call PGDuckSerializeWithKind directly.
+ */
+char *
+PGDuckSerialize(FmgrInfo *flinfo, Oid columnType, Datum value,
+				CopyDataFormat format)
+{
+	PGDuckSerializeKind serializeKind =
+		GetPGDuckSerializeKind(flinfo, columnType, format);
+
+	return PGDuckSerializeWithKind(flinfo, serializeKind, value, format);
 }
 
 


### PR DESCRIPTION
## Problem

`PGDuckSerialize` re-derives how to serialize a value on every call. It resolves
the column's domain base type, and for arrays it additionally checks whether the
type is a map, so every field of every row pays at least two syscache lookups.
That answer is the same for every value of a column: it only depends on the type,
its output function and the target format. Next to the output function call
itself (an int4 field is on the order of 100ns end to end, of which `int4out` is
about 25ns) the repeated dispatch is a large share of per-field write cost, and
`ShouldUseDuckSerialization` returns true for every column when writing Iceberg.

## Solution

Split the decision out into `GetPGDuckSerializeKind()`, which returns a
`PGDuckSerializeKind` enum, and have `PGDuckSerializeWithKind()` switch on it.
The CSV writer resolves the kind once per column in `StartCopyTo`, next to the
existing `useDuckSerialization` / `out_functions` arrays, and the array and map
converters resolve it once per array or map instead of once per element.
`PGDuckSerialize` stays as a wrapper for the callers that serialize a single
value (FDW parameters, data file stats, field defaults), so their behavior is
unchanged.

Measured with `COPY <table> TO '<file>' WITH (format 'parquet')`, best of 3,
repeated twice per build (spread under 1.5%):

| workload | before | after |
|---|---|---|
| 16 int columns, 1M rows | 3.17s | 1.67s (-47%) |
| 8 mixed columns, 250k rows | 1.69s | 1.45s (-14%) |
| `int[20]` arrays, 100k rows | 0.60s | 0.38s (-36%) |

These are on a local aarch64 box with PostgreSQL built at `-Og`, so the ratios
are the signal and a production `-O2` build will see less. The wide-int case is
the shape where per-column dispatch dominates.

## Test plan

- [x] `pg_lake_copy` pytests pass (243 passed, 3 skipped), including the complex
      type, parquet, csv, json and Iceberg copy suites that cover arrays, maps,
      structs, domains, bytea, timetz and BC dates.
- [x] `make check-indent` clean on the C side.
- [x] CI green on this PR (all 68 checks, PG 16/17/18 on debian and almalinux).
