### PR TITLE
POC: compress the temporary exchange CSVs (gzip or zstd)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN if [ "$BASE_IMAGE_OS" = "almalinux" ]; then \
             protobuf-c-devel \
             uuid-devel \
             lz4-devel \
+            libzstd-devel \
             xz-devel \
             snappy-devel \
             perl \
@@ -93,6 +94,7 @@ RUN if [ "$BASE_IMAGE_OS" = "debian" ]; then \
             uuid-dev \
             libossp-uuid-dev \
             liblz4-dev \
+            libzstd-dev \
             liblzma-dev \
             libsnappy-dev \
             perl \
@@ -330,6 +332,7 @@ RUN if [ "$BASE_IMAGE_OS" = "almalinux" ]; then \
     protobuf-c \
     uuid \
     lz4 \
+    libzstd \
     xz \
     snappy \
     perl \
@@ -356,6 +359,7 @@ RUN if [ "$BASE_IMAGE_OS" = "debian" ]; then \
     uuid-runtime \
     libossp-uuid16 \
     liblz4-1 \
+    libzstd1 \
     liblzma5 \
     libsnappy1v5 \
     perl \

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -263,6 +263,7 @@ apt-get install -y \
     uuid-dev \
     libossp-uuid-dev \
     liblz4-dev \
+    libzstd-dev \
     liblzma-dev \
     libsnappy-dev \
     perl \
@@ -304,6 +305,7 @@ dnf -y install \
     protobuf-c-devel \
     uuid-devel \
     lz4-devel \
+    libzstd-devel \
     xz-devel \
     snappy-devel \
     perl \
@@ -345,6 +347,7 @@ brew install \
     json-c \
     protobuf-c \
     lz4 \
+    zstd \
     xz \
     snappy \
     jansson \

