### PR TITLE
pg_extension_base: do not wait forever for a worker that never attaches

### DIFF
--- a/pg_extension_base/include/pg_extension_base/attached_worker.h
+++ b/pg_extension_base/include/pg_extension_base/attached_worker.h
@@ -38,6 +38,13 @@ typedef struct AttachedWorker
 	/* background worker handle */
 	pid_t		workerPid;
 	BackgroundWorkerHandle *workerHandle;
+
+	/*
+	 * Set once the worker sent ReadyForQuery, which is the last thing it does
+	 * before exiting. Until then, a detached queue means the worker died with
+	 * the command unfinished.
+	 */
+	bool		workerFinished;
 }			AttachedWorker;
 
 extern PGDLLEXPORT AttachedWorker * StartAttachedWorker(char *command);

--- a/pg_extension_base/include/pg_extension_base/injection_points.h
+++ b/pg_extension_base/include/pg_extension_base/injection_points.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Snowflake Inc.
+ * Copyright 2026 Snowflake Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pg_extension_base/include/pg_extension_base/injection_points.h
+++ b/pg_extension_base/include/pg_extension_base/injection_points.h
@@ -17,8 +17,25 @@
 
 #pragma once
 
-/*
- * INJECTION_POINT_COMPAT moved to pg_extension_base so that extension can use
- * it as well. This header remains as the pg_lake spelling of the same macro.
- */
-#include "pg_extension_base/injection_points.h"
+#include "postgres.h"
+
+#if PG_VERSION_NUM >= 180000
+
+#include "utils/injection_point.h"
+
+#define INJECTION_POINT_COMPAT(name) \
+    INJECTION_POINT(name, NULL)
+
+#elif PG_VERSION_NUM >= 170000
+
+#include "utils/injection_point.h"
+
+#define INJECTION_POINT_COMPAT(name) \
+    INJECTION_POINT(name)
+
+#else
+
+#define INJECTION_POINT_COMPAT(name) \
+    ((void) name)
+
+#endif

--- a/pg_extension_base/src/attached_worker.c
+++ b/pg_extension_base/src/attached_worker.c
@@ -33,6 +33,7 @@
 #include "catalog/pg_authid.h"
 #include "commands/dbcommands.h"
 #include "pg_extension_base/attached_worker.h"
+#include "pg_extension_base/injection_points.h"
 #include "pg_extension_base/pg_compat.h"
 #include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
@@ -89,7 +90,7 @@ static AttachedWorker * StartAttachedWorkerInternal(char *command, char *databas
 static void RunAttachedWorker(char *command, char *databaseName, char *userName, ReturnSetInfo *rsinfo);
 static void RunAttachedWorkerReturning(char *command, char *databaseName,
 									   char *userName, ReturnSetInfo *rsinfo);
-static char *ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
+static char *ProcessProtocolMessages(AttachedWorker * worker, bool nowait,
 									 TupleDesc *resultDesc);
 static void ValidateWorkerTupleDesc(TupleDesc workerDesc, TupleDesc expectedDesc);
 static void ExecuteSqlString(const char *sql, shm_mq_handle *tupleQueue);
@@ -427,8 +428,24 @@ StartAttachedWorkerInternal(char *command, char *databaseName, char *userName,
 						errhint("You might need to increase max_worker_processes.")));
 	}
 
-	/* wait for the background worker to start */
-	pid_t		pid;
+	/*
+	 * Associate the queues with the worker. Without a handle, shm_mq cannot
+	 * tell a worker that has not attached yet from one that will never
+	 * attach, so a blocking receive on the queue of a worker that failed to
+	 * start or died during startup waits forever.
+	 */
+	shm_mq_set_handle(outputQueueHandle, workerHandle);
+	if (tupleQueueHandle != NULL)
+		shm_mq_set_handle(tupleQueueHandle, workerHandle);
+
+	/*
+	 * Wait for the background worker to start. BGWH_STOPPED is not
+	 * necessarily a failure, since a short command can run to completion
+	 * before we get here and its output is still in the queue. It is the
+	 * queue handles set above that catch a worker which exited without
+	 * finishing the command.
+	 */
+	pid_t		pid = 0;
 	BgwHandleStatus status = WaitForBackgroundWorkerStartup(workerHandle, &pid);
 
 	if (status != BGWH_STARTED && status != BGWH_STOPPED)
