### PR TITLE
Report a removal outcome per path in a batch delete

### DIFF
--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -380,8 +380,12 @@ PGLakeCachingFileSystem::RemoveFile(const string &filename,
  * functions.cpp do.
  */
 void
-PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string> &paths)
+PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string> &paths,
+									 vector<string> *pathErrors)
 {
+	if (pathErrors != nullptr)
+		pathErrors->assign(paths.size(), string());
+
 	if (paths.empty())
 		return;
 
@@ -392,8 +396,13 @@ PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string
 
 	vector<string> s3Paths;
 
-	for (const string &path : paths)
+	/* which path each entry of s3Paths came from, to report an outcome per path */
+	vector<idx_t> s3PathIndexes;
+
+	for (idx_t pathIndex = 0; pathIndex < paths.size(); pathIndex++)
 	{
+		const string &path = paths[pathIndex];
+
 		/*
 		 * Only S3 has a bulk delete API. Everything else -- Azure, HTTP, local
 		 * -- goes through the ordinary per-file RemoveFile, which is one round
@@ -408,9 +417,23 @@ PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string
 		 * which takes the whole server down rather than failing the statement.
 		 */
 		if (s3fs.CanHandleFile(path))
+		{
 			s3Paths.push_back(path);
-		else
+			s3PathIndexes.push_back(pathIndex);
+			continue;
+		}
+
+		try
+		{
 			virtualFs.RemoveFile(path);
+		}
+		catch (std::exception &e)
+		{
+			if (pathErrors == nullptr)
+				throw;
+
+			(*pathErrors)[pathIndex] = e.what();
+		}
 	}
 
 	if (s3Paths.empty())
@@ -420,11 +443,11 @@ PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string
 	 * The batch delete goes straight to S3 rather than through this wrapper, so
 	 * evict the cache entries here instead, both before and after.
 	 *
-	 * Before, because RemoveFiles sends the keys in batches and throws as soon as
-	 * one batch reports an error: evicting only afterwards would leave the
-	 * already-deleted batches holding a local copy, which is the stale cache this
-	 * is meant to prevent. Dropping the copy of a file whose delete then fails
-	 * only costs a re-download.
+	 * Before, because RemoveFiles sends the keys in batches and a batch can
+	 * delete some of its keys and fail on the rest: evicting only afterwards
+	 * would leave the deleted ones holding a local copy, which is the stale cache
+	 * this is meant to prevent. Dropping the copy of a file whose delete then
+	 * fails only costs a re-download.
 	 *
 	 * After, because a concurrent reader can cache the file again in the window
 	 * between the eviction and the delete. Eviction of an uncached file is a
@@ -433,7 +456,19 @@ PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string
 	for (const string &path : s3Paths)
 		RemoveCachedCopy(context, path, opener);
 
-	s3fs.RemoveFiles(s3Paths, opener);
+	if (pathErrors == nullptr)
+	{
+		s3fs.RemoveFiles(s3Paths, opener);
+	}
+	else
+	{
+		vector<string> s3PathErrors;
+
+		s3fs.RemoveFiles(s3Paths, opener, &s3PathErrors);
+
+		for (idx_t s3PathIndex = 0; s3PathIndex < s3Paths.size(); s3PathIndex++)
+			(*pathErrors)[s3PathIndexes[s3PathIndex]] = s3PathErrors[s3PathIndex];
+	}
 
 	for (const string &path : s3Paths)
 		RemoveCachedCopy(context, path, opener);

--- a/duckdb_pglake/src/fs/functions.cpp
+++ b/duckdb_pglake/src/fs/functions.cpp
@@ -596,6 +596,77 @@ RemoveFileScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
 
 
 /*
+ * Implementation of the pg_lake_try_remove_file scalar function.
+ *
+ * It removes the same files pg_lake_remove_file does, but reports the outcome per
+ * row instead of failing the statement: a path that is gone comes back as NULL
+ * and a path that could not be removed comes back as the reason. So a caller can
+ * delete a list of unrelated files in one request and still tell which ones it
+ * has to try again, which is what the deletion queue needs: the alternative is
+ * charging one poison path's failure to the up to 1000 healthy paths that shared
+ * its request, or narrowing the batch down with a series of further requests.
+ *
+ * pg_lake_remove_file keeps failing the statement. A caller that deletes a set of
+ * files that belong together has nothing to attribute and would have to check a
+ * result it does not otherwise read.
+ */
+static void
+TryRemoveFileScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnifiedVectorFormat fileNames;
+
+	args.data[0].ToUnifiedFormat(args.size(), fileNames);
+
+	auto fileNameData = UnifiedVectorFormat::GetData<string_t>(fileNames);
+
+	vector<string> paths;
+	vector<idx_t> pathRows;
+
+	paths.reserve(args.size());
+	pathRows.reserve(args.size());
+
+	/*
+	 * Collect the chunk's paths first and remove them in one go, as
+	 * RemoveFileScalarFun does, so that the whole chunk costs one batch of
+	 * DeleteObjects requests rather than one request per row. Hence the unified
+	 * format rather than UnaryExecutor: the result of a row is not known until
+	 * every row has been collected.
+	 */
+	for (idx_t row = 0; row < args.size(); row++)
+	{
+		idx_t entry = fileNames.sel->get_index(row);
+
+		if (!fileNames.validity.RowIsValid(entry))
+			continue;
+
+		paths.push_back(fileNameData[entry].GetString());
+		pathRows.push_back(row);
+	}
+
+	vector<string> pathErrors;
+
+	PGLakeCachingFileSystem::RemoveFiles(state.GetContext(), paths, &pathErrors);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+
+	/* a removed file has nothing to report, and neither does a NULL path */
+	FlatVector::Validity(result).SetAllInvalid(args.size());
+
+	auto resultData = FlatVector::GetData<string_t>(result);
+
+	for (idx_t pathIndex = 0; pathIndex < paths.size(); pathIndex++)
+	{
+		if (pathErrors[pathIndex].empty())
+			continue;
+
+		idx_t row = pathRows[pathIndex];
+
+		resultData[row] = StringVector::AddString(result, pathErrors[pathIndex]);
+		FlatVector::Validity(result).SetValid(row);
+	}
+}
+
+
+/*
  * AddS3ExpressRegionEndpointScalarFun is a wrapper around AddS3ExpressRegionEndpoint
  * for testing purposes.
  */
@@ -817,6 +888,17 @@ PgLakeFileSystemFunctions::RegisterFunctions(ExtensionLoader &loader)
 						   RemoveFileScalarFun);
 
 		loader.RegisterFunction(pg_lake_remove_file);
+	}
+
+	/* pg_lake_try_remove_file function definition */
+	{
+		ScalarFunction pg_lake_try_remove_file =
+			ScalarFunction("pg_lake_try_remove_file",
+						   {LogicalType::VARCHAR},
+						   LogicalType::VARCHAR,
+						   TryRemoveFileScalarFun);
+
+		loader.RegisterFunction(pg_lake_try_remove_file);
 	}
 
 	/* pg_lake_test_add_s3_express(text) function definition */

--- a/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
+++ b/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
@@ -213,18 +213,25 @@ ExtractXmlElementText(const string &xml, const string &tag)
  * POST targets /?delete, and every key must live in that bucket. The caller is
  * responsible for keeping the range within S3_DELETE_OBJECTS_MAX_KEYS.
  *
- * Throws on a malformed response or if S3 reports per-key <Error> entries.
- * Deleting a key that does not exist is not an error in S3, so a well-formed
- * DeleteResult that still carries an <Error> means a real failure (e.g. access
- * denied) that we must surface rather than silently dropping keys.
+ * Throws on a malformed response. Deleting a key that does not exist is not an
+ * error in S3, so a well-formed DeleteResult that still carries an <Error> means
+ * a real failure (e.g. access denied) that we must surface rather than silently
+ * dropping keys.
  *
