### PR TITLE
pgduck_server: stop interrupting a disconnected DuckDB connection

### DIFF
--- a/pgduck_server/include/pgserver/client_threadpool.h
+++ b/pgduck_server/include/pgserver/client_threadpool.h
@@ -41,7 +41,6 @@ extern int	pgclient_threadpool_cancel_thread(int cancellationProcId, uint8 *canc
 extern int	pgclient_threadpool_cancel_thread(int cancellationProcId, int32 cancellationToken);
 #endif
 extern void pgclient_threadpool_set_duckdb_conn(int threadIndex, duckdb_connection conn);
-extern void pgclient_threadpool_clear_duckdb_conn(int threadIndex);
 extern int	pgclient_threadpool_cancel_all(void);
 
 #endif							/* PGDUCK_CLIENT_THREAD_H */

--- a/pgduck_server/include/pgserver/client_threadpool.h
+++ b/pgduck_server/include/pgserver/client_threadpool.h
@@ -41,6 +41,7 @@ extern int	pgclient_threadpool_cancel_thread(int cancellationProcId, uint8 *canc
 extern int	pgclient_threadpool_cancel_thread(int cancellationProcId, int32 cancellationToken);
 #endif
 extern void pgclient_threadpool_set_duckdb_conn(int threadIndex, duckdb_connection conn);
+extern void pgclient_threadpool_clear_duckdb_conn(int threadIndex);
 extern int	pgclient_threadpool_cancel_all(void);
 
 #endif							/* PGDUCK_CLIENT_THREAD_H */

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -55,7 +55,14 @@ typedef struct PgClientThreadState
 	int32		cancellationToken;
 #endif
 
-	/* DuckDB connection to interrupt */
+	/*
+	 * DuckDB connection to interrupt.
+	 *
+	 * The cancel paths call duckdb_interrupt() on this pointer, so it must be
+	 * NULL whenever the connection behind it is not alive.  The thread owning
+	 * the slot has to clear it with pgclient_threadpool_clear_duckdb_conn()
+	 * *before* it disconnects, not when it frees the slot.
+	 */
 	duckdb_connection duckdbConnection;
 
 }			PgClientThreadState;
@@ -337,6 +344,29 @@ pgclient_threadpool_set_duckdb_conn(int threadIndex, duckdb_connection conn)
 	threadState->duckdbConnection = conn;
 
 	pthread_rwlock_unlock(&rwlock);
+}
+
+
+/*
+ * pgclient_threadpool_clear_duckdb_conn removes the DuckDB connection of a
+ * thread from the pool.
+ *
+ * A client thread must call this before disconnecting its DuckDB connection.
+ * The cancel paths read the pointer and call duckdb_interrupt() on it while
+ * holding the lock, so a connection that is left in the pool after
+ * duckdb_disconnect() gets interrupted after it has been freed: an incoming
+ * cancel request, or cancel_all() during shutdown, then dereferences freed
+ * memory and crashes the server.  Clearing under the write lock closes that
+ * window -- a cancel either runs before this call and finds a live
+ * connection, or after it and finds NULL.
+ *
+ * The slot itself stays reserved; it is released by
+ * pgclient_threadpool_free_slot() once the thread is done.
+ */
+void
+pgclient_threadpool_clear_duckdb_conn(int threadIndex)
+{
+	pgclient_threadpool_set_duckdb_conn(threadIndex, NULL);
 }
 
 

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -60,8 +60,8 @@ typedef struct PgClientThreadState
 	 *
 	 * The cancel paths call duckdb_interrupt() on this pointer, so it must be
 	 * NULL whenever the connection behind it is not alive.  The thread owning
-	 * the slot has to clear it with pgclient_threadpool_clear_duckdb_conn()
-	 * *before* it disconnects, not when it frees the slot.
+	 * the slot has to clear it (set_duckdb_conn with NULL) *before* it
+	 * disconnects, not when it frees the slot.
 	 */
 	duckdb_connection duckdbConnection;
 
@@ -344,29 +344,6 @@ pgclient_threadpool_set_duckdb_conn(int threadIndex, duckdb_connection conn)
 	threadState->duckdbConnection = conn;
 
 	pthread_rwlock_unlock(&rwlock);
