### PR TITLE
duckdb_pglake: verify a copy delivered the whole source before caching it

### DIFF
--- a/duckdb_pglake/src/fs/file_cache_manager.cpp
+++ b/duckdb_pglake/src/fs/file_cache_manager.cpp
@@ -702,6 +702,15 @@ FileCacheManager::ManageCache(ClientContext &context, int64_t maxCacheSize)
 		}
 		catch (std::exception &ex)
 		{
+			/*
+			 * The summary below only counts these, and the same counter ticks
+			 * for an ordinary timeout, so without the reason a fill that was
+			 * rejected because it did not match the object looks like any other
+			 * transient failure.
+			 */
+			PGDUCK_SERVER_WARN("could not add %s to cache: %.500s",
+							   cacheFile.url.c_str(), ex.what());
+
 			actions.push_back({
 				.url = cacheFile.url,
 				.fileSize = cacheFile.fileSize,

--- a/duckdb_pglake/src/fs/file_cache_manager.cpp
+++ b/duckdb_pglake/src/fs/file_cache_manager.cpp
@@ -341,7 +341,12 @@ FileCacheManager::CacheFileInternal(ClientContext &context, string url, bool for
 	/* prefix the URL with nocache to prevent copying an already-cached file to itself */
 	string sourceUrl = NO_CACHE_PREFIX + url;
 
-	/* first, copy the file from the URL into a staging file */
+	/*
+	 * First, copy the file from the URL into a staging file. A failure here
+	 * leaves the staging file behind on purpose: unwinding releases the cache
+	 * lock, so the sweep at the top of ManageCache reclaims it on its next run,
+	 * and cleaning up here would only duplicate that.
+	 */
 	string stagingCacheFilePath = finalCacheFilePath + STAGING_SUFFIX;
 	int64_t size = FileUtils::CopyFile(context, sourceUrl, stagingCacheFilePath);
 

--- a/duckdb_pglake/src/fs/file_utils.cpp
+++ b/duckdb_pglake/src/fs/file_utils.cpp
@@ -142,6 +142,14 @@ FileUtils::CopyFile(ClientContext &context,
 
 	int64_t totalBytesWritten = 0L;
 
+	/*
+	 * Taken before the copy so it can be compared against what we actually
+	 * transferred. Zero means the source does not report a size -- an http
+	 * server that sends no Content-Length, for instance -- in which case there
+	 * is nothing to compare against.
+	 */
+	idx_t sourceSize = sourceHandle->GetFileSize();
+
 	if (sourceHandle->file_system.GetName() == "HTTPFileSystem")
 	{
 		/* when opening http(s), we go through CachedFileSystem */
@@ -200,6 +208,33 @@ FileUtils::CopyFile(ClientContext &context,
 			totalBytesWritten += destinationHandle->Write(buffer.get(), bytesRead);
 		}
 	}
+
+	/*
+	 * Check before finalizing, so a transfer that did not deliver the whole
+	 * source is never published. For a cache fill the staging file is simply
+	 * left for the sweep at the top of ManageCache; for an upload the object
+	 * never appears, because the multipart upload is completed by Sync().
+	 *
+	 * The reason this is not left to each backend: a transfer that reports
+	 * success is not the same as one that delivered everything. The clearest
+	 * case is the http/s3 path above. A transport failure part way through the
+	 * body is retried by HTTPUtil::SendRequest, which re-runs the content
+	 * handler from the start of the body -- and that handler appends, while the
+	 * output file still holds whatever the previous attempt delivered. So a
+	 * retry that succeeds leaves the partial attempt followed by a complete one:
+	 * longer than the source, with no error raised. The generic loop below
+	 * cannot double count that way, because Read() is positional, but it stops
+	 * at the first zero-length read and equally does not check what it got.
+	 *
+	 * Since FileCacheManager::CacheFileInternal renames the result into the
+	 * cache, and nothing revalidates a cache entry afterwards, either shape
+	 * would be served for every later read of that URL.
+	 */
+	if (sourceSize > 0 && (idx_t) totalBytesWritten != sourceSize)
+		throw IOException("Copied %llu bytes of '%s' but it is %llu bytes; the "
+						  "transfer was incomplete or was retried",
+						  (unsigned long long) totalBytesWritten, sourcePath,
+						  (unsigned long long) sourceSize);
 
 	destinationHandle->Sync();
 	destinationHandle->Close();

--- a/duckdb_pglake/src/fs/file_utils.cpp
+++ b/duckdb_pglake/src/fs/file_utils.cpp
@@ -210,31 +210,29 @@ FileUtils::CopyFile(ClientContext &context,
 	}
 
 	/*
-	 * Check before finalizing, so a transfer that did not deliver the whole
-	 * source is never published. For a cache fill the staging file is simply
-	 * left for the sweep at the top of ManageCache; for an upload the object
-	 * never appears, because the multipart upload is completed by Sync().
+	 * A transfer that reports success is not the same as one that delivered
+	 * everything: a retried http/s3 body can leave a partial attempt followed by
+	 * a complete one, and the generic loop stops at the first zero-length read.
+	 * Since the result may be renamed into the cache, and nothing revalidates a
+	 * cache entry afterwards, either shape would be served from then on.
 	 *
-	 * The reason this is not left to each backend: a transfer that reports
-	 * success is not the same as one that delivered everything. The clearest
-	 * case is the http/s3 path above. A transport failure part way through the
-	 * body is retried by HTTPUtil::SendRequest, which re-runs the content
-	 * handler from the start of the body -- and that handler appends, while the
-	 * output file still holds whatever the previous attempt delivered. So a
-	 * retry that succeeds leaves the partial attempt followed by a complete one:
-	 * longer than the source, with no error raised. The generic loop below
-	 * cannot double count that way, because Read() is positional, but it stops
-	 * at the first zero-length read and equally does not check what it got.
-	 *
-	 * Since FileCacheManager::CacheFileInternal renames the result into the
-	 * cache, and nothing revalidates a cache entry afterwards, either shape
-	 * would be served for every later read of that URL.
+	 * Checked before finalizing, so nothing bad is published: a cache fill
+	 * leaves its staging file for the sweep in ManageCache, and an upload never
+	 * appears because Sync() is what completes the multipart upload.
 	 */
 	if (sourceSize > 0 && (idx_t) totalBytesWritten != sourceSize)
+	{
+		/* a cache fill asks for nocache<url>, which is no use to the reader */
+		string reportedPath =
+			StringUtil::StartsWith(sourcePath, NO_CACHE_PREFIX)
+			? sourcePath.substr(NO_CACHE_PREFIX.length())
+			: sourcePath;
+
 		throw IOException("Copied %llu bytes of '%s' but it is %llu bytes; the "
 						  "transfer was incomplete or was retried",
-						  (unsigned long long) totalBytesWritten, sourcePath,
+						  (unsigned long long) totalBytesWritten, reportedPath,
 						  (unsigned long long) sourceSize);
+	}
 
 	destinationHandle->Sync();
 	destinationHandle->Close();

--- a/duckdb_pglake/src/fs/httpfs_extended.cpp
+++ b/duckdb_pglake/src/fs/httpfs_extended.cpp
@@ -81,6 +81,12 @@ PgLakeHTTPFileSystem::Download(ClientContext &context, FileHandle &inputHandle, 
 
 	hfh.StoreClient(std::move(http_client));
 
+	/*
+	 * The byte count is verified by FileUtils::CopyFile, which does it for every
+	 * transfer rather than only the ones that come through here. Note that a
+	 * request reporting success does not mean the whole body arrived: see the
+	 * comment there.
+	 */
 	return total_request_bytes;
 }
 

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -1,8 +1,10 @@
 import os
 import pytest
+import socket
 import threading
 import time
 from decimal import Decimal
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from utils_pytest import *
 
 CACHE_FILE_PREFIX = "pgl-cache."
@@ -86,6 +88,173 @@ def test_cache_rejects_non_regular_file(s3, pgduck_conn, tmp_path):
     assert cached_path.is_file() and not cached_path.is_symlink()
     assert cached_path.stat().st_size == real_size
     assert (cached_path.stat().st_mode & 0o777) == 0o600
+
+    run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
+    pgduck_conn.rollback()
+
+
+TRUNCATED_BODY_SIZE = 64 * 1024
+TRUNCATED_BODY_SENT = 4 * 1024
+
+
+@pytest.fixture(scope="module")
+def flaky_http_server():
+    """Truncate the first GET of the body, then serve it in full.
+
+    This is the case that corrupts silently. A body that is *always* short ends
+    up failing anyway, because HTTPUtil::SendRequest runs out of retries and
+    throws -- so it proves nothing about the download path. Truncating only the
+    first attempt lets the retry succeed, and a successful retry is what leaves
+    the partial attempt and the complete one both in the output file.
+
+    The handler keeps its own state so that a re-run does not inherit a counter.
+    """
+
+    state = {"gets": 0}
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _headers(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(TRUNCATED_BODY_SIZE))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+
+        def do_HEAD(self):
+            self._headers()
+
+        def do_GET(self):
+            state["gets"] += 1
+            first = state["gets"] == 1
+            self._headers()
+            self.wfile.write(
+                b"x" * (TRUNCATED_BODY_SENT if first else TRUNCATED_BODY_SIZE)
+            )
+            self.wfile.flush()
+            if first:
+                self.close_connection = True
+
+        def log_message(self, *args):
+            pass
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield port, state
+
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=10)
+
+
+def test_retried_download_is_not_cached(flaky_http_server, pgduck_conn):
+    """A download whose retry succeeded must still match the object.
+
+    HTTPUtil::SendRequest retries a request error by re-running the content
+    handler from the start of the body, and the handler appends to an output
+    file that still holds whatever the previous attempt delivered. So a retry
+    that succeeds leaves a partial copy followed by a complete one: longer than
+    the object, with no exception, and reported as success.
+
+    Nothing revalidates a finalized cache entry against object storage, so that
+    entry would be served for every later read of the URL. For an Avro manifest
+    the second copy begins exactly where the reader looks for the next block
+    header, which is the shape that produces the corruption in #550.
+    """
+    port, state = flaky_http_server
+    url = f"http://127.0.0.1:{port}/flaky.bin"
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/http/127.0.0.1:{port}"
+        f"/{CACHE_FILE_PREFIX}flaky.bin"
+    )
+    stage_path = Path(f"{cached_path}.pgl-stage")
+
+    error = run_query(
+        f"CALL pg_lake_cache_file('{url}');", pgduck_conn, raise_error=False
+    )
+    pgduck_conn.rollback()
+
+    # Guards against the test passing for the wrong reason: the request has to
+    # have been retried, otherwise this is just a plain failed download.
+    assert state["gets"] >= 2, (
+        f"the download was not retried ({state['gets']} GET(s)), so the "
+        f"accumulation this test is about never happened"
+    )
+
+    cached_size = cached_path.stat().st_size if cached_path.exists() else None
+    assert isinstance(error, str), (
+        f"a retried download was cached as {cached_size} bytes for a "
+        f"{TRUNCATED_BODY_SIZE}-byte object"
+    )
+    assert not cached_path.exists(), f"over-long download was published: {cached_path}"
+
+    # The rejected download stays staged, which is deliberate: the sweep at the
+    # top of ManageCache reclaims it. Nothing races us for it here -- this suite
+    # talks to pgduck_server directly, so there is no cache worker running, and
+    # unwinding out of CacheFile released the lock the sweep needs.
+    assert stage_path.exists(), (
+        f"expected the rejected download to stay staged for the sweep to "
+        f"reclaim: {stage_path}"
+    )
+
+    # A budget far above the cache contents, so this only exercises the staging
+    # sweep and does not evict anything another test cached.
+    run_command("SELECT count(*) FROM pg_lake_manage_cache(21474836480);", pgduck_conn)
+    pgduck_conn.rollback()
+
+    assert (
+        not stage_path.exists()
+    ), f"sweep did not reclaim the staging file: {stage_path}"
+
+
+def test_azure_download_is_length_checked(azure, pgduck_conn):
+    """Azure goes through the same length check, and is not tripped up by it.
+
+    The check lives in FileUtils::CopyFile rather than in the http/s3 download
+    helper, because CopyFile dispatches on the file system name and only
+    HTTPFileSystem and RegionAwareS3FileSystem use that helper. Azure registers
+    as AzureBlobStorageFileSystem / AzureDfsStorageFileSystem, so it takes the
+    generic Read/Write loop and would otherwise be left unverified.
+
+    A truncated Azure body cannot be provoked here -- azurite serves what it is
+    given -- so the truncation case is covered by the http test above, where the
+    server is ours. What this pins down is that the generic branch is subject to
+    the check and that a healthy transfer satisfies it, byte for byte, which is
+    what a wrong expected-size would break.
+    """
+    key = "test_azure_download_is_length_checked/data.csv"
+    url = f"az://{TEST_BUCKET}/{key}"
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/az/{TEST_BUCKET}"
+        f"/test_azure_download_is_length_checked/{CACHE_FILE_PREFIX}data.csv"
+    )
+
+    run_command(
+        f"COPY (SELECT * FROM generate_series(1,5000)) TO '{url}' WITH (header false);",
+        pgduck_conn,
+    )
+
+    remote_size = pg_lake_file_size(f"nocache{url}", pgduck_conn)
+
+    # Writing the blob populated the cache on the way out, so drop that entry
+    # first. Without this, pg_lake_cache_file finds the file already cached and
+    # returns without copying anything, and the check would never be reached.
+    run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
+    assert not cached_path.exists(), "cache entry survived the uncache"
+
+    run_command(f"CALL pg_lake_cache_file('{url}');", pgduck_conn)
+
+    assert cached_path.exists(), f"azure blob was not cached: {cached_path}"
+    assert local_file_size(str(cached_path)) == remote_size, (
+        f"cache entry is {local_file_size(str(cached_path))} bytes for a "
+        f"{remote_size}-byte blob"
+    )
 
     run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
     pgduck_conn.rollback()


### PR DESCRIPTION
Closes #551. Follow-up to #550, found while implementing what I originally
thought was just a missing return-value check there.

## The problem

`PgLakeHTTPFileSystem::Download` streams a GET body into an output file and
returns the byte count without ever comparing it to the object. The interesting
part is not a plain short read -- it is what retries do with it.

`HTTPUtil::SendRequest` retries a request error (reset connection, TLS error,
read timeout) by re-running the content handler **from the start of the body**.
The handler appends, and the output file still holds whatever the previous
attempt delivered. So a retry that succeeds leaves the partial attempt followed
by a complete one:

* longer than the object,
* no exception,
* reported as success.

`FileCacheManager::CacheFileInternal` then renames that into place, and nothing
revalidates a finalized cache entry afterwards, so every later read of the URL
gets those bytes until it happens to be evicted.

For an Avro manifest the second copy begins exactly where the reader looks for
the next block header, which is the corruption #550 addressed -- but reached with
**no crash, no full disk and no orphaned staging file**, just one badly timed
network hiccup. That makes it a more plausible cause of the original incident
than what #550 fixed.

Worth noting for anyone reading #551: a body that is *always* short already
fails, because `SendRequest` throws once it runs out of retries. It is the
**transient** case that corrupts silently, which is why the test truncates only
the first attempt and asserts the request really was retried.

## The fix

Compare the bytes written against the length established when the handle was
opened, and fail the download if they disagree. Zero length means the server did
not tell us the size, so there is nothing to compare against.

Rejecting is safe rather than disruptive: the cache manager records `ADD_FAILED`
and moves on, reads keep going to object storage and get correct data, and the
next read of the URL registers it as a candidate again so a later pass retries.
The same reasoning makes the one false positive harmless -- an object
legitimately replaced mid-download costs a skipped cache fill and nothing else.

~~I considered making each retry start from a clean slate instead, by truncating
the output between attempts. That is the more complete fix, but the public
`HTTPUtil::Request` has no retry-callback hook, so it means driving
`RunRequestWithRetry` directly and reimplementing what `SendRequest` does around
it.~~

**Correction** (thanks @sfc-gh-mslot): a per-attempt hook *does* exist. The
response handler passed to `GetRequestInfo` runs once per attempt, because
`RunRequestWithRetry` re-invokes `on_request` and `HTTPLibClient::Get` passes both
handlers through every time. What is actually missing is a retry *callback* on the
public `HTTPUtil::Request`, and I over-generalised from that.

So resetting the byte count and rewinding the output in that handler would give
each attempt a clean slate, turning a transient mid-body drop into a retry rather
than a failed cache fill. Left as a follow-up rather than done here, because
`FileSystem::Truncate` default-throws `NotImplementedException` and s3fs does not
override it, so a reset has to be conditional on what the destination supports --
`pg_lake_copy_file(s3://a, s3://b)` reaches this path with an S3 destination. The
post-condition check stands on its own regardless: it catches the short outcome
too, which a per-attempt reset would not.

The rejected file stays staged, and the sweep at the top of `ManageCache`
reclaims it. That is deliberate rather than an omission: unwinding out of
`CacheFile` releases the cache lock the sweep needs, and the sweep runs on every
pass regardless of the size budget, so there is nothing to clean up here and no
second copy of the cleanup to keep in step. I had an eager cleanup in the first
version of this and dropped it on review -- the exposure is bounded by one
`cache_manager_interval` (10s by default) and by one staged file per URL, which
is not worth a duplicate code path.

## Test plan

New `test_retried_download_is_not_cached` stands up a stub HTTP server that
truncates the first GET and serves the body in full afterwards, so the retry
succeeds and the accumulation actually happens. It asserts the request was
retried, so it cannot pass for the wrong reason -- my first attempt at this test
used an always-short body and passed without the fix, because that path already
throws.

Without the change:

```
AssertionError: a retried download was cached as 69632 bytes for a 65536-byte object
```

4096 bytes from the first attempt plus the full 65536 from the retry. With it:

```
IO Error: Downloaded 69632 bytes of 'http://127.0.0.1:.../flaky.bin' but it is
65536 bytes; the transfer was incomplete or was retried
```

The test also asserts the staging file *is* present afterwards, then that a
single `pg_lake_manage_cache` call removes it -- so the sweep this relies on is
covered rather than assumed.

`check-pgduck_server` caching suite: 22 passed, 1 error (`azurite` not installed
locally). `make check-indent` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

