### PR TITLE
Fix write-through cache poisoning and unvalidated Avro block headers

### DIFF
--- a/avro.patch
+++ b/avro.patch
@@ -21,7 +21,7 @@ index ffbb68dc5..5bb2ee699 100644
  avro_file_reader_get_writer_schema(avro_file_reader_t reader);
  
 diff --git a/lang/c/src/datafile.c b/lang/c/src/datafile.c
-index c9d4dfeb6..8dc775eb5 100644
+index c9d4dfeb6..4a1fdb25f 100644
 --- a/lang/c/src/datafile.c
 +++ b/lang/c/src/datafile.c
 @@ -73,7 +73,7 @@ static int write_sync(avro_file_writer_t w)
@@ -155,7 +155,35 @@ index c9d4dfeb6..8dc775eb5 100644
  	if (r->current_blockdata && len > r->current_blocklen) {
  		r->current_blockdata = (char *) avro_realloc(r->current_blockdata, r->current_blocklen, len);
  		r->current_blocklen = len;
-@@ -541,6 +598,93 @@ int avro_file_reader_fp(FILE *fp, const char *path, int should_close,
+@@ -466,6 +523,27 @@ static int file_read_block_count(avro_file_reader_t r)
+ 
+ 		check_prefix(rval, avro_codec_decode(r->codec, r->current_blockdata, len),
+ 			     "Cannot decode file block: ");
++	} else {
++		/*
++		 * Nothing was read, so nothing was decoded, and the codec still holds
++		 * the *previous* block's decompressed bytes. Handing those to
++		 * block_reader below would satisfy this block's record count out of
++		 * stale data, so the caller silently receives records that are not in
++		 * the file. Report an empty block instead, and a count that cannot be
++		 * satisfied from it fails the read.
++		 *
++		 * Only used_size may be cleared here. block_data is owned by codecs
++		 * that allocate an output buffer -- deflate frees it in its reset --
++		 * and it aliases current_blockdata for the null codec, so clearing the
++		 * pointer would either leak or double free.
++		 *
++		 * A zero length is not rejected outright because it is representable in
++		 * a well-formed file: a record schema with no fields encodes to zero
++		 * bytes per record, so with the null codec a block of N such records
++		 * legitimately carries a count of N and a size of 0, and libavro's own
++		 * writer emits exactly that.
++		 */
++		r->codec->used_size = 0;
+ 	}
+ 
+ 	avro_reader_memory_set_source(r->block_reader, (const char *) r->codec->block_data, r->codec->used_size);
+@@ -541,6 +619,93 @@ int avro_file_reader_fp(FILE *fp, const char *path, int should_close,
  	return 0;
  }
  

--- a/avro.patch
+++ b/avro.patch
@@ -21,7 +21,7 @@ index ffbb68dc5..5bb2ee699 100644
  avro_file_reader_get_writer_schema(avro_file_reader_t reader);
  
 diff --git a/lang/c/src/datafile.c b/lang/c/src/datafile.c
-index c9d4dfeb6..a2c9d54b1 100644
+index c9d4dfeb6..8dc775eb5 100644
 --- a/lang/c/src/datafile.c
 +++ b/lang/c/src/datafile.c
 @@ -73,7 +73,7 @@ static int write_sync(avro_file_writer_t w)
@@ -118,7 +118,44 @@ index c9d4dfeb6..a2c9d54b1 100644
  	if (rval) {
  		avro_codec_reset(w->codec);
  		avro_freet(struct avro_codec_t_, w->codec);
-@@ -541,6 +568,93 @@ int avro_file_reader_fp(FILE *fp, const char *path, int should_close,
+@@ -452,6 +479,36 @@ static int file_read_block_count(avro_file_reader_t r)
+ 	check_prefix(rval, enc->read_long(r->reader, &len),
+ 		     "Cannot read file block size: ");
+ 
++	/*
++	 * Both counts come straight off the wire as zigzag varints, so a corrupt
++	 * or misaligned file can decode them to anything, including negatives.
++	 * Neither is meaningful below zero, and letting them through does real
++	 * damage:
++	 *
++	 *   - a negative len reaches avro_malloc(len) as a size_t, which is a
++	 *     nonsensically huge allocation request (embedders that route
++	 *     avro_malloc to their own allocator see it as such);
++	 *   - or, when current_blockdata is already allocated, a negative len is
++	 *     not greater than current_blocklen, so no buffer is resized, the
++	 *     "len > 0" read and decode below are both skipped, and block_reader
++	 *     is re-pointed at the *previous* block's decompressed bytes. The
++	 *     caller then happily re-reads stale records, silently returning data
++	 *     that is not in the file;
++	 *   - a negative blocks_total makes blocks_read == blocks_total never
++	 *     true, so the sync marker is never checked again.
++	 *
++	 * Fail the read instead, so a damaged file is reported as damaged.
++	 */
++	if (r->blocks_total < 0) {
++		avro_set_error("Invalid file block count %" PRId64, r->blocks_total);
++		return EILSEQ;
++	}
++
++	if (len < 0) {
++		avro_set_error("Invalid file block size %" PRId64, len);
++		return EILSEQ;
++	}
++
+ 	if (r->current_blockdata && len > r->current_blocklen) {
+ 		r->current_blockdata = (char *) avro_realloc(r->current_blockdata, r->current_blocklen, len);
+ 		r->current_blocklen = len;
+@@ -541,6 +598,93 @@ int avro_file_reader_fp(FILE *fp, const char *path, int should_close,
  	return 0;
  }
  

--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -113,12 +113,33 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 								 openFlags.Lock(),
 								 openFlags.Compression());
 
-		/* create a handle for the file in cache */
-		wrappedHandle = localfs.OpenFile(cacheFilePath, localFlags);
+		/*
+		 * Nothing holds the per-path cache lock across the decision above and
+		 * this open, so the entry can stop being usable in between -- cache
+		 * management evicting it under pressure is the ordinary case, and the
+		 * check itself only establishes that a regular file owned by us was
+		 * there a moment ago. Fall back to the remote file rather than failing
+		 * the statement: a re-read costs a download, whereas propagating the
+		 * open failure kills a query over an object that is perfectly readable
+		 * in storage, and reports it as a bare "Cannot open file" naming an
+		 * internal cache path.
+		 */
+		try
+		{
+			/* create a handle for the file in cache */
+			wrappedHandle = localfs.OpenFile(cacheFilePath, localFlags);
 
-		PGDUCK_SERVER_DEBUG("using local cache for %s", cacheFilePath.c_str());
+			PGDUCK_SERVER_DEBUG("using local cache for %s", cacheFilePath.c_str());
+		}
+		catch (std::exception &ex)
+		{
+			PGDUCK_SERVER_DEBUG("cannot use local cache for %s, reading from "
+								"the remote file instead: %s",
+								cacheFilePath.c_str(), ex.what());
+		}
 	}
-	else
+
+	if (wrappedHandle == nullptr)
 	{
 		/* create a handle for the remote file */
 		try

--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -131,11 +131,20 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 
 			PGDUCK_SERVER_DEBUG("using local cache for %s", cacheFilePath.c_str());
 		}
-		catch (std::exception &ex)
+		catch (IOException &ex)
 		{
+			/*
+			 * Only IOException: that is what LocalFileSystem::OpenFile raises
+			 * when open() fails, which is the case worth absorbing. Anything
+			 * else out of this call -- an InternalException, an unsupported
+			 * compression type -- is a bug rather than a lost race, and
+			 * quietly turning it into a remote read would hide it.
+			 */
+			ErrorData error(ex);
+
 			PGDUCK_SERVER_DEBUG("cannot use local cache for %s, reading from "
 								"the remote file instead: %s",
-								cacheFilePath.c_str(), ex.what());
+								cacheFilePath.c_str(), error.Message().c_str());
 		}
 	}
 