--- a/install.sh
+++ b/install.sh
@@ -248,6 +248,7 @@ install_system_deps() {
                 uuid-dev \
                 libossp-uuid-dev \
                 liblz4-dev \
+                libzstd-dev \
                 liblzma-dev \
                 libsnappy-dev \
                 perl \
@@ -290,6 +291,7 @@ install_system_deps() {
                 protobuf-c-devel \
                 uuid-devel \
                 lz4-devel \
+                libzstd-devel \
                 xz-devel \
                 snappy-devel \
                 perl \
@@ -332,6 +334,7 @@ install_system_deps() {
                 json-c \
                 protobuf-c \
                 lz4 \
+                zstd \
                 xz \
                 snappy \
                 jansson \

--- a/pg_lake_copy/tests/pytests/test_temp_file_compression.py
+++ b/pg_lake_copy/tests/pytests/test_temp_file_compression.py
@@ -6,7 +6,8 @@ from utils_pytest import *
 # compressed (pg_lake_engine.temp_file_compression).  It is an internal exchange
 # format, so the setting must make no difference to anything a user can observe.
 
-COMPRESSION_MODES = ["none", "gzip"]
+COMPRESSION_MODES = ["none", "gzip", "zstd"]
+COMPRESSED_MODES = [mode for mode in COMPRESSION_MODES if mode != "none"]
 
 # Values chosen to stress the CSV dialect rather than the type system: embedded
 # delimiters and quotes, the literal null sentinel next to a real NULL, an empty
@@ -26,9 +27,11 @@ ADVERSARIAL_QUERY = r"""
 """
 
 
-def write_parquet(conn, tmp_path, mode, name):
+def write_parquet(conn, tmp_path, mode, name, level=None):
     """COPY the adversarial rows out as Parquet with the given compression mode."""
     run_command(f"SET pg_lake_engine.temp_file_compression TO '{mode}'", conn)
+    if level is not None:
+        run_command(f"SET pg_lake_engine.temp_file_compression_level TO {level}", conn)
 
     parquet_path = tmp_path / f"{name}.parquet"
     copy_to_file(
@@ -90,7 +93,40 @@ def test_temp_file_compression_matches_uncompressed(pg_conn, duckdb_conn, tmp_pa
         duckdb_conn.execute("SELECT * FROM read_parquet($1) ORDER BY id", [str(path)])
         contents[mode] = duckdb_conn.fetchall()
 
-    assert contents["gzip"] == contents["none"]
+    for mode in COMPRESSED_MODES:
+        assert contents[mode] == contents["none"], mode
+
+    pg_conn.rollback()
+
+
+# One setting carries the level for both codecs, so it spans the union of their
+# ranges: gzip's 1 to 9, and zstd's negative fast modes through 22.  A level the
+# active codec cannot use is clamped, not rejected.
+@pytest.mark.parametrize(
+    "mode,level",
+    [
+        ("gzip", 1),
+        ("gzip", 9),
+        ("gzip", 22),
+        ("gzip", -22),
+        ("zstd", -22),
+        ("zstd", -3),
+        ("zstd", 1),
+        ("zstd", 19),
+        ("zstd", 22),
+    ],
+)
+def test_temp_file_compression_levels(pg_conn, duckdb_conn, tmp_path, mode, level):
+    parquet_path = write_parquet(
+        pg_conn, tmp_path, mode, f"level_{mode}_{level}", level=level
+    )
+
+    duckdb_conn.execute(
+        "SELECT count(*), count(DISTINCT whitespace) FROM read_parquet($1)",
+        [str(parquet_path)],
+    )
+
+    assert duckdb_conn.fetchall() == [(2000, 1)]
 
     pg_conn.rollback()
 

--- a/pg_lake_copy/tests/pytests/test_temp_file_compression.py
+++ b/pg_lake_copy/tests/pytests/test_temp_file_compression.py
@@ -1,0 +1,133 @@
+import pytest
+from utils_pytest import *
+
+
+# The temporary CSV that carries rows from PostgreSQL to the query engine can be
+# compressed (pg_lake_engine.temp_file_compression).  It is an internal exchange
+# format, so the setting must make no difference to anything a user can observe.
+
+COMPRESSION_MODES = ["none", "gzip"]
+
+# Values chosen to stress the CSV dialect rather than the type system: embedded
+# delimiters and quotes, the literal null sentinel next to a real NULL, an empty
+# string, and a value carrying its own newlines.
+ADVERSARIAL_QUERY = r"""
+	SELECT g AS id,
+		   'has,comma and "quote"' AS punctuated,
+		   '\N' AS null_sentinel,
+		   NULL::text AS real_null,
+		   '' AS empty,
+		   E'multi\nline\ttab' AS whitespace,
+		   ('\x' || md5(g::text))::bytea AS blob,
+		   ARRAY[1.5, NULL, 3.25]::numeric[] AS nums,
+		   '2020-01-01 00:00:00+00'::timestamptz + (g || ' seconds')::interval AS ts,
+		   jsonb_build_object('k', g) AS j
+	FROM generate_series(1, 2000) g
+"""
+
+
+def write_parquet(conn, tmp_path, mode, name):
+    """COPY the adversarial rows out as Parquet with the given compression mode."""
+    run_command(f"SET pg_lake_engine.temp_file_compression TO '{mode}'", conn)
+
+    parquet_path = tmp_path / f"{name}.parquet"
+    copy_to_file(
+        f"COPY ({ADVERSARIAL_QUERY}) TO STDOUT WITH (format 'parquet')",
+        parquet_path,
+        conn,
+    )
+
+    return parquet_path
+
+
+@pytest.mark.parametrize("mode", COMPRESSION_MODES)
+def test_temp_file_compression_preserves_values(pg_conn, duckdb_conn, tmp_path, mode):
+    parquet_path = write_parquet(pg_conn, tmp_path, mode, f"values_{mode}")
+
+    duckdb_conn.execute(
+        """
+		SELECT count(*),
+			   count(DISTINCT punctuated),
+			   count(DISTINCT null_sentinel),
+			   count(real_null),
+			   count(DISTINCT empty),
+			   count(DISTINCT whitespace)
+		FROM read_parquet($1)
+	""",
+        [str(parquet_path)],
+    )
+
+    # The three text columns each hold one distinct value across all rows, and
+    # real_null is NULL everywhere, so count() over it is zero.
+    assert duckdb_conn.fetchall() == [(2000, 1, 1, 0, 1, 1)]
+
+    duckdb_conn.execute(
+        """
+		SELECT DISTINCT punctuated, null_sentinel, empty, whitespace
+		FROM read_parquet($1)
+	""",
+        [str(parquet_path)],
+    )
+
+    # The null sentinel has to survive as its own text rather than becoming NULL.
+    assert duckdb_conn.fetchall() == [
+        ('has,comma and "quote"', "\\N", "", "multi\nline\ttab")
+    ]
+
+    pg_conn.rollback()
+
+
+def test_temp_file_compression_matches_uncompressed(pg_conn, duckdb_conn, tmp_path):
+    paths = {
+        mode: write_parquet(pg_conn, tmp_path, mode, f"compare_{mode}")
+        for mode in COMPRESSION_MODES
+    }
+
+    # The Parquet writer does not promise byte-identical files, so compare
+    # contents rather than checksums.
+    contents = {}
+    for mode, path in paths.items():
+        duckdb_conn.execute("SELECT * FROM read_parquet($1) ORDER BY id", [str(path)])
+        contents[mode] = duckdb_conn.fetchall()
+
+    assert contents["gzip"] == contents["none"]
+
+    pg_conn.rollback()
+
+
+@pytest.mark.parametrize("mode", COMPRESSION_MODES)
+def test_temp_file_compression_iceberg_dml(
+    extension, s3, pg_conn, with_default_location, mode
+):
+    # DELETE and UPDATE write their own exchange CSVs (the position list and the
+    # re-inserted rows), and a large enough DELETE rewrites the data file by
+    # reading that CSV back, so all three exchange paths run here.
+    run_command(
+        f"""
+		SET pg_lake_engine.temp_file_compression TO '{mode}';
+		CREATE TABLE temp_file_compression_{mode} (id int, txt text) USING iceberg;
+		INSERT INTO temp_file_compression_{mode}
+			SELECT g, 'row-' || g FROM generate_series(1, 5000) g;
+		DELETE FROM temp_file_compression_{mode} WHERE id % 3 = 0;
+		UPDATE temp_file_compression_{mode} SET txt = txt || '-updated'
+			WHERE id % 7 = 0;
+	""",
+        pg_conn,
+    )
+
+    result = run_query(
+        f"""
+		SELECT count(*),
+			   count(*) FILTER (WHERE txt LIKE '%-updated'),
+			   sum(id)
+		FROM temp_file_compression_{mode}
+	""",
+        pg_conn,
+    )
+
+    updated = len([g for g in range(1, 5001) if g % 3 != 0 and g % 7 == 0])
+    remaining = [g for g in range(1, 5001) if g % 3 != 0]
+    assert result == [[len(remaining), updated, sum(remaining)]]
+
+    run_command(f"DROP TABLE temp_file_compression_{mode}", pg_conn)
+    pg_conn.commit()

--- a/pg_lake_engine/Makefile
+++ b/pg_lake_engine/Makefile
@@ -7,8 +7,9 @@ SOURCES := $(wildcard src/*.c) $(wildcard src/*/*.c)
 OBJS := $(patsubst %.c,%.o,$(sort $(SOURCES)))
 SHLIB_LINK_INTERNAL = $(libpq)
 
-# zlib, for compressing the temporary exchange CSVs (see src/csv/csv_compression.c)
-SHLIB_LINK += -lz
+# zlib and libzstd, for compressing the temporary exchange CSVs
+# (see src/csv/csv_compression.c)
+SHLIB_LINK += -lz -lzstd
 
 PG_LAKE_DELTA_SUPPORT ?= 0
 

--- a/pg_lake_engine/Makefile
+++ b/pg_lake_engine/Makefile
@@ -7,6 +7,9 @@ SOURCES := $(wildcard src/*.c) $(wildcard src/*/*.c)
 OBJS := $(patsubst %.c,%.o,$(sort $(SOURCES)))
 SHLIB_LINK_INTERNAL = $(libpq)
 
+# zlib, for compressing the temporary exchange CSVs (see src/csv/csv_compression.c)
+SHLIB_LINK += -lz
+
 PG_LAKE_DELTA_SUPPORT ?= 0
 
 PG_CPPFLAGS = -I$(libpq_srcdir) -Iinclude -I../pg_extension_base/include -std=gnu99 -g -DPG_LAKE_DELTA_SUPPORT=$(PG_LAKE_DELTA_SUPPORT)

--- a/pg_lake_engine/include/pg_lake/csv/csv_compression.h
+++ b/pg_lake_engine/include/pg_lake/csv/csv_compression.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PG_LAKE_CSV_COMPRESSION_H
+#define PG_LAKE_CSV_COMPRESSION_H
+
+#include <stdio.h>
+
+#include "pg_lake/copy/copy_format.h"
+
+/* pg_lake_engine.temp_file_compression setting */
+extern PGDLLEXPORT int TempFileCompression;
+
+/* pg_lake_engine.temp_file_compression_level setting */
+extern PGDLLEXPORT int TempFileCompressionLevel;
+
+/* a compressor wrapped around a stdio stream */
+typedef struct CSVCompressor CSVCompressor;
+
+extern PGDLLEXPORT CopyDataCompression InternalCSVCompression(void);
+extern PGDLLEXPORT CSVCompressor * CSVCompressorCreate(FILE *file,
+													   CopyDataCompression method,
+													   int level);
+extern PGDLLEXPORT void CSVCompressorWrite(CSVCompressor * compressor,
+										   const void *data, size_t size);
+extern PGDLLEXPORT void CSVCompressorFinish(CSVCompressor * compressor);
+
+#endif

--- a/pg_lake_engine/include/pg_lake/csv/csv_compression.h
+++ b/pg_lake_engine/include/pg_lake/csv/csv_compression.h
@@ -22,6 +22,14 @@
 
 #include "pg_lake/copy/copy_format.h"
 
+/*
+ * Bounds of pg_lake_engine.temp_file_compression_level: the union of what the
+ * codecs accept, since one setting serves both.  Each codec clamps the level
+ * into its own range, so gzip stops at 9 and only zstd sees the rest.
+ */
+#define PG_LAKE_MIN_TEMP_FILE_COMPRESSION_LEVEL (-22)
+#define PG_LAKE_MAX_TEMP_FILE_COMPRESSION_LEVEL 22
+
 /* pg_lake_engine.temp_file_compression setting */
 extern PGDLLEXPORT int TempFileCompression;
 
@@ -32,6 +40,8 @@ extern PGDLLEXPORT int TempFileCompressionLevel;
 typedef struct CSVCompressor CSVCompressor;
 
 extern PGDLLEXPORT CopyDataCompression InternalCSVCompression(void);
+extern PGDLLEXPORT void CSVCompressionLevelRange(CopyDataCompression method,
+												 int *minLevel, int *maxLevel);
 extern PGDLLEXPORT CSVCompressor * CSVCompressorCreate(FILE *file,
 													   CopyDataCompression method,
 													   int level);

--- a/pg_lake_engine/src/csv/csv_compression.c
+++ b/pg_lake_engine/src/csv/csv_compression.c
@@ -27,8 +27,18 @@
  * text, and bytea costs four bytes per input byte -- so a bulk load can need
  * several times the table's size in temporary space.  Compressing it trades
  * CPU for that space and for the write and read bandwidth underneath it.
+ *
+ * The codec has to be one both ends understand, which leaves gzip and zstd:
+ * those are the only two DuckDB's CSV reader can unwrap, and the only two of
+ * PostgreSQL's own compression methods it shares.  lz4 does not qualify, even
+ * though DuckDB decompresses it for Parquet column pages -- that is the raw
+ * block format, and there is no file system there to unwrap an lz4 frame off a
+ * CSV.  zstd is the faster of the two survivors at any given ratio, and its
+ * negative levels are faster still, so it is what to reach for when the point
+ * is throughput rather than space.
  */
 #include <zlib.h>
+#include <zstd.h>
 
 #include "postgres.h"
 
@@ -42,9 +52,10 @@ int			TempFileCompression = DATA_COMPRESSION_NONE;
 int			TempFileCompressionLevel = 1;
 
 /*
- * Staging buffer for deflate() output.  Only needs to be large enough to keep
- * the write count down; deflate is called repeatedly until it stops filling
- * the buffer.
+ * Staging buffer for compressor output.  Only needs to be large enough to keep
+ * the write count down; both codecs are called repeatedly until they run out of
+ * output.  It also clears ZSTD_CStreamOutSize(), one zstd block plus framing,
+ * which is what lets the frame usually close in a single pass.
  */
 #define COMPRESS_BUFFER_SIZE (256 * 1024)
 
@@ -60,18 +71,31 @@ int			TempFileCompressionLevel = 1;
 
 struct CSVCompressor
 {
+	CopyDataCompression method;
 	FILE	   *file;
-	z_stream	stream;
 
-	/* holds all of zlib's allocations, so an error can't leak them */
+	/* gzip state, plus the context holding all of zlib's allocations */
+	z_stream	stream;
 	MemoryContext context;
+
+	/* zstd state, released by ReleaseZstdStream() on the error path */
+	ZSTD_CStream *zstd;
 
 	unsigned char buffer[COMPRESS_BUFFER_SIZE];
 };
 
+static void GzipCompressorCreate(CSVCompressor * compressor, int level);
+static void GzipCompressorWrite(CSVCompressor * compressor, const void *data,
+								size_t size);
+static void GzipCompressorFinish(CSVCompressor * compressor);
+static void ZstdCompressorCreate(CSVCompressor * compressor, int level);
+static void ZstdCompressorWrite(CSVCompressor * compressor, const void *data,
+								size_t size);
+static void ZstdCompressorFinish(CSVCompressor * compressor);
+static void ReleaseZstdStream(void *arg);
 static void *CompressorAlloc(void *opaque, unsigned int items, unsigned int size);
 static void CompressorFree(void *opaque, void *address);
-static void FlushCompressorBuffer(CSVCompressor * compressor);
+static void WriteCompressorBuffer(CSVCompressor * compressor, size_t produced);
 
 
 /*
@@ -88,6 +112,40 @@ InternalCSVCompression(void)
 
 
 /*
+ * CSVCompressionLevelRange reports the levels a codec accepts.
+ */
+void
+CSVCompressionLevelRange(CopyDataCompression method, int *minLevel, int *maxLevel)
+{
+	switch (method)
+	{
+		case DATA_COMPRESSION_GZIP:
+			*minLevel = Z_BEST_SPEED;
+			*maxLevel = Z_BEST_COMPRESSION;
+			break;
+
+		case DATA_COMPRESSION_ZSTD:
+
+			/*
+			 * Below zero is zstd's "fast" mode, which gives up ratio for a
+			 * good deal of speed.  ZSTD_minCLevel() names a floor far below
+			 * anything useful on a file that lives for one statement, so the
+			 * setting's own bound stands in for it.
+			 */
+			*minLevel = PG_LAKE_MIN_TEMP_FILE_COMPRESSION_LEVEL;
+			*maxLevel = Min(ZSTD_maxCLevel(),
+							PG_LAKE_MAX_TEMP_FILE_COMPRESSION_LEVEL);
+			break;
+
+		default:
+			*minLevel = 0;
+			*maxLevel = 0;
+			break;
+	}
+}
+
+
+/*
  * CSVCompressorCreate starts a compressed stream on top of an already-open
  * file.  The caller keeps ownership of the file and must not write to it
  * directly while the compressor is alive.
@@ -95,7 +153,10 @@ InternalCSVCompression(void)
 CSVCompressor *
 CSVCompressorCreate(FILE *file, CopyDataCompression method, int level)
 {
-	if (method != DATA_COMPRESSION_GZIP)
+	int			minLevel;
+	int			maxLevel;
+
+	if (method != DATA_COMPRESSION_GZIP && method != DATA_COMPRESSION_ZSTD)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("unsupported temporary file compression \"%s\"",
@@ -103,8 +164,67 @@ CSVCompressorCreate(FILE *file, CopyDataCompression method, int level)
 
 	CSVCompressor *compressor = palloc0(sizeof(CSVCompressor));
 
+	compressor->method = method;
 	compressor->file = file;
 
+	/*
+	 * One setting covers both codecs, and they disagree about how far a level
+	 * goes, so a level meant for the other one is clamped rather than
+	 * rejected: all it can change is how the codec spends CPU, and refusing
+	 * to write the CSV over it would be a poor trade.
+	 */
+	CSVCompressionLevelRange(method, &minLevel, &maxLevel);
+	level = Min(Max(level, minLevel), maxLevel);
+
+	if (method == DATA_COMPRESSION_GZIP)
+		GzipCompressorCreate(compressor, level);
+	else
+		ZstdCompressorCreate(compressor, level);
+
+	return compressor;
+}
+
+
+/*
+ * CSVCompressorWrite compresses a buffer into the underlying file.
+ */
+void
+CSVCompressorWrite(CSVCompressor * compressor, const void *data, size_t size)
+{
+	if (size == 0)
+	{
+		/* deflate() reports Z_BUF_ERROR when there is nothing to do */
+		return;
+	}
+
+	if (compressor->method == DATA_COMPRESSION_GZIP)
+		GzipCompressorWrite(compressor, data, size);
+	else
+		ZstdCompressorWrite(compressor, data, size);
+}
+
+
+/*
+ * CSVCompressorFinish drains the codec's buffers and writes whatever closes
+ * out its container.  It must be called before the underlying file is closed,
+ * otherwise the file is a truncated stream that no reader will accept.
+ */
+void
+CSVCompressorFinish(CSVCompressor * compressor)
+{
+	if (compressor->method == DATA_COMPRESSION_GZIP)
+		GzipCompressorFinish(compressor);
+	else
+		ZstdCompressorFinish(compressor);
+}
+
+
+/*
+ * GzipCompressorCreate starts a gzip stream.
+ */
+static void
+GzipCompressorCreate(CSVCompressor * compressor, int level)
+{
 	/*
 	 * Route zlib's allocations into a context of our own so that an error
 	 * anywhere in the COPY -- which skips deflateEnd() -- still releases the
@@ -127,24 +247,16 @@ CSVCompressorCreate(FILE *file, CopyDataCompression method, int level)
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("could not initialize gzip compression: %s",
 						compressor->stream.msg ? compressor->stream.msg : "unknown error")));
-
-	return compressor;
 }
 
 
 /*
- * CSVCompressorWrite compresses a buffer into the underlying file.
+ * GzipCompressorWrite deflates a buffer into the underlying file.
  */
-void
-CSVCompressorWrite(CSVCompressor * compressor, const void *data, size_t size)
+static void
+GzipCompressorWrite(CSVCompressor * compressor, const void *data, size_t size)
 {
 	z_stream   *stream = &compressor->stream;
-
-	if (size == 0)
-	{
-		/* deflate() reports Z_BUF_ERROR when there is nothing to do */
-		return;
-	}
 
 	stream->next_in = (Bytef *) data;
 	stream->avail_in = size;
@@ -167,7 +279,8 @@ CSVCompressorWrite(CSVCompressor * compressor, const void *data, size_t size)
 					 errmsg("could not compress COPY file: %s",
 							stream->msg ? stream->msg : "unknown error")));
 
-		FlushCompressorBuffer(compressor);
+		WriteCompressorBuffer(compressor,
+							  sizeof(compressor->buffer) - stream->avail_out);
 	} while (stream->avail_out == 0);
 
 	Assert(stream->avail_in == 0);
@@ -175,12 +288,11 @@ CSVCompressorWrite(CSVCompressor * compressor, const void *data, size_t size)
 
 
 /*
- * CSVCompressorFinish drains zlib's internal buffers and writes the gzip
- * trailer.  It must be called before the underlying file is closed, otherwise
- * the file is a truncated gzip stream that no reader will accept.
+ * GzipCompressorFinish drains zlib's internal buffers and writes the gzip
+ * trailer.
  */
-void
-CSVCompressorFinish(CSVCompressor * compressor)
+static void
+GzipCompressorFinish(CSVCompressor * compressor)
 {
 	z_stream   *stream = &compressor->stream;
 	int			returnCode;
@@ -201,13 +313,138 @@ CSVCompressorFinish(CSVCompressor * compressor)
 					 errmsg("could not finish compressing COPY file: %s",
 							stream->msg ? stream->msg : "unknown error")));
 
-		FlushCompressorBuffer(compressor);
+		WriteCompressorBuffer(compressor,
+							  sizeof(compressor->buffer) - stream->avail_out);
 	} while (returnCode != Z_STREAM_END);
 
 	/* deflateEnd frees through the context, so it has to go first */
 	deflateEnd(stream);
 	MemoryContextDelete(compressor->context);
 	compressor->context = NULL;
+}
+
+
+/*
+ * ZstdCompressorCreate starts a zstd stream.
+ */
+static void
+ZstdCompressorCreate(CSVCompressor * compressor, int level)
+{
+	compressor->zstd = ZSTD_createCStream();
+
+	if (compressor->zstd == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("could not initialize zstd compression")));
+
+	/*
+	 * zstd's stable API takes no allocator, so the compression state -- tens
+	 * of megabytes at the higher levels -- sits outside any memory context,
+	 * and an error in the middle of the COPY, which skips
+	 * CSVCompressorFinish(), would strand it.  A reset callback on the
+	 * current context frees it on the way out instead; the callback and the
+	 * normal path keep out of each other's way through compressor->zstd.
+	 */
+	MemoryContextCallback *callback = palloc0(sizeof(MemoryContextCallback));
+
+	callback->func = ReleaseZstdStream;
+	callback->arg = compressor;
+	MemoryContextRegisterResetCallback(CurrentMemoryContext, callback);
+
+	size_t		returnCode = ZSTD_initCStream(compressor->zstd, level);
+
+	if (ZSTD_isError(returnCode))
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not initialize zstd compression: %s",
+						ZSTD_getErrorName(returnCode))));
+}
+
+
+/*
+ * ZstdCompressorWrite compresses a buffer into the underlying file.
+ */
+static void
+ZstdCompressorWrite(CSVCompressor * compressor, const void *data, size_t size)
+{
+	ZSTD_inBuffer input = {.src = data,.size = size,.pos = 0};
+
+	/*
+	 * Unlike deflate(), zstd reports how much of the input it consumed, so
+	 * the loop can run until the input is drained rather than until the
+	 * output buffer comes back full.
+	 */
+	while (input.pos < input.size)
+	{
+		ZSTD_outBuffer output = {
+			.dst = compressor->buffer,
+			.size = sizeof(compressor->buffer),
+			.pos = 0
+		};
+
+		size_t		returnCode = ZSTD_compressStream2(compressor->zstd, &output,
+													  &input, ZSTD_e_continue);
+
+		if (ZSTD_isError(returnCode))
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("could not compress COPY file: %s",
+							ZSTD_getErrorName(returnCode))));
+
+		WriteCompressorBuffer(compressor, output.pos);
+	}
+}
+
+
+/*
+ * ZstdCompressorFinish flushes zstd's block buffer and closes the frame.
+ */
+static void
+ZstdCompressorFinish(CSVCompressor * compressor)
+{
+	ZSTD_inBuffer input = {.src = NULL,.size = 0,.pos = 0};
+	size_t		remaining;
+
+	do
+	{
+		ZSTD_outBuffer output = {
+			.dst = compressor->buffer,
+			.size = sizeof(compressor->buffer),
+			.pos = 0
+		};
+
+		/* on success the return value is what is left of the frame */
+		remaining = ZSTD_compressStream2(compressor->zstd, &output, &input,
+										 ZSTD_e_end);
+
+		if (ZSTD_isError(remaining))
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("could not finish compressing COPY file: %s",
+							ZSTD_getErrorName(remaining))));
+
+		WriteCompressorBuffer(compressor, output.pos);
+	} while (remaining > 0);
+
+	ZSTD_freeCStream(compressor->zstd);
+	compressor->zstd = NULL;
+}
+
+
+/*
+ * ReleaseZstdStream frees a zstd stream that CSVCompressorFinish() never got
+ * to, which is the case whenever the COPY raised an error.
+ */
+static void
+ReleaseZstdStream(void *arg)
+{
+	CSVCompressor *compressor = (CSVCompressor *) arg;
+
+	if (compressor->zstd != NULL)
+	{
+		ZSTD_freeCStream(compressor->zstd);
+		compressor->zstd = NULL;
+	}
 }
 
 