-}
-
-
-/*
- * pgclient_threadpool_clear_duckdb_conn removes the DuckDB connection of a
- * thread from the pool.
- *
- * A client thread must call this before disconnecting its DuckDB connection.
- * The cancel paths read the pointer and call duckdb_interrupt() on it while
- * holding the lock, so a connection that is left in the pool after
- * duckdb_disconnect() gets interrupted after it has been freed: an incoming
- * cancel request, or cancel_all() during shutdown, then dereferences freed
- * memory and crashes the server.  Clearing under the write lock closes that
- * window -- a cancel either runs before this call and finds a live
- * connection, or after it and finds NULL.
- *
- * The slot itself stays reserved; it is released by
- * pgclient_threadpool_free_slot() once the thread is done.
- */
-void
-pgclient_threadpool_clear_duckdb_conn(int threadIndex)
-{
-	pgclient_threadpool_set_duckdb_conn(threadIndex, NULL);
 }
 
 

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -1142,6 +1142,13 @@ static int
 pgsession_destroy(PGSession * pgSession)
 {
 	pg_free(pgSession->pqSendBuffer);
+
+	/*
+	 * Take the connection out of the thread pool before disconnecting it, so
+	 * that a concurrent cancellation cannot interrupt a freed connection.
+	 */
+	pgclient_threadpool_clear_duckdb_conn(pgSession->pgClient->threadIndex);
+
 	duckdb_session_destroy(&pgSession->duckSession);
 	return OK;
 }

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -1144,10 +1144,13 @@ pgsession_destroy(PGSession * pgSession)
 	pg_free(pgSession->pqSendBuffer);
 
 	/*
-	 * Take the connection out of the thread pool before disconnecting it, so
-	 * that a concurrent cancellation cannot interrupt a freed connection.
+	 * Clear the connection in the thread pool before disconnecting it, so
+	 * that a concurrent cancellation cannot call duckdb_interrupt() on a
+	 * freed connection. Setting it under the write lock means a cancel either
+	 * runs before this and finds a live connection, or after it and finds
+	 * NULL.
 	 */
-	pgclient_threadpool_clear_duckdb_conn(pgSession->pgClient->threadIndex);
+	pgclient_threadpool_set_duckdb_conn(pgSession->pgClient->threadIndex, NULL);
 
 	duckdb_session_destroy(&pgSession->duckSession);
 	return OK;


### PR DESCRIPTION
`pgduck_server/tests/pytests/test_server_start.py::test_server_pidfile_signal`
flakes in CI: the final `assert not os.path.exists(pidfile_path)` fails, and the
server log of a failing run stops right after
`Shutting down: closing listening socket` and never reaches `Done running`.

### Cause

A client thread publishes its DuckDB connection in the thread pool
(`pgclient_threadpool_set_duckdb_conn`) so cancellations can
`duckdb_interrupt()` it. On the way out it disconnects that connection in
`pgsession_destroy()`, but the pool only finds out later, when
`pgclient_thread_cleanup()` releases the slot. In between, the slot is still
`isStarted` and still holds the pointer — so a concurrent cancellation
interrupts a freed connection:

```
#0  std::__atomic_base<bool>::store
#3  duckdb::ClientContext::Interrupt (this=0xfff137eccbf2)
#4  duckdb::Connection::Interrupt
#5  duckdb_interrupt
#6  pgclient_threadpool_cancel_all () at src/pgserver/client_threadpool.c:365
#7  pgserver_destroy () at src/pgserver/pgserver.c:542
#8  main () at src/main.c:104
```

That SIGSEGV is why the pidfile survives: it is unlinked from an `atexit`
handler, which a killed process never runs.

Two ways in, and the shutdown one is only the visible half:

* `pgclient_threadpool_cancel_all()` during shutdown — the flake.
* `pgclient_threadpool_cancel_thread()` when a cancel request happens to arrive
  while some other session is tearing down — same crash, at runtime.

The cancel paths do take the pool lock, and the comment there reasons that this
makes the interrupt safe. It doesn't: `duckdb_disconnect()` happens outside the
lock and before the slot is freed, so the lock protects the wrong window.

### Fix

Clear the pool's pointer under the write lock *before* disconnecting. A
cancellation then either runs before the clear and finds a live connection, or
after it and finds NULL.

### Verification

I widened the window with a temporary 3s sleep between the disconnect and the
slot release, then did connect → `select 1` → disconnect → `SIGTERM`:

* before: SIGSEGV every run (3/3), exit 139, pidfile left behind, log stops at
  `Shutting down: closing listening socket` — the backtrace above is from that
  core.
* after: exit 0 every run (3/3), `Done running` logged, pidfile removed.

`tests/pytests/test_server_start.py` passes (29 tests), as do
`test_cancellations.py` and `test_server_protocol_failures.py`.
(`test_simple_server.py::test_queries` fails on this box with a `_csv` field
limit error both with and without the change — unrelated.)

No test is skipped or relaxed.
