### PR TITLE
Wait for reloaded GUCs before the first REST catalog test runs

### DIFF
--- a/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
+++ b/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
@@ -400,40 +400,22 @@ def test_writable_rest_iceberg_table(
 
 @pytest.fixture(scope="module")
 def set_polaris_gucs(
+    pg_conn,
     superuser_conn,
+    app_user,
     extension,
     installcheck,
     credentials_file: str = server_params.POLARIS_PRINCIPAL_CREDS_FILE,
 ):
+    # Same as the helpers.polaris fixture of this name, but hung off the
+    # pg_lake `extension` fixture rather than `iceberg_extension`.
     if not installcheck:
-
-        creds = json.loads(Path(credentials_file).read_text())
-        client_id = creds["credentials"]["clientId"]
-        client_secret = creds["credentials"]["clientSecret"]
-
-        run_command_outside_tx(
-            [
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO '{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}'""",
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO '{client_id}'""",
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO '{client_secret}'""",
-                "SELECT pg_reload_conf()",
-            ],
-            superuser_conn,
-        )
+        apply_polaris_gucs([pg_conn, superuser_conn], app_user, credentials_file)
 
     yield
 
     if not installcheck:
-
-        run_command_outside_tx(
-            [
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host""",
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id""",
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret""",
-                "SELECT pg_reload_conf()",
-            ],
-            superuser_conn,
-        )
+        reset_polaris_gucs(app_user)
 
 
 @pytest.fixture(scope="module")

--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -4742,40 +4742,22 @@ def get_current_manifests(pg_conn, tbl_namespace, tbl_name):
 
 @pytest.fixture(scope="module")
 def set_polaris_gucs(
+    pg_conn,
     superuser_conn,
+    app_user,
     extension,
     installcheck,
     credentials_file: str = server_params.POLARIS_PRINCIPAL_CREDS_FILE,
 ):
+    # Same as the helpers.polaris fixture of this name, but hung off the
+    # pg_lake `extension` fixture rather than `iceberg_extension`.
     if not installcheck:
-
-        creds = json.loads(Path(credentials_file).read_text())
-        client_id = creds["credentials"]["clientId"]
-        client_secret = creds["credentials"]["clientSecret"]
-
-        run_command_outside_tx(
-            [
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO '{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}'""",
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO '{client_id}'""",
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO '{client_secret}'""",
-                "SELECT pg_reload_conf()",
-            ],
-            superuser_conn,
-        )
+        apply_polaris_gucs([pg_conn, superuser_conn], app_user, credentials_file)
 
     yield
 
     if not installcheck:
-
-        run_command_outside_tx(
-            [
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host""",
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id""",
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret""",
-                "SELECT pg_reload_conf()",
-            ],
-            superuser_conn,
-        )
+        reset_polaris_gucs(app_user)
 
 
 @pytest.fixture(scope="module")

--- a/test_common/helpers/db.py
+++ b/test_common/helpers/db.py
@@ -3,6 +3,7 @@
 import subprocess
 import threading
 import queue
+import time
 
 import psycopg2
 import psycopg2.extras
@@ -178,6 +179,39 @@ def run_command_outside_tx(query_list, raise_error=True):
     finally:
         conn.close()
 
+
+def wait_for_reloaded_settings(conns, expected, timeout=30):
+    """Wait until every connection in ``conns`` observes ``expected``.
+
+    ``pg_reload_conf()`` only signals the postmaster, so it returns before
+    the postmaster has re-read ``postgresql.auto.conf`` and before any
+    already-connected backend has processed its SIGHUP.  A statement sent
+    on an open connection right after ``ALTER SYSTEM SET`` can therefore
+    still see the old value.  Call this after the reload to make the new
+    values visible to the connections the test is about to use.
+
+    ``expected`` maps setting names to the values ``SHOW`` should report.
+    The roles behind ``conns`` must be able to read those settings; for a
+    GUC_SUPERUSER_ONLY setting that means superuser or pg_read_all_settings.
+
+    The transaction the polling opens is committed before returning, so the
+    caller is not left idle in transaction -- psycopg2 refuses to flip
+    autocommit on a connection with a transaction in progress.
+    """
+    deadline = time.monotonic() + timeout
+    for conn in conns:
+        for name, value in expected.items():
+            while True:
+                current = run_query(f"SHOW {name}", conn)[0][0]
+                if current == value:
+                    break
+                if time.monotonic() > deadline:
+                    raise AssertionError(
+                        f"{name} still reads {current!r} instead of {value!r} "
+                        f"{timeout}s after pg_reload_conf()"
+                    )
+                time.sleep(0.01)
+        conn.commit()
 
 
 # Example usage for thread_run_query() and thread_run_command():

--- a/test_common/helpers/polaris.py
+++ b/test_common/helpers/polaris.py
@@ -23,6 +23,7 @@ from utils_pytest import (
     AWS_ROLE_ARN,
     run_command_outside_tx,
     stop_process_via_pidfile,
+    wait_for_reloaded_settings,
 )
 
 
@@ -204,39 +205,68 @@ def polaris_session(installcheck) -> requests.Session:
     return sess
 
 
+def apply_polaris_gucs(conns, app_user, credentials_file):
+    """Point the REST catalog GUCs at the local Polaris server.
+
+    The GUCs go in via ALTER SYSTEM + pg_reload_conf(), which the
+    already-connected backends behind ``conns`` only pick up once they
+    have processed their SIGHUP -- so wait for them before returning,
+    or the first statement of the first test can still run without any
+    REST credentials.
+
+    The three GUCs are GUC_SUPERUSER_ONLY, so the application user cannot
+    SHOW them while waiting.  Grant it pg_read_all_settings, which is the
+    read-only role Postgres points at in that error.
+    """
+    creds = json.loads(Path(credentials_file).read_text())
+    client_id = creds["credentials"]["clientId"]
+    client_secret = creds["credentials"]["clientSecret"]
+    host = f"{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}"
+
+    run_command_outside_tx(
+        [
+            f"""GRANT pg_read_all_settings TO {app_user}""",
+            f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO '{host}'""",
+            f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO '{client_id}'""",
+            f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO '{client_secret}'""",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+    wait_for_reloaded_settings(
+        conns,
+        {
+            "pg_lake_iceberg.rest_catalog_host": host,
+            "pg_lake_iceberg.rest_catalog_client_id": client_id,
+            "pg_lake_iceberg.rest_catalog_client_secret": client_secret,
+        },
+    )
+
+
+def reset_polaris_gucs(app_user):
+    run_command_outside_tx(
+        [
+            f"""REVOKE pg_read_all_settings FROM {app_user}""",
+            """ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host""",
+            """ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id""",
+            """ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret""",
+            "SELECT pg_reload_conf()",
+        ]
+    )
+
+
 @pytest.fixture(scope="module")
 def set_polaris_gucs(
+    pg_conn,
     superuser_conn,
+    app_user,
     iceberg_extension,
     installcheck,
     credentials_file: str = server_params.POLARIS_PRINCIPAL_CREDS_FILE,
 ):
     if not installcheck:
-
-        creds = json.loads(Path(credentials_file).read_text())
-        client_id = creds["credentials"]["clientId"]
-        client_secret = creds["credentials"]["clientSecret"]
-
-        run_command_outside_tx(
-            [
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_host TO '{server_params.POLARIS_HOSTNAME}:{server_params.POLARIS_PORT}'""",
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_id TO '{client_id}'""",
-                f"""ALTER SYSTEM SET pg_lake_iceberg.rest_catalog_client_secret TO '{client_secret}'""",
-                "SELECT pg_reload_conf()",
-            ],
-            superuser_conn,
-        )
+        apply_polaris_gucs([pg_conn, superuser_conn], app_user, credentials_file)
 
     yield
 
     if not installcheck:
-
-        run_command_outside_tx(
-            [
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_host""",
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_id""",
-                f"""ALTER SYSTEM RESET pg_lake_iceberg.rest_catalog_client_secret""",
-                "SELECT pg_reload_conf()",
-            ],
-            superuser_conn,
-        )
+        reset_polaris_gucs(app_user)


### PR DESCRIPTION
`test_writable_rest_iceberg_table[rest-100-8-0]` errored at setup on main
([run 32659617669](https://github.com/Snowflake-Labs/pg_lake/actions/runs/32659617669)) with:

```
ERROR: no credentials found for REST catalog "rest"
```

It is the *first* test of `test_modify_iceberg_rest_table.py`, and the next test
in the same module passed, so the credentials were there a moment later.

### Cause

The module fixture sets the three REST catalog GUCs with `ALTER SYSTEM SET` +
`pg_reload_conf()`. `pg_reload_conf()` only sends SIGHUP to the postmaster; it
returns before the postmaster has re-read `postgresql.auto.conf` and before any
already-connected backend has processed its own SIGHUP. `pg_conn` and
`superuser_conn` are `scope="module"` and are constructed *before*
`set_polaris_gucs`, so the first statement of the first test can still run in a
backend that has not seen the new values yet.

Reproduced on this box with an unrelated SIGHUP-level GUC. On a pre-existing,
non-autocommit connection the immediate `SHOW` read the stale value on **25 of
25** reloads, converging within **11 ms**.

### Fix

After the reload, poll `SHOW` on each connection the module is about to use
until it reports the new value (30s cap, then a clear assertion). Only the SET
path waits: teardown keeps its plain `RESET`, so a leaked session-level `SET`
cannot turn into a teardown hang.

Two things the first version of this wait got wrong, both caught by CI on this
branch and fixed here:

* The `pg_lake_iceberg.rest_catalog_*` GUCs are `GUC_SUPERUSER_ONLY`
  (`pg_lake_iceberg/src/init.c`), and `pg_conn` connects as the non-superuser
  app user, so `SHOW` raised `permission denied to examine
  "pg_lake_iceberg.rest_catalog_host"`. That aborted `pg_conn`'s transaction and
  every later test in the module then failed at setup with
  `InFailedSqlTransaction` (44 errors in shard 2 alone). The fixture now grants
  `pg_read_all_settings` to the app user alongside the `ALTER SYSTEM SET`s and
  revokes it in teardown, matching how `pg_lake_table/tests/conftest.py` already
  grants `pg_read_server_files`.
* `SHOW` on a non-autocommit connection leaves a transaction open, and the
  function-scoped `adjust_object_store_settings` fixture then sets
  `superuser_conn.autocommit = True`, which psycopg2 rejects with
  `set_session cannot be used inside a transaction`. The wait now commits each
  connection before returning.

Also folded the three identical copies of this fixture onto shared
`apply_polaris_gucs()` / `reset_polaris_gucs()` helpers, and dropped the stray
positional connection argument they passed to `run_command_outside_tx()`, whose
signature is `(query_list, raise_error)`, so the connection was binding to
`raise_error`.

No test is skipped or relaxed.