@@ -461,10 +478,12 @@ StartAttachedWorkerInternal(char *command, char *databaseName, char *userName,
  * message arrives.
  *
  * Returns the command tag on CommandComplete, or NULL when the queue
- * is exhausted or detached.
+ * is exhausted or detached. A queue that detaches before the worker sent
+ * ReadyForQuery means the worker died with the command unfinished, which is
+ * reported as an error.
  */
 static char *
-ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
+ProcessProtocolMessages(AttachedWorker * worker, bool nowait,
 						TupleDesc *resultDesc)
 {
 	StringInfoData msg;
@@ -477,8 +496,15 @@ ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
 
 		Size		messageLength;
 		void	   *data;
-		shm_mq_result res = shm_mq_receive(queue, &messageLength,
+		shm_mq_result res = shm_mq_receive(worker->outputQueue, &messageLength,
 										   &data, nowait);
+
+		if (res == SHM_MQ_DETACHED && !worker->workerFinished)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("attached worker exited before finishing the command"),
+					 errhint("The worker may have failed to start. Look for its "
+							 "error in the server log.")));
 
 		if (res != SHM_MQ_SUCCESS)
 			break;
@@ -546,12 +572,20 @@ ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
 					}
 					break;
 				}
+			case 'Z':
+				{
+					/*
+					 * ReadyForQuery is the last message the worker sends, so
+					 * from here on a detached queue is an orderly exit.
+					 */
+					worker->workerFinished = true;
+					break;
+				}
 			case 'A':
 			case 'D':
 			case 'G':
 			case 'H':
 			case 'W':