- * The response also lists the keys that were deleted, but for a request without
- * errors that is simply the keys we asked for, and when there are errors we
- * throw. So we only read the <Error> entries.
+ * How the per-key <Error> entries are surfaced depends on outcomes. Without it
+ * they are collected into one exception, since a caller that gets a single
+ * status has no use for a verdict per key. With it every key in [begin, end)
+ * gets its own entry, so a caller can tell a poison key from the ones that went
+ * with it in the same request.
+ *
+ * The response also lists the keys that were deleted, but that is simply the
+ * keys we asked for minus the ones it reported an error for. So we only read the
+ * <Error> entries.
  */
 static void
 PostDeleteObjects(PgLakeS3FileSystem &fs, S3FileHandle *s3Handle,
-				  const vector<string> &keys, idx_t begin, idx_t end)
+				  const vector<string> &keys, idx_t begin, idx_t end,
+				  vector<FileRemovalOutcome> *outcomes)
 {
 	/*
 	 * Following S3FileSystem::FinalizeMultipartUpload
@@ -260,13 +267,20 @@ PostDeleteObjects(PgLakeS3FileSystem &fs, S3FileHandle *s3Handle,
 	idx_t errorCount = 0;
 	string errorDetails;
 
+	/* why S3 refused a key, for the caller that reports an outcome per key */
+	unordered_map<string, string> errorByKey;
+
 	for (size_t errorPos = result.find("<Error>");
 		 errorPos != string::npos;
 		 errorPos = result.find("<Error>", errorPos + 1))
 	{
 		errorCount++;
 
-		if (errorCount > S3_DELETE_OBJECTS_MAX_REPORTED_ERRORS)
+		/*
+		 * The cap is on what one exception says, so it does not apply when every
+		 * key carries its own reason.
+		 */
+		if (outcomes == nullptr && errorCount > S3_DELETE_OBJECTS_MAX_REPORTED_ERRORS)
 			continue;
 
 		/* limit the search to this entry, in case one of the elements is absent */
@@ -274,13 +288,40 @@ PostDeleteObjects(PgLakeS3FileSystem &fs, S3FileHandle *s3Handle,
 		string errorEntry = result.substr(errorPos, errorEnd == string::npos
 												   ? string::npos : errorEnd - errorPos);
 
+		string key = ExtractXmlElementText(errorEntry, "Key");
+		string reason = StringUtil::Format("%s (%s)",
+										   ExtractXmlElementText(errorEntry, "Code"),
+										   ExtractXmlElementText(errorEntry, "Message"));
+
+		if (outcomes != nullptr)
+		{
+			errorByKey[key] = reason;
+			continue;
+		}
+
 		if (!errorDetails.empty())
 			errorDetails += ", ";
 
-		errorDetails += StringUtil::Format("%s: %s (%s)",
-										   ExtractXmlElementText(errorEntry, "Key"),
-										   ExtractXmlElementText(errorEntry, "Code"),
-										   ExtractXmlElementText(errorEntry, "Message"));
+		errorDetails += StringUtil::Format("%s: %s", key, reason);
+	}
+
+	if (outcomes != nullptr)
+	{
+		/*
+		 * Everything S3 did not refuse it deleted, so the keys that are absent
+		 * from the errors are the ones that are gone.
+		 */
+		for (idx_t i = begin; i < end; i++)
+		{
+			auto errorEntry = errorByKey.find(keys[i]);
+
+			if (errorEntry == errorByKey.end())
+				(*outcomes)[i].removed = true;
+			else
+				(*outcomes)[i].error = errorEntry->second;
+		}
+
+		return;
 	}
 
 	if (errorCount > 0)
@@ -341,7 +382,7 @@ PgLakeS3FileSystem::RemoveFileFromS3(string path, optional_ptr<FileOpener> opene
 	/* Change the file handle to / to POST to /?delete */
 	s3Handle->path = bucketUrl + "/";
 
-	PostDeleteObjects(*this, s3Handle, keys, 0, keys.size());
+	PostDeleteObjects(*this, s3Handle, keys, 0, keys.size(), nullptr);
 
 	/*
 	 * Remove the file from HTTP metadata cache now that it has been deleted.
@@ -368,14 +409,33 @@ PgLakeS3FileSystem::RemoveFileFromS3(string path, optional_ptr<FileOpener> opene
  * query arguments the request needs, region included, and the paths can be
  * plain s3:// URLs. RegionAwareS3FileSystem::RemoveFiles groups them by bucket
  * and resolves the region.
+ *
+ * When outcomes is given it must have an entry per path, and a key S3 refuses is
+ * recorded there instead of throwing. A request that fails as a whole still
+ * throws: the keys of the batch it was carrying keep their empty outcome, so the
+ * caller can tell them apart from the ones S3 named.
  */
 void
 PgLakeS3FileSystem::RemoveFilesFromS3(const string &bucketUrl,
 									  const vector<string> &paths,
-									  optional_ptr<FileOpener> opener)
+									  optional_ptr<FileOpener> opener,
+									  vector<FileRemovalOutcome> *outcomes)
 {
 	if (paths.empty())
 		return;
+
+	/*
+	 * Start every key from "nothing happened to it yet". WithResolvedRegion
+	 * re-runs its callback when the region turns out to be wrong, so the
+	 * outcomes of the attempt that hit the mismatch must not be left standing.
+	 */
+	if (outcomes != nullptr)
+	{
+		D_ASSERT(outcomes->size() == paths.size());
+
+		for (FileRemovalOutcome &outcome : *outcomes)
+			outcome = FileRemovalOutcome();
+	}
 
 	optional_ptr<HTTPMetadataCache> metadataCache = GetGlobalCache();
 
@@ -456,15 +516,15 @@ PgLakeS3FileSystem::RemoveFilesFromS3(const string &bucketUrl,
 		/*
 		 * Evict per batch rather than once at the end, and both before and after
 		 * the request, for the same reasons the file cache does it in
-		 * PGLakeCachingFileSystem::RemoveFiles: PostDeleteObjects throws when S3
-		 * reports a per-key error, and the keys it did delete are gone whether or
+		 * PGLakeCachingFileSystem::RemoveFiles: a batch can delete some of its
+		 * keys and fail on the rest, and the ones it deleted are gone whether or
 		 * not we get to the second eviction; a concurrent reader can also cache
 		 * an entry again in the window between the eviction and the delete.
 		 * Evicting an entry for a file that is still there only costs a HEAD.
 		 */
 		evictBatch(begin, end);
 
-		PostDeleteObjects(*this, s3Handle, keys, begin, end);
+		PostDeleteObjects(*this, s3Handle, keys, begin, end, outcomes);
 
 		evictBatch(begin, end);
 	}

--- a/duckdb_pglake/src/fs/region_aware_s3fs.cpp
+++ b/duckdb_pglake/src/fs/region_aware_s3fs.cpp
@@ -604,11 +604,20 @@ RegionAwareS3FileSystem::GetBucketRegionFromS3(const string &url, optional_ptr<F
 /*
  * RemoveFiles deletes many files, using a batched DeleteObjects request per
  * bucket instead of one request per file.
+ *
+ * pathErrors, when given, has an entry per path: empty for a path that was
+ * removed and the reason otherwise. Nothing throws in that mode, so a caller
+ * that removes files on behalf of many independent owners can charge each
+ * failure to the path it belongs to rather than to the request they shared.
  */
 void
 RegionAwareS3FileSystem::RemoveFiles(const vector<string> &paths,
-									 optional_ptr<FileOpener> opener)
+									 optional_ptr<FileOpener> opener,
+									 vector<string> *pathErrors)
 {
+	if (pathErrors != nullptr)
+		pathErrors->assign(paths.size(), string());
+
 	/*
 	 * DeleteObjects targets one bucket at a time, and the region is a property
 	 * of the bucket, so group the paths by bucket URL.
@@ -619,17 +628,37 @@ RegionAwareS3FileSystem::RemoveFiles(const vector<string> &paths,
 	 */
 	map<string, vector<string>> pathsByBucket;
 
-	for (const string &path : paths)
-	{
-		if (!StringUtil::StartsWith(path, "s3://") ||
-			UrlHasQueryArgument(path, "s3_region") ||
-			UrlHasQueryArgument(path, "s3_endpoint"))
-		{
-			RemoveFile(path, opener);
-			continue;
-		}
+	/* which path each bucket's keys came from, to report an outcome per path */
+	map<string, vector<idx_t>> pathIndexesByBucket;
 
-		pathsByBucket[GetBucketUrl(path, opener)].push_back(path);
+	for (idx_t pathIndex = 0; pathIndex < paths.size(); pathIndex++)
+	{
+		const string &path = paths[pathIndex];
+
+		try
+		{
+			if (!StringUtil::StartsWith(path, "s3://") ||
+				UrlHasQueryArgument(path, "s3_region") ||
+				UrlHasQueryArgument(path, "s3_endpoint"))
+			{
+				RemoveFile(path, opener);
+				continue;
+			}
+
+			string bucketUrl = GetBucketUrl(path, opener);
+
+			pathsByBucket[bucketUrl].push_back(path);
+
+			if (pathErrors != nullptr)
+				pathIndexesByBucket[bucketUrl].push_back(pathIndex);
+		}
+		catch (std::exception &e)
+		{
+			if (pathErrors == nullptr)
+				throw;
+
+			(*pathErrors)[pathIndex] = e.what();
+		}
 	}
 
 	/*
@@ -642,10 +671,52 @@ RegionAwareS3FileSystem::RemoveFiles(const vector<string> &paths,
 	{
 		const vector<string> &bucketPaths = bucket.second;
 
-		WithResolvedRegion(bucket.first + "/", opener,
-						   [&](const string &resolvedBucketUrl) {
-							   s3fs.RemoveFilesFromS3(resolvedBucketUrl, bucketPaths, opener);
-						   });
+		vector<FileRemovalOutcome> outcomes(bucketPaths.size());
+		string requestError;
+
+		try
+		{
+			WithResolvedRegion(bucket.first + "/", opener,
+							   [&](const string &resolvedBucketUrl) {
+								   s3fs.RemoveFilesFromS3(resolvedBucketUrl, bucketPaths,
+														  opener, pathErrors == nullptr
+																  ? nullptr : &outcomes);
+							   });
+		}
+		catch (std::exception &e)
+		{
+			if (pathErrors == nullptr)
+				throw;
+
+			/*
+			 * A request that fails as a whole says nothing about its keys, so
+			 * this covers whatever S3 did not confirm. That includes the keys of
+			 * an earlier batch to the same bucket when a later one failed:
+			 * removal is idempotent, so reporting a deleted key as failed costs
+			 * the caller one more attempt, while the other way around loses a
+			 * file that is still there.
+			 */
+			requestError = e.what();
+		}
+
+		if (pathErrors == nullptr)
+			continue;
+
+		const vector<idx_t> &pathIndexes = pathIndexesByBucket[bucket.first];
+
+		for (idx_t keyIndex = 0; keyIndex < outcomes.size(); keyIndex++)
+		{
+			const FileRemovalOutcome &outcome = outcomes[keyIndex];
+
+			if (outcome.removed)
+				continue;
+
+			const string &error = !outcome.error.empty() ? outcome.error
+														 : requestError;
+
+			(*pathErrors)[pathIndexes[keyIndex]] =
+				error.empty() ? "the object store did not report an outcome" : error;
+		}
 	}
 }
 

--- a/duckdb_pglake/src/include/pg_lake/fs/caching_file_system.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/caching_file_system.hpp
@@ -174,8 +174,13 @@ public:
 	 * PGLakeCachingFileSystem instances registered in the virtual file system;
 	 * it looks up what it needs from the context, as the file system functions
 	 * in functions.cpp do.
+	 *
+	 * Without pathErrors a failure throws, which is one status for the whole
+	 * call. With it nothing throws and every path that was not removed gets its
+	 * reason in the matching entry.
 	 */
-	static void RemoveFiles(ClientContext &context, const vector<string> &paths);
+	static void RemoveFiles(ClientContext &context, const vector<string> &paths,
+							vector<string> *pathErrors = nullptr);
 
 	/* Custom overrides */
 	duckdb::unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags openFlags,

--- a/duckdb_pglake/src/include/pg_lake/fs/pg_lake_s3fs.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/pg_lake_s3fs.hpp
@@ -30,6 +30,22 @@ extern const string MANAGED_STORAGE_KEY_ID_SETTING;
 
 
 /*
+ * FileRemovalOutcome is what a bulk removal has to say about one of its paths.
+ *
+ * A DeleteObjects request can partially succeed: S3 reports an <Error> per key
+ * it refused and silently deletes the rest, so a batch has as many outcomes as
+ * it has keys. removed says the object store confirmed this key, error says why
+ * it refused. Neither set means the request never got far enough to say
+ * anything about this key, and the caller that catches the exception is the one
+ * that knows why.
+ */
+struct FileRemovalOutcome {
+	bool removed = false;
+	string error;
+};
+
+
+/*
  * PgLakeS3FileSystem extends S3FileSystem to override certain functions
  * with the goal of injecting customer headers.
  */
@@ -41,7 +57,8 @@ public:
 	/* Custom functions */
 	void RemoveFileFromS3(string path, optional_ptr<FileOpener> opener);
 	void RemoveFilesFromS3(const string &bucketUrl, const vector<string> &paths,
-						   optional_ptr<FileOpener> opener);
+						   optional_ptr<FileOpener> opener,
+						   vector<FileRemovalOutcome> *outcomes = nullptr);
 	int64_t Download(ClientContext &context, FileHandle &inputHandle, FileHandle &outputHandle);
 	vector<OpenFileInfo> List(const string &glob_pattern, bool is_glob, FileOpener *opener);
 

--- a/duckdb_pglake/src/include/pg_lake/fs/region_aware_s3fs.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/region_aware_s3fs.hpp
@@ -68,8 +68,13 @@ public:
 	 * batches keys into DeleteObjects requests (up to 1000 keys each), resolving
 	 * the region once per bucket. Paths that carry their own region or endpoint,
 	 * and non-S3 paths, fall back to per-file RemoveFile.
+	 *
+	 * Without pathErrors the first failure throws. With it nothing throws and
+	 * every path that was not removed gets its reason in the matching entry,
+	 * which is what a caller that has to say which path to try again needs.
 	 */
-	void RemoveFiles(const vector<string> &paths, optional_ptr<FileOpener> opener);
+	void RemoveFiles(const vector<string> &paths, optional_ptr<FileOpener> opener,
+					 vector<string> *pathErrors = nullptr);
 
 	/*
 	 * Resolve the region for url (cache or S3 headers), then call s3Operation

--- a/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
+++ b/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
@@ -44,7 +44,8 @@ extern int	OrphanedFileRetentionPeriod;
 extern int	VacuumFileRemoveMaxRetries;
 
 extern PGDLLEXPORT List *GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords);
-extern PGDLLEXPORT bool RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose);
+extern PGDLLEXPORT bool RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose,
+												   int *filesRemoved);
 extern PGDLLEXPORT void InsertDeletionQueueRecord(char *path, Oid relationId, TimestampTz deleteAfterTime);
 extern PGDLLEXPORT void InsertPrefixDeletionRecord(char *path, TimestampTz orphanedAt);
 extern PGDLLEXPORT void InsertMetadataResolveRecord(char *metadataPath, Oid relationId,

--- a/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
+++ b/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
@@ -21,7 +21,19 @@
 #include "nodes/pg_list.h"
 #include "datatype/timestamp.h"
 
-#define PER_LOOP_FILE_CLEANUP_LIMIT 50
+#include "pg_lake/pgduck/remote_storage.h"
+
+/* deletion batches issued per drain pass, see PER_LOOP_FILE_CLEANUP_LIMIT */
+#define FILE_DELETION_BATCHES_PER_LOOP 5
+
+/*
+ * Queue rows claimed per drain pass. Each pass runs in its own transaction, so
+ * this bounds how long the deletion queue holds a transaction (and its xmin)
+ * open before the caller gets control back and can let the rest of the vacuum
+ * cycle -- including the object-store catalog export -- have a turn.
+ */
+#define PER_LOOP_FILE_CLEANUP_LIMIT \
+	(FILE_DELETION_BATCH_SIZE * FILE_DELETION_BATCHES_PER_LOOP)
 
 /* managed by a GUC */
 extern int	OrphanedFileRetentionPeriod;

--- a/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
+++ b/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
@@ -28,10 +28,15 @@
 
 /*
  * Upper bound on the queue rows claimed per drain pass. Each pass runs in its
- * own transaction, so this bounds how long the deletion queue holds a
- * transaction (and its xmin) open before the caller gets control back and can
- * let the rest of the vacuum cycle -- including the object-store catalog
- * export -- have a turn.
+ * own transaction, so this is what makes a pass end at all: the caller gets
+ * control back and can let the rest of the vacuum cycle -- including the
+ * object-store catalog export -- have a turn.
+ *
+ * It is a row count, not a duration. Two row kinds still cost unbounded work,
+ * so a pass holding this many of them can run for an unbounded time with the
+ * claim's FOR UPDATE held on all of them: a resolve_metadata row is a metadata
+ * walk over a dropped table, and an is_prefix row is a listing of everything
+ * under a prefix. Bounding those is tracked in #538.
  *
  * A caller that has its own budget for the whole cycle asks for fewer rows via
  * the maxRecords argument of GetDeletionQueueRecords.
@@ -42,6 +47,7 @@
 /* managed by a GUC */
 extern int	OrphanedFileRetentionPeriod;
 extern int	VacuumFileRemoveMaxRetries;
+extern int	VacuumFileRemoveRetryInterval;
 
 extern PGDLLEXPORT List *GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords);
 extern PGDLLEXPORT bool RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose,

--- a/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
+++ b/pg_lake_engine/include/pg_lake/cleanup/deletion_queue.h
@@ -27,10 +27,14 @@
 #define FILE_DELETION_BATCHES_PER_LOOP 5
 
 /*
- * Queue rows claimed per drain pass. Each pass runs in its own transaction, so
- * this bounds how long the deletion queue holds a transaction (and its xmin)
- * open before the caller gets control back and can let the rest of the vacuum
- * cycle -- including the object-store catalog export -- have a turn.
+ * Upper bound on the queue rows claimed per drain pass. Each pass runs in its
+ * own transaction, so this bounds how long the deletion queue holds a
+ * transaction (and its xmin) open before the caller gets control back and can
+ * let the rest of the vacuum cycle -- including the object-store catalog
+ * export -- have a turn.
+ *
+ * A caller that has its own budget for the whole cycle asks for fewer rows via
+ * the maxRecords argument of GetDeletionQueueRecords.
  */
 #define PER_LOOP_FILE_CLEANUP_LIMIT \
 	(FILE_DELETION_BATCH_SIZE * FILE_DELETION_BATCHES_PER_LOOP)
@@ -39,7 +43,7 @@
 extern int	OrphanedFileRetentionPeriod;
 extern int	VacuumFileRemoveMaxRetries;
 
-extern PGDLLEXPORT List *GetDeletionQueueRecords(Oid relationId, bool isFull);
+extern PGDLLEXPORT List *GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords);
 extern PGDLLEXPORT bool RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose);
 extern PGDLLEXPORT void InsertDeletionQueueRecord(char *path, Oid relationId, TimestampTz deleteAfterTime);
 extern PGDLLEXPORT void InsertPrefixDeletionRecord(char *path, TimestampTz orphanedAt);

--- a/pg_lake_engine/include/pg_lake/pgduck/remote_storage.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/remote_storage.h
@@ -21,6 +21,13 @@
 #include "nodes/pg_list.h"
 
 /*
+ * Number of files removed per object-store request by DeleteRemoteFileBatch.
+ * 1000 is the largest batch S3 accepts in a single DeleteObjects call, so a
+ * fuller batch would only be split up again one level down.
+ */
+#define FILE_DELETION_BATCH_SIZE 1000
+
+/*
  * RemoteFileDesc holds a descriptions of a remote file.
  */
 typedef struct RemoteFileDesc
@@ -42,4 +49,7 @@ extern PGDLLEXPORT List *ListRemoteFileDescriptions(char *pattern);
 extern PGDLLEXPORT List *ListRemoteFileNames(char *pattern);
 extern PGDLLEXPORT bool RemoteFileExists(char *path);
 extern PGDLLEXPORT bool DeleteRemoteFile(char *path);
+extern PGDLLEXPORT bool DeleteRemoteFiles(List *paths);
+extern PGDLLEXPORT void DeleteRemoteFileBatch(List *paths, List **deletedPaths,
+											  List **failedPaths);
 extern PGDLLEXPORT bool DeleteRemotePrefix(char *path);

--- a/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
+++ b/pg_lake_engine/pg_lake_engine--3.4--3.5.sql
@@ -1,1 +1,8 @@
 -- Upgrade script for pg_lake_engine from 3.4 to 3.5
+
+-- When we last tried and failed to remove a queued path. Retries are spaced by
+-- pg_lake_engine.vacuum_file_remove_retry_interval, so that
+-- vacuum_file_remove_max_retries bounds how long we keep trying a path rather
+-- than how many VACUUM passes happen to reach it.
+ALTER TABLE lake_engine.deletion_queue
+    ADD COLUMN last_attempt_at timestamptz;

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -78,7 +78,8 @@ flush_deletion_queue(PG_FUNCTION_ARGS)
 	/* remove all */
 	bool		isFull = true;
 	bool		isVerbose = false;
-	List	   *deletionQueueRecords = GetDeletionQueueRecords(relationId, isFull);
+	List	   *deletionQueueRecords = GetDeletionQueueRecords(relationId, isFull,
+															   PER_LOOP_FILE_CLEANUP_LIMIT);
 
 	RemoveDeletionQueueRecords(deletionQueueRecords, isVerbose);
 
@@ -390,9 +391,15 @@ IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
 /*
  * GetDeletionQueueRecords gets a list of paths that are eligible for
  * deletion, meaning delete_after condition is met on DELETION_QUEUE_TABLE.
+ *
+ * Unless isFull is set, at most maxRecords rows are claimed, capped at
+ * PER_LOOP_FILE_CLEANUP_LIMIT so that one pass cannot hold a transaction open
+ * for an unbounded amount of work no matter what the caller asks for. Callers
+ * that drain in a loop under a budget of their own pass what is left of that
+ * budget, so the budget is respected exactly rather than to the nearest pass.
  */
 List *
-GetDeletionQueueRecords(Oid relationId, bool isFull)
+GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords)
 {
 	MemoryContext callerContext = CurrentMemoryContext;
 	List	   *result = NIL;
@@ -432,7 +439,8 @@ GetDeletionQueueRecords(Oid relationId, bool isFull)
 	if (!isFull)
 	{
 		appendStringInfo(query,
-						 "    LIMIT %d", PER_LOOP_FILE_CLEANUP_LIMIT);
+						 "    LIMIT %d",
+						 Min(maxRecords, PER_LOOP_FILE_CLEANUP_LIMIT));
 	}
 
 	appendStringInfo(query,

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -415,12 +415,11 @@ IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
  *
  * A row that failed within the last VacuumFileRemoveRetryInterval is also left
  * alone, so a path that cannot be removed is retried on a clock rather than
- * once per pass. Without it a pass rate the callers do not control decides both
- * halves of the retry budget: the path is re-claimed by every pass, each of
- * those passes pays the cost of finding out which path in its batch failed,
- * and retry_count reaches VacuumFileRemoveMaxRetries in whatever time that many
- * passes take -- minutes when a drain is catching up on a backlog, rather than
- * the day the default is sized for.
+ * once per pass. Without it a pass rate the callers do not control decides how
+ * long we keep trying a path: it is re-claimed by every pass, so retry_count
+ * reaches VacuumFileRemoveMaxRetries in whatever time that many passes take --
+ * minutes when a drain is catching up on a backlog, rather than the day the
+ * default is sized for.
  *
  * isFull skips the backoff: that is the manual flush, where the caller is
  * asking to try everything now.

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -29,7 +29,6 @@
 #include "pg_lake/pgduck/remote_storage.h"
 #include "pg_lake/util/array_utils.h"
 #include "pg_extension_base/spi_helpers.h"
-#include "pg_lake/util/string_utils.h"
 #include "datatype/timestamp.h"
 #include "storage/procarray.h"
 
@@ -58,7 +57,7 @@ typedef struct DeletionQueueEntry
 static void RemoveDeletionQueuePathsFromCatalog(List *filePaths);
 static void IncrementDeletionQueueRetryCount(List *failedRemovalPaths);
 static bool ExpandMetadataResolveRecord(char *metadataPath);
-static bool DeleteQueuedObject(char *path, bool isPrefix, bool isVerbose);
+static bool DeleteQueuedPrefix(char *path, bool isVerbose);
 
 
 PG_FUNCTION_INFO_V1(flush_deletion_queue);
@@ -129,7 +128,15 @@ RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose)
 	 * so the expensive metadata walk is paid once: each file then gets the
 	 * normal retry_count budget and batching, and an interrupted VACUUM
 	 * resumes from committed rows.
