### PR TITLE
pg_extension_base: guard GetBaseWorkerPid and document its pid contract

### DIFF
--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -3101,10 +3101,26 @@ BaseWorkerTransactionCallback(XactEvent event, void *arg)
 /*
  * GetBaseWorkerPid returns the PID of a running base worker given its worker
  * ID, or 0 if the worker is not found in the current database.
+ *
+ * Never raises, so it can be called from places where an error would be
+ * promoted to PANIC, such as an XACT_EVENT_COMMIT callback.  That is why an
+ * uninitialized hash reads as "not found" here, instead of raising the way
+ * StartBaseWorker does on the same check.
+ *
+ * The returned PID is only good for reporting, or for comparing against a PID
+ * observed earlier (see WaitForBaseWorkerExit).  Do not use it to look the
+ * worker's PGPROC up: a PID is only unique while the process is alive, so the
+ * worker can exit and an unrelated backend can be handed the same PID before
+ * BackendPidGetProc runs.  Signaling a base worker safely needs a stable handle
+ * recorded alongside the PID and read under BaseWorkerControl->lock, the way
+ * the database starter wakeup uses procno; this function is not that.
  */
 pid_t
 GetBaseWorkerPid(int32 workerId)
 {
+	if (BaseWorkerHash == NULL)
+		return 0;
+
 	pid_t		workerPid = 0;
 
 	LWLockAcquire(&BaseWorkerControl->lock, LW_SHARED);

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -3102,18 +3102,14 @@ BaseWorkerTransactionCallback(XactEvent event, void *arg)
  * GetBaseWorkerPid returns the PID of a running base worker given its worker
  * ID, or 0 if the worker is not found in the current database.
  *
- * Never raises, so it can be called from places where an error would be
- * promoted to PANIC, such as an XACT_EVENT_COMMIT callback.  That is why an
- * uninitialized hash reads as "not found" here, instead of raising the way
- * StartBaseWorker does on the same check.
+ * Never raises, so it is safe from an XACT_EVENT_COMMIT callback where an error
+ * would become a PANIC.  Hence an uninitialized hash reads as "not found" here
+ * rather than raising the way StartBaseWorker does.
  *
- * The returned PID is only good for reporting, or for comparing against a PID
- * observed earlier (see WaitForBaseWorkerExit).  Do not use it to look the
- * worker's PGPROC up: a PID is only unique while the process is alive, so the
- * worker can exit and an unrelated backend can be handed the same PID before
- * BackendPidGetProc runs.  Signaling a base worker safely needs a stable handle
- * recorded alongside the PID and read under BaseWorkerControl->lock, the way
- * the database starter wakeup uses procno; this function is not that.
+ * Use the PID for reporting or to compare against one observed earlier (see
+ * WaitForBaseWorkerExit), not to find the worker's PGPROC: the worker can exit
+ * and an unrelated backend can be handed the same PID before BackendPidGetProc
+ * runs.
  */
 pid_t
 GetBaseWorkerPid(int32 workerId)


### PR DESCRIPTION
Addresses the first half of #555. Deliberately leaves the second half open —
see below — so the issue should stay open when this merges.

### What this does

`GetBaseWorkerPid` acquired `BaseWorkerControl->lock` and searched
`BaseWorkerHash` without checking that shared memory was initialized. It now
returns 0 in that case, which is the "not found" answer its callers already
handle. `StartBaseWorker` and `ComputeNextWakeTimeMs` make the same check;
`StartBaseWorker` raises, which this function cannot do — its xact-commit caller
runs after the commit record, where `ereport(ERROR)` becomes a PANIC. That
contract is now written down instead of being a property its current callers
happen to satisfy.

The comment also says what the returned pid is good for — reporting, and
comparing against a pid observed earlier, which is what `WaitForBaseWorkerExit`
does — and that feeding it to `BackendPidGetProc` is a TOCTOU on pid reuse.

### What this does not do

The issue also asks for the pid reuse window to be closed, by recording a stable
handle at registration and looking up through that. I prototyped it (a `procno`
field set and cleared with `workerPid`, plus a `WakeUpBaseWorker` doing the
lookup and `ProcSendSignal` under the lock) and dropped it, because there is no
caller that would benefit yet:

- Nothing in this repo signals a base worker.
- The out-of-tree caller the issue names, `AtEOXact_ReverseApplyWorkers`, sets
  the latch of a reverse-apply worker at commit — but that worker waits out its
  cadence in ≤1s chunks and re-sleeps for the remaining interval after any latch
  set, by design, so the wake does not currently shorten anything. Making the
  nudge real is a change to that worker's wait loop, not to this framework.

So the safe-wake API is worth adding when something can act on it, and the
sequencing is: fix the consumer's wait loop first, then add the framework
function it needs. Until then it would be untested-in-practice API surface
whose only justification is a caller that ignores it.

### Testing

Comment and a two-line guard; the guard is not reachable from SQL, since the
hash is initialized long before any caller can run. Existing
`test_get_worker_pid_running` / `test_get_worker_pid_not_found` cover the
function's behavior, and the pg_extension_base suite is green locally.
