### PR TITLE
duckdb_pglake: size the Postgres ctid scan from the relation size

### DIFF
--- a/duckdb_pglake/patches/duckdb-postgres/relation-size-page-estimate.patch
+++ b/duckdb_pglake/patches/duckdb-postgres/relation-size-page-estimate.patch
@@ -1,0 +1,14 @@
+diff --git a/src/storage/postgres_table_set.cpp b/src/storage/postgres_table_set.cpp
+index 61b74cd..cc99bd5 100644
+--- a/src/storage/postgres_table_set.cpp
++++ b/src/storage/postgres_table_set.cpp
+@@ -21,7 +21,8 @@ PostgresTableSet::PostgresTableSet(PostgresSchemaEntry &schema, unique_ptr<Postg
+ 
+ string PostgresTableSet::GetInitializeQuery(const string &schema, const string &table) {
+ 	string base_query = R"(
+-SELECT pg_namespace.oid AS namespace_id, relname, relpages, attname,
++SELECT pg_namespace.oid AS namespace_id, relname,
++    pg_relation_size(pg_class.oid) / current_setting('block_size')::bigint AS relpages, attname,
+     pg_type.typname type_name, atttypmod type_modifier, pg_attribute.attndims ndim,
+     atttypid type_oid, attnum, pg_attribute.attnotnull AS notnull, NULL constraint_id,
+     NULL constraint_type, NULL constraint_key


### PR DESCRIPTION
## Description

### Problem

`postgres_scan` takes its page count from `pg_class.relpages`, which only ANALYZE and VACUUM maintain, and that one number drives two things at once:

* `SetTablePages()` → `max_threads = relpages / pages_per_task`, i.e. how many parallel ctid-range tasks the scan runs.
* `PostgresScanProgress()` → `100 * page_idx / relpages`.

On a table that has never been analyzed, `relpages` is 0. `GetLocalState` then takes the `pages_approx == 0` branch: a single task covering `(0, POSTGRES_TID_MAX)` — one task, one connection, no parallelism — with `gstate.page_idx` set to `POSTGRES_TID_MAX` up front. So `PostgresScanProgress` computes `100 * 4294967295 / 0`, which is `+inf` clamped to 100: the scan claims to be finished before it has read a row.

A `relpages` that is stale and much smaller than the table has the same effect, because the last ctid task is extended to `POSTGRES_TID_MAX`. One thread reads everything past the stale bound while progress sits at 100%.

Reproducing with a copy out of Postgres into Parquet, 20M rows × 5 columns (176,792 pages), 16 threads, warm cache, sampling `pg_lake_stat_activity()` + `pg_lake_query_progress()` 5×/s from a second session:

| source table state | copy time | progress samples |
|---|---|---|
| `relpages = 0` (never analyzed) | 14.28 / 14.32 / 14.35 s | frozen for all 67 samples |
| `relpages` correct (176,792) | 1.84 / 1.79 / 1.81 s | 0 → 12 → 23 → 45 → 62 → 76 → 93 → 96% |
| `relpages` stale 10× low (17,679) | 14.09 s | pinned at 99.99% after 0.4 s, for the remaining 13.7 s |

So it costs ~8x on the scan, and it is the common case for reading a table that was just loaded, or any table whose statistics predate a large load.

In the frozen case the reported progress is not a coarse estimate but arithmetic: `PostgresScanCardinality` also returns 0, so the scan pipeline's cardinality is clamped to 1, the scan reports `done=1, total=1`, and the two one-row pipelines of the copy plan sit at `done=0, total=1`, so `ProgressBar::Update` sums to `1/3` = 33.333…% and stays there, because the percentage is monotonic.

### Fix

Take the page estimate from the relation's actual size instead of its statistics, as a new patch in `duckdb_pglake/patches/duckdb-postgres/`:

```diff
-SELECT pg_namespace.oid AS namespace_id, relname, relpages, attname,
+SELECT pg_namespace.oid AS namespace_id, relname,
+    pg_relation_size(pg_class.oid) / current_setting('block_size')::bigint AS relpages, attname,
```

`pg_relation_size` is the real main-fork size: never 0 for a non-empty heap, never stale. It returns 0 rather than an error for relkinds without storage — views, partitioned parents, foreign tables — so those keep today's non-ctid path, and the column keeps its `relpages` name so nothing downstream of `GetInitializeQuery` changes.

The extra cost is one stat per relation. The single-table bind path `postgres_scan` uses pays exactly one; listing a whole schema at ATTACH went from 17 ms to 50 ms on a catalog of 2,071 tables / 12,135 attribute rows with almost none of them analyzed, which is the worst case for this change.

Nothing here is pg_lake-specific, so it is worth sending to `duckdb/duckdb-postgres` as well; the patch is shaped to apply there unchanged.

### Testing

Built into `libduckdb.so` and re-measured on the same table and box:

| source table state | copy time | progress samples |
|---|---|---|
| `relpages = 0` | 1.79 / 1.81 / 1.84 s | 0 → 14 → 27 → 45 → 65 → 81 → 90 → 99.55% |
| `relpages` stale 10× low | 1.86 s | 0 → 19 → 42 → 65 → 79 → 96% |

Also verified that the full `patches/duckdb-postgres/` series still applies in sorted order at the pinned submodule commit — the new file sorts after `composite-type-resolution.patch`, which is the other patch that touches `postgres_table_set.cpp`.

No new automated test: the observable effects are a timing difference and a progress value, neither of which makes a deterministic assertion, and the patched statement is exercised by every existing `postgres_scan` test.

Two things this does not fix, both pre-existing:

* `page_idx` counts pages handed out rather than pages read, and the final task is extended to `POSTGRES_TID_MAX`, so the percentage leads reality and tops out slightly below 100 while the last task drains.
* `PostgresScanProgress` still divides by zero when there genuinely is no page count, which is the case for `postgres_query()`. Returning `-1` (DuckDB's "unknown") there instead of a confident 100 would be a good follow-up.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**