@@ -230,13 +467,11 @@ CompressorFree(void *opaque, void *address)
 
 
 /*
- * FlushCompressorBuffer writes whatever deflate() just produced.
+ * WriteCompressorBuffer writes whatever the codec just produced.
  */
 static void
-FlushCompressorBuffer(CSVCompressor * compressor)
+WriteCompressorBuffer(CSVCompressor * compressor, size_t produced)
 {
-	size_t		produced = sizeof(compressor->buffer) - compressor->stream.avail_out;
-
 	if (produced == 0)
 		return;
 

--- a/pg_lake_engine/src/csv/csv_compression.c
+++ b/pg_lake_engine/src/csv/csv_compression.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * csv_compression.c
+ *
+ * Compression for the temporary CSV files that carry rows between PostgreSQL
+ * and the query engine.  The CSV writer pushes each finished row through a
+ * CSVCompressor instead of writing it to stdio directly, and the read_csv()
+ * call that reads the file back gets a matching compression= argument.
+ *
+ * The exchange CSV is much larger than the Parquet it becomes -- values are
+ * text, and bytea costs four bytes per input byte -- so a bulk load can need
+ * several times the table's size in temporary space.  Compressing it trades
+ * CPU for that space and for the write and read bandwidth underneath it.
+ */
+#include <zlib.h>
+
+#include "postgres.h"
+
+#include "pg_lake/csv/csv_compression.h"
+#include "utils/memutils.h"
+
+/* pg_lake_engine.temp_file_compression setting */
+int			TempFileCompression = DATA_COMPRESSION_NONE;
+
+/* pg_lake_engine.temp_file_compression_level setting */
+int			TempFileCompressionLevel = 1;
+
+/*
+ * Staging buffer for deflate() output.  Only needs to be large enough to keep
+ * the write count down; deflate is called repeatedly until it stops filling
+ * the buffer.
+ */
+#define COMPRESS_BUFFER_SIZE (256 * 1024)
+
+/*
+ * windowBits 15 (the maximum, and zlib's default) plus 16 to ask for a gzip
+ * container rather than a raw zlib one, which is what DuckDB's read_csv()
+ * expects from compression = 'gzip'.
+ */
+#define GZIP_WINDOW_BITS (15 + 16)
+
+/* zlib's own default, which trades memory for compression ratio */
+#define GZIP_MEM_LEVEL 8
+
+struct CSVCompressor
+{
+	FILE	   *file;
+	z_stream	stream;
+
+	/* holds all of zlib's allocations, so an error can't leak them */
+	MemoryContext context;
+
+	unsigned char buffer[COMPRESS_BUFFER_SIZE];
+};
+
+static void *CompressorAlloc(void *opaque, unsigned int items, unsigned int size);
+static void CompressorFree(void *opaque, void *address);
+static void FlushCompressorBuffer(CSVCompressor * compressor);
+
+
+/*
+ * InternalCSVCompression returns the compression method to apply to temporary
+ * CSV files.  Both the writer and the read_csv() clause that reads the file
+ * back call this, and a temporary CSV never outlives the statement that wrote
+ * it, so the two always agree.
+ */
+CopyDataCompression
+InternalCSVCompression(void)
+{
+	return (CopyDataCompression) TempFileCompression;
+}
+
+
+/*
+ * CSVCompressorCreate starts a compressed stream on top of an already-open
+ * file.  The caller keeps ownership of the file and must not write to it
+ * directly while the compressor is alive.
+ */
+CSVCompressor *
+CSVCompressorCreate(FILE *file, CopyDataCompression method, int level)
+{
+	if (method != DATA_COMPRESSION_GZIP)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("unsupported temporary file compression \"%s\"",
+						CopyDataCompressionToName(method))));
+
+	CSVCompressor *compressor = palloc0(sizeof(CSVCompressor));
+
+	compressor->file = file;
+
+	/*
+	 * Route zlib's allocations into a context of our own so that an error
+	 * anywhere in the COPY -- which skips deflateEnd() -- still releases the
+	 * deflate state when the surrounding context goes away.
+	 */
+	compressor->context = AllocSetContextCreate(CurrentMemoryContext,
+												"pg_lake CSV compressor",
+												ALLOCSET_SMALL_SIZES);
+
+	compressor->stream.zalloc = CompressorAlloc;
+	compressor->stream.zfree = CompressorFree;
+	compressor->stream.opaque = compressor->context;
+
+	int			returnCode = deflateInit2(&compressor->stream, level, Z_DEFLATED,
+										  GZIP_WINDOW_BITS, GZIP_MEM_LEVEL,
+										  Z_DEFAULT_STRATEGY);
+
+	if (returnCode != Z_OK)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not initialize gzip compression: %s",
+						compressor->stream.msg ? compressor->stream.msg : "unknown error")));
+
+	return compressor;
+}
+
+
+/*
+ * CSVCompressorWrite compresses a buffer into the underlying file.
+ */
+void
+CSVCompressorWrite(CSVCompressor * compressor, const void *data, size_t size)
+{
+	z_stream   *stream = &compressor->stream;
+
+	if (size == 0)
+	{
+		/* deflate() reports Z_BUF_ERROR when there is nothing to do */
+		return;
+	}
+
+	stream->next_in = (Bytef *) data;
+	stream->avail_in = size;
+
+	/*
+	 * Keep calling deflate() as long as it fills the buffer completely, which
+	 * is the only way to know it has more to give.  A single row wider than
+	 * the buffer goes around more than once.
+	 */
+	do
+	{
+		stream->next_out = compressor->buffer;
+		stream->avail_out = sizeof(compressor->buffer);
+
+		int			returnCode = deflate(stream, Z_NO_FLUSH);
+
+		if (returnCode != Z_OK)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("could not compress COPY file: %s",
+							stream->msg ? stream->msg : "unknown error")));
+
+		FlushCompressorBuffer(compressor);
+	} while (stream->avail_out == 0);
+
+	Assert(stream->avail_in == 0);
+}
+
+
+/*
+ * CSVCompressorFinish drains zlib's internal buffers and writes the gzip
+ * trailer.  It must be called before the underlying file is closed, otherwise
+ * the file is a truncated gzip stream that no reader will accept.
+ */
+void
+CSVCompressorFinish(CSVCompressor * compressor)
+{
+	z_stream   *stream = &compressor->stream;
+	int			returnCode;
+
+	stream->next_in = NULL;
+	stream->avail_in = 0;
+
+	do
+	{
+		stream->next_out = compressor->buffer;
+		stream->avail_out = sizeof(compressor->buffer);
+
+		returnCode = deflate(stream, Z_FINISH);
+
+		if (returnCode != Z_OK && returnCode != Z_STREAM_END)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("could not finish compressing COPY file: %s",
+							stream->msg ? stream->msg : "unknown error")));
+
+		FlushCompressorBuffer(compressor);
+	} while (returnCode != Z_STREAM_END);
+
+	/* deflateEnd frees through the context, so it has to go first */
+	deflateEnd(stream);
+	MemoryContextDelete(compressor->context);
+	compressor->context = NULL;
+}
+
+
+/*
+ * CompressorAlloc and CompressorFree let zlib allocate out of a PostgreSQL
+ * memory context.
+ */
+static void *
+CompressorAlloc(void *opaque, unsigned int items, unsigned int size)
+{
+	return MemoryContextAlloc((MemoryContext) opaque, (Size) items * size);
+}
+
+
+static void
+CompressorFree(void *opaque, void *address)
+{
+	pfree(address);
+}
+
+
+/*
+ * FlushCompressorBuffer writes whatever deflate() just produced.
+ */
+static void
+FlushCompressorBuffer(CSVCompressor * compressor)
+{
+	size_t		produced = sizeof(compressor->buffer) - compressor->stream.avail_out;
+
+	if (produced == 0)
+		return;
+
+	if (fwrite(compressor->buffer, produced, 1, compressor->file) != 1 ||
+		ferror(compressor->file))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write to COPY file: %m")));
+}

