### PR TITLE
duckdb_pglake: treat an already-deleted object as removed on Azure

### DIFF
--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -410,9 +410,11 @@ PGLakeCachingFileSystem::ListFiles(const string &directory,
  * abort reaches here from ~CopyToFunctionGlobalState while the write-through
  * handle for this same path is still alive and holds that lock; the lock is
  * only released once the handle destructs, which is sequenced after the
- * destructor body that called us. Blocking on it would deadlock. A held lock
- * means another operation owns the entry and will clean it up itself, so
- * skipping is both safe and correct.
+ * destructor body that called us, so waiting deadlocks. A held lock therefore
+ * skips the eviction, which the cache manager logs: on that abort there is no
+ * finalized cache file to drop, but a cache download of the same path racing
+ * the removal can leave a cache entry for an object that is already gone,
+ * until size-based eviction drops it.
  *
  * If the file is not cached then this is a noop.
  */

--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -403,8 +403,16 @@ PGLakeCachingFileSystem::ListFiles(const string &directory,
  * RemoveCachedCopy drops the local cache entry for a file that has been removed
  * from the remote file system.
  *
- * Even if the file no longer exists remotely, we always remove from cache,
- * since we may have failed to do so last time.
+ * Even if the file no longer exists remotely, we always attempt to remove it
+ * from the cache, since we may have failed to do so last time.
+ *
+ * The eviction must not wait for the per-path cache lock. A cache-on-write
+ * abort reaches here from ~CopyToFunctionGlobalState while the write-through
+ * handle for this same path is still alive and holds that lock; the lock is
+ * only released once the handle destructs, which is sequenced after the
+ * destructor body that called us. Blocking on it would deadlock. A held lock
+ * means another operation owns the entry and will clean it up itself, so
+ * skipping is both safe and correct.
  *
  * If the file is not cached then this is a noop.
  */
@@ -419,24 +427,9 @@ RemoveCachedCopy(ClientContext &context, const string &filename,
 	if (cacheManager->TryGetCacheDir(opener, cacheDir) &&
 		cacheManager->TryGetCacheFilePath(cacheDir, filename, cacheFilePath))
 	{
-		bool waitForLock = true;
+		bool waitForLock = false;
 		cacheManager->RemoveCacheFile(context, filename, waitForLock);
 	}
-}
-
-
-/*
- * IsAzureUrl returns whether a URL is handled by the azure extension. Matching
- * on the scheme rather than asking the file system keeps this usable without an
- * instance of it, which is what the static RemoveFiles below has.
- */
-static bool
-IsAzureUrl(const string &url)
-{
-	return StringUtil::StartsWith(url, "azure://") ||
-		   StringUtil::StartsWith(url, "az://") ||
-		   StringUtil::StartsWith(url, "abfss://") ||
-		   StringUtil::StartsWith(url, "abfs://");
 }
 
 
@@ -448,11 +441,34 @@ void
 PGLakeCachingFileSystem::RemoveFile(const string &filename,
 							  optional_ptr<FileOpener> opener)
 {
+	TryRemoveFile(filename, opener);
+}
+
+
+/*
+ * TryRemoveFile removes a file and its cache entry and reports whether the file
+ * was there to begin with.
+ *
+ * This goes through the remote file system's TryRemoveFile rather than
+ * RemoveFile so that a file that is already gone is not an error: the deletion
+ * queue reaches this path with objects a previous, interrupted attempt already
+ * removed, and Azure (unlike S3) raises BlobNotFound for those.
+ *
+ * That also keeps the cache eviction below reachable. An attempt that deleted
+ * the object but failed before evicting has to be able to finish the job on the
+ * next attempt, and it cannot if the missing object throws first.
+ */
+bool
+PGLakeCachingFileSystem::TryRemoveFile(const string &filename,
+									   optional_ptr<FileOpener> opener)
+{
 	optional_ptr<ClientContext> context = opener->TryGetClientContext();
 
-	remoteFs->RemoveFile(filename, opener);
+	bool removed = remoteFs->TryRemoveFile(filename, opener);
 
 	RemoveCachedCopy(*context, filename, opener);
+
+	return removed;
 }
 
 
@@ -488,6 +504,12 @@ PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string
 		 * caching land here too: s3fs does not recognize the prefix, and the
 		 * virtual file system strips it.
 		 *
+		 * RemoveFile, not TryRemoveFile: the remote file systems are registered
+		 * wrapped in this class, so an object that is already gone is tolerated
+		 * by the RemoveFile above. Asking the virtual file system to try instead
+		 * would also swallow a path that no remote file system claims, which
+		 * falls through to the local file system and is a real failure.
+		 *
 		 * No opener here, unlike the s3fs call below: what a ClientContext hands
 		 * out is a ClientContextFileSystem, an OpenerFileSystem, which pushes
 		 * its own opener into every call and rejects one from the caller with
@@ -496,16 +518,6 @@ PGLakeCachingFileSystem::RemoveFiles(ClientContext &context, const vector<string
 		 */
 		if (s3fs.CanHandleFile(path))
 			s3Paths.push_back(path);
-		else if (IsAzureUrl(path))
-			/*
-			 * On Azure, an object that is already gone counts as removed, the
-			 * same as for the S3 batch delete below, so that a deletion queue
-			 * record for an externally removed object gets retired instead of
-			 * retried. TryRemoveFile is DeleteIfExists there, so it costs no
-			 * extra request. Other back ends keep RemoveFile, whose failure is
-			 * what makes an unremovable path retryable.
-			 */
-			virtualFs.TryRemoveFile(path);
 		else
 			virtualFs.RemoveFile(path);
 	}

--- a/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
+++ b/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
@@ -159,7 +159,8 @@ PgLakeS3FileSystem::RemoveFile(const string &filename,
 /*
  * TryRemoveFile removes a file from S3 and reports whether it was there to
  * begin with, so that a caller deleting a file that is already gone does not
- * have to treat that as a failure.
+ * have to treat that as a failure. Every other error, a permissions error in
+ * particular, is still raised.
  */
 bool
 PgLakeS3FileSystem::TryRemoveFile(const string &filename,
@@ -176,16 +177,10 @@ PgLakeS3FileSystem::TryRemoveFile(const string &filename,
 		PGDUCK_SERVER_DEBUG("Remove failed: %s", error.Message().c_str());
 
 		/*
-		 * If the file is not found, we can consider it removed, but still
-		 * clear the cache below.
-		 *
-		 * The reason is that the last invocation may have failed before
-		 * removing from cache, so if we return here then the file would
-		 * remain readable no matter how many times we try to remove it.
-		 *
-		 * Checking for 404 error is cheaper and more reliable than FileExists,
-		 * which opens the file and returns false in case of any exception,
-		 * but we do want to surface permissions errors.
+		 * A file that is not found counts as removed, so the caller does not
+		 * treat it as a failure. Checking the status code is cheaper and more
+		 * reliable than FileExists, which opens the file and returns false on
+		 * any exception, but we do want to surface permissions errors.
 		 */
 		if (!IsNotFoundError(error))
 			throw;

--- a/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
+++ b/duckdb_pglake/src/fs/pg_lake_s3fs.cpp
@@ -152,6 +152,19 @@ void
 PgLakeS3FileSystem::RemoveFile(const string &filename,
 								optional_ptr<FileOpener> opener)
 {
+	TryRemoveFile(filename, opener);
+}
+
+
+/*
+ * TryRemoveFile removes a file from S3 and reports whether it was there to
+ * begin with, so that a caller deleting a file that is already gone does not
+ * have to treat that as a failure.
+ */
+bool
+PgLakeS3FileSystem::TryRemoveFile(const string &filename,
+								  optional_ptr<FileOpener> opener)
+{
 	try
 	{
 		RemoveFileFromS3(filename, opener);
@@ -176,7 +189,11 @@ PgLakeS3FileSystem::RemoveFile(const string &filename,
 		 */
 		if (!IsNotFoundError(error))
 			throw;
+
+		return false;
 	}
+
+	return true;
 }
 
 

--- a/duckdb_pglake/src/include/pg_lake/fs/caching_file_system.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/caching_file_system.hpp
@@ -187,6 +187,7 @@ public:
 
 	/* Overrides that are not in s3fs */
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 
     /* pass through to wrapped handle */
 	void Read(FileHandle &handle, void *buffer, int64_t byteCount, idx_t location) override {

--- a/duckdb_pglake/src/include/pg_lake/fs/pg_lake_s3fs.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/pg_lake_s3fs.hpp
@@ -58,6 +58,7 @@ public:
 
 	/* Overrides that are not in S3FileSystem */
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 
 	string GetName() const override {
 		return "PgLakeS3FileSystem";

--- a/duckdb_pglake/src/include/pg_lake/fs/region_aware_s3fs.hpp
+++ b/duckdb_pglake/src/include/pg_lake/fs/region_aware_s3fs.hpp
@@ -179,6 +179,13 @@ public:
 			[&](const string &regionUrl) { s3fs.RemoveFile(regionUrl, opener); });
 	}
 
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
+		bool result = false;
+		WithResolvedRegion(filename, opener,
+			[&](const string &regionUrl) { result = s3fs.TryRemoveFile(regionUrl, opener); });
+		return result;
+	}
+
 	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
 		return s3fs.IsPipe(filename, opener);
 	}

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -1603,6 +1603,59 @@ def run_test_pg_lake_remove_file(query_arg, s3, pgduck_conn):
     )
 
 
+def test_pg_lake_remove_file_azure_missing_blob(azure, pgduck_conn):
+    """Removing an Azure blob that is already gone is not an error.
+
+    Azure raises BlobNotFound where S3 answers a plain 404 that the S3 file
+    system treats as removed, so cleanup of an object a previous attempt already
+    deleted used to fail the whole statement. Deleting the blob out of band
+    reaches the same state as an interrupted delete and also checks that the
+    cache entry is still evicted, which is the reason a missing object cannot be
+    allowed to throw before the eviction runs.
+    """
+    key = "test_remove_file_azure_missing/data.parquet"
+    url = f"az://{TEST_BUCKET}/{key}"
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/az/{TEST_BUCKET}"
+        f"/test_remove_file_azure_missing/{CACHE_FILE_PREFIX}data.parquet"
+    )
+
+    run_command(
+        f"""
+        COPY (SELECT s AS s FROM generate_series(1,100) as g(s)) TO '{url}' (format 'parquet');
+    """,
+        pgduck_conn,
+    )
+
+    assert cached_path.exists()
+
+    run_command(f"SELECT pg_lake_remove_file('{url}');", pgduck_conn)
+
+    assert not cached_path.exists()
+    assert not any(azure.list_blobs(name_starts_with=key))
+
+    # Removing twice does not give an error
+    run_command(f"SELECT pg_lake_remove_file('{url}');", pgduck_conn)
+
+    # A blob deleted out of band still gets its cache entry evicted
+    run_command(
+        f"""
+        COPY (SELECT s AS s FROM generate_series(1,100) as g(s)) TO '{url}' (format 'parquet');
+    """,
+        pgduck_conn,
+    )
+
+    assert cached_path.exists()
+
+    azure.get_blob_client(key).delete_blob()
+
+    run_command(f"SELECT pg_lake_remove_file('{url}');", pgduck_conn)
+
+    assert not cached_path.exists()
+
+    pgduck_conn.rollback()
+
+
 # Test that query arguments are included in the path
 def test_http_query_args(s3, pgduck_conn):
     key = "test_http_query_args/data.parquet"


### PR DESCRIPTION
✓ Switched active account for github.com to sfc-gh-mslot
Deleting an object that is already gone is an error on Azure and a success on S3, so cleanup on Azure fails on state it created itself.

`AzureBlobStorageFileSystem::RemoveFile` (and the `abfss://` variant) calls `Delete()`, which raises `BlobNotFound`; the S3 path deliberately swallows a 404 and reports the file as removed. Cleanup reaches that state routinely — an attempt that deleted the object but was interrupted before the catalog row was retired, and `DeleteRemoteFileBatch`, whose retry-one-path-at-a-time step is built on "removing a file twice is a no-op", re-issuing paths the failed batch already deleted. In production this shows up as

```
WARNING: query on duckdb failed: IO Error: AzureBlobStorageFileSystem Delete of
azure://.../metadata/snap-...avro failed with BlobNotFound
Reason Phrase: The specified blob does not exist.
```

Three consequences, all Azure-only:

- **The deletion queue never drains.** One already-deleted path fails its whole batch, the batch is retried path by path, and every path that is already gone lands in `failedFilePathList`. Its row is not removed, `retry_count` climbs, and past `VacuumFileRemoveMaxRetries` the row stops being claimed — it stays in `lake_engine.deletion_queue` forever, invisible and unreported.
- **Every vacuum pass pays for it.** Until the retry budget runs out, each pass fails a batch and then spends one request per path on the retry — the per-file cost batching exists to avoid, permanently, on the paths that need no work at all.
- **The cache entry is never evicted.** `RemoveFile` throws before `RemoveCachedCopy` runs, so an object that *was* deleted (by an attempt that then failed on a sibling) keeps its local cache copy. pgduck does not revalidate cache entries, so the deleted object stays readable until size-based eviction — exactly what the S3 404-swallow comment says it is there to prevent.

The fix uses the idempotent path the file systems already offer: `TryRemoveFile`, which duckdb-azure implements with `DeleteIfExists()` — one request, no existence check, real failures (403, unreachable account) still raised. `PGLakeCachingFileSystem`, `RegionAwareS3FileSystem` and `PgLakeS3FileSystem` gain a `TryRemoveFile` override and their `RemoveFile` delegates to it, so a missing object is uniformly "already removed" and cache eviction is always reached.

The remote file systems are registered wrapped in `PGLakeCachingFileSystem`, so the bulk `RemoveFiles` fallback for back ends without a batch delete keeps calling `RemoveFile` and gets the same tolerance. Going through the virtual file system's `TryRemoveFile` instead would reach further than intended: a path no remote file system claims falls through to the local file system, where the base-class `FileExists` + `RemoveFile` default reports an unroutable path as "already gone" rather than the failure it is.

Overriding rather than relying on the base class matters: `FileSystem::TryRemoveFile` defaults to `FileExists` + `RemoveFile`, which would add a round trip, reintroduce the race, and skip cache eviction whenever the object is absent.

Reaching the eviction unconditionally means it must not wait for the per-path cache lock. A cache-on-write `COPY` that aborts runs `~CopyToFunctionGlobalState` → `TryRemoveFile` while the write-through handle for that same path is still alive and holds that lock; the lock is released only when the handle destructs, which is sequenced after the destructor body that called us — so waiting deadlocks. `RemoveCachedCopy` therefore evicts without waiting, and skips when the lock is held. On the abort there is nothing finalized to drop, so that case loses nothing. A cache download for the same path racing the removal is the case it does cost: the download finishes and the cache entry outlives the deleted object until size-based eviction drops it, and the cache manager logs the skip. The old `FileExists` + `RemoveFile` default avoided that only by not evicting at all when the object was absent.

`pg_lake_remove_file` still returns true per path, as before — S3's batch delete cannot report per-key existence, so the return value never carried that information.

### Test

`test_pg_lake_remove_file_azure_missing_blob` covers both halves against azurite: removing the same blob twice, and removing a blob deleted out of band while it is still cached, asserting the cache entry goes away. Both fail before the change (`BlobNotFound`), pass after.


✓ Switched active account for github.com to marco-slot_snow