+	 *
+	 * Plain file rows are not deleted one by one. They are collected into
+	 * batches of FILE_DELETION_BATCH_SIZE and removed with one object-store
+	 * request per batch, because a request per file made draining a large
+	 * queue take time proportional to the number of files -- with the whole
+	 * vacuum cycle, and therefore catalog publication, waiting behind it.
 	 */
+	List	   *deletionBatch = NIL;
+
 	foreach(cleanupRecordCell, deletionQueueRecords)
 	{
 		DeletionQueueEntry *entry = lfirst(cleanupRecordCell);
@@ -154,11 +161,41 @@ RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose)
 			continue;
 		}
 
-		if (DeleteQueuedObject(entry->path, entry->isPrefix, isVerbose))
-			deletedFilePathList = lappend(deletedFilePathList, entry->path);
-		else
-			failedFilePathList = lappend(failedFilePathList, entry->path);
+		if (entry->isPrefix)
+		{
+			/*
+			 * A prefix row expands into an unbounded listing plus delete, so
+			 * it stays a request of its own.
+			 */
+			if (DeleteQueuedPrefix(entry->path, isVerbose))
+				deletedFilePathList = lappend(deletedFilePathList, entry->path);
+			else
+				failedFilePathList = lappend(failedFilePathList, entry->path);
+
+			continue;
+		}
+
+		ereport(isVerbose ? INFO : LOG,
+				(errmsg("deleting expired file %s", entry->path)));
+
+		deletionBatch = lappend(deletionBatch, entry->path);
+
+		if (list_length(deletionBatch) >= FILE_DELETION_BATCH_SIZE)
+		{
+			DeleteRemoteFileBatch(deletionBatch, &deletedFilePathList,
+								  &failedFilePathList);
+			deletionBatch = NIL;
+
+			/*
+			 * A batch is a long-running request; give the caller a chance to
+			 * cancel the drain between batches.
+			 */
+			CHECK_FOR_INTERRUPTS();
+		}
 	}
+
+	/* whatever did not fill a batch */
+	DeleteRemoteFileBatch(deletionBatch, &deletedFilePathList, &failedFilePathList);
 
 	if (list_length(deletedFilePathList) > 0)
 	{
@@ -179,22 +216,17 @@ RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose)
 
 
 /*
- * DeleteQueuedObject removes the object(s) named by a direct deletion-queue
- * row -- a single file, or the whole tree under a prefix when isPrefix is set
- * -- and reports whether the removal succeeded.
+ * DeleteQueuedPrefix removes the whole tree under the prefix named by a
+ * deletion-queue row with is_prefix set, and reports whether the removal
+ * succeeded.
  */
 static bool
-DeleteQueuedObject(char *path, bool isPrefix, bool isVerbose)
+DeleteQueuedPrefix(char *path, bool isVerbose)
 {
 	ereport(isVerbose ? INFO : LOG,
-			(errmsg("deleting expired %s %s",
-					isPrefix ? "prefix" : "file",
-					path)));
+			(errmsg("deleting expired prefix %s", path)));
 
-	if (isPrefix)
-		return DeleteRemotePrefix(path);
-
-	return DeleteRemoteFile(path);
+	return DeleteRemotePrefix(path);
 }
 
 
@@ -400,7 +432,7 @@ GetDeletionQueueRecords(Oid relationId, bool isFull)
 	if (!isFull)
 	{
 		appendStringInfo(query,
-						 "    LIMIT " PG_LAKE_TOSTRING(PER_LOOP_FILE_CLEANUP_LIMIT));
+						 "    LIMIT %d", PER_LOOP_FILE_CLEANUP_LIMIT);
 	}
 
 	appendStringInfo(query,

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -81,7 +81,10 @@ flush_deletion_queue(PG_FUNCTION_ARGS)
 	List	   *deletionQueueRecords = GetDeletionQueueRecords(relationId, isFull,
 															   PER_LOOP_FILE_CLEANUP_LIMIT);
 
-	RemoveDeletionQueueRecords(deletionQueueRecords, isVerbose);
+	/* removes everything it can, so there is no budget to report back on */
+	int		   *filesRemoved = NULL;
+
+	RemoveDeletionQueueRecords(deletionQueueRecords, isVerbose, filesRemoved);
 
 	ListCell   *fileCell = NULL;
 
@@ -101,9 +104,15 @@ flush_deletion_queue(PG_FUNCTION_ARGS)
 /*
  * RemoveDeletionQueueRecords removes all files that are no longer referenced .
  * Returns true if at least one file was successfully removed.
+ *
+ * When filesRemoved is given it reports how many of the records were actually
+ * removed, which is fewer than the number of records whenever a removal failed.
+ * Callers that spend a budget on this count what they removed, not what they
+ * claimed, so paths that can never be removed do not consume the budget over
+ * and over.
  */
 bool
-RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose)
+RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose, int *filesRemoved)
 {
 	List	   *deletedFilePathList = NIL;
 	List	   *failedFilePathList = NIL;
@@ -206,6 +215,11 @@ RemoveDeletionQueueRecords(List *deletionQueueRecords, bool isVerbose)
 	if (list_length(failedFilePathList) > 0)
 	{
 		IncrementDeletionQueueRetryCount(failedFilePathList);
+	}
+
+	if (filesRemoved != NULL)
+	{
+		*filesRemoved = list_length(deletedFilePathList);
 	}
 
 	/*
@@ -438,9 +452,15 @@ GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords)
 
 	if (!isFull)
 	{
+		/*
+		 * Clamp at 0 as well as at the per-pass limit. No caller asks for
+		 * fewer than 0 rows today, but a negative LIMIT is an error rather
+		 * than an empty result, and the callers that compute a remaining
+		 * budget do so in another module.
+		 */
 		appendStringInfo(query,
 						 "    LIMIT %d",
-						 Min(maxRecords, PER_LOOP_FILE_CLEANUP_LIMIT));
+						 Max(Min(maxRecords, PER_LOOP_FILE_CLEANUP_LIMIT), 0));
 	}
 
 	appendStringInfo(query,

--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -40,6 +40,7 @@ int			OrphanedFileRetentionPeriod = 60 * 60 * 24 * 10;	/* 10 days */
 
 /* managed by GUC, not exposed to the users */
 int			VacuumFileRemoveMaxRetries = 145;
+int			VacuumFileRemoveRetryInterval = 600;	/* 10 minutes */
 
 /*
  * DeletionQueueEntry represents a deletion entry from the
@@ -82,9 +83,7 @@ flush_deletion_queue(PG_FUNCTION_ARGS)
 															   PER_LOOP_FILE_CLEANUP_LIMIT);
 
 	/* removes everything it can, so there is no budget to report back on */
-	int		   *filesRemoved = NULL;
-
-	RemoveDeletionQueueRecords(deletionQueueRecords, isVerbose, filesRemoved);
+	RemoveDeletionQueueRecords(deletionQueueRecords, isVerbose, NULL);
 
 	ListCell   *fileCell = NULL;
 
@@ -376,7 +375,9 @@ RemoveDeletionQueuePathsFromCatalog(List *filePaths)
 
 /*
 * IncrementDeletionQueueRetryCount increments the retry count
-* for the given paths in the deletion queue.
+* for the given paths in the deletion queue, and records when the failed
+* attempt happened so the next one can be held off for
+* VacuumFileRemoveRetryInterval (see GetDeletionQueueRecords).
 */
 static void
 IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
@@ -386,7 +387,7 @@ IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
 
 	char	   *updateQuery =
 		"UPDATE " DELETION_QUEUE_TABLE " "
-		"SET retry_count = retry_count + 1 "
+		"SET retry_count = retry_count + 1, last_attempt_at = pg_catalog.now() "
 		"WHERE path OPERATOR(pg_catalog.=) ANY($1) ";
 
 	DECLARE_SPI_ARGS(1);
@@ -411,6 +412,18 @@ IncrementDeletionQueueRetryCount(List *failedRemovalPaths)
  * for an unbounded amount of work no matter what the caller asks for. Callers
  * that drain in a loop under a budget of their own pass what is left of that
  * budget, so the budget is respected exactly rather than to the nearest pass.
+ *
+ * A row that failed within the last VacuumFileRemoveRetryInterval is also left
+ * alone, so a path that cannot be removed is retried on a clock rather than
+ * once per pass. Without it a pass rate the callers do not control decides both
+ * halves of the retry budget: the path is re-claimed by every pass, each of
+ * those passes pays the cost of finding out which path in its batch failed,
+ * and retry_count reaches VacuumFileRemoveMaxRetries in whatever time that many
+ * passes take -- minutes when a drain is catching up on a backlog, rather than
+ * the day the default is sized for.
+ *
+ * isFull skips the backoff: that is the manual flush, where the caller is
+ * asking to try everything now.
  */
 List *
 GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords)
@@ -429,9 +442,15 @@ GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords)
 						 "    SELECT ctid, path, orphaned_at, retry_count, is_prefix, resolve_metadata "
 						 "    FROM " DELETION_QUEUE_TABLE " "
 						 "    WHERE (orphaned_at IS NULL or pg_catalog.now() OPERATOR(pg_catalog.>=) (orphaned_at OPERATOR(pg_catalog.+) INTERVAL '%d seconds')) AND "
-						 "		  table_name OPERATOR(pg_catalog.=) %d AND retry_count OPERATOR(pg_catalog.<=) %d  FOR UPDATE",
+						 "		  table_name OPERATOR(pg_catalog.=) %d AND retry_count OPERATOR(pg_catalog.<=) %d ",
 						 OrphanedFileRetentionPeriod, relationId, VacuumFileRemoveMaxRetries);
 
+		if (!isFull)
+			appendStringInfo(query,
+							 "      AND (last_attempt_at IS NULL OR pg_catalog.now() OPERATOR(pg_catalog.>=) (last_attempt_at OPERATOR(pg_catalog.+) INTERVAL '%d seconds')) ",
+							 VacuumFileRemoveRetryInterval);
+
+		appendStringInfoString(query, " FOR UPDATE");
 	}
 	else
 	{
@@ -445,9 +464,15 @@ GetDeletionQueueRecords(Oid relationId, bool isFull, int maxRecords)
 						 "    FROM " DELETION_QUEUE_TABLE " del "
 						 "    LEFT JOIN pg_catalog.pg_class c ON c.oid OPERATOR(pg_catalog.=) del.table_name "
 						 "    WHERE (del.orphaned_at IS NULL or pg_catalog.now() OPERATOR(pg_catalog.>=) (del.orphaned_at OPERATOR(pg_catalog.+) INTERVAL '%d seconds')) AND "
-						 "          c.oid IS NULL  AND retry_count OPERATOR(pg_catalog.<=) %d FOR UPDATE OF del",
+						 "          c.oid IS NULL  AND retry_count OPERATOR(pg_catalog.<=) %d ",
 						 OrphanedFileRetentionPeriod, VacuumFileRemoveMaxRetries);
 
+		if (!isFull)
+			appendStringInfo(query,
+							 "      AND (del.last_attempt_at IS NULL OR pg_catalog.now() OPERATOR(pg_catalog.>=) (del.last_attempt_at OPERATOR(pg_catalog.+) INTERVAL '%d seconds')) ",
+							 VacuumFileRemoveRetryInterval);
+
+		appendStringInfoString(query, " FOR UPDATE OF del");
 	}
 
 	if (!isFull)

--- a/pg_lake_engine/src/cleanup/in_progress_files.c
+++ b/pg_lake_engine/src/cleanup/in_progress_files.c
@@ -167,6 +167,14 @@ RemoveInProgressFiles(char *location, bool isFull, bool isVerbose, List **delete
 
 	ListCell   *fileCell = NULL;
 
+	/*
+	 * Plain paths are removed in batches of FILE_DELETION_BATCH_SIZE, one
+	 * object-store request per batch, so that draining a long in-progress
+	 * queue does not cost a request per file. Prefix entries expand into an
+	 * unbounded listing plus delete, so they stay a request of their own.
+	 */
+	List	   *deletionBatch = NIL;
+
 	foreach(fileCell, inProgressFileRecords)
 	{
 		InProgressFiles *entry = lfirst(fileCell);
@@ -198,22 +206,36 @@ RemoveInProgressFiles(char *location, bool isFull, bool isVerbose, List **delete
 		}
 		else
 		{
-			DeleteRemoteFile(entry->path);
+			deletionBatch = lappend(deletionBatch, entry->path);
+
+			if (list_length(deletionBatch) >= FILE_DELETION_BATCH_SIZE)
+			{
+				DeleteRemoteFileBatch(deletionBatch, NULL, NULL);
+				deletionBatch = NIL;
+
+				/*
+				 * A batch is a long-running request; give the caller a chance
+				 * to cancel the drain between batches.
+				 */
+				CHECK_FOR_INTERRUPTS();
+			}
 		}
 
 		*deletedPaths = lappend(*deletedPaths, entry->path);
 	}
+
+	/* whatever did not fill a batch */
+	DeleteRemoteFileBatch(deletionBatch, NULL, NULL);
 
 	/*
 	 * Drop the catalog rows for the paths we just unlinked from remote
 	 * storage in a single DELETE. Per-row DeleteInProgressFileRecord would
 	 * take a fresh plan-cache + snapshot per file, which on large backlogs (a
 	 * stuck VACUUM walk of a long in-progress queue) was a notable share of
-	 * the loop. Remote DeleteObject above is still the dominant cost, so this
-	 * is a tidy-up rather than a hot-path win; the per-iteration semantics
-	 * are preserved because the catalog DELETE is idempotent against missing
-	 * paths and DeleteRemoteFile is idempotent against missing remote
-	 * objects, so a mid-loop error still recovers via the next VACUUM cycle.
+	 * the loop. The per-iteration semantics are preserved because the catalog
+	 * DELETE is idempotent against missing paths and remote removal is
+	 * idempotent against missing remote objects, so a mid-loop error still
+	 * recovers via the next VACUUM cycle.
 	 */
 	DeleteInProgressFileRecords(*deletedPaths);
 

--- a/pg_lake_engine/src/init.c
+++ b/pg_lake_engine/src/init.c
@@ -148,14 +148,34 @@ _PG_init(void)
 										 "with vacuum. Once this number of retries is reached, "
 										 "the file will be removed from the deletion queue and "
 										 "won't be retried to remove."),
-							NULL,
+							gettext_noop("Retries are spaced by "
+										 "pg_lake_engine.vacuum_file_remove_retry_interval, so this "
+										 "bounds how long we keep trying a file rather than how "
+										 "many vacuum passes happen to reach it."),
 							&VacuumFileRemoveMaxRetries,
-							145 /* With the default vacuum naptime, we try up
-							  * to 1 day */ ,
+							145 /* At the default retry interval, we try for
+							  * at least 1 day */ ,
 							0,
 							INT32_MAX,
 							PGC_SUSET,
 							GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL, NULL, NULL);
+
+	DefineCustomIntVariable("pg_lake_engine.vacuum_file_remove_retry_interval",
+							gettext_noop("The minimum time to wait before vacuum tries to remove "
+										 "a file that it failed to remove before."),
+							gettext_noop("A file that cannot be removed is otherwise retried by "
+										 "every vacuum pass that reaches it, which spends "
+										 "pg_lake_engine.vacuum_file_remove_max_retries at "
+										 "whatever rate those passes happen to run at. Set to 0 "
+										 "to retry on every pass."),
+							&VacuumFileRemoveRetryInterval,
+							600 /* the default
+							  * pg_lake_iceberg.autovacuum_naptime */ ,
+							0,
+							INT32_MAX,
+							PGC_SUSET,
+							GUC_UNIT_S | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							NULL, NULL, NULL);
 
 	/*

--- a/pg_lake_engine/src/pgduck/remote_storage.c
+++ b/pg_lake_engine/src/pgduck/remote_storage.c
@@ -16,7 +16,6 @@
  */
 
 #include "postgres.h"