--- a/pg_lake_engine/src/csv/csv_options.c
+++ b/pg_lake_engine/src/csv/csv_options.c
@@ -21,6 +21,7 @@
 #include "postgres.h"
 
 #include "commands/defrem.h"
+#include "pg_lake/csv/csv_compression.h"
 #include "pg_lake/csv/csv_options.h"
 #include "nodes/makefuncs.h"
 
@@ -57,13 +58,17 @@ InternalCSVOptions(bool includeHeader)
  * InternalCSVReadOptions returns the options to use when reading an
  * internal/temporary CSV back through DuckDB's read_csv().
  *
- * It is InternalCSVOptions() plus a synthetic allow_quoted_nulls=false
- * option.  That option is not a real COPY option (ProcessCopyOptions would
- * reject it on the write side), so it lives only on the read path, where
- * CopyOptionsToReadCSVParams translates it into the read_csv() argument.
- * We need it because the CSV writer force-quotes any value that matches the
- * null sentinel (\N); disabling allow_quoted_nulls keeps a quoted "\N" from
- * being collapsed back to SQL NULL.
+ * It is InternalCSVOptions() plus synthetic allow_quoted_nulls and compression
+ * options.  Neither is a real COPY option (ProcessCopyOptions would reject
+ * them on the write side), so they live only on the read path, where
+ * CopyOptionsToReadCSVParams translates them into read_csv() arguments.
+ *
+ * We need allow_quoted_nulls=false because the CSV writer force-quotes any
+ * value that matches the null sentinel (\N); disabling it keeps a quoted "\N"
+ * from being collapsed back to SQL NULL.
+ *
+ * compression has to be stated explicitly because temporary file paths carry
+ * no extension for DuckDB to infer the codec from.
  */
 List *
 InternalCSVReadOptions(bool includeHeader)