@@ -198,15 +207,25 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 						/*
 						 * FILE_FLAGS_FILE_CREATE_NEW (O_CREAT|O_TRUNC), not
 						 * FILE_FLAGS_FILE_CREATE (O_CREAT): a staging file
-						 * orphaned by a hard crash or kill -- the case
-						 * ~CachingFSFileHandle() cannot cover -- may still sit
-						 * at this exact path. Without O_TRUNC we write the new
-						 * contents over its prefix and leave whatever of the
-						 * older, longer file extends past them, then rename
-						 * that hybrid in as a complete cache entry. Readers
-						 * trust a finalized cache file without revalidating it
-						 * against object storage, so that poisons every later
-						 * read of this URL until the entry is evicted.
+						 * orphaned by an earlier write may still sit at this
+						 * exact path, and the path is fully deterministic.
+						 * Without O_TRUNC we write the new contents over its
+						 * prefix and leave whatever of the older, longer file
+						 * extends past them, then rename that hybrid in as a
+						 * complete cache entry. Readers trust a finalized cache
+						 * file without revalidating it against object storage,
+						 * so that poisons every later read of this URL until
+						 * the entry is evicted.
+						 *
+						 * Do not assume orphans are rare. ~CachingFSFileHandle()
+						 * only removes one when it actually runs, so a hard
+						 * crash or kill escapes it -- and before that cleanup
+						 * existed, so did every ordinary caught abort: a
+						 * runtime error mid-write, a cancellation, or an ENOSPC
+						 * that DuckDB throws and pgduck_server catches. That
+						 * leaves an orphan with the process still running and
+						 * its pid unchanged, which is what was observed in the
+						 * field.
 						 */
 						cacheOnWriteHandle =
 							localfs.OpenFile(cacheFilePath + cacheManager->STAGING_SUFFIX,

--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -174,9 +174,22 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 				{
 					try
 					{
+						/*
+						 * FILE_FLAGS_FILE_CREATE_NEW (O_CREAT|O_TRUNC), not
+						 * FILE_FLAGS_FILE_CREATE (O_CREAT): a staging file
+						 * orphaned by a hard crash or kill -- the case
+						 * ~CachingFSFileHandle() cannot cover -- may still sit
+						 * at this exact path. Without O_TRUNC we write the new
+						 * contents over its prefix and leave whatever of the
+						 * older, longer file extends past them, then rename
+						 * that hybrid in as a complete cache entry. Readers
+						 * trust a finalized cache file without revalidating it
+						 * against object storage, so that poisons every later
+						 * read of this URL until the entry is evicted.
+						 */
 						cacheOnWriteHandle =
 							localfs.OpenFile(cacheFilePath + cacheManager->STAGING_SUFFIX,
-											 FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+											 FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
 
 						cacheOnWritePath = cacheFilePath;
 					}

--- a/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
+++ b/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
@@ -451,7 +451,14 @@ PgLakeS3FileSystem::RemoveFilesFromS3(const string &bucketUrl,
 
 	for (idx_t begin = 0; begin < keys.size(); begin += S3_DELETE_OBJECTS_MAX_KEYS)
 	{
-		idx_t end = MinValue(begin + S3_DELETE_OBJECTS_MAX_KEYS, keys.size());
+		/*
+		 * Both arguments must be the same type for MinValue to deduce one: idx_t
+		 * is uint64_t, which is "unsigned long long" on macOS/arm64 but
+		 * "unsigned long" -- the same type vector::size_type already is -- on
+		 * Linux/x86_64, so leaving keys.size() unconverted only compiles there.
+		 */
+		idx_t end = MinValue<idx_t>(begin + S3_DELETE_OBJECTS_MAX_KEYS,
+									static_cast<idx_t>(keys.size()));
 
 		/*
 		 * Evict per batch rather than once at the end, and both before and after

--- a/pg_lake_engine/src/storage/local_storage.c
+++ b/pg_lake_engine/src/storage/local_storage.c
@@ -135,7 +135,18 @@ WriteStringToFile(char *content, FILE *file)
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("failed to write to file")));
 	}
-	fflush(file);
+
+	/*
+	 * fwrite may have only filled the stdio buffer, so the flush is where a
+	 * write error surfaces. ferror() is sticky, so it also reports one whose
+	 * flush already consumed the buffer.
+	 */
+	if (fflush(file) != 0 || ferror(file))
+	{
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("failed to write to file: %m")));
+	}
 }
 
 
@@ -155,5 +166,10 @@ WriteStringToFilePath(char *content, char *localFilePath)
 	}
 
 	WriteStringToFile(content, localFile);
-	FreeFile(localFile);
+
+	/* the final fclose() can still fail, e.g. out of space */
+	if (FreeFile(localFile) != 0)
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not close file \"%s\": %m",
+							   localFilePath)));
 }