-#include "miscadmin.h"
 
 #include "pg_lake/data_file/data_file_stats.h"
 #include "pg_lake/parquet/leaf_field.h"
@@ -28,8 +27,8 @@
 #include "utils/builtins.h"
 #include "utils/timestamp.h"
 
-static void AttributeFailedDeletion(List *paths, List **deletedPaths,
-									List **failedPaths);
+static void DeleteRemoteFilesReportingOutcomes(List *paths, List **deletedPaths,
+											   List **failedPaths);
 
 
 /*
@@ -272,24 +271,17 @@ DeleteRemoteFiles(List *paths)
  * *deletedPaths and paths that were not to *failedPaths. Either output list
  * may be NULL when the caller does not track that outcome.
  *
- * pgduck reports one status for the whole request and does not say which path
- * was at fault, so a failed batch has to be narrowed down. Without that, a
- * single unreachable object would charge its failure to every path that shared
- * its request, so a caller that retires paths by failure count (such as the
- * deletion queue) would eventually retire a whole batch of healthy ones.
- * Removing a file twice is a no-op, so replaying paths the failed batch had
- * already deleted is safe.
+ * A batch of paths that have nothing to do with each other needs an outcome per
+ * path. Without one, a single unreachable object charges its failure to every
+ * path that shared its request, so a caller that retires paths by failure count
+ * (such as the deletion queue) would eventually retire a whole batch of healthy
+ * ones. pg_lake_try_remove_file reports the outcome per row rather than failing
+ * the statement, so one request answers for the whole batch.
  *
- * The narrowing bisects rather than walking the batch, because a path that
- * cannot be removed is claimed again by every following pass, so whatever a
- * failed batch costs is paid once per pass until retry_count retires the row.
- * Walking makes that a request per path; bisecting finds k bad paths out of n
- * in O(k log n) requests, so the usual case of one poison path in a full batch
- * costs about 20 requests instead of 1000.
- *
- * A caller that tracks neither outcome has nothing to tell apart, so it skips
- * the narrowing entirely: producing a verdict nobody reads is the per-file cost
- * this batching exists to remove.
+ * A caller that tracks neither outcome has nothing to attribute, so it takes the
+ * cheaper statement that reports a single status: a boolean per path is more than
+ * it needs coming back, and a verdict nobody reads is the per-file cost this
+ * batching exists to remove.
  */
 void
 DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
@@ -297,67 +289,163 @@ DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
 	if (paths == NIL)
 		return;
 
-	if (DeleteRemoteFiles(paths))
-	{
-		if (deletedPaths != NULL)
-			*deletedPaths = list_concat(*deletedPaths, paths);
-
-		return;
-	}
-
 	if (deletedPaths == NULL && failedPaths == NULL)
 	{
-		/* no outcome to record, so no reason to find out which path failed */
+		DeleteRemoteFiles(paths);
 		return;
 	}
 
-	AttributeFailedDeletion(paths, deletedPaths, failedPaths);
+	MemoryContext savedContext = CurrentMemoryContext;
+	volatile bool outcomesReported = false;
+
+	PG_TRY();
+	{
+		DeleteRemoteFilesReportingOutcomes(paths, deletedPaths, failedPaths);
+		outcomesReported = true;
+	}
+	PG_CATCH();
+	{
+		/*
+		 * continue with a warning unless it was a cancellation, as
+		 * ExecuteOptionalCommandInPGDuck does
+		 */
+		MemoryContextSwitchTo(savedContext);
+
+		ErrorData  *edata = CopyErrorData();
+
+		FlushErrorState();
+
+		if (edata->sqlerrcode != ERRCODE_QUERY_CANCELED)
+			edata->elevel = WARNING;
+
+		ThrowErrorData(edata);
+	}
+	PG_END_TRY();
+
+	if (outcomesReported)
+		return;
+
+	/*
+	 * A request that did not complete says nothing about any of its paths, so
+	 * none of them is accounted for. Report them all as failed: a path the
+	 * request did remove is claimed again by the next pass, and removing a
+	 * file twice is a no-op, while the other way around loses a file that is
+	 * still there.
+	 */
+	if (failedPaths != NULL)
+		*failedPaths = list_concat(*failedPaths, paths);
 }
 
 
 /*
- * AttributeFailedDeletion works out which of the paths of a failed batch could
- * not be removed, by halving the batch and re-issuing each half. A half that
- * succeeds accounts for all of its paths in one request; only a half that fails
- * is split further, so the requests spent follow the number of bad paths rather
- * than the size of the batch.
+ * DeleteRemoteFilesReportingOutcomes deletes the given files in a single pgduck
+ * request and reads back what became of each one: pg_lake_try_remove_file returns
+ * NULL for a path that is gone and the reason for a path that could not be
+ * removed. Throws if the request itself did not complete, in which case the
+ * output lists are left untouched.
+ *
+ * The reason is only reported here, since the deletion queue records how often a
+ * path failed and not why. It is the same reason a failed removal used to raise,
+ * so a batch that partially fails still says as much about it as one that failed
+ * outright.
  */
 static void
-AttributeFailedDeletion(List *paths, List **deletedPaths, List **failedPaths)
+DeleteRemoteFilesReportingOutcomes(List *paths, List **deletedPaths,
+								   List **failedPaths)
 {
-	if (list_length(paths) == 1)
+	StringInfo	query = makeStringInfo();
+
+	appendStringInfoString(query,
+						   "SELECT file, pg_lake_try_remove_file(file) AS error "
+						   "FROM (VALUES ");
+
+	ListCell   *pathCell = NULL;
+
+	foreach(pathCell, paths)
 	{
-		char	   *path = linitial(paths);
+		char	   *path = lfirst(pathCell);
 
-		/*
-		 * A single path is its own verdict: the batch we just failed was this
-		 * one request, so there is nothing left to re-issue.
-		 */
-		if (failedPaths != NULL)
-			*failedPaths = lappend(*failedPaths, path);
+		if (pathCell != list_head(paths))
+			appendStringInfoChar(query, ',');
 
-		return;
+		appendStringInfo(query, "(%s)", quote_literal_cstr(path));
 	}
 
-	int			halfLength = list_length(paths) / 2;
-	List	   *halves[] = {
-		list_truncate(list_copy(paths), halfLength),
-		list_copy_tail(paths, halfLength)
-	};
+	appendStringInfoString(query, ") AS batch(file)");
 
-	for (int halfIndex = 0; halfIndex < 2; halfIndex++)
+	PGDuckConnection *pgDuckConn = GetPGDuckConnection();
+
+	List	   *volatile removedPaths = NIL;
+	List	   *volatile unremovedPaths = NIL;
+	char	   *volatile firstError = NULL;
+	char	   *volatile firstFailedPath = NULL;
+
+	/*
+	 * Release the connection whichever way we leave, because our caller turns
+	 * an error here into a warning and carries on: a connection left behind
+	 * would be one more per pass.
+	 */
+	PGresult   *volatile resultToClear = NULL;
+
+	PG_TRY();
 	{
-		List	   *half = halves[halfIndex];
+		PGresult   *result = ExecuteQueryOnPGDuckConnection(pgDuckConn, query->data);
 
-		if (DeleteRemoteFiles(half))
+		/* throws, having cleared the result, if the request failed */
+		CheckPGDuckResult(pgDuckConn, result);
+
+		resultToClear = result;
+
+		if (PQntuples(result) != list_length(paths))
 		{
-			if (deletedPaths != NULL)
-				*deletedPaths = list_concat(*deletedPaths, half);
+			ereport(ERROR,
+					(errmsg("query engine reported %d outcomes for a batch of %d files",
+							PQntuples(result), list_length(paths))));
 		}
-		else
-			AttributeFailedDeletion(half, deletedPaths, failedPaths);
 
-		/* narrowing a batch is a sequence of requests, so stay cancellable */
-		CHECK_FOR_INTERRUPTS();
+		for (int rowIndex = 0; rowIndex < PQntuples(result); rowIndex++)
+		{
+			char	   *path = pstrdup(PQgetvalue(result, rowIndex, 0));
+
+			if (PQgetisnull(result, rowIndex, 1))
+			{
+				removedPaths = lappend(removedPaths, path);
+				continue;
+			}
+
+			char	   *error = pstrdup(PQgetvalue(result, rowIndex, 1));
+
+			unremovedPaths = lappend(unremovedPaths, path);
+
+			ereport(DEBUG1, (errmsg("could not remove %s: %s", path, error)));
+
+			if (firstFailedPath == NULL)
+			{
+				firstFailedPath = path;
+				firstError = error;
+			}
+		}
 	}
+	PG_FINALLY();
+	{
+		if (resultToClear != NULL)
+			PQclear(resultToClear);
+
+		ReleasePGDuckConnection(pgDuckConn);
+	}
+	PG_END_TRY();
+
+	if (unremovedPaths != NIL)
+	{
+		ereport(WARNING,
+				(errmsg("could not remove %d of %d files from object storage",
+						list_length(unremovedPaths), list_length(paths)),
+				 errdetail("%s: %s", firstFailedPath, firstError)));
+	}
+
+	if (deletedPaths != NULL)
+		*deletedPaths = list_concat(*deletedPaths, removedPaths);
+
+	if (failedPaths != NULL)
+		*failedPaths = list_concat(*failedPaths, unremovedPaths);
 }

--- a/pg_lake_engine/src/pgduck/remote_storage.c
+++ b/pg_lake_engine/src/pgduck/remote_storage.c
@@ -179,10 +179,6 @@ RemoteFileExists(char *path)
 * pg_lake_remove_file gets a whole vector of file names at a time and, for S3,
 * deletes them in batched DeleteObjects requests (up to 1000 keys each) rather
 * than one request per file.
-*
-* The call goes in WHERE rather than the select list so that we get a single
-* count back instead of a row per file, without DuckDB pruning a projection
-* that nothing reads.
 */
 bool
 DeleteRemotePrefix(char *path)
@@ -194,7 +190,7 @@ DeleteRemotePrefix(char *path)
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
-					 "SELECT count(*) FROM glob(%s) WHERE pg_lake_remove_file(file)",
+					 "SELECT pg_lake_remove_file(file) FROM glob(%s)",
 					 quote_literal_cstr(recursivePath->data));
 
 	return ExecuteOptionalCommandInPGDuck(query->data);
@@ -220,7 +216,7 @@ DeleteRemoteFile(char *path)
  * Deleting an arbitrary set of files used to cost one request per file, which
  * made cleanup of a large backlog take as long as the backlog was long. One
  * statement over a VALUES list arrives as a single vector instead, so
- * pg_lake_remove_file can collapse it into one bulk delete against the object
+ * pg_lake_remove_file collapses it into one bulk delete against the object
  * store.
  *
  * Callers are expected to keep a batch within FILE_DELETION_BATCH_SIZE: the
@@ -272,6 +268,11 @@ DeleteRemoteFiles(List *paths)
  * the deletion queue) would eventually retire a whole batch of healthy ones.
  * Removing a file twice is a no-op, so replaying paths the failed batch had
  * already deleted is safe.
+ *
+ * A caller that tracks neither outcome has nothing to tell apart, so it skips
+ * the retry: paying up to FILE_DELETION_BATCH_SIZE individual requests to
+ * produce a verdict nobody reads is the per-file cost this batching exists to
+ * remove.
  */
 void
 DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
@@ -280,6 +281,12 @@ DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
 		return;
 
 	bool		batchSucceeded = DeleteRemoteFiles(paths);
+
+	if (deletedPaths == NULL && failedPaths == NULL)
+	{
+		/* no outcome to record, so no reason to find out which path failed */
+		return;
+	}
 
 	ListCell   *pathCell = NULL;
 

--- a/pg_lake_engine/src/pgduck/remote_storage.c
+++ b/pg_lake_engine/src/pgduck/remote_storage.c
@@ -211,3 +211,89 @@ DeleteRemoteFile(char *path)
 
 	return ExecuteOptionalCommandInPGDuck(query);
 }
+
+
+/*
+ * DeleteRemoteFiles deletes the given files in a single pgduck request and
+ * reports whether the request succeeded.
+ *
+ * Deleting an arbitrary set of files used to cost one request per file, which
+ * made cleanup of a large backlog take as long as the backlog was long. One
+ * statement over a VALUES list arrives as a single vector instead, so
+ * pg_lake_remove_file can collapse it into one bulk delete against the object
+ * store.
+ *
+ * Callers are expected to keep a batch within FILE_DELETION_BATCH_SIZE: the
+ * point of batching is to bound the work behind one request, not to move an
+ * unbounded delete from Postgres into pgduck.
+ */
+bool
+DeleteRemoteFiles(List *paths)
+{
+	if (paths == NIL)
+		return true;
+
+	/* keep the single-file case on the plain, cheaper statement */
+	if (list_length(paths) == 1)
+		return DeleteRemoteFile((char *) linitial(paths));
+
+	StringInfo	query = makeStringInfo();
+
+	appendStringInfoString(query, "SELECT pg_lake_remove_file(file) FROM (VALUES ");
+
+	ListCell   *pathCell = NULL;
+
+	foreach(pathCell, paths)
+	{
+		char	   *path = lfirst(pathCell);
+
+		if (pathCell != list_head(paths))
+			appendStringInfoChar(query, ',');
+
+		appendStringInfo(query, "(%s)", quote_literal_cstr(path));
+	}
+
+	appendStringInfoString(query, ") AS batch(file)");
+
+	return ExecuteOptionalCommandInPGDuck(query->data);
+}
+
+
+/*
+ * DeleteRemoteFileBatch deletes the given files in one pgduck request and
+ * records the per-path outcome: paths that were removed are appended to
+ * *deletedPaths and paths that were not to *failedPaths. Either output list
+ * may be NULL when the caller does not track that outcome.
+ *
+ * pgduck reports one status for the whole request and does not say which path
+ * was at fault, so a failed batch is retried one file at a time. Without that,
+ * a single unreachable object would charge its failure to every path that
+ * shared its request, so a caller that retires paths by failure count (such as
+ * the deletion queue) would eventually retire a whole batch of healthy ones.
+ * Removing a file twice is a no-op, so replaying paths the failed batch had
+ * already deleted is safe.
+ */
+void
+DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
+{
+	if (paths == NIL)
+		return;
+
+	bool		batchSucceeded = DeleteRemoteFiles(paths);
+
+	ListCell   *pathCell = NULL;
+
+	foreach(pathCell, paths)
+	{
+		char	   *path = lfirst(pathCell);
+		bool		deleted = batchSucceeded || DeleteRemoteFile(path);
+
+		if (deleted)
+		{
+			if (deletedPaths != NULL)
+				*deletedPaths = lappend(*deletedPaths, path);
+		}
+		else if (failedPaths != NULL)
+			*failedPaths = lappend(*failedPaths, path);
+	}
+}

--- a/pg_lake_engine/src/pgduck/remote_storage.c
+++ b/pg_lake_engine/src/pgduck/remote_storage.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include "miscadmin.h"
 
 #include "pg_lake/data_file/data_file_stats.h"
 #include "pg_lake/parquet/leaf_field.h"
@@ -26,6 +27,9 @@
 
 #include "utils/builtins.h"
 #include "utils/timestamp.h"
+
+static void AttributeFailedDeletion(List *paths, List **deletedPaths,
+									List **failedPaths);
 
 
 /*
@@ -179,6 +183,13 @@ RemoteFileExists(char *path)
 * pg_lake_remove_file gets a whole vector of file names at a time and, for S3,
 * deletes them in batched DeleteObjects requests (up to 1000 keys each) rather
 * than one request per file.
+*
+* The call goes in WHERE rather than the select list so that we get a single
+* count back instead of a row per file, without DuckDB pruning a projection
+* that nothing reads. DeleteRemoteFiles writes the same call in the select list
+* because there the paths going out dwarf a boolean per path coming back. Here
+* nothing goes out but the pattern, so a row per object under the prefix is the
+* whole response.
 */
 bool
 DeleteRemotePrefix(char *path)
