### PR TITLE
duckdb_pglake: fix libpq resource leaks in duckdb-postgres

### DIFF
--- a/duckdb_pglake/patches/duckdb-postgres/libpq-resource-leaks.patch
+++ b/duckdb_pglake/patches/duckdb-postgres/libpq-resource-leaks.patch
@@ -1,0 +1,115 @@
+diff --git a/src/postgres_binary_reader.cpp b/src/postgres_binary_reader.cpp
+index 86ebe30..fea0b5f 100644
+--- a/src/postgres_binary_reader.cpp
++++ b/src/postgres_binary_reader.cpp
+@@ -83,12 +83,16 @@ bool PostgresBinaryReader::Next() {
+ 		return false;
+ 	}
+ 
++	// take ownership of the buffer before validating it, so that a short read
++	// does not leak it - PQgetCopyData allocates even when it returns a length
++	// we cannot use
++	buffer = new_buffer;
++
+ 	// len -2 is error
+ 	// we expect at least 2 bytes in each message for the tuple count
+ 	if (!new_buffer || len < sizeof(int16_t)) {
+ 		throw IOException("Unable to read binary COPY data from Postgres: %s", string(PQerrorMessage(con.GetConn())));
+ 	}
+-	buffer = new_buffer;
+ 	buffer_ptr = buffer;
+ 	end = buffer + len;
+ 	return true;
+diff --git a/src/postgres_connection.cpp b/src/postgres_connection.cpp
+index 4baf81b..5334d41 100644
+--- a/src/postgres_connection.cpp
++++ b/src/postgres_connection.cpp
+@@ -103,6 +103,7 @@ vector<unique_ptr<PostgresResult>> PostgresConnection::ExecuteQueries(const stri
+ 		throw std::runtime_error("Failed to execute query \"" + queries + "\": " + string(PQerrorMessage(GetConn())));
+ 	}
+ 	vector<unique_ptr<PostgresResult>> results;
++	string error_message;
+ 	while (true) {
+ 		auto res = PQgetResult(GetConn());
+ 		if (!res) {
+@@ -110,14 +111,22 @@ vector<unique_ptr<PostgresResult>> PostgresConnection::ExecuteQueries(const stri
+ 		}
+ 		auto result = make_uniq<PostgresResult>(res);
+ 		if (ResultHasError(res)) {
+-			throw std::runtime_error("Failed to execute query \"" + queries +
+-			                         "\": " + string(PQresultErrorMessage(res)));
++			// keep draining - throwing here would leave the remaining results
++			// queued on the connection, which then rejects the next PQsendQuery
++			// with "another command is already in progress"
++			if (error_message.empty()) {
++				error_message = "Failed to execute query \"" + queries + "\": " + string(PQresultErrorMessage(res));
++			}
++			continue;
+ 		}
+ 		if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+ 			continue;
+ 		}
+ 		results.push_back(std::move(result));
+ 	}
++	if (!error_message.empty()) {
++		throw std::runtime_error(error_message);
++	}
+ 	return results;
+ }
+ 
+diff --git a/src/postgres_copy_from.cpp b/src/postgres_copy_from.cpp
+index 7108ae2..28b40c3 100644
+--- a/src/postgres_copy_from.cpp
++++ b/src/postgres_copy_from.cpp
+@@ -7,7 +7,8 @@ void PostgresConnection::BeginCopyFrom(const string &query, ExecStatusType expec
+ 	PostgresResult pg_res(PQExecute(query.c_str()));
+ 	auto result = pg_res.res;
+ 	if (!result || PQresultStatus(result) != expected_result) {
+-		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
++		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
++		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(error));
+ 	}
+ }
+ 
+diff --git a/src/postgres_copy_to.cpp b/src/postgres_copy_to.cpp
+index a235b45..498e325 100644
+--- a/src/postgres_copy_to.cpp
++++ b/src/postgres_copy_to.cpp
+@@ -59,7 +59,8 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
+ 	PostgresResult pg_res(PQExecute(query.c_str()));
+ 	auto result = pg_res.res;
+ 	if (!result || PQresultStatus(result) != PGRES_COPY_IN) {
+-		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
++		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
++		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(error));
+ 	}
+ 	if (state.format == PostgresCopyFormat::BINARY) {
+ 		// binary copy requires a header
+@@ -108,8 +109,8 @@ void PostgresConnection::FinishCopyTo(PostgresCopyState &state) {
+ 	PostgresResult pg_res(PQgetResult(GetConn()));
+ 	auto result = pg_res.res;
+ 	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK) {
+-		string error_msg(PQresultErrorMessage(result));
+-		throw std::runtime_error("Failed to copy data: " + error_msg);
++		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
++		throw std::runtime_error("Failed to copy data: " + string(error));
+ 	}
+ }
+ 
+diff --git a/src/postgres_utils.cpp b/src/postgres_utils.cpp
+index 90490a0..0f6794f 100644
+--- a/src/postgres_utils.cpp
++++ b/src/postgres_utils.cpp
+@@ -14,7 +14,11 @@ PGconn *PostgresUtils::PGConnect(const string &dsn, const string &attach_path) {
+ 
+ 	// both PQStatus and PQerrorMessage check for nullptr
+ 	if (PQstatus(conn) == CONNECTION_BAD) {
+-		throw IOException("Unable to connect to Postgres at \"%s\": %s", attach_path, string(PQerrorMessage(conn)));
++		// PQconnectdb allocates the PGconn even when the connection fails, so it
++		// still has to be handed back with PQfinish
++		string error_message(PQerrorMessage(conn));
++		PQfinish(conn);
++		throw IOException("Unable to connect to Postgres at \"%s\": %s", attach_path, error_message);
+ 	}
+ 	PQsetNoticeProcessor(conn, PGNoticeProcessor, nullptr);
+ 	return conn;


### PR DESCRIPTION
## Problem

Issue #415 reported four libpq resource bugs in the vendored duckdb-postgres. All four are real at the pinned submodule commit.

The one that matters is `PGConnect()` throwing without calling `PQfinish()`. `PQconnectdb` allocates the `PGconn` even when the connection fails, so a failed `postgres_scan` leaks it. `pgduck_server` is long lived, so anything that retries against an unreachable source Postgres grows it without bound. Measured on a private `pgduck_server`, 2000 failed `postgres_scan` calls took RSS from 78.8 MB to 116.5 MB, and the next 2000 added the same again, so about 19 kB per attempt and nothing given back.

`ExecuteQueries()` throws on the first bad result and leaves the rest of the libpq pipeline queued. The results themselves are freed when the connection eventually closes, so the leak is small, but the connection goes back to the pool still busy and the next `PQsendQuery` on it fails with `another command is already in progress` rather than running. `LoadEntries()` sends five concatenated statements over one connection, so it is the caller that hits this.

The other two are error paths that are hard to reach: `PostgresBinaryReader::Next()` leaks the `PQgetCopyData` buffer if a COPY message is shorter than the tuple count it has to contain, and three COPY error paths pass a possibly null `PGresult` to `PQresultErrorMessage()`. The second is not a crash, current libpq returns an empty string, but it is how `Failed to copy data: ` with no reason after it gets produced.

## Solution

A new `patches/duckdb-postgres/libpq-resource-leaks.patch`, in the same style as the patches already there.

`PGConnect()` reads the message, calls `PQfinish()`, then throws. `ExecuteQueries()` drains every result and throws the first error afterwards. `Next()` takes ownership of the buffer before validating the length, so `Reset()` frees it on the way out. The COPY error paths fall back to `PQerrorMessage()` when there is no result, which is what `ExecuteQueries()` and `PostgresQueryBind()` already do.

The first two are already fixed on duckdb-postgres main, so this patch should be dropped when the submodule pin moves past them. The other two are in duckdb/duckdb-postgres#555.

## Test plan

Confirmed the leak first, outside pg_lake, with a standalone libpq program: 2000 failed `PQconnectdb` calls without `PQfinish` grow RSS by 31.8 MB, with `PQfinish` by 20 kB. The same program shows the abandoned pipeline wedging a connection, where the next `PQsendQuery` returns `another command is already in progress` while `PQexec` still works because `PQexecStart` drains for you.

Then end to end. With the patch built in, `pgduck_server` RSS over failed `postgres_scan` calls against an unreachable Postgres:

```
before:  80120 kB
2000:    80144 kB
4000:    80080 kB
6000:    80080 kB
```

against 78792 -> 116452 -> 154008 kB for the same run without it. Error messages are unchanged.

Verified all eight duckdb-postgres patches still apply in `sort` order, which is the order `patch_duckdb` uses.

Closes #415.