@@ -73,6 +78,17 @@ InternalCSVReadOptions(bool includeHeader)
 	options = lappend(options,
 					  makeDefElem("allow_quoted_nulls",
 								  (Node *) makeBoolean(false), -1));
+
+	CopyDataCompression compression = InternalCSVCompression();
+
+	if (compression != DATA_COMPRESSION_NONE)
+	{
+		char	   *compressionName = pstrdup(CopyDataCompressionToName(compression));
+
+		options = lappend(options,
+						  makeDefElem("compression",
+									  (Node *) makeString(compressionName), -1));
+	}
 
 	return options;
 }

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -33,6 +33,7 @@
 #include "catalog/pg_type_d.h"
 #include "commands/copy.h"
 #include "commands/defrem.h"
+#include "pg_lake/csv/csv_compression.h"
 #include "pg_lake/csv/csv_writer.h"
 #include "pg_lake/extensions/postgis.h"
 #include "pg_lake/pgduck/numeric.h"
@@ -133,6 +134,14 @@ typedef struct CopyToStateData
 	int			maxLineSize;
 	bool		quoteEmptyLines;
 	CopyDataFormat targetFormat;
+
+	/*
+	 * Compression applied to the file, and the live compressor once the file
+	 * is open.  Both are unset when compression is off, in which case rows go
+	 * straight to stdio.
+	 */
+	CopyDataCompression compression;
+	CSVCompressor *compressor;
 
 	/* whether the CSV writer should survive multiple transactions */
 	bool		sessionLifetime;