@@ -190,7 +201,7 @@ DeleteRemotePrefix(char *path)
 	StringInfo	query = makeStringInfo();
 
 	appendStringInfo(query,
-					 "SELECT pg_lake_remove_file(file) FROM glob(%s)",
+					 "SELECT count(*) FROM glob(%s) WHERE pg_lake_remove_file(file)",
 					 quote_literal_cstr(recursivePath->data));
 
 	return ExecuteOptionalCommandInPGDuck(query->data);
@@ -262,17 +273,23 @@ DeleteRemoteFiles(List *paths)
  * may be NULL when the caller does not track that outcome.
  *
  * pgduck reports one status for the whole request and does not say which path
- * was at fault, so a failed batch is retried one file at a time. Without that,
- * a single unreachable object would charge its failure to every path that
- * shared its request, so a caller that retires paths by failure count (such as
- * the deletion queue) would eventually retire a whole batch of healthy ones.
+ * was at fault, so a failed batch has to be narrowed down. Without that, a
+ * single unreachable object would charge its failure to every path that shared
+ * its request, so a caller that retires paths by failure count (such as the
+ * deletion queue) would eventually retire a whole batch of healthy ones.
  * Removing a file twice is a no-op, so replaying paths the failed batch had
  * already deleted is safe.
  *
+ * The narrowing bisects rather than walking the batch, because a path that
+ * cannot be removed is claimed again by every following pass, so whatever a
+ * failed batch costs is paid once per pass until retry_count retires the row.
+ * Walking makes that a request per path; bisecting finds k bad paths out of n
+ * in O(k log n) requests, so the usual case of one poison path in a full batch
+ * costs about 20 requests instead of 1000.
+ *
  * A caller that tracks neither outcome has nothing to tell apart, so it skips
- * the retry: paying up to FILE_DELETION_BATCH_SIZE individual requests to
- * produce a verdict nobody reads is the per-file cost this batching exists to
- * remove.
+ * the narrowing entirely: producing a verdict nobody reads is the per-file cost
+ * this batching exists to remove.
  */
 void
 DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
@@ -280,7 +297,13 @@ DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
 	if (paths == NIL)
 		return;
 
-	bool		batchSucceeded = DeleteRemoteFiles(paths);
+	if (DeleteRemoteFiles(paths))
+	{
+		if (deletedPaths != NULL)
+			*deletedPaths = list_concat(*deletedPaths, paths);
+
+		return;
+	}
 
 	if (deletedPaths == NULL && failedPaths == NULL)
 	{
@@ -288,19 +311,53 @@ DeleteRemoteFileBatch(List *paths, List **deletedPaths, List **failedPaths)
 		return;
 	}
 
-	ListCell   *pathCell = NULL;
+	AttributeFailedDeletion(paths, deletedPaths, failedPaths);
+}
 
-	foreach(pathCell, paths)
+
+/*
+ * AttributeFailedDeletion works out which of the paths of a failed batch could
+ * not be removed, by halving the batch and re-issuing each half. A half that
+ * succeeds accounts for all of its paths in one request; only a half that fails
+ * is split further, so the requests spent follow the number of bad paths rather
+ * than the size of the batch.
+ */
+static void
+AttributeFailedDeletion(List *paths, List **deletedPaths, List **failedPaths)
+{
+	if (list_length(paths) == 1)
 	{
-		char	   *path = lfirst(pathCell);
-		bool		deleted = batchSucceeded || DeleteRemoteFile(path);
+		char	   *path = linitial(paths);
 
-		if (deleted)
+		/*
+		 * A single path is its own verdict: the batch we just failed was this
+		 * one request, so there is nothing left to re-issue.
+		 */
+		if (failedPaths != NULL)
+			*failedPaths = lappend(*failedPaths, path);
+
+		return;
+	}
+
+	int			halfLength = list_length(paths) / 2;
+	List	   *halves[] = {
+		list_truncate(list_copy(paths), halfLength),
+		list_copy_tail(paths, halfLength)
+	};
+
+	for (int halfIndex = 0; halfIndex < 2; halfIndex++)
+	{
+		List	   *half = halves[halfIndex];
+
+		if (DeleteRemoteFiles(half))
 		{
 			if (deletedPaths != NULL)
-				*deletedPaths = lappend(*deletedPaths, path);
+				*deletedPaths = list_concat(*deletedPaths, half);
 		}
-		else if (failedPaths != NULL)
-			*failedPaths = lappend(*failedPaths, path);
+		else
+			AttributeFailedDeletion(half, deletedPaths, failedPaths);
+
+		/* narrowing a batch is a sequence of requests, so stay cancellable */
+		CHECK_FOR_INTERRUPTS();
 	}
 }

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -77,6 +77,16 @@ int			MaxCompactionsPerVacuum = 100;
 /* managed by a GUC, not exposed to the user, see note in VacuumRemoveInProgressFiles */
 int			MaxFileRemovalsPerVacuum = 100000;
 
+/*
+ * Set when a file removal loop stopped at MaxFileRemovalsPerVacuum with files
+ * still queued, meaning the backlog outlives this cycle. The autovacuum loop
+ * reads it to start the next cycle right away instead of napping for
+ * pg_lake_iceberg.autovacuum_naptime (10 minutes by default) with known work
+ * pending. A VACUUM issued by a client sets it in its own backend, where
+ * nothing reads it.
+ */
+static bool VacuumStoppedWithFilesQueued = false;
+
 
 PG_FUNCTION_INFO_V1(pg_lake_iceberg_vacuum);
 
@@ -153,10 +163,19 @@ pg_lake_iceberg_vacuum(PG_FUNCTION_ARGS)
 	{
 		TimestampTz currentTime = GetCurrentTimestamp();
 
+		/*
+		 * Skip the nap when the previous cycle stopped on its own per-vacuum
+		 * limit with files still queued: the backlog is known to be there,
+		 * and waiting a full naptime for it is how a queue that grows faster
+		 * than one naptime drains it never catches up.
+		 */
 		if (IcebergAutovacuumEnabled &&
-			TimestampDifferenceExceeds(lastVacuumTime, currentTime,
-									   IcebergAutovacuumNaptime * 1000))
+			(VacuumStoppedWithFilesQueued ||
+			 TimestampDifferenceExceeds(lastVacuumTime, currentTime,
+										IcebergAutovacuumNaptime * 1000)))
 		{
+			VacuumStoppedWithFilesQueued = false;
+
 			START_TRANSACTION();
 			{
 				PgLakeIcebergVacuumForTables(outOfTransactionMemoryContext, firstLoop);
@@ -912,8 +931,18 @@ VacuumRemoveDeletionQueueRecords(Oid relationId, bool isFull, bool isVerbose)
 		{
 			INJECTION_POINT_COMPAT("deletion-queue");
 
+			/*
+			 * Claim no more rows than this VACUUM has left in its budget. A
+			 * drain pass claims up to PER_LOOP_FILE_CLEANUP_LIMIT rows, which
+			 * is well above MaxFileRemovalsPerVacuum's smaller settings, and
+			 * the loop condition below can only be checked once a pass has
+			 * already deleted what it claimed.
+			 */
+			int			remainingBudget = MaxFileRemovalsPerVacuum - totalFilesRemoved;
+
 			/* do cleanup */
-			deletionQueueRecords = GetDeletionQueueRecords(relationId, isFull);
+			deletionQueueRecords = GetDeletionQueueRecords(relationId, isFull,
+														   remainingBudget);
 
 			hasRemainingFiles = RemoveDeletionQueueRecords(deletionQueueRecords, isVerbose);
 
@@ -955,6 +984,9 @@ VacuumRemoveDeletionQueueRecords(Oid relationId, bool isFull, bool isVerbose)
 	while (!isFull				/* when isFull, we'll remove all files */
 		   && totalFilesRemoved < MaxFileRemovalsPerVacuum	/* per-vacuum limit */
 		   && hasRemainingFiles /* no more files to remove */ );
+
+	if (hasRemainingFiles && totalFilesRemoved >= MaxFileRemovalsPerVacuum)
+		VacuumStoppedWithFilesQueued = true;
 
 	if (totalFilesRemoved > 0)
 	{
@@ -1045,6 +1077,9 @@ VacuumRemoveInProgressFiles(Oid relationId, bool isFull, bool isVerbose)
 	while (!isFull				/* when isFull, we'll remove all files */
 		   && totalFilesRemoved < MaxFileRemovalsPerVacuum	/* per-vacuum limit */
 		   && hasRemainingFiles /* no more files to remove */ );
+
+	if (hasRemainingFiles && totalFilesRemoved >= MaxFileRemovalsPerVacuum)
+		VacuumStoppedWithFilesQueued = true;
 
 	if (totalFilesRemoved > 0)
 	{

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -249,6 +249,15 @@ PgLakeIcebergVacuumForTables(MemoryContext outOfTransactionMemoryContext,
 
 	MemoryContextSwitchTo(oldctx);
 
+	/*
+	 * Ahead of the per-table loop: these are the rows no per-table pass
+	 * claims, nothing below depends on them being gone, and the loop can run
+	 * for minutes and abort the rest of the pass if anything escapes a
+	 * stage's subtransaction. Going first makes the drain the part of a cycle
+	 * most likely to complete.
+	 */
+	VacuumRemoveDroppedTableFiles();
+
 	foreach_oid(relationId, vacuumRelationIdList)
 	{
 		/* vacuum the iceberg table */
@@ -260,8 +269,6 @@ PgLakeIcebergVacuumForTables(MemoryContext outOfTransactionMemoryContext,
 		 */
 		CHECK_FOR_INTERRUPTS();
 	}
-
-	VacuumRemoveDroppedTableFiles();
 }
 
 
@@ -285,6 +292,9 @@ PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext)
 	bool		isFull = false;
 	bool		isVerbose = false;
 
+	/* first, for the same reasons as in PgLakeIcebergVacuumForTables */
+	VacuumRemoveDroppedTableFiles();
+
 	foreach_oid(relationId, vacuumRelationIdList)
 	{
 		if (!ActiveSnapshotSet())
@@ -294,7 +304,7 @@ PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext)
 		{
 			/*
 			 * Table dropped since we built the list. Whatever it left queued
-			 * is claimed by VacuumRemoveDroppedTableFiles below.
+			 * is claimed by the next cycle's VacuumRemoveDroppedTableFiles.
 			 */
 			continue;
 		}
@@ -317,8 +327,6 @@ PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext)
 		 */
 		CHECK_FOR_INTERRUPTS();
 	}
-
-	VacuumRemoveDroppedTableFiles();
 }
 
 
@@ -978,7 +986,7 @@ VacuumDroppedPgLakeIcebergTables(VacuumStmt *vacuumStmt)
 
 /*
 * VacuumRemoveDroppedTableFiles removes the queued files of tables that no
-* longer exist. The autovacuum worker calls it after the per-table passes,
+* longer exist. The autovacuum worker calls it ahead of the per-table passes,
 * which cannot reach those rows: a row for a dropped table points at an oid
 * that is gone from pg_class, so it is only claimed by the InvalidOid pass.
 * Without this, a dropped table would keep its files (and its share of the
@@ -1059,13 +1067,11 @@ VacuumRemoveDeletionQueueRecords(Oid relationId, bool isFull, bool isVerbose)
 
 			/*
 			 * Charge the budget for what came off the queue, not for what was
-			 * claimed: a path that can never be removed is claimed by every
-			 * pass, and charging those would let a block of them spend the
-			 * whole budget, take the loop to its limit, and leave the worker
-			 * thinking it stopped mid-progress. It would then come straight
-			 * back and charge them again, so the failing rows would reach
-			 * VacuumFileRemoveMaxRetries in minutes rather than the day that
-			 * limit is sized for.
+			 * claimed. Charging claims would let a block of rows that failed
+			 * spend the whole budget without removing anything, take the loop
+			 * to its limit, and leave the worker thinking it stopped
+			 * mid-progress, so it would come straight back and try the same
+			 * rows again.
 			 *
 			 * A pass that removed nothing but resolved dropped-table metadata
 			 * did make progress, so it is charged one to keep the loop
@@ -1196,6 +1202,14 @@ VacuumRemoveInProgressFiles(Oid relationId, bool isFull, bool isVerbose)
 		}
 		PG_END_TRY();
 
+		/*
+		 * Rows claimed, unlike the deletion queue loop, which charges rows
+		 * removed. Safe here because RemoveInProgressFiles drops the catalog
+		 * row whatever the remote outcome, so a claimed row is gone from the
+		 * queue either way: an in-progress path cannot fail forever, cannot
+		 * be re-claimed by the next pass, and so cannot spend a budget
+		 * without making progress.
+		 */
 		totalFilesRemoved += list_length(removedFiles);
 
 		/* rotate into a new transaction to release locks and save progress */

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -80,10 +80,10 @@ int			MaxFileRemovalsPerVacuum = 100000;
 /*
  * Set when a file removal loop stopped at MaxFileRemovalsPerVacuum with files
  * still queued, meaning the backlog outlives this cycle. The autovacuum loop
- * reads it to start the next cycle right away instead of napping for
- * pg_lake_iceberg.autovacuum_naptime (10 minutes by default) with known work
- * pending. A VACUUM issued by a client sets it in its own backend, where
- * nothing reads it.
+ * reads it to keep removing files without napping for
+ * pg_lake_iceberg.autovacuum_naptime (10 minutes by default) while there is
+ * known work pending. A VACUUM issued by a client sets it in its own backend,
+ * where nothing reads it.
  */
 static bool VacuumStoppedWithFilesQueued = false;
 
@@ -94,6 +94,7 @@ PG_FUNCTION_INFO_V1(pg_lake_iceberg_vacuum);
 static void VacuumRegisterMissingFieldsForAllTables(MemoryContext outOfTransactionMemoryContext);
 static void PgLakeIcebergVacuumForTables(MemoryContext outOfTransactionMemoryContext,
 										 bool firstLoop);
+static void PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext);
 static bool IsVacuumLakeTable(VacuumStmt *vacuumStmt);
 static List *GetAutoVacuumEnabledTables(List *relationIdList);
 static bool IsAutoVacuumEnabled(Oid relationId);
@@ -163,16 +164,9 @@ pg_lake_iceberg_vacuum(PG_FUNCTION_ARGS)
 	{
 		TimestampTz currentTime = GetCurrentTimestamp();
 
-		/*
-		 * Skip the nap when the previous cycle stopped on its own per-vacuum
-		 * limit with files still queued: the backlog is known to be there,
-		 * and waiting a full naptime for it is how a queue that grows faster
-		 * than one naptime drains it never catches up.
-		 */
 		if (IcebergAutovacuumEnabled &&
-			(VacuumStoppedWithFilesQueued ||
-			 TimestampDifferenceExceeds(lastVacuumTime, currentTime,
-										IcebergAutovacuumNaptime * 1000)))
+			TimestampDifferenceExceeds(lastVacuumTime, currentTime,
+									   IcebergAutovacuumNaptime * 1000))
 		{
 			VacuumStoppedWithFilesQueued = false;
 
@@ -186,6 +180,28 @@ pg_lake_iceberg_vacuum(PG_FUNCTION_ARGS)
 
 			/* we wait for nap time _after_ vacuum completed */
 			lastVacuumTime = GetCurrentTimestamp();
+		}
+		else if (IcebergAutovacuumEnabled && VacuumStoppedWithFilesQueued)
+		{
+			/*
+			 * The last pass stopped on MaxFileRemovalsPerVacuum with files
+			 * still queued, so we keep removing files without waiting a
+			 * naptime first: a queue that grows faster than one naptime
+			 * drains it never catches up.
+			 *
+			 * Only the file removal stages run here. A long deletion queue
+			 * says nothing about how badly the data files need rewriting, and
+			 * running the whole cycle back to back would compact much more
+			 * often than the naptime asks for. lastVacuumTime is left alone
+			 * for the same reason, so the other stages keep their schedule.
+			 */
+			VacuumStoppedWithFilesQueued = false;
+
+			START_TRANSACTION();
+			{
+				PgLakeIcebergRemoveFilesForTables(outOfTransactionMemoryContext);
+			}
+			END_TRANSACTION_NO_THROW(WARNING);
 		}
 
 		if (EnableObjectStoreCatalog &&
@@ -236,6 +252,58 @@ PgLakeIcebergVacuumForTables(MemoryContext outOfTransactionMemoryContext,
 	{
 		/* vacuum the iceberg table */
 		PgLakeIcebergVacuumForRelation(relationId, firstLoop);
+
+		/*
+		 * This loop could take a long time, so we check for interrupts on
+		 * each iteration.
+		 */
+		CHECK_FOR_INTERRUPTS();
+	}
+}
+
+
+/*
+* PgLakeIcebergRemoveFilesForTables runs the file removal stages of VACUUM, and
+* only those, for every table autovacuum covers. The autovacuum worker uses it
+* to work off a backlog that a previous pass left behind (see
+* VacuumStoppedWithFilesQueued) without pulling the other stages forward with
+* it.
+*/
+static void
+PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext)
+{
+	MemoryContext oldctx = MemoryContextSwitchTo(outOfTransactionMemoryContext);
+	List	   *relationIdList = GetAllInternalIcebergRelationIds();
+
+	List	   *vacuumRelationIdList = GetAutoVacuumEnabledTables(relationIdList);
+
+	MemoryContextSwitchTo(oldctx);
+
+	bool		isFull = false;
+	bool		isVerbose = false;
+
+	foreach_oid(relationId, vacuumRelationIdList)
+	{
+		if (!ActiveSnapshotSet())
+			PushActiveSnapshot(GetTransactionSnapshot());
+
+		if (!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(relationId)))
+		{
+			/* table dropped */
+			continue;
+		}
+
+		if (IsReadOnlyIcebergTable(relationId))
+		{
+			/*
+			 * Read-only tables are skipped by the regular cycle too, which
+			 * already warned about them.
+			 */
+			continue;
+		}
+
+		VacuumRemoveDeletionQueueRecords(relationId, isFull, isVerbose);
+		VacuumRemoveInProgressFiles(relationId, isFull, isVerbose);
 
 		/*
 		 * This loop could take a long time, so we check for interrupts on

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -111,6 +111,7 @@ static void PgLakeIcebergVacuumForRelation(Oid relationId, bool firstLoop);
 static void VacuumTableInSeparateXacts(Oid relationId, bool isFull, bool isVerbose,
 									   bool isAutoVacuum);
 static void VacuumDroppedPgLakeIcebergTables(VacuumStmt *vacuumStmt);
+static void VacuumRemoveDroppedTableFiles(void);
 static char *GetMetadataLocationPrefixForRelationId(Oid relationId);
 static void VacuumConsumeTrackedIcebergMetadataChanges(bool isVerbose);
 
@@ -259,15 +260,17 @@ PgLakeIcebergVacuumForTables(MemoryContext outOfTransactionMemoryContext,
 		 */
 		CHECK_FOR_INTERRUPTS();
 	}
+
+	VacuumRemoveDroppedTableFiles();
 }
 
 
 /*
 * PgLakeIcebergRemoveFilesForTables runs the file removal stages of VACUUM, and
-* only those, for every table autovacuum covers. The autovacuum worker uses it
-* to work off a backlog that a previous pass left behind (see
-* VacuumStoppedWithFilesQueued) without pulling the other stages forward with
-* it.
+* only those, for every table autovacuum covers plus the tables that were
+* dropped. The autovacuum worker uses it to work off a backlog that a previous
+* pass left behind (see VacuumStoppedWithFilesQueued) without pulling the other
+* stages forward with it.
 */
 static void
 PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext)