--- a/pg_lake_iceberg/src/avro/avro_writer.c
+++ b/pg_lake_iceberg/src/avro/avro_writer.c
@@ -35,7 +35,8 @@ typedef struct ExtraMetadata
 }			ExtraMetadata;
 
 static AvroWriter * AvroWriterCreate(const char *filePath, avro_schema_t schema, avro_value_t * meta);
-static void AvroFileWriterClose(AvroWriter * writer);
+static bool AvroFileWriterClose(AvroWriter * writer);
+static void AvroFileWriterCloseCallback(void *arg);
 static void AvroPrepareSetNullable(avro_value_t * record, char *fieldName, avro_value_t * innerValue, bool isSet);
 static void WriteExtraMetadataToAvro(avro_value_t * record, ExtraMetadata * metadata);
 static avro_value_t * CreateAvroExtraMetadata(const char *schemaJson);
@@ -116,7 +117,7 @@ AvroWriterCreate(const char *filePath, avro_schema_t schema, avro_value_t * meta
 	MemoryContextCallback *cb = MemoryContextAllocZero(CurrentMemoryContext,
 													   sizeof(MemoryContextCallback));
 
-	cb->func = (MemoryContextCallbackFunction) AvroFileWriterClose;
+	cb->func = AvroFileWriterCloseCallback;
 	cb->arg = writer;
 	MemoryContextRegisterResetCallback(CurrentMemoryContext, cb);
 
@@ -146,20 +147,48 @@ GetSchemaFromJson(const char *schemaJson)
 
 
 /*
- * AvroFileWriterClose is called via a MemoryContextCallback to make sure we
- * close the Avro file writer. Even though we use a custom allocator, it
- * does not propagate to some the libraries that libavro calls (e.g. libz).
+ * AvroFileWriterClose closes the Avro file writer, and returns whether it
+ * managed to. It is also called via a MemoryContextCallback to make sure we
+ * close the writer. Even though we use a custom allocator, it does not
+ * propagate to some the libraries that libavro calls (e.g. libz).
  */
-static void
+static bool
 AvroFileWriterClose(AvroWriter * writer)
 {
+	bool		succeeded = true;
+
 	if (writer->initializedDataWriter)
 	{
-		avro_file_writer_flush(writer->dataWriter);
-		avro_file_writer_close(writer->dataWriter);
+		/* clear first, so the callback does not touch a half-closed writer */
+		writer->initializedDataWriter = false;
+
+		/*
+		 * Do not close after a failed flush: avro_file_writer_close() flushes
+		 * again, and file_write_block() does not reset the pending block when
+		 * it fails, so the retry appends a second copy of it. Either way the
+		 * writer's own allocations go with its memory context.
+		 */
+		if (avro_file_writer_flush(writer->dataWriter) != 0)
+			succeeded = false;
+		else if (avro_file_writer_close(writer->dataWriter) != 0)
+			succeeded = false;
 	}
 
-	writer->initializedDataWriter = false;
+	return succeeded;
+}
+
+
+/*
+ * AvroFileWriterCloseCallback closes the writer from a memory context reset.
+ *
+ * The result is ignored: a reset callback must not throw, and this only runs
+ * ahead of AvroWriterClose() when the transaction is failing anyway, in which
+ * case the file is discarded with it.
+ */
+static void
+AvroFileWriterCloseCallback(void *arg)
+{
+	(void) AvroFileWriterClose((AvroWriter *) arg);
 }
 
 
@@ -251,12 +280,36 @@ AvroWriterWriteRecord(AvroWriter * writer, AvroSerializeFunction serializeFn, vo
 
 /*
  * AvroWriterClose releases all Avro-related resources.
+ *
+ * Nothing here may fail quietly. Records are buffered until a block fills and
+ * the block goes through stdio, so for a manifest of ordinary size none of it
+ * has reached the file system until now, and the caller takes the file's length
+ * with GetLocalFileSize() once we return -- so a short file yields a
+ * manifest_length that agrees with it and nothing downstream can tell.
  */
 void
 AvroWriterClose(AvroWriter * writer)
 {
-	AvroFileWriterClose(writer);
-	FreeFile(writer->avroFile);
+	bool		succeeded = AvroFileWriterClose(writer);
+
+	if (!succeeded)
+		ereport(ERROR, (errmsg("could not write avro file: %s",
+							   avro_strerror())));
+
+	/*
+	 * libavro's avro_writer_flush() is declared void and discards fflush()'s
+	 * result, so the flush above can fail while still reporting success, and
+	 * once it has consumed the buffer fclose() succeeds too. ferror() reports
+	 * it regardless, because the stream's error indicator is sticky.
+	 */
+	if (fflush(writer->avroFile) != 0 || ferror(writer->avroFile))
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not write avro file: %m")));
+
+	if (FreeFile(writer->avroFile) != 0)
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not close avro file: %m")));
+
 	MemoryContextDelete(writer->memoryContext);
 }
 

--- a/pg_lake_iceberg/src/iceberg/api/table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/api/table_metadata.c
@@ -395,7 +395,18 @@ WriteMetadataJsonToTemporaryFile(IcebergTableMetadata * metadata, FILE *file)
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("Failed to write metadata file to temporary file")));
 	}