@@ -235,9 +244,14 @@ CopySendEndOfRow(CopyToState cstate)
 #endif
 			}
 
-			if (fwrite(fe_msgbuf->data, fe_msgbuf->len, 1,
-					   cstate->copy_file) != 1 ||
-				ferror(cstate->copy_file))
+			if (cstate->compressor != NULL)
+			{
+				CSVCompressorWrite(cstate->compressor, fe_msgbuf->data,
+								   fe_msgbuf->len);
+			}
+			else if (fwrite(fe_msgbuf->data, fe_msgbuf->len, 1,
+							cstate->copy_file) != 1 ||
+					 ferror(cstate->copy_file))
 			{
 				ereport(ERROR,
 						(errcode_for_file_access(),
@@ -250,7 +264,11 @@ CopySendEndOfRow(CopyToState cstate)
 			break;
 	}
 
-	/* Update the progress */
+	/*
+	 * Update the progress.  This counts CSV bytes, not bytes landed on disk,
+	 * so the write-file rotation threshold keeps measuring the same thing
+	 * when compression is on.
+	 */
 	cstate->bytes_processed += fe_msgbuf->len;
 
 	resetStringInfo(fe_msgbuf);
@@ -297,6 +315,13 @@ EndCopy(CopyToState cstate)
 		CopySendInt16(cstate, -1);
 		/* Need to flush out the trailer */
 		CopySendEndOfRow(cstate);
+	}
+
+	/* the gzip trailer has to be written before the file is closed */
+	if (cstate->compressor != NULL)
+	{
+		CSVCompressorFinish(cstate->compressor);
+		cstate->compressor = NULL;
 	}
 
 	if (cstate->filename != NULL)
@@ -383,6 +408,13 @@ CreateCopyToState(char *filename, List *copyOptions)
 	cstate->maxLineSize = 0;
 	cstate->bytes_processed = 0;
 
+	/*
+	 * Every file this writer produces is an internal exchange CSV that is
+	 * read back through InternalCSVReadOptions(), so the two ends agree on
+	 * the codec by both consulting the setting.
+	 */
+	cstate->compression = InternalCSVCompression();
+
 	MemoryContextSwitchTo(oldContext);
 
 	return cstate;
@@ -441,6 +473,10 @@ StartCopyTo(CopyToState cstate, TupleDesc tupDesc)
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is a directory", cstate->filename)));
 
+	if (cstate->compression != DATA_COMPRESSION_NONE)
+		cstate->compressor = CSVCompressorCreate(cstate->copy_file,
+												 cstate->compression,
+												 TempFileCompressionLevel);
 
 	/* get the attribute names from the tuple descriptor */
 	List	   *attnamelist = TupleDescColumnNameList(tupDesc);

--- a/pg_lake_engine/src/csv/csv_writer.c
+++ b/pg_lake_engine/src/csv/csv_writer.c
@@ -317,7 +317,7 @@ EndCopy(CopyToState cstate)
 		CopySendEndOfRow(cstate);
 	}
 