@@ -289,7 +292,10 @@ PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext)
 
 		if (!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(relationId)))
 		{
-			/* table dropped */
+			/*
+			 * Table dropped since we built the list. Whatever it left queued
+			 * is claimed by VacuumRemoveDroppedTableFiles below.
+			 */
 			continue;
 		}
 
@@ -311,6 +317,8 @@ PgLakeIcebergRemoveFilesForTables(MemoryContext outOfTransactionMemoryContext)
 		 */
 		CHECK_FOR_INTERRUPTS();
 	}
+
+	VacuumRemoveDroppedTableFiles();
 }
 
 
@@ -965,6 +973,30 @@ VacuumDroppedPgLakeIcebergTables(VacuumStmt *vacuumStmt)
 
 	VacuumRemoveDeletionQueueRecords(relationId, isFull, isVerbose);
 	VacuumRemoveInProgressFiles(relationId, isFull, isVerbose);
+}
+
+
+/*
+* VacuumRemoveDroppedTableFiles removes the queued files of tables that no
+* longer exist. The autovacuum worker calls it after the per-table passes,
+* which cannot reach those rows: a row for a dropped table points at an oid
+* that is gone from pg_class, so it is only claimed by the InvalidOid pass.
+* Without this, a dropped table would keep its files (and its share of the
+* queue, which every other drain has to page through) until someone ran
+* VACUUM (ICEBERG) by hand.
+*
+* Only the deletion queue is drained here. The in-progress file cleanup for
+* dropped tables works off an empty location prefix, so it covers every table
+* rather than the dropped ones, and it stays with the manual command.
+*/
+static void
+VacuumRemoveDroppedTableFiles(void)
+{
+	Oid			relationId = InvalidOid;
+	bool		isFull = false;
+	bool		isVerbose = false;
+
+	VacuumRemoveDeletionQueueRecords(relationId, isFull, isVerbose);
 }
 
 

--- a/pg_lake_table/src/ddl/vacuum.c
+++ b/pg_lake_table/src/ddl/vacuum.c
@@ -1009,7 +1009,15 @@ VacuumRemoveDroppedTableFiles(void)
 static void
 VacuumRemoveDeletionQueueRecords(Oid relationId, bool isFull, bool isVerbose)
 {
-	int			totalFilesRemoved = 0;
+	/*
+	 * Files this VACUUM removed, and what it has spent of its per-vacuum
+	 * budget. The two only differ for a pass that resolved dropped-table
+	 * metadata: such a pass removes nothing but converts rows that the next
+	 * pass deletes, so it is charged a unit of budget to keep this loop
+	 * finite without showing up in the count we report.
+	 */
+	volatile int totalFilesRemoved = 0;
+	volatile int budgetSpent = 0;
 
 	volatile bool hasRemainingFiles = true;
 	MemoryContext savedContext = CurrentMemoryContext;
@@ -1038,13 +1046,35 @@ VacuumRemoveDeletionQueueRecords(Oid relationId, bool isFull, bool isVerbose)
 			 * the loop condition below can only be checked once a pass has
 			 * already deleted what it claimed.
 			 */
-			int			remainingBudget = MaxFileRemovalsPerVacuum - totalFilesRemoved;
+			int			remainingBudget = MaxFileRemovalsPerVacuum - budgetSpent;
 
 			/* do cleanup */
 			deletionQueueRecords = GetDeletionQueueRecords(relationId, isFull,
 														   remainingBudget);
 
-			hasRemainingFiles = RemoveDeletionQueueRecords(deletionQueueRecords, isVerbose);
+			int			filesRemoved = 0;
+			bool		madeProgress = RemoveDeletionQueueRecords(deletionQueueRecords,
+																  isVerbose,
+																  &filesRemoved);
+
+			/*
+			 * Charge the budget for what came off the queue, not for what was
+			 * claimed: a path that can never be removed is claimed by every
+			 * pass, and charging those would let a block of them spend the
+			 * whole budget, take the loop to its limit, and leave the worker
+			 * thinking it stopped mid-progress. It would then come straight
+			 * back and charge them again, so the failing rows would reach
+			 * VacuumFileRemoveMaxRetries in minutes rather than the day that
+			 * limit is sized for.
+			 *
+			 * A pass that removed nothing but resolved dropped-table metadata
+			 * did make progress, so it is charged one to keep the loop
+			 * finite.
+			 */
+			totalFilesRemoved += filesRemoved;
+			budgetSpent += (filesRemoved > 0) ? filesRemoved : (madeProgress ? 1 : 0);
+
+			hasRemainingFiles = madeProgress;
 
 			VacuumConsumeTrackedIcebergMetadataChanges(isVerbose);
 
@@ -1073,7 +1103,6 @@ VacuumRemoveDeletionQueueRecords(Oid relationId, bool isFull, bool isVerbose)
 		}
 		PG_END_TRY();
 
-		totalFilesRemoved += list_length(deletionQueueRecords);
 		hasRemainingFiles = hasRemainingFiles ? list_length(deletionQueueRecords) > 0 : false;
 
 		/* rotate into a new transaction to release locks and save progress */
@@ -1082,10 +1111,10 @@ VacuumRemoveDeletionQueueRecords(Oid relationId, bool isFull, bool isVerbose)
 		StartTransactionCommand();
 	}
 	while (!isFull				/* when isFull, we'll remove all files */
-		   && totalFilesRemoved < MaxFileRemovalsPerVacuum	/* per-vacuum limit */
+		   && budgetSpent < MaxFileRemovalsPerVacuum	/* per-vacuum limit */
 		   && hasRemainingFiles /* no more files to remove */ );
 
-	if (hasRemainingFiles && totalFilesRemoved >= MaxFileRemovalsPerVacuum)
+	if (hasRemainingFiles && budgetSpent >= MaxFileRemovalsPerVacuum)
 		VacuumStoppedWithFilesQueued = true;
 
 	if (totalFilesRemoved > 0)