-	fflush(file);
+
+	/*
+	 * fwrite may have only filled the stdio buffer, so the flush is where a
+	 * write error surfaces. ferror() is sticky, so it also reports one whose
+	 * flush already consumed the buffer.
+	 */
+	if (fflush(file) != 0 || ferror(file))
+	{
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write metadata file to temporary file: %m")));
+	}
 }
 
 /*
@@ -423,7 +434,14 @@ UploadTableMetadataToURI(IcebergTableMetadata * tableMetadata, char *metadataURI
 
 	ScheduleFileCopyToS3WithCleanup(localFilePath, metadataURI, autoDeleteRecord);
 
-	FreeFile(localFile);
+	/*
+	 * The final fclose() can still fail; unchecked, a truncated metadata.json
+	 * would be uploaded and committed as the table's current metadata.
+	 */
+	if (FreeFile(localFile) != 0)
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not close file \"%s\": %m",
+							   localFilePath)));
 }
 
 /*

--- a/pg_lake_iceberg/tests/pytests/test_avro_block_header.py
+++ b/pg_lake_iceberg/tests/pytests/test_avro_block_header.py
@@ -118,6 +118,33 @@ def reserialize_functions(create_reserialize_helper_functions, superuser_conn):
     superuser_conn.commit()
 
 
+def _count_records(data):
+    """Sum the record counts of every block header in a container file."""
+    offset = _first_block_header_offset(data)
+    total = 0
+
+    while offset < len(data):
+        count, offset = _decode_zigzag_long(data, offset)
+        size, offset = _decode_zigzag_long(data, offset)
+        assert size >= 0, f"unreadable output: negative block size {size}"
+        offset += size + 16  # payload plus the sync marker
+        total += count
+
+    return total
+
+
+def _reserialize(manifest_url, out_path, superuser_conn):
+    """Reserialize into out_path; return the error text, or None if it worked."""
+    result = run_query(
+        f"SELECT lake_iceberg.reserialize_iceberg_manifest("
+        f"'{manifest_url}', '{out_path}')",
+        superuser_conn,
+        raise_error=False,
+    )
+
+    return result if isinstance(result, str) else None
+
+
 def _upload(tmp_path, s3, key, payload):
     local = tmp_path / "manifest.avro"
     local.write_bytes(payload)
@@ -174,39 +201,67 @@ def test_first_block_header_with_negative_field_is_rejected(
     ), f"{label}: expected a block-header validation error, got: {error}"
 
 
-def test_trailing_block_header_with_negative_size_does_not_return_stale_records(
-    tmp_path, superuser_conn, s3, reserialize_functions
+@pytest.mark.parametrize("label,block_size", [("negative", -53), ("zero", 0)])
+def test_trailing_block_header_does_not_add_phantom_records(
+    label, block_size, tmp_path, superuser_conn, s3, reserialize_functions
 ):
     """Garbage after the final sync marker must not be read as extra records.
 
-    Appending a block header whose length is negative used to be silently
-    accepted: no buffer was resized, the read and decode were skipped, and the
-    block reader still pointed at the previous block's decompressed bytes, so
-    the declared record count was satisfied from stale data. The manifest then
-    read back with more entries than it contains -- in Iceberg terms, phantom
-    data files -- and nothing reported a problem.
+    A trailing block header whose length is not positive used to reach the
+    stale-buffer path: no buffer is resized, the "len > 0" read and decode are
+    both skipped, and block_reader is left pointing at the previous block's
+    decompressed bytes, so the declared record count is satisfied out of them.
+
+    The count matters for whether that is even visible. Claim more records than
+    the stale buffer holds and the reader overruns it and errors, which looks
+    like correct behaviour for the wrong reason. Claim exactly one and it fits,
+    so the read succeeds and the manifest comes back with an extra entry that is
+    not in the file -- in Iceberg terms a phantom data file -- reported as
+    success. So this asserts on the record count, not merely that an error
+    occurred.
+
+    Zero is the likelier length of the two in practice: the fields are
+    independent zigzag varints, so a single 0x00 decodes to it, and zero is what
+    a misaligned read into a zero-filled region finds.
     """
     original = _sample_manifest_bytes()
+    expected = _count_records(original)
 
-    # A well-formed sync marker followed by a block header claiming 4 records of
-    # negative length: the shape a partially-overwritten cache file produces.
+    # The trailing bytes are a bare block header, with no sync marker in front:
+    # the reader consumed the file's own final sync while finishing the last
+    # block, so it is already positioned where a block header would start.
+    #
+    # Closing with a sync marker is what makes the failure silent rather than
+    # merely wrong: after the phantom record the reader looks for a sync marker,
+    # finds a valid one, then hits end-of-file and stops cleanly. End the file
+    # any other way and it reports "Incorrect sync bytes" *after* having already
+    # handed the extra record to the caller.
     trailing = (
-        _sync_marker(original)
-        + _encode_zigzag_long(4)
-        + _encode_zigzag_long(-53)
-        + b"\x00" * 64
+        _encode_zigzag_long(1)
+        + _encode_zigzag_long(block_size)
+        + _sync_marker(original)
     )
 
     url = _upload(
-        tmp_path, s3, "avro_block_header/stale_records.avro", original + trailing
+        tmp_path,
+        s3,
+        f"avro_block_header/phantom_records_{label}.avro",
+        original + trailing,
     )
-    error = _read_manifest_error(url, superuser_conn)
+    out_path = tmp_path / f"out_{label}.avro"
+    error = _reserialize(url, str(out_path), superuser_conn)
     superuser_conn.rollback()
 
-    assert error is not None, (
-        "a trailing block header with a negative length was accepted; the "
-        "reader re-emitted the previous block's records instead of failing"
+    if error is not None:
+        # Failing the read outright is the acceptable outcome; it just must not
+        # be the unvalidated-length allocation error.
+        assert "invalid memory alloc request size" not in str(
+            error
+        ), f"{label}: unvalidated block length reached the allocator: {error}"
+        return
+
+    actual = _count_records(out_path.read_bytes())
+    assert actual == expected, (
+        f"{label}: read {actual} records from a manifest holding {expected}; the "
+        f"trailing block header was satisfied from the previous block's bytes"
     )
-    assert "Invalid file block size" in str(
-        error
-    ), f"expected a block-size validation error, got: {error}"

--- a/pg_lake_iceberg/tests/pytests/test_avro_block_header.py
+++ b/pg_lake_iceberg/tests/pytests/test_avro_block_header.py
@@ -1,0 +1,212 @@
+"""
+Regression tests for Avro container block-header validation.
+
+An Avro container file stores, before each data block, a record count and a
+compressed byte length, both as zigzag varints. libavro's
+file_read_block_count() used them without checking their sign, so a corrupt or
+misaligned file could steer the reader in two bad directions:
+
+  * a negative length reached avro_malloc(len), and pg_lake routes libavro's
+    allocator to palloc (see AvroPostgresAllocator in avro_init.c), so the
+    negative value arrived as a size_t -- surfacing as
+    "invalid memory alloc request size 18446744073709551563" for len == -53,
+    an error that names neither the file nor the real problem;
+
+  * or, once a block buffer already existed, a negative length is not greater
+    than current_blocklen, so nothing was resized, the read and the codec
+    decode were both skipped, and the block reader was left pointing at the
+    *previous* block's decompressed bytes. The reader then re-emitted stale
+    records and returned data that is not in the file, with no error at all.
+
+Both are now rejected up front, so a damaged manifest is reported as damaged.
+"""
+
+import tempfile
+
+import pytest
+from utils_pytest import *
+
+
+def _encode_zigzag_long(value):
+    """Encode an int64 the way Avro's binary encoding does: zigzag + varint."""
+    zigzag = (value << 1) ^ (value >> 63)
+    zigzag &= (1 << 64) - 1
+
+    out = bytearray()
+    while True:
+        chunk = zigzag & 0x7F
+        zigzag >>= 7
+        if zigzag:
+            out.append(chunk | 0x80)
+        else:
+            out.append(chunk)
+            return bytes(out)
+
+
+def _decode_zigzag_long(data, offset):
+    result = 0
+    shift = 0
+    while True:
+        byte = data[offset]
+        offset += 1
+        result |= (byte & 0x7F) << shift
+        shift += 7
+        if not byte & 0x80:
+            break
+    return (result >> 1) ^ -(result & 1), offset
+
+
+def _first_block_header_offset(data):
+    """Return the offset just past the container header, where the first block
+    header (count, length) begins: magic, the metadata map, then a 16-byte sync
+    marker."""
+    assert data[:4] == b"Obj\x01", "not an Avro container file"
+
+    offset = 4
+    while True:
+        count, offset = _decode_zigzag_long(data, offset)
+        if count == 0:
+            break
+        if count < 0:
+            # a negative map block count is followed by its byte size
+            _, offset = _decode_zigzag_long(data, offset)
+            count = -count
+        for _ in range(count):
+            key_len, offset = _decode_zigzag_long(data, offset)
+            offset += key_len
+            value_len, offset = _decode_zigzag_long(data, offset)
+            offset += value_len
+
+    return offset + 16  # skip the sync marker
+
+
+def _sync_marker(data):
+    start = _first_block_header_offset(data) - 16
+    return data[start : start + 16]
+
+
+def _sample_manifest_bytes():
+    with open(sample_avro_filepath("equality-ids-manifest.avro"), "rb") as f:
+        return f.read()
+
+
+def _read_manifest_error(manifest_url, superuser_conn):
+    """Reserialize the manifest and return the error text, or None if it worked.
+
+    run_query returns result rows on success and the error string on failure, so
+    the type is what distinguishes the two.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".avro") as out_file:
+        result = run_query(
+            f"SELECT lake_iceberg.reserialize_iceberg_manifest("
+            f"'{manifest_url}', '{out_file.name}')",
+            superuser_conn,
+            raise_error=False,
+        )
+
+    return result if isinstance(result, str) else None
+
+
+@pytest.fixture(scope="module")
+def reserialize_functions(create_reserialize_helper_functions, superuser_conn):
+    """Commit the helper function DDL.
+
+    create_reserialize_helper_functions leaves it uncommitted, and every test
+    here has to roll back after the failure it provokes, which would otherwise
+    take the CREATE FUNCTION statements with it.
+    """
+    superuser_conn.commit()
+
+
+def _upload(tmp_path, s3, key, payload):
+    local = tmp_path / "manifest.avro"
+    local.write_bytes(payload)
+    s3.upload_file(str(local), TEST_BUCKET, key)
+    return f"s3://{TEST_BUCKET}/{key}"
+
+
+@pytest.mark.parametrize(
+    "label,block_count,block_size",
+    [
+        ("negative_size", 1, -53),
+        ("negative_count", -7, 84),
+    ],
+)
+def test_first_block_header_with_negative_field_is_rejected(
+    label,
+    block_count,
+    block_size,
+    tmp_path,
+    superuser_conn,
+    s3,
+    reserialize_functions,
+):
+    """A negative count or length in the *first* block header must fail the read.
+
+    The first block is the case where no block buffer exists yet, so before the
+    fix a negative length went straight to avro_malloc() and the statement died
+    with "invalid memory alloc request size 18446744073709551563" instead of
+    anything that identifies the file as corrupt.
+    """
+    original = _sample_manifest_bytes()
+    header_end = _first_block_header_offset(original)
+
+    corrupt = bytearray(original[:header_end])
+    corrupt += _encode_zigzag_long(block_count)
+    corrupt += _encode_zigzag_long(block_size)
+    # Keep a plausible amount of trailing data so the failure has to come from
+    # the block header itself and not from hitting end-of-file.
+    corrupt += original[header_end:]
+
+    url = _upload(tmp_path, s3, f"avro_block_header/{label}.avro", bytes(corrupt))
+    error = _read_manifest_error(url, superuser_conn)
+    superuser_conn.rollback()
+
+    assert error is not None, (
+        f"{label}: reading a manifest with a negative block header field "
+        f"succeeded; file_read_block_count() must reject it"
+    )
+    assert "invalid memory alloc request size" not in str(
+        error
+    ), f"{label}: unvalidated block length reached the allocator: {error}"
+    assert "Invalid file block" in str(
+        error
+    ), f"{label}: expected a block-header validation error, got: {error}"
+
+
+def test_trailing_block_header_with_negative_size_does_not_return_stale_records(
+    tmp_path, superuser_conn, s3, reserialize_functions
+):
+    """Garbage after the final sync marker must not be read as extra records.
+
+    Appending a block header whose length is negative used to be silently
+    accepted: no buffer was resized, the read and decode were skipped, and the
+    block reader still pointed at the previous block's decompressed bytes, so
+    the declared record count was satisfied from stale data. The manifest then
+    read back with more entries than it contains -- in Iceberg terms, phantom
+    data files -- and nothing reported a problem.
+    """
+    original = _sample_manifest_bytes()
+
+    # A well-formed sync marker followed by a block header claiming 4 records of
+    # negative length: the shape a partially-overwritten cache file produces.
+    trailing = (
+        _sync_marker(original)
+        + _encode_zigzag_long(4)
+        + _encode_zigzag_long(-53)
+        + b"\x00" * 64
+    )
+
+    url = _upload(
+        tmp_path, s3, "avro_block_header/stale_records.avro", original + trailing
+    )
+    error = _read_manifest_error(url, superuser_conn)
+    superuser_conn.rollback()
+
+    assert error is not None, (
+        "a trailing block header with a negative length was accepted; the "
+        "reader re-emitted the previous block's records instead of failing"
+    )
+    assert "Invalid file block size" in str(
+        error
+    ), f"expected a block-size validation error, got: {error}"

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -91,6 +91,64 @@ def test_cache_rejects_non_regular_file(s3, pgduck_conn, tmp_path):
     pgduck_conn.rollback()
 
 
+def test_unusable_cache_file_falls_back_to_remote(s3, pgduck_conn):
+    """A cache entry that cannot be opened must not fail the read.
+
+    OpenFile() decides to read from the cache with IsOwnedByCurrentUser() and
+    then opens the file, and nothing holds the per-path cache lock across those
+    two steps. So the entry can stop being usable in between -- cache management
+    evicting it under pressure is the ordinary case, and the check only
+    establishes that a regular file owned by us was there a moment ago. The open
+    used to propagate, killing the statement with a bare
+    "IO Error: Cannot open file <cache path>" for an object that is still
+    perfectly readable in object storage.
+
+    A cache file owned by us but with no read permission reaches the same open
+    failure deterministically, without having to win a race: lstat() still
+    reports a regular file owned by the effective UID, so the cache branch is
+    taken, and only then does the open fail.
+    """
+    key = "test_unusable_cache_file_falls_back_to_remote/data.csv"
+    url = f"s3://{TEST_BUCKET}/{key}"
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/s3/{TEST_BUCKET}"
+        f"/test_unusable_cache_file_falls_back_to_remote/{CACHE_FILE_PREFIX}data.csv"
+    )
+
+    run_command(
+        f"COPY (SELECT * FROM generate_series(1,10)) TO '{url}' WITH (header false);",
+        pgduck_conn,
+    )
+    run_command(f"CALL pg_lake_cache_file('{url}');", pgduck_conn)
+    assert cached_path.is_file(), "file was not cached, nothing to exercise"
+
+    remote_size = pg_lake_file_size(f"nocache{url}", pgduck_conn)
+    original_mode = cached_path.stat().st_mode & 0o777
+
+    cached_path.chmod(0o000)
+    try:
+        result = run_query(
+            f"SELECT octet_length(content) AS size FROM read_blob('{url}')",
+            pgduck_conn,
+            raise_error=False,
+        )
+    finally:
+        cached_path.chmod(original_mode)
+
+    # run_query hands back the error string rather than rows when it fails.
+    assert not isinstance(result, str), (
+        f"an unusable cache entry failed the read instead of falling back to "
+        f"object storage: {result}"
+    )
+    assert int(result[0]["size"]) == remote_size, (
+        f"fell back but returned {result[0]['size']} bytes for a "
+        f"{remote_size}-byte object"
+    )
+
+    run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
+    pgduck_conn.rollback()
+
+
 def test_pg_lake_cache_file(s3, gcs, azure, pgduck_conn):
     run_pg_lake_cache_file_test_for_protocol("s3", TEST_BUCKET, pgduck_conn, s3)
     run_pg_lake_cache_file_test_for_protocol("gs", TEST_BUCKET_GCS, pgduck_conn, gcs)

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -945,6 +945,69 @@ def test_cache_on_write_abort_removes_stage_file(s3, pgduck_conn):
         assert not stage_path.exists(), f"{ext}: orphaned staging file not cleaned up"
 
 
+def test_cache_on_write_truncates_orphaned_stage_file(s3, pgduck_conn):
+    """Reusing a .pgl-stage file left by a crash must truncate it first.
+
+    ~CachingFSFileHandle() removes the staging file on a caught abort, but a
+    hard crash or kill skips the destructor entirely and leaves one on disk at a
+    fully deterministic path. Opening that file with O_CREAT alone writes the new
+    contents over its prefix and leaves whatever of the older, longer file
+    extends past them; FileSync()/Close() then renames the hybrid in as a
+    finalized cache entry. Nothing revalidates a finalized entry against object
+    storage, so every later read of that URL gets the wrong bytes until it is
+    evicted -- for an Avro manifest, a trailing fragment past the final sync
+    marker is read as another block header.
+
+    The orphan is written directly here because that is precisely the on-disk
+    state a crash leaves behind, and the one state the destructor cannot cover.
+    """
+    test_dir = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/s3/{TEST_BUCKET}"
+        f"/test_cache_on_write_truncates_orphaned_stage_file"
+    )
+
+    # A small limit left over from another test would disable write-through
+    # caching, so pin it back to the 1GB default.
+    run_command(
+        "SET GLOBAL pg_lake_cache_on_write_max_size TO '1073741824';", pgduck_conn
+    )
+
+    # Far larger than the file about to be written, so a surviving tail is
+    # unmistakable rather than a handful of bytes.
+    filler = b"ORPHAN.." * (128 * 1024)
+
+    for ext in ("parquet", "csv"):
+        url = (
+            f"s3://{TEST_BUCKET}"
+            f"/test_cache_on_write_truncates_orphaned_stage_file/data.{ext}"
+        )
+        cached_path = test_dir / f"{CACHE_FILE_PREFIX}data.{ext}"
+        stage_path = test_dir / f"{CACHE_FILE_PREFIX}data.{ext}.pgl-stage"
+
+        test_dir.mkdir(parents=True, exist_ok=True)
+        cached_path.unlink(missing_ok=True)
+        stage_path.write_bytes(filler)
+
+        run_command(
+            f"COPY (SELECT s AS s, s * 2 AS d FROM generate_series(1, 100) g(s)) "
+            f"TO '{url}' (format '{ext}');",
+            pgduck_conn,
+        )
+
+        assert cached_path.exists(), f"{ext}: write-through cache file is missing"
+        assert not stage_path.exists(), f"{ext}: staging file was not finalized"
+
+        cached_bytes = cached_path.read_bytes()
+        assert b"ORPHAN" not in cached_bytes, (
+            f"{ext}: content of the orphaned staging file survived into the "
+            f"finalized cache entry ({len(cached_bytes)} bytes cached)"
+        )
+        assert len(cached_bytes) == pg_lake_file_size(f"nocache{url}", pgduck_conn), (
+            f"{ext}: finalized cache entry ({len(cached_bytes)} bytes) disagrees "
+            f"with the object in storage"
+        )
+
+
 # we cannot cache the same file concurrently
 def test_copy_concurrently(s3, pgduck_conn):
     url_1 = f"s3://{TEST_BUCKET}/test_copy_concurrently/file_1.csv"

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -91,6 +91,11 @@ def test_cache_rejects_non_regular_file(s3, pgduck_conn, tmp_path):
     pgduck_conn.rollback()
 
 
+@pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="mode 0 does not deny root, so the cache open succeeds and this "
+    "would pass with or without the fallback",
+)
 def test_unusable_cache_file_falls_back_to_remote(s3, pgduck_conn):
     """A cache entry that cannot be opened must not fail the read.
 


### PR DESCRIPTION
## Summary

Guard rails around Iceberg Avro metadata, from investigating a production
incident where manifests read back corrupt while the pgduck_server cache volume
was full, surfacing as

```
ERROR:  invalid memory alloc request size 18446744073709551563
ERROR:  unable to read avro record: Cannot decode file block: Error decompressing block with deflate (-3)
```

The corruption was reproduced end to end locally. Both symptoms turn out to be
the same class of damage seen at different offsets, and each commit closes one
way of producing or of failing to notice it.

## `duckdb_pglake: fix RemoveFiles batch loop build on macOS/arm64`

Unrelated to the incident, but `main` does not compile on macOS/arm64 without
it, which blocked verifying everything else. `MinValue` is a single-parameter
template, and `idx_t` is `unsigned long long` on macOS/arm64 while
`vector::size_type` is `unsigned long`, so deduction is ambiguous there and
fine on Linux/x86_64.

## `duckdb_pglake: truncate an orphaned write-through cache staging file`

Write-through caching staged into `<cache path>.pgl-stage` opened with
`FILE_FLAGS_FILE_CREATE` (`O_CREAT`) instead of `FILE_FLAGS_FILE_CREATE_NEW`
(`O_CREAT|O_TRUNC`), so an existing file at that fully deterministic path was
written into from offset 0 without being truncated. Whatever of the older,
longer file extended past the new contents survived into the rename, published
as a finalized cache entry. Nothing revalidates a finalized entry against object
storage, so every later read of that URL got the wrong bytes until eviction.

Reproduced against a real object store:

| | before | after |
|---|---|---|
| S3 object | 8481 B `eecc0162…` | 8481 B `eecc0162…` |
| published cache entry | **1048576 B `b9c97d16…`** | 8481 B `eecc0162…` |
| read through the cache | **1048576 B `b9c97d16…`** | 8481 B `eecc0162…` |

For an Avro manifest the surviving fragment sits immediately after the final
sync marker — exactly where the reader looks for the next block header — which
is how a cache-layer bug produced Avro-layer errors.

**How orphans arise, corrected.** The first version of this said a hard crash or
kill was the only route. `~CachingFSFileHandle()` only removes a staging file
when it actually runs, so a crash does escape it — but before that cleanup
existed (#445, not yet everywhere), so did every ordinary caught abort: a
runtime error mid-write, a cancellation, or an ENOSPC that DuckDB throws and
pgduck_server catches. Each leaves an orphan with the process still running and
its pid unchanged, which is what was observed in the field, where the pid was
verified constant across the whole incident. The precondition is therefore far
more common than first described. Thanks to @sfc-gh-rsirma for the pid history.

New test `test_cache_on_write_truncates_orphaned_stage_file`; without the fix:

```
AssertionError: parquet: content of the orphaned staging file survived into the
finalized cache entry (1048576 bytes cached)
```

## `avro: reject negative block count and block size` + `avro: do not serve a previous block's bytes for a zero-length block`

`file_read_block_count()` used both block-header fields without checking them.
Consequences, all reproduced:

- a negative length reaches `avro_malloc(len)` (a `size_t` parameter), and
  pg_lake points libavro's allocator at `palloc`, so `len == -53` gives exactly
  the production error `invalid memory alloc request size 18446744073709551563`;
- a length that is **not positive** — negative *or zero* — leaves the block
  buffer unresized, skips the read and the decode, and leaves `block_reader`
  pointing at the *previous* block's decompressed bytes, so this block's record
  count is satisfied from stale data and the caller silently receives records
  that are not in the file. For a manifest that is a phantom data-file entry,
  reported as success;
- a negative count makes `blocks_read == blocks_total` unreachable, so the sync
  marker is never verified again.

Negatives are rejected. Zero is handled by reporting an empty block rather than
rejecting it, because `count > 0, size == 0` is representable in a well-formed
file: a record schema with no fields encodes to zero bytes per record, so with
the null codec a block of N such records legitimately carries a count of N and a
size of 0, and libavro's own writer emits exactly that. Only `used_size` is
cleared; `block_data` is owned by codecs that allocate an output buffer and
aliases `current_blockdata` for the null codec.

Zero is also the likelier of the two lengths in practice: the fields are
independent zigzag varints, so a single `0x00` decodes to it, and zero is what a
misaligned read into a zero-filled region finds. Caught in review by
@sfc-gh-rsirma; without the fix the zero case reads 2 records from a manifest
holding 1.

Carried in `avro.patch`. Tests in `test_avro_block_header.py` assert on the
record count rather than merely on an error, because whether the damage surfaces
depends on the declared count and on what follows the block.

## `duckdb_pglake: fall back to the remote file when a cache entry cannot be opened`

`OpenFile()` decides to read from the cache with `IsOwnedByCurrentUser()` and
then opens the file, with nothing holding the per-path cache lock across the two
steps. Under concurrent cache management the entry is evicted in that window and
the open threw, failing the statement with a bare
`IO Error: Cannot open file <cache path>` for an object still readable in
storage. Observed naturally while hammering concurrent Iceberg writers and
readers against an aggressively evicting cache manager, on both a reader and a
writer. Narrowed to `IOException` per review, so a genuine bug out of that call
is not absorbed.

## `pg_lake_iceberg: fail the transaction when a manifest cannot be written`

The write side had the mirror-image problem: finalizing a manifest discarded
every result that could report a write error — `avro_file_writer_flush()`,
`avro_file_writer_close()` and `FreeFile()` (the final `fclose`) — and the
metadata.json writer and `WriteStringToFile()` dropped `fflush()`'s result.

Silent, not untidy: records are buffered until a block fills and the block goes
through stdio, so for an ordinary manifest nothing has reached the file system
until finalization, and the caller takes the file's length *after* closing, so a
short file yields a `manifest_length` that agrees with it. The transaction
commits a truncated manifest and reports success.

Checking libavro's return values is not enough, which testing showed:
`avro_writer_flush()` is declared `void` and throws `fflush()`'s result away, so
`avro_file_writer_flush()` reports success even when the flush it just performed
failed, and once that flush consumed the buffer `fclose()` also succeeds. So the
stream's sticky `ferror()` indicator is checked too. Two call sites in the tree
already checked `FreeFile()` this way (`copy_io.c`, `csv_writer.c`).

Verified on a 1 GB volume with 4096 bytes free, reserializing an 8481-byte
manifest onto it. Before: no error, 4096-byte file, statement succeeds. After:
`could not write avro file: No space left on device`.

## Scope

Deliberately **not** here, filed as follow-ups:

- `PgLakeHTTPFileSystem::Download` accumulates bytes across HTTP retries. DuckDB
  retries a request error by re-invoking the content handler, which appends to
  the same output handle, so a *transient* truncation yields `success = true` and
  a destination longer than the object (partial attempt plus full attempt) —
  renamed into the cache as valid. Another route to a poisoned entry needing no
  crash and no full disk. Needs its own review of httpfs retry semantics.
- Self-healing on a corrupt cached file (@sfc-gh-rsirma). Worth doing, but the
  Avro failure is an `ereport(ERROR)` from inside libavro and
  `s3_reader_utils.c` documents why catching one to retry is unsafe, so it is a
  design change rather than a hunk.

Also note the `…551563` variant needs the divergence at the *first* block, which
the staging-file bug cannot produce on its own; the Avro-side validation makes
either variant fail loudly and diagnosably rather than as a wild allocation or
as silent phantom records, which is what was missing when this had to be
diagnosed after the fact.

## Test plan

Verified on macOS/arm64 against MinIO. Every fix was checked by reverting it,
rebuilding, and confirming its test fails with the diagnostic quoted above.

- `pgduck_server` caching suite: **21 passed**, 1 error (`azurite` not installed
  locally), including two new tests.
- `pg_lake_iceberg`: `test_avro_block_header.py` 4 passed; the rest of the suite
  is **146 passed / 0 failed** with the same 40 pre-existing fixture errors it
  has without these commits.
- Deterministic cache-poisoning reproduction passes only with the `O_TRUNC` fix.

Pre-existing on this machine, unrelated, and reproduced with the sources
reverted:

- `test_iceberg_avro.py::test_iceberg_table_with_large_avro_allocs` crashes the
  backend where it expects "Value too large for file block size" — confirmed
  identical with an unmodified libavro. It takes the test cluster down, which
  cascades into most of the fixture errors above. Filed separately.
- `test_polaris_conn.py` (Polaris server fails to start),
  `test_iceberg_metadata_via_spark.py` (needs Spark/JDBC) and the `azurite`
  error are missing local test dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