-	/* the gzip trailer has to be written before the file is closed */
+	/* the codec has to close its container before the file is closed */
 	if (cstate->compressor != NULL)
 	{
 		CSVCompressorFinish(cstate->compressor);

--- a/pg_lake_engine/src/init.c
+++ b/pg_lake_engine/src/init.c
@@ -64,10 +64,15 @@ bool		EnableHeavyAsserts = false;
 /* pg_lake.stage_location setting */
 char	   *PgLakeStageLocation = NULL;
 
-/* allowed values of pg_lake_engine.temp_file_compression */
+/*
+ * Allowed values of pg_lake_engine.temp_file_compression.  gzip and zstd are
+ * the only codecs both ends of the exchange CSV understand; see
+ * src/csv/csv_compression.c.
+ */
 static const struct config_enum_entry TempFileCompressionOptions[] = {
 	{"none", DATA_COMPRESSION_NONE, false},
 	{"gzip", DATA_COMPRESSION_GZIP, false},
+	{"zstd", DATA_COMPRESSION_ZSTD, false},
 	{NULL, 0, false}
 };
 
@@ -220,7 +225,8 @@ _PG_init(void)
 										  "carry rows between PostgreSQL and the query engine."),
 							 gettext_noop("The exchange CSV is several times the size of the "
 										  "Parquet it becomes, so compressing it saves temporary "
-										  "space and I/O at the cost of CPU on both ends."),
+										  "space and I/O at the cost of CPU on both ends.  zstd "
+										  "reaches a given ratio for less CPU than gzip does."),
 							 &TempFileCompression,
 							 DATA_COMPRESSION_NONE,
 							 TempFileCompressionOptions,
@@ -231,11 +237,14 @@ _PG_init(void)
 	DefineCustomIntVariable("pg_lake_engine.temp_file_compression_level",
 							gettext_noop("Compression level for temporary CSV files."),
 							gettext_noop("These files live for the length of one statement, so the "
-										 "default favours throughput over ratio."),
+										 "default favours throughput over ratio.  gzip accepts 1 "
+										 "through 9; zstd also accepts negative levels, which are "
+										 "its fast modes.  A level outside the active codec's "
+										 "range is clamped into it."),
 							&TempFileCompressionLevel,
 							1,
-							1,
-							9,
+							PG_LAKE_MIN_TEMP_FILE_COMPRESSION_LEVEL,
+							PG_LAKE_MAX_TEMP_FILE_COMPRESSION_LEVEL,
 							PGC_USERSET,
 							0,
 							NULL, NULL, NULL);

--- a/pg_lake_engine/src/init.c
+++ b/pg_lake_engine/src/init.c
@@ -26,6 +26,7 @@
 
 #include "pg_lake/cleanup/deletion_queue.h"
 #include "pg_lake/copy/copy_format.h"
+#include "pg_lake/csv/csv_compression.h"
 #include "pg_lake/ddl/utility_hook.h"
 #include "pg_lake/extensions/btree_gist.h"
 #include "pg_lake/extensions/pg_lake_benchmark.h"
@@ -62,6 +63,13 @@ bool		EnableHeavyAsserts = false;
 
 /* pg_lake.stage_location setting */
 char	   *PgLakeStageLocation = NULL;
+
+/* allowed values of pg_lake_engine.temp_file_compression */
+static const struct config_enum_entry TempFileCompressionOptions[] = {
+	{"none", DATA_COMPRESSION_NONE, false},
+	{"gzip", DATA_COMPRESSION_GZIP, false},
+	{NULL, 0, false}
+};
 
 
 /*
@@ -203,6 +211,31 @@ _PG_init(void)
 							DEFAULT_MAX_PARALLEL_FILE_UPLOADS /* default */ ,
 							1,
 							256,
+							PGC_USERSET,
+							0,
+							NULL, NULL, NULL);
+
+	DefineCustomEnumVariable("pg_lake_engine.temp_file_compression",
+							 gettext_noop("Compression to apply to the temporary CSV files that "
+										  "carry rows between PostgreSQL and the query engine."),
+							 gettext_noop("The exchange CSV is several times the size of the "
+										  "Parquet it becomes, so compressing it saves temporary "
+										  "space and I/O at the cost of CPU on both ends."),
+							 &TempFileCompression,
+							 DATA_COMPRESSION_NONE,
+							 TempFileCompressionOptions,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
+	DefineCustomIntVariable("pg_lake_engine.temp_file_compression_level",
+							gettext_noop("Compression level for temporary CSV files."),
+							gettext_noop("These files live for the length of one statement, so the "
+										 "default favours throughput over ratio."),
+							&TempFileCompressionLevel,
+							1,
+							1,
+							9,
 							PGC_USERSET,
 							0,
 							NULL, NULL, NULL);

--- a/pg_lake_engine/src/pgduck/delete_data.c
+++ b/pg_lake_engine/src/pgduck/delete_data.c
@@ -130,13 +130,21 @@ DeleteFromParquetQuery(char *sourceDataFilePath, List *positionDeleteFiles,
 	appendStringInfo(&command,
 					 "%s %s file_row_number NOT IN ("
 					 "  SELECT pos "
-					 "  FROM read_csv(%s"
-					 ", header=true, delim=',', quote='\"', escape='\"', nullstr='\\N'"
-					 ", columns={'file_path':'varchar', 'pos':'bigint', 'row':'varchar'}))",
+					 "  FROM ",
 					 readFileQuery,
 	/* position delete files adds a WHERE clause, so then we should use AND */
-					 positionDeleteFiles != NIL ? "AND" : "WHERE",
-					 quote_literal_cstr(deletionFilePath));
+					 positionDeleteFiles != NIL ? "AND" : "WHERE");
+
+	/*
+	 * The deletion file is an internal exchange CSV, so read it back through
+	 * the shared builder rather than spelling out the dialect here; that is
+	 * what keeps the reader in step with whatever the writer did.
+	 */
+	AppendReadCSVClause(&command, deletionFilePath, -1,
+						"{'file_path':'varchar', 'pos':'bigint', 'row':'varchar'}",
+						InternalCSVReadOptions(true));
+
+	appendStringInfoString(&command, ")");
 
 	return command.data;
 }