--- a/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
+++ b/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
@@ -125,6 +125,69 @@ def test_deletion_queue_batch_isolates_failing_path(s3, superuser_conn, extensio
     superuser_conn.commit()
 
 
+def test_autovacuum_removes_files_for_dropped_tables(
+    s3, superuser_conn, extension, installcheck
+):
+    """The autovacuum worker drains what a dropped table left queued.
+
+    Those rows point at an oid that is gone from pg_class, so no per-table pass
+    claims them. Before, only a manual VACUUM (ICEBERG) removed them, and until
+    someone ran one the files stayed and every drain paged through their rows.
+    """
+    if installcheck:
+        return
+
+    prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/dropped"
+    file_count = 3
+    naptime_seconds = 2
+    deadline_seconds = 60
+
+    paths = [f"{prefix}/f{i}.parquet" for i in range(file_count)]
+
+    for path in paths:
+        bucket, key = parse_s3_path(path)
+        s3.put_object(Bucket=bucket, Key=key, Body=b"x")
+
+    assert _existing_files(superuser_conn, prefix) == file_count
+    superuser_conn.commit()
+
+    run_command_outside_tx(
+        [
+            f"ALTER SYSTEM SET pg_lake_iceberg.autovacuum_naptime TO '{naptime_seconds}s'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    try:
+        _queue_paths(superuser_conn, paths)
+
+        remaining = file_count
+        deadline = time.monotonic() + deadline_seconds
+
+        while time.monotonic() < deadline:
+            remaining = len(_queued_rows(superuser_conn, prefix))
+            superuser_conn.commit()
+
+            if remaining == 0:
+                break
+
+            time.sleep(0.5)
+
+        assert (
+            remaining == 0
+        ), f"{remaining} of {file_count} dropped-table rows still queued after {deadline_seconds}s"
+
+        assert _existing_files(superuser_conn, prefix) == 0
+        superuser_conn.commit()
+    finally:
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_iceberg.autovacuum_naptime",
+                "SELECT pg_reload_conf()",
+            ]
+        )
+
+
 def test_autovacuum_drains_a_backlog_without_napping(
     s3, superuser_conn, extension, installcheck
 ):
@@ -150,7 +213,7 @@ def test_autovacuum_drains_a_backlog_without_napping(
     prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/backlog"
     file_count = 12
     naptime_seconds = 15
-    deadline_seconds = 70
+    deadline_seconds = 120
 
     paths = [f"{prefix}/f{i}.parquet" for i in range(file_count)]
 
@@ -182,7 +245,8 @@ def test_autovacuum_drains_a_backlog_without_napping(
         _queue_paths(superuser_conn, paths, table=table)
 
         remaining = file_count
-        deadline = time.monotonic() + deadline_seconds
+        start = time.monotonic()
+        deadline = start + deadline_seconds
 
         while time.monotonic() < deadline:
             remaining = len(_queued_rows(superuser_conn, prefix))
@@ -192,6 +256,8 @@ def test_autovacuum_drains_a_backlog_without_napping(
                 break
 
             time.sleep(0.5)
+
+        elapsed = time.monotonic() - start
 
         assert remaining == 0, (
             f"{remaining} of {file_count} rows still queued after "
@@ -213,13 +279,16 @@ def test_autovacuum_drains_a_backlog_without_napping(
             if "Vacuuming iceberg table" in line and table in line
         ]
 
-        # the drain took at least file_count passes and ran well under
-        # file_count naptimes, so anything near file_count cycles here means
-        # the whole cycle came along for the ride
-        assert len(cycles) < file_count / 2, (
+        # the file removal passes ran back to back, but the rest of the cycle
+        # kept the naptime, so the drain fits in about one cycle per naptime
+        # however long it took. One per removed file means the whole cycle came
+        # along for the ride.
+        max_cycles = int(elapsed / naptime_seconds) + 2
+
+        assert len(cycles) <= max_cycles, (
             f"{len(cycles)} full vacuum cycles while removing {file_count} "
-            f"files, expected about one per {naptime_seconds}s naptime: "
-            + "\n".join(cycles)
+            f"files in {elapsed:.1f}s, expected at most {max_cycles} at one per "
+            f"{naptime_seconds}s naptime: " + "\n".join(cycles)
         )
     finally:
         run_command(f"DROP TABLE IF EXISTS {table}", superuser_conn)

--- a/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
+++ b/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
@@ -92,11 +92,10 @@ def test_deletion_queue_drains_multiple_batches(s3, superuser_conn, extension):
 def test_deletion_queue_batch_isolates_failing_path(s3, superuser_conn, extension):
     """One unremovable path does not take its batch down with it.
 
-    A batch is one request and its failure does not say which path was at
-    fault, so a failed batch is re-issued in halves until it does. Without that,
-    the healthy paths sharing the request would collect retry_count for a
-    failure that was never theirs and eventually be abandoned at
-    VacuumFileRemoveMaxRetries.
+    A batch is one request, and the request reports an outcome per path rather
+    than one status for all of them. Without that, the healthy paths sharing the
+    request would collect retry_count for a failure that was never theirs and
+    eventually be abandoned at VacuumFileRemoveMaxRetries.
     """
     prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/isolate"
 
@@ -140,9 +139,7 @@ def test_unremovable_path_is_retried_on_a_clock(s3, superuser_conn, extension):
     retry_count is spent against vacuum_file_remove_max_retries, so if every
     pass reaching a failing row charged it, how long we keep trying a path would
     be decided by how often passes happen to run -- minutes while a drain works
-    through a backlog, rather than the day the default is sized for. Re-claiming
-    the row also makes every one of those passes pay for finding out which path
-    in its batch failed.
+    through a backlog, rather than the day the default is sized for.
     """
     prefix = f"nosuchfs://{TEST_PREFIX}/clock"
     bad_path = f"{prefix}/f.parquet"

--- a/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
+++ b/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
@@ -188,6 +188,119 @@ def test_autovacuum_removes_files_for_dropped_tables(
         )
 
 
+def test_autovacuum_does_not_spin_on_unremovable_paths(
+    s3, superuser_conn, extension, installcheck
+):
+    """A queue whose rows cannot be removed does not keep the worker busy.
+
+    The catch-up pass is meant for a queue the worker is making progress on, so
+    a pass has to charge its budget for files it removed rather than rows it
+    claimed. A permanently failing path is claimed by every pass, so charging
+    claims would take any pass with such a path to its limit, and the worker
+    would then run file removal every second. That is not just wasted work: each
+    of those passes increments retry_count, so the failing rows would pass
+    vacuum_file_remove_max_retries in minutes instead of the day that default is
+    sized for, and be abandoned.
+    """
+    if installcheck:
+        return
+
+    table = "test_deletion_queue_spin"
+    prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/spin"
+    bad_prefix = f"nosuchfs://{TEST_PREFIX}/spin"
+    good_count = 2
+    bad_count = 3
+    naptime_seconds = 30
+    quiet_seconds = 10
+    deadline_seconds = 90
+
+    good_paths = [f"{prefix}/f{i}.parquet" for i in range(good_count)]
+    bad_paths = [f"{bad_prefix}/f{i}.parquet" for i in range(bad_count)]
+
+    for path in good_paths:
+        bucket, key = parse_s3_path(path)
+        s3.put_object(Bucket=bucket, Key=key, Body=b"x")
+
+    run_command_outside_tx(
+        [
+            # low enough that one pass claims both kinds of row and reaches the
+            # limit if failures are charged for
+            f"ALTER SYSTEM SET pg_lake_table.max_file_removals_per_vacuum TO {good_count + bad_count - 1}",
+            f"ALTER SYSTEM SET pg_lake_iceberg.autovacuum_naptime TO '{naptime_seconds}s'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    try:
+        run_command(
+            f"CREATE TABLE {table} (id int) USING pg_lake_iceberg "
+            f"WITH (location = 's3://{TEST_BUCKET}/{TEST_PREFIX}/{table}/')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        _queue_paths(superuser_conn, good_paths + bad_paths, table=table)
+
+        # wait for the worker to run a cycle, which we see by the removable
+        # files going away
+        remaining = good_count
+        deadline = time.monotonic() + deadline_seconds
+
+        while time.monotonic() < deadline:
+            remaining = len(_queued_rows(superuser_conn, prefix))
+            superuser_conn.commit()
+
+            if remaining == 0:
+                break
+
+            time.sleep(0.5)
+
+        assert remaining == 0, (
+            f"{remaining} of {good_count} removable rows still queued after "
+            f"{deadline_seconds}s"
+        )
+
+        def max_retry_count():
+            rows = _queued_rows(superuser_conn, bad_prefix)
+            superuser_conn.commit()
+
+            assert len(rows) == bad_count, (
+                f"{len(rows)} of {bad_count} failing rows left in the queue, "
+                f"so retry_count no longer says how often they were tried"
+            )
+
+            return max(row[1] for row in rows)
+
+        before = max_retry_count()
+
+        # the next cycle is a naptime away, so a worker that is not spinning
+        # leaves the failing rows alone for the whole window
+        time.sleep(quiet_seconds)
+
+        after = max_retry_count()
+
+        assert after - before <= 2, (
+            f"retry_count on the failing rows went {before} -> {after} in "
+            f"{quiet_seconds}s with a {naptime_seconds}s naptime, so the worker "
+            f"kept re-running file removal on a queue it could not drain"
+        )
+    finally:
+        run_command(f"DROP TABLE IF EXISTS {table}", superuser_conn)
+        run_command(
+            f"DELETE FROM lake_engine.deletion_queue WHERE path LIKE '{bad_prefix}%'",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_table.max_file_removals_per_vacuum",
+                "ALTER SYSTEM RESET pg_lake_iceberg.autovacuum_naptime",
+                "SELECT pg_reload_conf()",
+            ]
+        )
+
+
 def test_autovacuum_drains_a_backlog_without_napping(
     s3, superuser_conn, extension, installcheck
 ):

--- a/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
+++ b/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 from utils_pytest import *
@@ -127,27 +128,29 @@ def test_deletion_queue_batch_isolates_failing_path(s3, superuser_conn, extensio
 def test_autovacuum_drains_a_backlog_without_napping(
     s3, superuser_conn, extension, installcheck
 ):
-    """A backlog larger than one vacuum's budget drains without a nap per cycle.
+    """A backlog larger than one vacuum's budget drains without a nap per file.
 
     A vacuum stops at pg_lake_table.max_file_removals_per_vacuum, so a longer
-    queue takes several cycles. If each of those cycles first waits
+    queue takes several passes. If each of those passes first waits
     pg_lake_iceberg.autovacuum_naptime (10 minutes by default), a queue that
-    grows faster than one naptime drains it never catches up, and the rest of
-    the cycle, including the catalog export, waits behind it. So a cycle that
-    stopped on its own limit with rows still queued starts the next one right
-    away.
+    grows faster than one naptime drains it never catches up. So a pass that
+    stopped on its own limit with files still queued keeps going.
 
-    The naptime below is set high enough that draining one file per cycle
-    cannot finish within the deadline if the cycles nap.
+    Only the file removal stages keep going. The rest of the vacuum cycle stays
+    on the naptime, so the log must show one cycle per naptime and not one per
+    removed file. The naptime below is set high enough that both halves of that
+    are measurable: draining one file per nap could not finish in time, and a
+    cycle per naptime is far fewer cycles than there are files.
     """
     if installcheck:
         return
 
+    logfile = f"{server_params.PG_DIR}/logfile"
     table = "test_deletion_queue_backlog"
     prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/backlog"
     file_count = 12
-    naptime_seconds = 8
-    deadline_seconds = 40
+    naptime_seconds = 15
+    deadline_seconds = 70
 
     paths = [f"{prefix}/f{i}.parquet" for i in range(file_count)]
 
@@ -159,6 +162,7 @@ def test_autovacuum_drains_a_backlog_without_napping(
         [
             "ALTER SYSTEM SET pg_lake_table.max_file_removals_per_vacuum TO 1",
             f"ALTER SYSTEM SET pg_lake_iceberg.autovacuum_naptime TO '{naptime_seconds}s'",
+            "ALTER SYSTEM SET pg_lake_iceberg.log_autovacuum_min_duration TO 0",
             "SELECT pg_reload_conf()",
         ]
     )
@@ -172,6 +176,8 @@ def test_autovacuum_drains_a_backlog_without_napping(
             superuser_conn,
         )
         superuser_conn.commit()
+
+        offset = os.path.getsize(logfile)
 
         _queue_paths(superuser_conn, paths, table=table)
 
@@ -190,12 +196,31 @@ def test_autovacuum_drains_a_backlog_without_napping(
         assert remaining == 0, (
             f"{remaining} of {file_count} rows still queued after "
             f"{deadline_seconds}s, which is only "
-            f"{deadline_seconds // naptime_seconds} cycles of one file each "
-            f"when every cycle naps first"
+            f"{deadline_seconds // naptime_seconds} files if every file waits "
+            f"a nap of its own"
         )
 
         assert _existing_files(superuser_conn, prefix) == 0
         superuser_conn.commit()
+
+        with open(logfile) as f:
+            f.seek(offset)
+            delta = f.read()
+
+        cycles = [
+            line
+            for line in delta.splitlines()
+            if "Vacuuming iceberg table" in line and table in line
+        ]
+
+        # the drain took at least file_count passes and ran well under
+        # file_count naptimes, so anything near file_count cycles here means
+        # the whole cycle came along for the ride
+        assert len(cycles) < file_count / 2, (
+            f"{len(cycles)} full vacuum cycles while removing {file_count} "
+            f"files, expected about one per {naptime_seconds}s naptime: "
+            + "\n".join(cycles)
+        )
     finally:
         run_command(f"DROP TABLE IF EXISTS {table}", superuser_conn)
         superuser_conn.commit()
@@ -204,6 +229,7 @@ def test_autovacuum_drains_a_backlog_without_napping(
             [
                 "ALTER SYSTEM RESET pg_lake_table.max_file_removals_per_vacuum",
                 "ALTER SYSTEM RESET pg_lake_iceberg.autovacuum_naptime",
+                "ALTER SYSTEM RESET pg_lake_iceberg.log_autovacuum_min_duration",
                 "SELECT pg_reload_conf()",
             ]
         )

--- a/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
+++ b/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
@@ -1,3 +1,5 @@
+import time
+
 from utils_pytest import *
 
 # Prefix under the shared test bucket that no table owns, so the rows we queue
@@ -5,11 +7,17 @@ from utils_pytest import *
 TEST_PREFIX = "deletion_queue_batching"
 
 
-def _queue_paths(superuser_conn, paths):
+def _queue_paths(superuser_conn, paths, table=None):
     """Queue the given object-store paths as plain, immediately eligible
-    deletion-queue rows for a table that does not exist, which is what a
-    dropped table leaves behind."""
-    values = ",".join(f"('{path}', 0, NULL, false, false)" for path in paths)
+    deletion-queue rows.
+
+    Without a table the rows belong to a table that does not exist, which is
+    what a dropped table leaves behind, and only the dropped-table path of
+    VACUUM drains them. With a table they are drained by that table's own
+    vacuum, which is the only path the autovacuum worker takes.
+    """
+    table_name = f"'{table}'::pg_catalog.regclass::pg_catalog.oid" if table else "0"
+    values = ",".join(f"('{path}', {table_name}, NULL, false, false)" for path in paths)
 
     run_command(
         f"INSERT INTO lake_engine.deletion_queue "
@@ -114,3 +122,88 @@ def test_deletion_queue_batch_isolates_failing_path(s3, superuser_conn, extensio
         superuser_conn,
     )
     superuser_conn.commit()
+
+
+def test_autovacuum_drains_a_backlog_without_napping(
+    s3, superuser_conn, extension, installcheck
+):
+    """A backlog larger than one vacuum's budget drains without a nap per cycle.
+
+    A vacuum stops at pg_lake_table.max_file_removals_per_vacuum, so a longer
+    queue takes several cycles. If each of those cycles first waits
+    pg_lake_iceberg.autovacuum_naptime (10 minutes by default), a queue that
+    grows faster than one naptime drains it never catches up, and the rest of
+    the cycle, including the catalog export, waits behind it. So a cycle that
+    stopped on its own limit with rows still queued starts the next one right
+    away.
+
+    The naptime below is set high enough that draining one file per cycle
+    cannot finish within the deadline if the cycles nap.
+    """
+    if installcheck:
+        return
+
+    table = "test_deletion_queue_backlog"
+    prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/backlog"
+    file_count = 12
+    naptime_seconds = 8
+    deadline_seconds = 40
+
+    paths = [f"{prefix}/f{i}.parquet" for i in range(file_count)]
+
+    for path in paths:
+        bucket, key = parse_s3_path(path)
+        s3.put_object(Bucket=bucket, Key=key, Body=b"x")
+
+    run_command_outside_tx(
+        [
+            "ALTER SYSTEM SET pg_lake_table.max_file_removals_per_vacuum TO 1",
+            f"ALTER SYSTEM SET pg_lake_iceberg.autovacuum_naptime TO '{naptime_seconds}s'",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+    try:
+        # the autovacuum worker only walks tables that still exist, so the
+        # queued rows have to belong to one
+        run_command(
+            f"CREATE TABLE {table} (id int) USING pg_lake_iceberg "
+            f"WITH (location = 's3://{TEST_BUCKET}/{TEST_PREFIX}/{table}/')",
+            superuser_conn,
+        )
+        superuser_conn.commit()
+
+        _queue_paths(superuser_conn, paths, table=table)
+
+        remaining = file_count
+        deadline = time.monotonic() + deadline_seconds
+
+        while time.monotonic() < deadline:
+            remaining = len(_queued_rows(superuser_conn, prefix))
+            superuser_conn.commit()
+
+            if remaining == 0:
+                break
+
+            time.sleep(0.5)
+
+        assert remaining == 0, (
+            f"{remaining} of {file_count} rows still queued after "
+            f"{deadline_seconds}s, which is only "
+            f"{deadline_seconds // naptime_seconds} cycles of one file each "
+            f"when every cycle naps first"
+        )
+
+        assert _existing_files(superuser_conn, prefix) == 0
+        superuser_conn.commit()
+    finally:
+        run_command(f"DROP TABLE IF EXISTS {table}", superuser_conn)
+        superuser_conn.commit()
+
+        run_command_outside_tx(
+            [
+                "ALTER SYSTEM RESET pg_lake_table.max_file_removals_per_vacuum",
+                "ALTER SYSTEM RESET pg_lake_iceberg.autovacuum_naptime",
+                "SELECT pg_reload_conf()",
+            ]
+        )

--- a/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
+++ b/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
@@ -43,13 +43,21 @@ def _existing_files(superuser_conn, prefix):
     )[0][0]
 
 
-def _vacuum_dropped_tables():
-    run_command_outside_tx(
-        [
-            "SET pg_lake_engine.orphaned_file_retention_period = 0",
-            "VACUUM (ICEBERG)",
-        ]
-    )
+def _vacuum_dropped_tables(retry_interval=None):
+    """Run the dropped-table drain, optionally with a retry interval in seconds.
+
+    A failed path is left alone until pg_lake_engine.vacuum_file_remove_retry_interval
+    has passed, so a test that cares about what a second pass does has to say
+    which side of that it wants.
+    """
+    settings = ["SET pg_lake_engine.orphaned_file_retention_period = 0"]
+
+    if retry_interval is not None:
+        settings.append(
+            f"SET pg_lake_engine.vacuum_file_remove_retry_interval = {retry_interval}"
+        )
+
+    run_command_outside_tx(settings + ["VACUUM (ICEBERG)"])
 
 
 def test_deletion_queue_drains_multiple_batches(s3, superuser_conn, extension):
@@ -85,9 +93,10 @@ def test_deletion_queue_batch_isolates_failing_path(s3, superuser_conn, extensio
     """One unremovable path does not take its batch down with it.
 
     A batch is one request and its failure does not say which path was at
-    fault, so a failed batch is retried per file. Without that, the healthy
-    paths sharing the request would collect retry_count for a failure that was
-    never theirs and eventually be abandoned at VacuumFileRemoveMaxRetries.
+    fault, so a failed batch is re-issued in halves until it does. Without that,
+    the healthy paths sharing the request would collect retry_count for a
+    failure that was never theirs and eventually be abandoned at
+    VacuumFileRemoveMaxRetries.
     """
     prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/isolate"
 
@@ -123,6 +132,58 @@ def test_deletion_queue_batch_isolates_failing_path(s3, superuser_conn, extensio
         superuser_conn,
     )
     superuser_conn.commit()
+
+
+def test_unremovable_path_is_retried_on_a_clock(s3, superuser_conn, extension):
+    """A path that cannot be removed is retried on a clock, not once per pass.
+
+    retry_count is spent against vacuum_file_remove_max_retries, so if every
+    pass reaching a failing row charged it, how long we keep trying a path would
+    be decided by how often passes happen to run -- minutes while a drain works
+    through a backlog, rather than the day the default is sized for. Re-claiming
+    the row also makes every one of those passes pay for finding out which path
+    in its batch failed.
+    """
+    prefix = f"nosuchfs://{TEST_PREFIX}/clock"
+    bad_path = f"{prefix}/f.parquet"
+
+    def retry_count():
+        rows = _queued_rows(superuser_conn, prefix)
+        superuser_conn.commit()
+
+        assert len(rows) == 1, f"{len(rows)} rows queued under {prefix}, expected 1"
+
+        return rows[0][1]
+
+    _queue_paths(superuser_conn, [bad_path])
+
+    try:
+        # the first pass has nothing to wait out, so it tries the path and
+        # charges the failure
+        _vacuum_dropped_tables(retry_interval=3600)
+        assert retry_count() == 1
+
+        # the passes after it fall well inside the interval
+        for _ in range(2):
+            _vacuum_dropped_tables(retry_interval=3600)
+
+        after_more_passes = retry_count()
+
+        assert after_more_passes == 1, (
+            f"retry_count reached {after_more_passes} over three passes inside "
+            f"one retry interval, so the path is retried per pass rather than on "
+            f"a clock"
+        )
+
+        # with no interval left to wait out, the next pass tries it again
+        _vacuum_dropped_tables(retry_interval=0)
+        assert retry_count() == 2
+    finally:
+        run_command(
+            f"DELETE FROM lake_engine.deletion_queue WHERE path LIKE '{prefix}%'",
+            superuser_conn,
+        )
+        superuser_conn.commit()
 
 
 def test_autovacuum_removes_files_for_dropped_tables(
@@ -197,10 +258,14 @@ def test_autovacuum_does_not_spin_on_unremovable_paths(
     a pass has to charge its budget for files it removed rather than rows it
     claimed. A permanently failing path is claimed by every pass, so charging
     claims would take any pass with such a path to its limit, and the worker
-    would then run file removal every second. That is not just wasted work: each
-    of those passes increments retry_count, so the failing rows would pass
-    vacuum_file_remove_max_retries in minutes instead of the day that default is
-    sized for, and be abandoned.
+    would then run file removal every second for as long as the path stays
+    unremovable.
+
+    retry_count is how we count those passes, which needs the retry interval out
+    of the way: at its default the failing rows are claimed once and then left
+    alone, so retry_count would stand still whether the worker is spinning or
+    not. The interval is what stops a spin from burning
+    vacuum_file_remove_max_retries; this test is about the spin itself.
     """
     if installcheck:
         return
@@ -227,6 +292,9 @@ def test_autovacuum_does_not_spin_on_unremovable_paths(
             # limit if failures are charged for
             f"ALTER SYSTEM SET pg_lake_table.max_file_removals_per_vacuum TO {good_count + bad_count - 1}",
             f"ALTER SYSTEM SET pg_lake_iceberg.autovacuum_naptime TO '{naptime_seconds}s'",
+            # so retry_count counts the passes that reached the failing rows,
+            # see the docstring
+            "ALTER SYSTEM SET pg_lake_engine.vacuum_file_remove_retry_interval TO 0",
             "SELECT pg_reload_conf()",
         ]
     )
@@ -296,6 +364,7 @@ def test_autovacuum_does_not_spin_on_unremovable_paths(
             [
                 "ALTER SYSTEM RESET pg_lake_table.max_file_removals_per_vacuum",
                 "ALTER SYSTEM RESET pg_lake_iceberg.autovacuum_naptime",
+                "ALTER SYSTEM RESET pg_lake_engine.vacuum_file_remove_retry_interval",
                 "SELECT pg_reload_conf()",
             ]
         )

--- a/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
+++ b/pg_lake_table/tests/pytests/test_deletion_queue_batching.py
@@ -1,0 +1,116 @@
+from utils_pytest import *
+
+# Prefix under the shared test bucket that no table owns, so the rows we queue
+# below are drained by the dropped-table path of VACUUM.
+TEST_PREFIX = "deletion_queue_batching"
+
+
+def _queue_paths(superuser_conn, paths):
+    """Queue the given object-store paths as plain, immediately eligible
+    deletion-queue rows for a table that does not exist, which is what a
+    dropped table leaves behind."""
+    values = ",".join(f"('{path}', 0, NULL, false, false)" for path in paths)
+
+    run_command(
+        f"INSERT INTO lake_engine.deletion_queue "
+        f"(path, table_name, orphaned_at, is_prefix, resolve_metadata) "
+        f"VALUES {values}",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
+def _queued_rows(superuser_conn, prefix):
+    return run_query(
+        f"SELECT path, retry_count FROM lake_engine.deletion_queue "
+        f"WHERE path LIKE '{prefix}%' ORDER BY path",
+        superuser_conn,
+    )
+
+
+def _existing_files(superuser_conn, prefix):
+    return run_query(
+        f"SELECT count(*) FROM lake_file.list('{prefix}/**')", superuser_conn
+    )[0][0]
+
+
+def _vacuum_dropped_tables():
+    run_command_outside_tx(
+        [
+            "SET pg_lake_engine.orphaned_file_retention_period = 0",
+            "VACUUM (ICEBERG)",
+        ]
+    )
+
+
+def test_deletion_queue_drains_multiple_batches(s3, superuser_conn, extension):
+    """A queue longer than one deletion batch drains completely.
+
+    The drain removes files FILE_DELETION_BATCH_SIZE (1000) at a time, so 2100
+    files cross the batch boundary twice and end on a partial batch -- the
+    shape most likely to drop or double-count paths if the batching is wrong.
+    """
+    prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/multi"
+    file_count = 2100
+
+    paths = [f"{prefix}/f{i}.parquet" for i in range(file_count)]
+
+    for path in paths:
+        bucket, key = parse_s3_path(path)
+        s3.put_object(Bucket=bucket, Key=key, Body=b"x")
+
+    assert _existing_files(superuser_conn, prefix) == file_count
+    superuser_conn.commit()
+
+    _queue_paths(superuser_conn, paths)
+
+    _vacuum_dropped_tables()
+
+    # every file is gone from the object store, and every row from the queue
+    assert _existing_files(superuser_conn, prefix) == 0
+    assert _queued_rows(superuser_conn, prefix) == []
+    superuser_conn.commit()
+
+
+def test_deletion_queue_batch_isolates_failing_path(s3, superuser_conn, extension):
+    """One unremovable path does not take its batch down with it.
+
+    A batch is one request and its failure does not say which path was at
+    fault, so a failed batch is retried per file. Without that, the healthy
+    paths sharing the request would collect retry_count for a failure that was
+    never theirs and eventually be abandoned at VacuumFileRemoveMaxRetries.
+    """
+    prefix = f"s3://{TEST_BUCKET}/{TEST_PREFIX}/isolate"
+
+    good_paths = [f"{prefix}/f{i}.parquet" for i in range(5)]
+
+    for path in good_paths:
+        bucket, key = parse_s3_path(path)
+        s3.put_object(Bucket=bucket, Key=key, Body=b"x")
+
+    # A path no filesystem can remove: an unknown scheme falls through to the
+    # local filesystem, where removing something absent is an error rather than
+    # the no-op it is on an object store. Keeping the failure local also keeps
+    # the test off the network.
+    bad_path = f"nosuchfs://{TEST_PREFIX}/f.parquet"
+
+    _queue_paths(superuser_conn, good_paths + [bad_path])
+
+    _vacuum_dropped_tables()
+
+    # the healthy files were removed and their rows are gone
+    assert _existing_files(superuser_conn, prefix) == 0
+    assert _queued_rows(superuser_conn, prefix) == []
+
+    # the failing path is the only row left, and it is the only one charged for
+    # the failure
+    remaining = _queued_rows(superuser_conn, f"nosuchfs://{TEST_PREFIX}")
+    assert len(remaining) == 1
+    assert remaining[0][0] == bad_path
+    assert remaining[0][1] >= 1
+
+    run_command(
+        f"DELETE FROM lake_engine.deletion_queue WHERE path = '{bad_path}'",
+        superuser_conn,
+    )
+    superuser_conn.commit()

--- a/pg_lake_table/tests/pytests/test_drop_table.py
+++ b/pg_lake_table/tests/pytests/test_drop_table.py
@@ -647,11 +647,14 @@ def _count_file_records(superuser_conn, location):
 
 def _vacuum_iceberg_now():
     """Force VACUUM to immediately drain the deletion queue and delete the
-    referenced object-store files (retention + snapshot age set to 0)."""
+    referenced object-store files (retention, snapshot age and the retry
+    interval set to 0, so a row a previous VACUUM failed on is tried again now
+    rather than left alone until the interval elapses)."""
     run_command_outside_tx(
         [
             "SET pg_lake_engine.orphaned_file_retention_period = 0",
             "SET pg_lake_iceberg.max_snapshot_age TO 0",
+            "SET pg_lake_engine.vacuum_file_remove_retry_interval = 0",
             "VACUUM (ICEBERG)",
         ]
     )

--- a/pg_lake_table/tests/pytests/test_vacuum_failure.py
+++ b/pg_lake_table/tests/pytests/test_vacuum_failure.py
@@ -159,6 +159,12 @@ def test_vacuum_without_s3_access(
         "SET pg_lake_engine.orphaned_file_retention_period TO '0s';",
         superuser_conn,
     )
+    # a failed path is otherwise left alone until the retry interval elapses, so
+    # the back-to-back VACUUMs below would claim nothing after the first one
+    run_command(
+        "SET pg_lake_engine.vacuum_file_remove_retry_interval TO 0;",
+        superuser_conn,
+    )
 
     superuser_conn.commit()
     for retry in range(1, test_retry_range + 1):
@@ -217,6 +223,9 @@ def test_vacuum_without_s3_access(
     run_command("RESET pg_lake_engine.vacuum_file_remove_max_retries", superuser_conn)
     run_command("RESET pg_lake_iceberg.max_snapshot_age;", superuser_conn)
     run_command("RESET pg_lake_engine.orphaned_file_retention_period;", superuser_conn)
+    run_command(
+        "RESET pg_lake_engine.vacuum_file_remove_retry_interval;", superuser_conn
+    )
     run_command("RESET client_min_messages;", superuser_conn)
     run_command("DROP SCHEMA test_vacuum_without_s3_access CASCADE;", superuser_conn)
     superuser_conn.commit()

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -464,3 +464,126 @@ def test_pg_lake_remove_file_azure(azure, pgduck_conn):
     assert list(azure.list_blobs(name_starts_with=f"{prefix}/")) == []
 
     pgduck_conn.rollback()
+
+
+def try_remove_files(paths, pgduck_conn):
+    """Runs pg_lake_try_remove_file over the given paths in one statement and
+    returns what it said about each of them, keyed by path."""
+    values = ", ".join("(NULL)" if path is None else f"('{path}')" for path in paths)
+    results = perform_query_on_cursor(
+        f"SELECT f, pg_lake_try_remove_file(f) FROM (VALUES {values}) v(f)",
+        pgduck_conn,
+    )
+
+    return {path: error for path, error in results}
+
+
+def test_pg_lake_try_remove_file_reports_each_path(s3, pgduck_conn):
+    """pg_lake_try_remove_file reports an outcome per path instead of failing the
+    statement: NULL for a path that is gone, a reason for one that could not be
+    removed.
+
+    A caller deleting an arbitrary set of files needs that. With one status for the
+    whole request, a single path it cannot remove charges its failure to every path
+    that shared the request, and a caller that gives up on a path after so many
+    failures eventually gives up on healthy ones."""
+    prefix = "test_try_remove_file"
+
+    keys = [f"{prefix}/a.parquet", f"{prefix}/b.parquet"]
+    for key in keys:
+        s3.put_object(Bucket=TEST_BUCKET, Key=key, Body=b"x")
+
+    paths = [f"s3://{TEST_BUCKET}/{key}" for key in keys]
+
+    # removing a file that is already gone is not a failure, so it reports NULL
+    paths.append(f"s3://{TEST_BUCKET}/{prefix}/missing.parquet")
+
+    # a scheme no file system claims cannot be removed, so it reports why
+    paths.append("nosuchfs://bucket/c.parquet")
+
+    outcomes = try_remove_files(paths, pgduck_conn)
+
+    assert outcomes[paths[0]] is None
+    assert outcomes[paths[1]] is None
+    assert outcomes[paths[2]] is None
+    assert outcomes[paths[3]] is not None
+
+    # the path it could not remove did not hold up the ones it could
+    assert list_objects(s3, TEST_BUCKET, f"{prefix}/") == []
+
+    pgduck_conn.rollback()
+
+
+def test_pg_lake_try_remove_file_isolates_failing_bucket(s3, pgduck_conn):
+    """A batch is one DeleteObjects request per bucket, and a request that does not
+    complete says nothing about any of its keys. The keys of the buckets that did
+    answer still get their own outcome.
+
+    Reporting a failure the object store never mentioned is the safe direction: a
+    removal is idempotent, so a path wrongly reported as failed costs one more
+    attempt, while a path wrongly reported as removed loses a file that is still
+    there."""
+    prefix = "test_try_remove_file_bucket"
+
+    key = f"{prefix}/a.parquet"
+    s3.put_object(Bucket=TEST_BUCKET, Key=key, Body=b"x")
+
+    good = f"s3://{TEST_BUCKET}/{key}"
+    bad = f"s3://{TEST_BUCKET}-does-not-exist/{prefix}/b.parquet"
+
+    outcomes = try_remove_files([bad, good], pgduck_conn)
+
+    assert outcomes[good] is None
+    assert outcomes[bad] is not None
+
+    assert list_objects(s3, TEST_BUCKET, f"{prefix}/") == []
+
+    pgduck_conn.rollback()
+
+
+def test_pg_lake_try_remove_file_null_path(s3, pgduck_conn):
+    """A NULL path has no outcome of its own, and it must not shift the outcomes of
+    the paths around it: the rows going in and the outcomes coming out are matched
+    up by position."""
+    prefix = "test_try_remove_file_null"
+
+    key = f"{prefix}/a.parquet"
+    s3.put_object(Bucket=TEST_BUCKET, Key=key, Body=b"x")
+
+    good = f"s3://{TEST_BUCKET}/{key}"
+    bad = "nosuchfs://bucket/b.parquet"
+
+    outcomes = try_remove_files([None, bad, None, good, None], pgduck_conn)
+
+    assert outcomes[None] is None
+    assert outcomes[good] is None
+    assert outcomes[bad] is not None
+
+    assert list_objects(s3, TEST_BUCKET, f"{prefix}/") == []
+
+    pgduck_conn.rollback()
+
+
+def test_pg_lake_try_remove_file_over_1000(s3, pgduck_conn):
+    """The keys of a batch go out 1000 at a time, and each request only answers for
+    its own slice of the batch. Every path of a batch that spans more than one
+    request still has to end up with the outcome of the request that carried it."""
+    prefix = "test_try_remove_file_batch"
+    count = 1001
+
+    for i in range(count):
+        s3.put_object(Bucket=TEST_BUCKET, Key=f"{prefix}/f{i}.parquet", Body=b"x")
+
+    results = perform_query_on_cursor(
+        f"""
+        SELECT count(*) FROM generate_series(0,{count - 1}) t(i)
+        WHERE pg_lake_try_remove_file(
+                  's3://{TEST_BUCKET}/{prefix}/f' || i || '.parquet') IS NULL
+        """,
+        pgduck_conn,
+    )
+    assert results[0][0] == count
+
+    assert list_objects(s3, TEST_BUCKET, f"{prefix}/") == []
+
+    pgduck_conn.rollback()


### PR DESCRIPTION
Follow-up to #539, based on its branch because `DeleteRemoteFileBatch` is not on main yet.

### The problem

`pg_lake_remove_file` reports one status for a whole batch: it returns a constant
`true` per row and throws if anything failed. So Postgres gets one error and zero
rows, and a caller deleting files that have nothing to do with each other cannot
tell which path was at fault.

The deletion queue is such a caller, and it retires a path by failure count. One
unremovable object in a batch therefore charges its failure to the up to 1000
healthy paths that shared the request.

#539 works around that by re-issuing a failed batch in halves until the failing
path is alone. That is ~20 extra requests for one bad path in a full batch, and
it is paid again on every pass for as long as the path stays unremovable.

### The fix

S3 already answers per key: `DeleteObjects` reports an `<Error>` per key it
refused and deletes the rest, and `duckdb_pglake` already parses those entries.
It just collapses them into one exception.

So this adds `pg_lake_try_remove_file(VARCHAR) -> VARCHAR`, which removes the
same files as `pg_lake_remove_file` and reports the outcome per row instead of
failing the statement: `NULL` for a path that is gone, the reason for a path that
could not be removed. `RemoveFiles` takes an optional `pathErrors` vector down
through `PGLakeCachingFileSystem`, `RegionAwareS3FileSystem` and
`RemoveFilesFromS3` to carry it.

`DeleteRemoteFileBatch` then reads the outcomes off one request and the halving
is gone.

`pg_lake_remove_file` is unchanged, and a caller that tracks neither outcome
keeps using it: a verdict nobody reads is the per-file cost the batching exists
to remove.

### Which way we round

A path the object store did not confirm is reported as failed. That includes the
keys of a request that did not complete at all, and the keys of an earlier batch
to the same bucket when a later batch failed. Removal is idempotent, so a path
wrongly reported as failed costs one more attempt, while a path wrongly reported
as removed loses a file that is still there.

`WithResolvedRegion` re-runs its callback on a region mismatch, so
`RemoveFilesFromS3` resets the outcomes at entry rather than letting the outcomes
of the attempt that hit the mismatch stand.

### Tests

`pgduck_server/tests/pytests/test_s3.py`, four new tests: an outcome per path
with a live key, an already-missing key and an unknown scheme; a failing bucket
that does not take the keys of the bucket that answered with it; a NULL path that
must not shift the outcomes around it; and a batch over 1000 keys, where each
request only answers for its own slice.

`pg_lake_table/tests/pytests/test_deletion_queue_batching.py` already covers the
Postgres side end to end (`test_deletion_queue_batch_isolates_failing_path`); its
docstrings are updated to describe one request with per-path outcomes rather than
the halving.