-			case 'Z':
 				break;
 			default:
 				elog(WARNING, "unknown message type: %c (%zu bytes)",
@@ -572,7 +606,7 @@ ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
 char *
 ReadFromAttachedWorker(AttachedWorker * worker, bool wait)
 {
-	return ProcessProtocolMessages(worker->outputQueue, !wait, NULL);
+	return ProcessProtocolMessages(worker, !wait, NULL);
 }
 
 
@@ -637,7 +671,7 @@ ReadResultsFromAttachedWorker(AttachedWorker * worker, Tuplestorestate *store,
 		 */
 		TupleDesc	workerDesc = NULL;
 
-		ProcessProtocolMessages(worker->outputQueue, true, &workerDesc);
+		ProcessProtocolMessages(worker, true, &workerDesc);
 
 		if (workerDesc != NULL)
 		{
@@ -679,7 +713,7 @@ ReadResultsFromAttachedWorker(AttachedWorker * worker, Tuplestorestate *store,
 	DestroyTupleQueueReader(reader);
 
 	/* Final drain to catch any trailing errors or notices */
-	ProcessProtocolMessages(worker->outputQueue, true, NULL);
+	ProcessProtocolMessages(worker, true, NULL);
 }
 
 
@@ -763,6 +797,12 @@ AttachedWorkerMain(Datum mainArg)
 								 (*flagsPtr & ATTACHED_WORKER_FLAG_RETURN_RESULTS) != 0);
 	bool		callerWritable = (flagsPtr != NULL &&
 								  (*flagsPtr & ATTACHED_WORKER_FLAG_CALLER_WRITABLE) != 0);
+
+	/*
+	 * Lets a test exercise a worker that dies before it attaches to the
+	 * queues, which is what the parent cannot see without a queue handle.
+	 */
+	INJECTION_POINT_COMPAT("attached-worker-before-queue-attach");
 
 	/* Attach to the response queue (protocol messages: errors, command tags) */
 	shm_mq_set_sender(messageQueue, MyProc);

--- a/pg_extension_base/tests/pytests/test_attached_workers.py
+++ b/pg_extension_base/tests/pytests/test_attached_workers.py
@@ -603,3 +603,46 @@ def test_returning_more_columns_expected(superuser_conn, pg_extension_base):
     # session should still be alive
     result = run_query("SELECT 1 as alive", superuser_conn)
     assert result[0]["alive"] == 1
+
+
+def test_worker_dies_before_attaching(
+    superuser_conn, pg_extension_base, create_injection_extension
+):
+    # A worker that exits before it attaches to the queues used to leave the
+    # caller waiting forever, since shm_mq cannot see the worker die without a
+    # queue handle. The caller should get an error instead.
+
+    if get_pg_version_num(superuser_conn) < 170000:
+        pytest.skip("Injection points not available (requires PostgreSQL 17+)")
+
+    run_command(
+        "SELECT injection_points_attach('attached-worker-before-queue-attach', 'error')",
+        superuser_conn,
+    )
+
+    try:
+        for command in [
+            "SELECT * FROM extension_base.run_attached($$SELECT 1$$)",
+            "SELECT * FROM extension_base.run_attached_returning($$SELECT 1$$) AS t(x int)",
+        ]:
+            # bound the wait so a regression fails the test instead of hanging
+            run_command("SET statement_timeout = '60s'", superuser_conn)
+
+            error = run_command(command, superuser_conn, raise_error=False)
+            superuser_conn.rollback()
+
+            assert error is not None
+            assert "attached worker exited before finishing the command" in error
+    finally:
+        run_command(
+            "SELECT injection_points_detach('attached-worker-before-queue-attach')",
+            superuser_conn,
+            raise_error=False,
+        )
+        superuser_conn.commit()
+
+    # session should still be alive, and workers should work again
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached($$SELECT 1$$)", superuser_conn
+    )
+    assert result[0]["command_tag"] == "SELECT 1"


### PR DESCRIPTION
Fixes #565.

## Problem

`StartAttachedWorkerInternal` attaches to the output queue and the tuple queue with `shm_mq_attach(queue, seg, NULL)` and never calls `shm_mq_set_handle()`. Without a handle, `shm_mq` has no way to tell a worker that has not attached *yet* from one that will *never* attach, so `shm_mq_wait_internal` skips its worker-death check entirely.

If the background worker fails to start, or dies during startup before it attaches (bad dsm segment, library load failure, a failed fork), the caller's blocking `shm_mq_receive()` in `ProcessProtocolMessages` waits forever on `IPC / MessageQueueInternal`. It does so with its transaction open, so it pins `backend_xmin`, stalls autovacuum, and head-of-line-blocks anything waiting out the running-transaction horizon. The only way out is `pg_terminate_backend()`.

The non-blocking path (`ReadFromAttachedWorker(worker, /*wait=*/false)`, used by `RunCommandsInParallel`) has the same root cause with a different symptom: `shm_mq_counterparty_gone()` also short-circuits on a NULL handle, so it returns `SHM_MQ_WOULD_BLOCK` forever and the caller spins.

## Solution

Call `shm_mq_set_handle()` on both queues right after `RegisterDynamicBackgroundWorker()`, the way core `parallel.c` does. `shm_mq` then reports `SHM_MQ_DETACHED` once the worker is gone.

That alone turns the hang into a silently empty result, so the caller also needs to know whether the detach was orderly. A detached queue is not an error by itself: a short command can run to completion before the parent reaches its first receive, which is also why `BGWH_STOPPED` from `WaitForBackgroundWorkerStartup` is not treated as a failure. So `AttachedWorker` now tracks whether the worker sent `ReadyForQuery` — the last message it sends before exiting — and `ProcessProtocolMessages` raises

```
ERROR:  attached worker exited before finishing the command
HINT:  The worker may have failed to start. Look for its error in the server log.
```

only when the queue detaches before that. This is race-free because `shm_mq_receive_bytes` returns whatever is still queued before it reports the detach, so a buffered `'Z'` is always consumed first. Worker errors that happen after `pq_redirect_to_shm_mq` still arrive as `'E'` and are rethrown as before; the new error covers exactly the window where the worker had no way to report anything.

Two smaller things that fall out of this:

* `pid` is now initialized. `WaitForBackgroundWorkerStartup` only writes `*pidp` on `BGWH_STARTED`, so the `BGWH_STOPPED` path was storing an uninitialized value in `worker->workerPid`.
* `INJECTION_POINT_COMPAT` moved from `pg_lake_engine` to `pg_extension_base` so the lower-level module can use it. The `pg_lake/util/injection_points.h` header now forwards to it, so its existing include sites are unchanged.

Note the behaviour change for `RunCommandsInParallel`: a worker that never ran used to be counted as a completed job, and now raises the error above.

## Test plan

`test_worker_dies_before_attaching` attaches a new injection point that makes the worker exit just before it attaches to the queues, and asserts that both `run_attached` and `run_attached_returning` fail with the new message.

Verified against a build with only the two `shm_mq_set_handle()` calls removed: the test hangs and fails after 60s with `canceling statement due to statement timeout`, which is the bug from the issue. With the fix, the full `pg_extension_base` pytest suite passes (67 tests, PG 18).