--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -1915,6 +1915,18 @@ CopyOptionsToReadCSVParams(List *copyOptions)
 			appendStringInfo(&command, ", allow_quoted_nulls=%s",
 							 allow_quoted_nulls ? "true" : "false");
 		}
+		else if (strcmp(option->defname, "compression") == 0)
+		{
+			/*
+			 * Also synthetic.  Temporary file names have no extension, so
+			 * DuckDB's own detection cannot see that the writer compressed
+			 * the file and we have to name the codec.
+			 */
+			char	   *compression = defGetString(option);
+
+			appendStringInfo(&command, ", compression=%s",
+							 quote_literal_cstr(compression));
+		}
 	}
 
 	return command.data;


### PR DESCRIPTION
**Proof of concept — do not merge.** Posted to show the shape of the change and the numbers behind it.

## What

Rows travel from PostgreSQL to the query engine through a temporary CSV file. That CSV is much larger than the Parquet it becomes — values are text, and `bytea` costs four bytes per input byte — so a bulk load or a copy-on-write `DELETE` can need several times the table's size in temporary space.

`pg_lake_engine.temp_file_compression` (`none` by default, or `gzip` or `zstd`) puts a compressor between the CSV writer and the file, and the `read_csv()` call that reads the file back names the same codec. `pg_lake_engine.temp_file_compression_level` picks the level.

## Which codecs

The exchange CSV is written by pg_lake and read back by DuckDB, so the codec has to be one both ends speak. DuckDB's CSV reader accepts exactly two `compression=` values, `gzip` and `zstd`, which is also the whole intersection with the compression methods PostgreSQL builds against. lz4 does not make the cut: DuckDB does decompress lz4, but as raw blocks for Parquet column pages, and there is no file system there to unwrap an lz4 frame off a CSV.

zstd's decompressor lives in DuckDB's parquet extension rather than its core. That costs nothing here, because pgduck_server loads parquet at startup.

## Numbers

COPY of 3M rows to Parquet, measuring peak temporary CSV size:

| mode | level | temp space | wall clock |
| --- | --- | --- | --- |
| `none` | | 403 MB | 8.5 s |
| `gzip` | 1 | 160 MB (2.5x) | 11.7 s (1.39x) |
| `gzip` | 6 | 146 MB (2.8x) | 31.0 s (3.6x) |
| `zstd` | -3 | 221 MB (1.8x) | 9.1 s (1.07x) |
| `zstd` | 1 | 146 MB (2.8x) | 9.4 s (1.11x) |
| `zstd` | 6 | 137 MB (2.9x) | 14.4 s (1.69x) |

zstd level 1 is both smaller and faster than gzip level 1, matches gzip level 6's ratio for a tenth of the added time, and costs 11% over writing the CSV uncompressed where gzip costs 39%. It is the codec to reach for when compression is on at all. Below zero is zstd's fast mode, for a caller who would rather have the wall clock back than the last 75 MB.

## How

- `pg_lake_engine/src/csv/csv_compression.c` — streaming gzip and zstd writers around a `FILE *`, chosen per statement. zlib allocates out of a dedicated memory context; zstd's stable API takes no allocator, so its state is freed through a memory-context reset callback instead. Either way an `ereport(ERROR)` mid-COPY releases the compression state rather than stranding it.
- `csv_writer.c` — the single `fwrite()` in `CopySendEndOfRow()` becomes a compressor write, and `EndCopy()` closes the container before the file is closed. `bytes_processed` still counts CSV bytes, so `pg_lake_table.max_write_temp_file_size_mb` rotation keeps measuring the same thing.
- `csv_options.c` — `InternalCSVReadOptions()` appends a synthetic `compression` option, alongside the existing `allow_quoted_nulls`; `read_data.c` translates it into a `compression=` argument. The codec has to be named explicitly because the temporary file names have no extension for DuckDB to detect it from.
- `delete_data.c` — the deletion CSV was the last internal read still spelling out its own `read_csv()` dialect, so it now goes through `AppendReadCSVClause()` like every other one. Without this, `DELETE` fails as soon as compression is on.
- `init.c` — `temp_file_compression_level` spans −22 through 22, the union of the two codecs' ranges, because one setting covers both. Each codec clamps into its own range, so gzip still stops at 9 and never sees the rest. Clamping rather than rejecting keeps a level left over from the other codec from failing a COPY over what is only a CPU/space trade.

Writer and reader agree without any signature changes: both call `InternalCSVCompression()`, and a temporary CSV never outlives the statement that wrote it.

## Build dependency

libzstd is new, added everywhere zlib and lz4 already appear: `docker/Dockerfile` (both distros, build and runtime stages), `install.sh` and `docs/building-from-source.md`. zlib was already a documented dependency.

## Testing

- `pg_lake_copy/tests/pytests/test_temp_file_compression.py`: 16 tests, green. Covers CSV-hostile values (embedded delimiters and quotes, the literal `\N` sentinel next to a real NULL, empty strings, embedded newlines and tabs, bytea, arrays, jsonb) for each mode, content equality against `none`, every level boundary including the clamped ones, and Iceberg INSERT/DELETE/UPDATE.
- 3M-row COPY, every mode crossed with levels −22/1/22: nine byte-identical Parquet files.
- Full `pg_lake_copy` suite with the cluster forced to `zstd`: 258 passed, 3 skipped.
- Full `pg_lake_table` suite, once forced to `zstd` and once at the default. Every failure is pre-existing in this environment (no Java/Spark or dbt); the handful of tests that differed between the two passes pass under both settings when run on their own, so the difference was one sandbox test run leaking state into the next rather than anything the codec did.
- CI green on PostgreSQL 16, 17 and 18 across both images, which is also what confirms the `libzstd` package names.

## Known limits of the POC

- Only the CSV `DestReceiver` path compresses. `COPY ... FROM STDIN`'s raw client spool (`CopyInputToFile`) is untouched.
- A compressed CSV handle is not seekable, so DuckDB reads it single-threaded. That is already priced into the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

