### PR TITLE
flaky tests: classify region mismatches by status code

### DIFF
--- a/duckdb_pglake/src/fs/region_aware_s3fs.cpp
+++ b/duckdb_pglake/src/fs/region_aware_s3fs.cpp
@@ -221,7 +221,7 @@ RegionAwareS3FileSystem::OpenFile(const string &url,
 
 /*
  * WithResolvedRegion runs s3Operation against an S3 URL, picking the region
- * from cache when available and falling back to GetBucketRegionFromS3 on a
+ * from cache when available and falling back to TryGetBucketRegionFromS3 on a
  * 400/301.
  *
  * Same shape as the old OpenFile: try once (with cached region or bare URL),

--- a/duckdb_pglake/src/fs/region_aware_s3fs.cpp
+++ b/duckdb_pglake/src/fs/region_aware_s3fs.cpp
@@ -617,6 +617,12 @@ RegionAwareS3FileSystem::GetBucketRegionFromS3(const string &url, optional_ptr<F
 	string bucketRootUrl = baseUrl + "/";
 
 	HeadRequestInfo headRequest(bucketRootUrl, requestHeaders, *httpParams);
+
+	/*
+	 * The request is unauthenticated, so S3 answers 403, or 301 when the
+	 * endpoint belongs to another region. httpfs returns those rather than
+	 * throwing, and the region header comes with them.
+	 */
 	unique_ptr<HTTPResponse> response = httpUtil.Request(headRequest, client);
 
 	if (!response->headers.HasHeader("x-amz-bucket-region"))
@@ -627,11 +633,10 @@ RegionAwareS3FileSystem::GetBucketRegionFromS3(const string &url, optional_ptr<F
 
 
 /*
- * TryGetBucketRegionFromS3 is GetBucketRegionFromS3 for callers that are
- * recovering from an error they still hold: it reports an unknown region when
- * the probe itself fails, so that the caller rethrows the error that made it
- * ask instead of one about the probe. The probe is unauthenticated and can fail
- * for reasons of its own, up to the endpoint not allowing it at all.
+ * TryGetBucketRegionFromS3 is GetBucketRegionFromS3 for callers that still hold
+ * the error that made them ask. The probe can fail for reasons of its own, up to
+ * the endpoint not allowing it at all, and an unknown region makes those callers
+ * rethrow their own error instead of one about the probe.
  */
 string
 RegionAwareS3FileSystem::TryGetBucketRegionFromS3(const string &url, optional_ptr<FileOpener> opener)

--- a/duckdb_pglake/src/fs/region_aware_s3fs.cpp
+++ b/duckdb_pglake/src/fs/region_aware_s3fs.cpp
@@ -52,6 +52,7 @@ static std::regex S3_EXPRESS_URL_PATTERN("s3://[a-z0-9-]+-([a-z0-9]+)-([a-z0-9]+
 static bool UrlHasQueryArgument(const string &url, const string &queryArgument);
 static string AddQueryArgumentToUrl(const string &url, const string &name, const string &value);
 static string RemoveQueryArgumentFromUrl(string url, const string &name);
+static bool LooksLikeRegionMismatch(const ErrorData &error);
 
 
 /*
@@ -133,18 +134,13 @@ RegionAwareS3FileSystem::List(const string &urlPattern, bool isGlob, FileOpener 
 			if (error.Type() != ExceptionType::HTTP)
 				throw;
 
-			/*
-			 * Slightly hacky to check for error messages, but we don't get
-			 * detailed error codes.
-			 */
-			if (error.Message().find("HTTP 400") != std::string::npos ||
-				error.Message().find("no list response") != std::string::npos ||
-				error.Message().find("301") != std::string::npos)
+			if (LooksLikeRegionMismatch(error) ||
+				error.Message().find("no list response") != std::string::npos)
 			{
 				PGDUCK_SERVER_DEBUG("Glob failed: %s", error.Message().c_str());
 
 				/* get the actual region from S3 headers */
-				string actualRegion = GetBucketRegionFromS3(urlPattern, opener);
+				string actualRegion = TryGetBucketRegionFromS3(urlPattern, opener);
 
 				/* could not determine region, fall back to original error */
 				if (actualRegion.empty())
@@ -296,19 +292,13 @@ RegionAwareS3FileSystem::WithResolvedRegion(const string &url,
 		if (error.Type() != ExceptionType::HTTP)
 			throw;
 
-		/*
-		 * A 400 error usually indicates wrong region, we get slightly different
-		 * errors for GET and PUT.
-		 */
-		if (error.Message().find("HTTP 400") == std::string::npos &&
-			error.Message().find("400 (Bad Request)") == std::string::npos &&
-			error.Message().find("301") == std::string::npos)
+		if (!LooksLikeRegionMismatch(error))
 			throw;
 
 		PGDUCK_SERVER_DEBUG("S3 operation failed (retrying with refreshed region): %s", error.Message().c_str());
 
 		/* get the actual region from S3 headers */
-		string actualRegion = GetBucketRegionFromS3(url, opener);
+		string actualRegion = TryGetBucketRegionFromS3(url, opener);
 
 		/* could not determine region, fall back to original error */
 		if (actualRegion.empty())
@@ -320,6 +310,37 @@ RegionAwareS3FileSystem::WithResolvedRegion(const string &url,
 		/* retry with the actual region (and hope for the best) */
 		s3Operation(AddQueryArgumentToUrl(url, "s3_region", actualRegion));
 	}
+}
+
+
+/*
+ * LooksLikeRegionMismatch determines whether an HTTP error is one that S3
+ * returns when the request went to the wrong region: 400 for the legacy
+ * endpoint, 301 for a redirect to the right one.
+ *
+ * httpfs attaches the status code to the error, so use that when it is there.
+ * Some error paths only give us a message, in which case we have to look for
+ * the status in the text. That text also contains the URL we tried to read, so
+ * the patterns have to be specific enough not to match an object key: a bare
+ * "301" matches roughly 1 in 100 of the uuid-named data files that Iceberg
+ * writes, and misreading an "access denied" as a region mismatch replaces it
+ * with whatever the region probe happens to return.
+ */
+static bool
+LooksLikeRegionMismatch(const ErrorData &error)
+{
+	const unordered_map<string, string> &extraInfo = error.ExtraInfo();
+	auto statusCode = extraInfo.find("status_code");
+
+	if (statusCode != extraInfo.end())
+		return statusCode->second == "400" || statusCode->second == "301";
+
+	const string &message = error.Message();
+
+	return message.find("HTTP 400") != std::string::npos ||
+		   message.find("400 (Bad Request)") != std::string::npos ||
+		   message.find("HTTP 301") != std::string::npos ||
+		   message.find("301 (Moved Permanently)") != std::string::npos;
 }
 
 
@@ -591,13 +612,39 @@ RegionAwareS3FileSystem::GetBucketRegionFromS3(const string &url, optional_ptr<F
 	unique_ptr<HTTPClient> client = httpUtil.InitializeClient(*httpParams, baseUrl);
 
 	HTTPHeaders requestHeaders;
-	HeadRequestInfo headRequest(baseUrl + "/", requestHeaders, *httpParams);
+
+	/* HeadRequestInfo keeps a reference to the URL, so it has to outlive the request */
+	string bucketRootUrl = baseUrl + "/";
+
+	HeadRequestInfo headRequest(bucketRootUrl, requestHeaders, *httpParams);
 	unique_ptr<HTTPResponse> response = httpUtil.Request(headRequest, client);
 
 	if (!response->headers.HasHeader("x-amz-bucket-region"))
 		return string();
 
 	return response->headers.GetHeaderValue("x-amz-bucket-region");
+}
+
+
+/*
+ * TryGetBucketRegionFromS3 is GetBucketRegionFromS3 for callers that are
+ * recovering from an error they still hold: it reports an unknown region when
+ * the probe itself fails, so that the caller rethrows the error that made it
+ * ask instead of one about the probe. The probe is unauthenticated and can fail
+ * for reasons of its own, up to the endpoint not allowing it at all.
+ */
+string
+RegionAwareS3FileSystem::TryGetBucketRegionFromS3(const string &url, optional_ptr<FileOpener> opener)
+{
+	try
+	{
+		return GetBucketRegionFromS3(url, opener);
+	}
+	catch (std::exception &ex)
+	{
+		PGDUCK_SERVER_DEBUG("could not determine region of %s: %s", url.c_str(), ex.what());
+		return string();
+	}
 }
 
 

--- a/duckdb_pglake/src/include/pg_lake/fs/region_aware_s3fs.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/region_aware_s3fs.hpp
@@ -60,6 +60,7 @@ public:
 	void ClearCachedRegion(const string &bucketUrl,
 						   optional_ptr<FileOpener> opener);
 	string GetBucketRegionFromS3(const string &url, optional_ptr<FileOpener> opener);
+	string TryGetBucketRegionFromS3(const string &url, optional_ptr<FileOpener> opener);
 	string GetBucketRegion(const string &url, optional_ptr<FileOpener> opener);
 	vector<OpenFileInfo> List(const string &globPattern, bool isGlob, FileOpener *opener);
 

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -283,21 +283,23 @@ def test_denied_key_containing_301_keeps_its_own_error(
         "region301_reader", [f"{prefix}_allowed"]
     )
 
-    perform_query(
-        f"""
+    # DuckDB holds secrets in a transactional catalog set, and a denied read
+    # aborts the transaction it ran in -- so the rollback that clears the abort
+    # takes the secret with it. Re-assert it before each read; without it the
+    # second read has no endpoint and goes to the real s3.amazonaws.com.
+    create_secret = f"""
         CREATE OR REPLACE SECRET region301 (
             TYPE S3, KEY_ID '{access_key_id}', SECRET '{secret_access_key}',
             REGION '{server.region}', ENDPOINT '{server.endpoint}',
             SCOPE 's3://{server.bucket}/{prefix}',
             URL_STYLE 'path', USE_SSL false
         );
-        """,
-        pgduck_conn,
-    )
+        """
     server.enforce()
 
     try:
         for key in keys:
+            perform_query(create_secret, pgduck_conn)
             error = run_command(
                 f"SELECT count(*) FROM read_parquet('s3://{server.bucket}/{key}')",
                 pgduck_conn,
@@ -307,6 +309,9 @@ def test_denied_key_containing_301_keeps_its_own_error(
 
             assert error is not None, f"the read of {key} was not denied"
             assert "403" in error, f"expected a denial for {key}, got: {error}"
+            # a read that lost the secret leaves for the real S3, which can deny
+            # it too -- for having no credentials, which proves nothing here
+            assert server.endpoint in error, f"{key} missed moto: {error}"
             assert key in error, f"{key}: the error is about another request: {error}"
     finally:
         server.relax()

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -239,17 +239,15 @@ def test_s3_express(pgduck_conn):
     pgduck_conn.rollback()
 
 
-# This test outputs a bad host name that seems like some sort of memory corruption at play
 def test_s3_get_region_invalid(pgduck_conn):
+    """A bucket whose host does not resolve reports the connection failure, with
+    the URL it failed on."""
     error = run_command(
         "select pg_lake_get_bucket_region('s3://.../abc/') test",
         pgduck_conn,
         raise_error=False,
     )
-    assert (
-        "Could not resolve hostname error" in error
-        or "server closed the connection" in error
-    )
+    assert "Could not resolve hostname error for HTTP HEAD to 'https://" in error
 
     # The failed statement above aborts the transaction on this module-scoped
     # connection; roll back so the following tests start clean.

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -254,6 +254,66 @@ def test_s3_get_region_invalid(pgduck_conn):
     pgduck_conn.rollback()
 
 
+def test_denied_key_containing_301_keeps_its_own_error(
+    enforcing_s3_server, pgduck_conn
+):
+    """A denied read reports the denial, on an object whose key happens to
+    contain a substring that reads like a redirect status.
+
+    RegionAwareS3FileSystem retries against a freshly probed region when a
+    request looks like it went to the wrong one, and it used to decide that by
+    searching the error text for "301". That text carries the URL of the object,
+    and Iceberg names data files after a uuid, so about one key in a hundred
+    turned an unrelated failure into a region probe -- whose own error then
+    replaced the denial the caller was about to report.
+
+    The second key is the control: it differs only in not containing "301"."""
+    server = enforcing_s3_server
+    prefix = "region_mismatch_classification"
+    keys = [
+        f"{prefix}/00000-0-3016a9de-0e0f-4a1b-9f0e-3b0d1e2f4a5b.parquet",
+        f"{prefix}/00000-0-7c4a9de0-0e0f-4a1b-9f0e-3b0d1e2f4a5b.parquet",
+    ]
+
+    for key in keys:
+        server.client().put_object(Bucket=server.bucket, Key=key, Body=b"denied")
+
+    # allowed under a sibling prefix only, so every read below is denied
+    access_key_id, secret_access_key = server.create_scoped_user(
+        "region301_reader", [f"{prefix}_allowed"]
+    )
+
+    perform_query(
+        f"""
+        CREATE OR REPLACE SECRET region301 (
+            TYPE S3, KEY_ID '{access_key_id}', SECRET '{secret_access_key}',
+            REGION '{server.region}', ENDPOINT '{server.endpoint}',
+            SCOPE 's3://{server.bucket}/{prefix}',
+            URL_STYLE 'path', USE_SSL false
+        );
+        """,
+        pgduck_conn,
+    )
+    server.enforce()
+
+    try:
+        for key in keys:
+            error = run_command(
+                f"SELECT count(*) FROM read_parquet('s3://{server.bucket}/{key}')",
+                pgduck_conn,
+                raise_error=False,
+            )
+            pgduck_conn.rollback()
+
+            assert error is not None, f"the read of {key} was not denied"
+            assert "403" in error, f"expected a denial for {key}, got: {error}"
+            assert key in error, f"{key}: the error is about another request: {error}"
+    finally:
+        server.relax()
+        perform_query("DROP SECRET IF EXISTS region301", pgduck_conn)
+        pgduck_conn.rollback()
+
+
 def test_pg_lake_remove_file_glob_recursive(s3, pgduck_conn):
     """The glob + pg_lake_remove_file form that DeleteRemotePrefix uses deletes
     every object under a prefix, recursing into sub-prefixes, and leaves objects


### PR DESCRIPTION
This is the nightly flaky test fix. Fixes #599.


`test_vended_credentials_enforced.py::test_two_principals_get_their_own_credentials`
fails intermittently in CI:

```
AssertionError: the second role was served the first role's credential: its
scan should have been denied, got: 'HTTP Error: Request returned HTTP 500 for
HTTP HEAD to \':\xc9\xc7\xff\xff\x00\x00G\xa1\x9d?\x9e)z\x00\x00\x00\x00\x00\x00\x00\''
```

The test is right that the scan was denied; it is the error text that is wrong.

Any test in that file can draw it, since what decides is the name of the data
file the scan happens to read. `test_scan_denied_without_vended_credentials`
drew it on 2026-08-27 (run 33038881094):

```
AssertionError: expected an access-denied error, got: "ERROR:  HTTP Error:
Request returned HTTP 500 for HTTP HEAD to
'\xef\xbf\xbd\xef\xbf\xbd\x01\xef\xbf\xbd\xef\xbf\xbd\x7f\\0\\0`\xef\xbf\xbd\\0\xef\xbf\xbd\xef\xbf\xbd\x7f\\0\\0\x04\\0\\0\\0\xef\xbf\xbd\x7f\\0'\n"
```

## Root cause

`RegionAwareS3FileSystem` decides whether a request went to the wrong region by
searching the error *message* for `HTTP 400` or `301`. The message contains the
URL of the object we tried to read, and Iceberg names data files
`00000-0-<uuid4>.parquet` — so with probability ~1% the object name itself
contains `301`, and an unrelated failure is classified as a region redirect.

What follows in that case: `GetBucketRegionFromS3()` sends an unauthenticated
`HEAD` to the bucket root, moto answers 500 under credential enforcement, and
because the probe throws, its error replaces the `AccessDenied` the test is
asserting on. The denial the test wanted to see is gone.

Two smaller bugs on that path made the message unreadable and the failure
harder to place:

- `HeadRequestInfo` (`BaseRequest`) holds `const string &url`, and it was
  constructed from `baseUrl + "/"` — a temporary that dies at the end of the
  declaration. Every later read of `request.url`, including the error message
  in `HTTPUtil::RunRequestWithRetry`, reads freed memory. That is the garbage
  above.
- `GetBucketRegionFromS3()` let the probe's exception escape, so a failed probe
  replaced the caller's error instead of leaving it alone. Both callers already
  handle "region unknown" by rethrowing the original error.

## Fix

Classify by status code. httpfs attaches `status_code` to the `ErrorData`
extra info, so use that when it is present; the 403 is then simply not a region
mismatch, whatever the object is called. pg_lake's own download path in
`httpfs_extended.cpp` built its `HTTPException` from a string, which dropped the
status, so pass the response instead. Where only a message is available, match
`HTTP 301` / `301 (Moved Permanently)` instead of a bare `301`.

Then hold the probe URL in a local so the request's reference stays valid, and
return an empty region when the probe fails.

No test is skipped, relaxed, or retried.

## Verification

Reproduced deterministically outside the pytest harness, against a local
`pgduck_server` and an S3 stand-in that returns 403 for object `GET`s and 500
for `HEAD /` (what moto does with credential enforcement on):

```
-- before, key contains "301"
ERROR:  HTTP Error: Request returned HTTP 500 for HTTP HEAD to ':<garbage>'
-- before, key does not
ERROR:  HTTP Error: HTTP GET error on 'http://127.0.0.1:18099/bkt/.../00000-0-aaaafffbbbb.parquet' (HTTP 403)
```

After, both report `HTTP 403`, which is what `_denied()` in the test checks
for:

```
ERROR:  HTTP Error: HTTP GET error on 'http://127.0.0.1:18099/bkt/.../00000-0-aaaa301bbbb.parquet' (HTTP 403)
```

Region resolution itself still works: against a second stand-in that answers
object `GET`s with `301` + `x-amz-bucket-region: us-west-2` and the bucket-root
`HEAD` with 200 + the same header, the scan succeeds and the server logs

```
LOG requests for s3://bkt2 will use region us-west-2
```

The dangling reference is a use-after-free on its own, independent of which
error message it ends up in. Compiled against the same duckdb the extension
links, constructing the request exactly as this file did, under
AddressSanitizer:

```
===== BEFORE =====
==2908508==ERROR: AddressSanitizer: heap-use-after-free on address 0xffffb1201fe0
READ of size 2 at 0xffffb1201fe0 thread T0
    #3 0x402060 in main /tmp/urlref/probe.cpp:40
0xffffb1201fe0 is located 0 bytes inside of 97-byte region, freed by thread T0 here:
===== AFTER =====
url = 'https://testbucketcdw.s3.us-west-2.amazonaws.com/'
```

and without the sanitizer, reading the URL the error message would print:

```
BEFORE: url = 'M-fb'
AFTER:  url = 'https://testbucketcdw.s3.us-west-2.amazonaws.com/'
```


## Regression test

The classification had no test of its own, since nothing in the suite reads an
object whose key contains "301". `test_s3.py` now does a denied read of two
keys that differ only in that substring, against the credential-enforcing moto
fixture, and asserts both report the denial and name the object they were
denied.

It reproduces the reported failure exactly on `main`:

```
ERROR:  HTTP Error: Request returned HTTP 500 for HTTP HEAD to 'P\0X..\0\0P\0X..\0\0\0X..\0'
```

while the neighbouring key, same prefix and same principal, reports

```
ERROR:  HTTP Error: HTTP GET error on '.../00000-0-7c4a9de0-....parquet' (HTTP 403)
```

With the fix both report the 403. Verified by reverting only the three source
files to `main` in a built tree and running the file again.

## Issue 599's other two candidates

Both are clean, so nothing else needs changing:

- `MakeVendedS3Secret` does shallow-copy every string from its
  `StorageCredential`, but the result is a stack local passed straight to
  `PushVendedSecretToPGDuck` in the same scope, while the credential it copied
  from is still in the list being iterated. The copy never outlives its owner.
- `LookupInheritedS3Settings` reads `secret_string` out of a `PGresult` that
  its own `PG_FINALLY` clears, but `ExtractFieldFromSecretString` returns a
  `pnstrdup` of the value rather than a pointer into it, so what the caller
  keeps is its own.
