### PR TITLE
pg_lake_engine: make releasing a pgduck connection idempotent

### DIFF
--- a/pg_lake_copy/src/test/pgduck_connection.c
+++ b/pg_lake_copy/src/test/pgduck_connection.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Snowflake Inc.
+ * Copyright 2026 Snowflake Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pg_lake_copy/src/test/pgduck_connection.c
+++ b/pg_lake_copy/src/test/pgduck_connection.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * User-defined functions for testing the pgduck_server connection lifecycle.
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+
+#include "pg_lake/pgduck/client.h"
+
+
+PG_FUNCTION_INFO_V1(release_pgduck_connection_twice);
+
+
+/*
+ * release_pgduck_connection_twice releases the same connection twice, which is
+ * what a caller does when it releases both in an error path and in the
+ * PG_FINALLY block that follows. The second release must be a no-op.
+ */
+Datum
+release_pgduck_connection_twice(PG_FUNCTION_ARGS)
+{
+	PGDuckConnection *pgDuckConnection = GetPGDuckConnection();
+
+	ReleasePGDuckConnection(pgDuckConnection);
+	ReleasePGDuckConnection(pgDuckConnection);
+
+	PG_RETURN_VOID();
+}

--- a/pg_lake_copy/tests/pytests/test_pgduck_connection.py
+++ b/pg_lake_copy/tests/pytests/test_pgduck_connection.py
@@ -1,0 +1,54 @@
+"""Regression test: releasing the same pgduck_server connection twice.
+
+ReleasePGDuckConnection() used to dereference the entry returned by
+HASH_REMOVE, and on the !found path it closed the connection through the
+caller's own handle. A second release therefore passed the same PGconn to
+PQfinish() twice, which aborts the backend and restarts the whole cluster,
+or closed a newer connection that had reused the hash entry.
+
+See https://github.com/Snowflake-Labs/pg_lake/issues/557.
+"""
+
+import pytest
+from utils_pytest import *
+
+
+@pytest.fixture()
+def release_pgduck_connection_twice(superuser_conn):
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION release_pgduck_connection_twice()
+        RETURNS void LANGUAGE C
+        AS 'pg_lake_copy', $$release_pgduck_connection_twice$$;
+    """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command("DROP FUNCTION release_pgduck_connection_twice()", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_double_release_is_a_noop(superuser_conn, release_pgduck_connection_twice):
+    superuser_conn.notices.clear()
+
+    run_command("SELECT release_pgduck_connection_twice()", superuser_conn)
+    superuser_conn.commit()
+
+    # The second release must recognize the connection as already released
+    # instead of taking the untracked path that closed the handle again.
+    assert not any(
+        "untracked connection" in notice for notice in superuser_conn.notices
+    )
+
+    # The first release must still have removed the hash entry, or the
+    # end-of-transaction sweep would have found a connection to close.
+    assert not any(
+        "connections on transaction commit" in notice
+        for notice in superuser_conn.notices
+    )
+
+    # The backend is still alive, so PQfinish() was not called twice.
+    assert run_query("SELECT 1 AS ok", superuser_conn)[0]["ok"] == 1

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -170,30 +170,48 @@ GetPGDuckConnection(void)
 
 /*
  * ReleasePGDuckConnection closes the current connection to the
- * pgduck_server, if any.
+ * pgduck_server, if any. Releasing a connection that was already released
+ * is a no-op.
  */
 void
 ReleasePGDuckConnection(PGDuckConnection * pgDuckConnection)
 {
+	/*
+	 * GetPGDuckConnection never hands out an entry with a NULL conn, so a
+	 * NULL here means this connection was already released.
+	 */
+	if (pgDuckConnection->conn == NULL)
+		return;
+
 	uint32		connectionId = pgDuckConnection->connectionId;
 	bool		found = false;
 	PgDuckServerConnectionHashEntry *entry =
-		hash_search(PgDuckConnectionHash, &connectionId, HASH_REMOVE, &found);
+		hash_search(PgDuckConnectionHash, &connectionId, HASH_FIND, &found);
 
 	if (!found)
 	{
-		elog(WARNING, "closing untracked connection to query engine");
-
-		if (pgDuckConnection->conn != NULL)
-			PQfinish(pgDuckConnection->conn);
-
-		pgDuckConnection->conn = NULL;
-
+		/*
+		 * A released entry goes back to dynahash's freelist while the caller
+		 * still points into it, so a handle we cannot find in the hash may
+		 * already be closed or may belong to a newer connection that reused
+		 * the entry. Leak it rather than risk closing the wrong connection.
+		 */
+		elog(WARNING, "ignoring release of untracked connection to query engine");
 		return;
 	}
 
-	if (entry->pgDuckConnection.conn != NULL)
-		PQfinish(entry->pgDuckConnection.conn);
+	PGconn	   *conn = entry->pgDuckConnection.conn;
+
+	/*
+	 * Clear the handle before removing the entry: HASH_REMOVE returns a
+	 * dangling pointer, so this is the last point at which the entry, and
+	 * with it the caller's PGDuckConnection, can be marked as released.
+	 */
+	entry->pgDuckConnection.conn = NULL;
+
+	hash_search(PgDuckConnectionHash, &connectionId, HASH_REMOVE, NULL);
+
+	PQfinish(conn);
 }
 
 


### PR DESCRIPTION
Fixes #557.

`ReleasePGDuckConnection()` removed the hash entry with `HASH_REMOVE` and then read the returned pointer. dynahash documents that pointer as dangling — the entry goes onto the freelist and the next `GetPGDuckConnection()` reuses it. And because callers hold an interior pointer into the entry (`&entry->pgDuckConnection`), a second release found nothing in the hash and took the `!found` branch, which closed the connection through the caller's own stale handle. So releasing the same `PGDuckConnection` twice passed the same `PGconn` to `PQfinish()` twice.

#326 removed the one caller that did this (`WaitForResult` released before the `PG_FINALLY` that released again), but the helper itself is still unsafe, and callers cannot tell whether a handle they hold was already released.

The fix clears `entry->pgDuckConnection.conn` before `HASH_REMOVE` — the last moment the entry, and with it the caller's handle, can still be marked released — and returns early when the handle is already NULL. `GetPGDuckConnection()` never hands out an entry with a NULL `conn`, so NULL unambiguously means released.

The `!found` path no longer closes anything. A handle that is not in the hash either was already released or points at an entry a newer connection has since reused; closing it would close the wrong connection. Leaking it and warning is the safe choice. This stays a WARNING rather than an ERROR because release runs from abort paths and transaction callbacks, where throwing is not an option.

### Verification

Against a live `pgduck_server`, using a test-only UDF that releases one connection twice.

Before:

```
WARNING:  closing untracked connection to query engine
munmap_chunk(): invalid pointer
LOG:  client backend (PID 2247354) was terminated by signal 6: Aborted
LOG:  database system is ready to accept connections
```

After: the function returns, no warning, backend and cluster stay up.

The new pytest asserts all three: no untracked-connection warning, no connection left for the end-of-transaction sweep to close (so the entry really was removed), and the backend still answers a query.
