### PR TITLE
pg_extension_base: recover from a worker launch that never runs

### DIFF
--- a/pg_extension_base/include/pg_extension_base/base_workers.h
+++ b/pg_extension_base/include/pg_extension_base/base_workers.h
@@ -112,8 +112,13 @@ extern int	WorkerRestartBackoffInitialMs;
 extern int	WorkerRestartBackoffMaxMs;
 extern int	WorkerRestartHealthyMs;
 
-/* pg_extension_base.worker_startup_timeout setting */
+/*
+ * pg_extension_base.worker_startup_timeout setting.  The minimum is a whole
+ * second: below that we would reclaim launches that are merely slow, and
+ * relaunch on top of a child that is still on its way up.
+ */
 #define DEFAULT_WORKER_STARTUP_TIMEOUT_MS (60000)
+#define MIN_WORKER_STARTUP_TIMEOUT_MS (1000)
 extern int	WorkerStartupTimeoutMs;
 
 void		BaseWorkerSharedMemoryInit(void);

--- a/pg_extension_base/include/pg_extension_base/base_workers.h
+++ b/pg_extension_base/include/pg_extension_base/base_workers.h
@@ -112,6 +112,10 @@ extern int	WorkerRestartBackoffInitialMs;
 extern int	WorkerRestartBackoffMaxMs;
 extern int	WorkerRestartHealthyMs;
 
+/* pg_extension_base.worker_startup_timeout setting */
+#define DEFAULT_WORKER_STARTUP_TIMEOUT_MS (60000)
+extern int	WorkerStartupTimeoutMs;
+
 void		BaseWorkerSharedMemoryInit(void);
 size_t		BaseWorkerSharedMemorySize(void);
 

--- a/pg_extension_base/include/pg_extension_base/injection_points.h
+++ b/pg_extension_base/include/pg_extension_base/injection_points.h
@@ -19,12 +19,25 @@
 
 #include "postgres.h"
 
+/*
+ * IS_INJECTION_POINT_ATTACHED_COMPAT lets a test steer a branch that cannot be
+ * reached by running code -- for instance a return value that only the kernel
+ * refusing to fork can produce.  Only Postgres 18 can answer the question, so
+ * on older versions it is constant false and the branch is unreachable; a test
+ * that relies on it has to skip.  Either way it compiles to nothing unless the
+ * server was built with --enable-injection-points, so it costs a regular build
+ * neither code nor a check.
+ */
+
 #if PG_VERSION_NUM >= 180000
 
 #include "utils/injection_point.h"
 
 #define INJECTION_POINT_COMPAT(name) \
     INJECTION_POINT(name, NULL)
+
+#define IS_INJECTION_POINT_ATTACHED_COMPAT(name) \
+    IS_INJECTION_POINT_ATTACHED(name)
 
 #elif PG_VERSION_NUM >= 170000
 
@@ -33,9 +46,15 @@
 #define INJECTION_POINT_COMPAT(name) \
     INJECTION_POINT(name)
 
+#define IS_INJECTION_POINT_ATTACHED_COMPAT(name) \
+    (false)
+
 #else
 
 #define INJECTION_POINT_COMPAT(name) \
     ((void) name)
+
+#define IS_INJECTION_POINT_ATTACHED_COMPAT(name) \
+    (false)
 
 #endif

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -847,11 +847,8 @@ StartDatabaseStarters(List *databaseList)
 		Oid			databaseId = entry->databaseId;
 
 		/*
-		 * StartDatabaseStarter conditionally acquires a lock that a
-		 * concurrent DROP DATABASE/EXTENSION holds, and skips the database if
-		 * it cannot get it. We hold the lock until leaving the function and
-		 * committing below, which keeps such a DROP out of the way while we
-		 * register the database starter.
+		 * Run in a transaction so the lock StartDatabaseStarter takes is held
+		 * until we commit below.
 		 */
 		StartTransactionCommand();
 
@@ -1076,7 +1073,10 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 	/*
 	 * A concurrent DROP DATABASE/EXTENSION that affects this database holds
 	 * this lock in ExclusiveLock mode until it commits or aborts, so we back
-	 * off and let the next iteration deal with the database.
+	 * off and let the next iteration deal with the database. When we do get
+	 * the lock, the caller holds it until its transaction commits, which
+	 * keeps such a DROP out of the way while we register the database
+	 * starter.
 	 *
 	 * In case of DROP DATABASE, proceeding would create a database starter
 	 * that connects to a database the DROP is waiting to become idle. The

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -322,7 +322,7 @@ typedef enum StartDatabaseStarterResult
 	 * up on the remaining databases for this pass rather than repeat the
 	 * failure for each one.
 	 */
-	DATABASE_STARTER_NO_WORKER_SLOT,
+	DATABASE_STARTER_OUT_OF_SLOTS,
 
 	/*
 	 * We registered the launch, but the postmaster reported that the child
@@ -331,7 +331,7 @@ typedef enum StartDatabaseStarterResult
 	 * with the other databases; the entry has been reset for a retry on the
 	 * next pass.
 	 */
-	DATABASE_STARTER_NEVER_RAN
+	DATABASE_STARTER_START_FAILED
 }			StartDatabaseStarterResult;
 
 /*
@@ -349,11 +349,11 @@ typedef enum StartBaseWorkerResult
 	/* one already ran to completion and does not need to run again */
 	BASE_WORKER_DONE,
 
-	/* see DATABASE_STARTER_NO_WORKER_SLOT */
-	BASE_WORKER_NO_WORKER_SLOT,
+	/* see DATABASE_STARTER_OUT_OF_SLOTS */
+	BASE_WORKER_OUT_OF_SLOTS,
 
-	/* see DATABASE_STARTER_NEVER_RAN */
-	BASE_WORKER_NEVER_RAN,
+	/* see DATABASE_STARTER_START_FAILED */
+	BASE_WORKER_START_FAILED,
 
 	/* its restart backoff has not elapsed yet */
 	BASE_WORKER_START_BLOCKED
@@ -861,7 +861,7 @@ StartDatabaseStarters(List *databaseList)
 		CommitTransactionCommand();
 		MemoryContextSwitchTo(outerContext);
 
-		if (startResult == DATABASE_STARTER_NO_WORKER_SLOT)
+		if (startResult == DATABASE_STARTER_OUT_OF_SLOTS)
 		{
 			/* no slots left, so the remaining databases will not start either */
 			ereport(LOG, (errmsg("failed to start pg base extension database starter in database %s",
@@ -870,7 +870,7 @@ StartDatabaseStarters(List *databaseList)
 
 			return;
 		}
-		else if (startResult == DATABASE_STARTER_NEVER_RAN)
+		else if (startResult == DATABASE_STARTER_START_FAILED)
 		{
 			/*
 			 * The launch was registered but never actually ran. The entry has
@@ -1193,7 +1193,7 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 		 * next time, hoping that another background worker stopped.
 		 */
 		LWLockRelease(&BaseWorkerControl->lock);
-		return DATABASE_STARTER_NO_WORKER_SLOT;
+		return DATABASE_STARTER_OUT_OF_SLOTS;
 	}
 
 	/*
@@ -1229,10 +1229,12 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 	{
 		/*
 		 * The postmaster never actually ran the child (fork() failure). Reset
-		 * the entry so the next pass retries rather than believing a starter
-		 * is running that never existed; without this the entry stays wedged
-		 * at WORKER_STARTING/pid=0 forever, since only the child's own
-		 * cleanup handler otherwise clears it.
+		 * the entry so the next pass retries: only the child's own cleanup
+		 * handler would otherwise clear it, so the entry would sit at
+		 * WORKER_STARTING with pid 0 forever.  The status only catches a
+		 * failed fork; a child that dies after the postmaster published its
+		 * pid still reports BGWH_STARTED, which is what the
+		 * worker_startup_timeout check above covers.
 		 */
 		LWLockAcquire(&BaseWorkerControl->lock, LW_EXCLUSIVE);
 		starterEntry->workerPid = 0;
@@ -1244,7 +1246,7 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 								 "did not start",
 								 quote_identifier(databaseName))));
 
-		return DATABASE_STARTER_NEVER_RAN;
+		return DATABASE_STARTER_START_FAILED;
 	}
 
 	return DATABASE_STARTER_STARTED;
@@ -1641,7 +1643,7 @@ StartAllBaseWorkers(List *workerRegistrationList)
 			StartBaseWorker(registration->workerId, registration->extensionId,
 							registration->entryPointFunctionId);
 
-		if (startResult == BASE_WORKER_NO_WORKER_SLOT)
+		if (startResult == BASE_WORKER_OUT_OF_SLOTS)
 		{
 			ereport(LOG, (errmsg("failed to start base worker %s in database %d",
 								 registration->workerName, MyDatabaseId)),
@@ -1650,7 +1652,7 @@ StartAllBaseWorkers(List *workerRegistrationList)
 			/* no slots left, so the remaining workers will not start either */
 			return false;
 		}
-		else if (startResult == BASE_WORKER_NEVER_RAN)
+		else if (startResult == BASE_WORKER_START_FAILED)
 		{
 			ereport(LOG, (errmsg("base worker %s in database %d did not start, "
 								 "will retry",
@@ -1878,7 +1880,7 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 							 MyDatabaseId),
 					  errhint("You may need to increase max_worker_processes.")));
 
-		return BASE_WORKER_NO_WORKER_SLOT;
+		return BASE_WORKER_OUT_OF_SLOTS;
 	}
 
 	/*
@@ -1933,7 +1935,7 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 								 "did not start",
 								 workerId, MyDatabaseId)));
 
-		return BASE_WORKER_NEVER_RAN;
+		return BASE_WORKER_START_FAILED;
 	}
 
 	return BASE_WORKER_STARTED;

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -192,6 +192,14 @@ typedef struct DatabaseStarterEntry
 
 	/* process number for signaling via ProcSendSignal */
 	int			procno;
+
+	/*
+	 * When the current launch attempt was issued (state set to
+	 * WORKER_STARTING).  Used to detect a launch that never actually ran
+	 * (e.g. the postmaster could not fork it) so we do not stay wedged at
+	 * WORKER_STARTING forever with workerPid still 0.
+	 */
+	TimestampTz launchedAt;
 }			DatabaseStarterEntry;
 
 
@@ -239,6 +247,15 @@ typedef struct BaseWorkerEntry
 
 	/* when the worker last started running (for the healthy-uptime reset) */
 	TimestampTz startTime;
+
+	/*
+	 * When the current launch attempt was issued (state set to
+	 * WORKER_STARTING).  Unlike startTime, this is set unconditionally at
+	 * launch time, so it lets us detect a launch that never actually ran
+	 * (e.g. the postmaster could not fork it) even though startTime itself
+	 * stays 0 forever in that case.
+	 */
+	TimestampTz launchedAt;
 }			BaseWorkerEntry;
 
 
@@ -283,11 +300,38 @@ typedef struct BaseWorkerRegistration
  */
 typedef enum StartDatabaseStarterResult
 {
+	/* we registered a launch and the postmaster ran it */
 	DATABASE_STARTER_STARTED,
+
+	/* one is already running, or its launch is still in flight */
 	DATABASE_STARTER_EXISTS,
+
+	/* one already ran to completion and does not need to run again */
 	DATABASE_STARTER_DONE,
+
+	/*
+	 * A concurrent DROP DATABASE/EXTENSION holds the database starter lock,
+	 * so we backed off; needsRestart stays set and the next pass deals with
+	 * the database.
+	 */
 	DATABASE_STARTER_BLOCKED,
-	DATABASE_STARTER_FAILED
+
+	/*
+	 * We could not even register the launch, because max_worker_processes is
+	 * exhausted.  That is a server-wide condition, so the caller should give
+	 * up on the remaining databases for this pass rather than repeat the
+	 * failure for each one.
+	 */
+	DATABASE_STARTER_NO_WORKER_SLOT,
+
+	/*
+	 * We registered the launch, but the postmaster reported that the child
+	 * never actually ran (e.g. it could not fork it).  This is specific to
+	 * one launch rather than server-wide, so the caller should keep going
+	 * with the other databases; the entry has been reset for a retry on the
+	 * next pass.
+	 */
+	DATABASE_STARTER_NEVER_RAN
 }			StartDatabaseStarterResult;
 
 /*
@@ -296,10 +340,22 @@ typedef enum StartDatabaseStarterResult
  */
 typedef enum StartBaseWorkerResult
 {
+	/* we registered a launch and the postmaster ran it */
 	BASE_WORKER_STARTED,
+
+	/* one is already running, or its launch is still in flight */
 	BASE_WORKER_EXISTS,
+
+	/* one already ran to completion and does not need to run again */
 	BASE_WORKER_DONE,
-	BASE_WORKER_START_FAILED,
+
+	/* see DATABASE_STARTER_NO_WORKER_SLOT */
+	BASE_WORKER_NO_WORKER_SLOT,
+
+	/* see DATABASE_STARTER_NEVER_RAN */
+	BASE_WORKER_NEVER_RAN,
+
+	/* its restart backoff has not elapsed yet */
 	BASE_WORKER_START_BLOCKED
 }			StartBaseWorkerResult;
 
@@ -318,6 +374,7 @@ static void PgBaseExtensionServerStarterSharedMemoryExit(int code, Datum arg);
 static void StartDatabaseStarters(List *databaseList);
 static List *GetDatabaseList(void);
 static void RemoveWorkerEntriesNotInDatabaseList(List *databaseList);
+static void ReclaimStaleBaseWorkerLaunches(void);
 static bool DatabaseExistsInList(List *databaseList, Oid databaseId);
 static StartDatabaseStarterResult StartDatabaseStarter(Oid databaseId,
 													   char *databaseName);
@@ -423,6 +480,9 @@ int32		MyBaseWorkerId = InvalidOid;
 int			WorkerRestartBackoffInitialMs = DEFAULT_WORKER_RESTART_BACKOFF_INITIAL_MS;
 int			WorkerRestartBackoffMaxMs = DEFAULT_WORKER_RESTART_BACKOFF_MAX_MS;
 int			WorkerRestartHealthyMs = DEFAULT_WORKER_RESTART_HEALTHY_MS;
+
+/* pg_extension_base.worker_startup_timeout */
+int			WorkerStartupTimeoutMs = DEFAULT_WORKER_STARTUP_TIMEOUT_MS;
 
 /*
  * InitializeBaseWorkerLauncher sets up hooks used by the base worker launcher.
@@ -725,6 +785,14 @@ PgExtensionServerStarterMain(Datum arg)
 		 */
 		RemoveWorkerEntriesNotInDatabaseList(databaseList);
 
+		/*
+		 * Reclaim base worker launches that never actually ran. This has to
+		 * happen here rather than only in StartBaseWorker: a database starter
+		 * exits as soon as every launch it issued reported success, so once
+		 * it is gone nothing else would ever revisit those entries.
+		 */
+		ReclaimStaleBaseWorkerLaunches();
+
 		/* start database starters when needed */
 		StartDatabaseStarters(databaseList);
 
@@ -793,14 +861,26 @@ StartDatabaseStarters(List *databaseList)
 		CommitTransactionCommand();
 		MemoryContextSwitchTo(outerContext);
 
-		if (startResult == DATABASE_STARTER_FAILED)
+		if (startResult == DATABASE_STARTER_NO_WORKER_SLOT)
 		{
-			/* failed to start, bail out for now */
+			/* no slots left, so the remaining databases will not start either */
 			ereport(LOG, (errmsg("failed to start pg base extension database starter in database %s",
 								 quote_identifier(entry->databaseName)),
 						  errhint("You may need to increase max_worker_processes.")));
 
 			return;
+		}
+		else if (startResult == DATABASE_STARTER_NEVER_RAN)
+		{
+			/*
+			 * The launch was registered but never actually ran. The entry has
+			 * already been reset so the next pass will retry; this is
+			 * unrelated to other databases, so keep going instead of bailing
+			 * out of the whole loop.
+			 */
+			ereport(LOG, (errmsg("pg base extension database starter in database %s "
+								 "did not start, will retry",
+								 quote_identifier(entry->databaseName))));
 		}
 	}
 }
@@ -887,6 +967,79 @@ RemoveWorkerEntriesNotInDatabaseList(List *databaseList)
 
 
 /*
+ * ReclaimStaleBaseWorkerLaunches resets base worker entries that have been
+ * sitting in WORKER_STARTING with no pid for longer than
+ * worker_startup_timeout.
+ *
+ * That state means the child never ran any of our code -- the postmaster
+ * could not fork it, or it died before reaching the before_shmem_exit handler
+ * that is otherwise the only thing that ever clears WORKER_STARTING. Note
+ * that WaitForBackgroundWorkerStartup cannot catch the latter: the postmaster
+ * publishes the child's pid before the child loads our library, so the launch
+ * reports BGWH_STARTED either way.
+ *
+ * Resetting the entry alone is not enough to get the worker running again,
+ * because only a database starter can launch base workers, so we also flag
+ * the owning database's starter for restart.
+ */
+static void
+ReclaimStaleBaseWorkerLaunches(void)
+{
+	if (BaseWorkerHash == NULL)
+	{
+		return;
+	}
+
+	TimestampTz now = GetCurrentTimestamp();
+
+	LWLockAcquire(&BaseWorkerControl->lock, LW_EXCLUSIVE);
+
+	HASH_SEQ_STATUS status;
+
+	hash_seq_init(&status, BaseWorkerHash);
+
+	BaseWorkerEntry *workerEntry;
+
+	while ((workerEntry = (BaseWorkerEntry *) hash_seq_search(&status)) != NULL)
+	{
+		if (workerEntry->state != WORKER_STARTING || workerEntry->workerPid > 0)
+		{
+			continue;
+		}
+
+		if (!TimestampDifferenceExceeds(workerEntry->launchedAt, now,
+										WorkerStartupTimeoutMs))
+		{
+			continue;
+		}
+
+		ereport(WARNING, (errmsg("pg base extension worker %d in database %d "
+								 "appears to have never started (stuck in "
+								 "starting state for over %d ms); retrying",
+								 workerEntry->key.workerId,
+								 workerEntry->key.databaseId,
+								 WorkerStartupTimeoutMs)));
+
+		workerEntry->state = WORKER_STOPPED;
+		workerEntry->needsRestart = true;
+		workerEntry->restartAfter = 0;
+
+		bool		starterFound = false;
+		DatabaseStarterEntry *starterEntry =
+			hash_search(DatabaseStarterHash, &workerEntry->key.databaseId,
+						HASH_FIND, &starterFound);
+
+		if (starterFound)
+		{
+			starterEntry->needsRestart = true;
+		}
+	}
+
+	LWLockRelease(&BaseWorkerControl->lock);
+}
+
+
+/*
  * DatabaseExistsInList returns whether databaseList contains a
  * DatabaseEntry for the database with OID databaseId.
  */
@@ -960,13 +1113,40 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 
 	if (isFound)
 	{
-		if (starterEntry->workerPid > 0 || starterEntry->state == WORKER_STARTING)
+		if (starterEntry->workerPid > 0)
 		{
 			/* database starter is already running */
 			LWLockRelease(&BaseWorkerControl->lock);
 			return DATABASE_STARTER_EXISTS;
 		}
-		else if (!starterEntry->needsRestart)
+		else if (starterEntry->state == WORKER_STARTING)
+		{
+			if (!TimestampDifferenceExceeds(starterEntry->launchedAt,
+											GetCurrentTimestamp(),
+											WorkerStartupTimeoutMs))
+			{
+				/* launch is still within its startup grace period */
+				LWLockRelease(&BaseWorkerControl->lock);
+				return DATABASE_STARTER_EXISTS;
+			}
+
+			/*
+			 * The launch has been stuck at WORKER_STARTING with no pid for
+			 * longer than worker_startup_timeout, which means the child never
+			 * ran (e.g. the postmaster could not fork it) and thus never
+			 * reached the cleanup handler that would otherwise reset our
+			 * state.  Reclaim the entry and fall through to retry the launch
+			 * below rather than staying wedged forever.
+			 */
+			ereport(WARNING, (errmsg("pg base extension database starter in database %s "
+									 "appears to have never started (stuck in starting "
+									 "state for over %d ms); retrying",
+									 quote_identifier(databaseName), WorkerStartupTimeoutMs)));
+			starterEntry->state = WORKER_STOPPED;
+			starterEntry->needsRestart = true;
+		}
+
+		if (!starterEntry->needsRestart)
 		{
 			/*
 			 * database starter is already finished and does not need a
@@ -1013,7 +1193,7 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 		 * next time, hoping that another background worker stopped.
 		 */
 		LWLockRelease(&BaseWorkerControl->lock);
-		return DATABASE_STARTER_FAILED;
+		return DATABASE_STARTER_NO_WORKER_SLOT;
 	}
 
 	/*
@@ -1022,6 +1202,7 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 	 */
 	starterEntry->needsRestart = false;
 	starterEntry->state = WORKER_STARTING;
+	starterEntry->launchedAt = GetCurrentTimestamp();
 
 	LWLockRelease(&BaseWorkerControl->lock);
 
@@ -1030,8 +1211,41 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 	 * creation. We let the process set its own PID.
 	 */
 	pid_t		workerPid = 0;
+	BgwHandleStatus status = WaitForBackgroundWorkerStartup(handle, &workerPid);
 
-	WaitForBackgroundWorkerStartup(handle, &workerPid);
+	Assert(status != BGWH_NOT_YET_STARTED);
+
+	/*
+	 * In production the branch below is reached when the postmaster could not
+	 * fork the child at all, which a test cannot arrange.  Let it say so
+	 * instead, having killed the child at
+	 * database-starter-before-exit-handler so that no starter is left running
+	 * behind our back.
+	 */
+	if (IS_INJECTION_POINT_ATTACHED_COMPAT("database-starter-launch-reported-stopped"))
+		status = BGWH_STOPPED;
+
+	if (status != BGWH_STARTED)
+	{
+		/*
+		 * The postmaster never actually ran the child (fork() failure). Reset
+		 * the entry so the next pass retries rather than believing a starter
+		 * is running that never existed; without this the entry stays wedged
+		 * at WORKER_STARTING/pid=0 forever, since only the child's own
+		 * cleanup handler otherwise clears it.
+		 */
+		LWLockAcquire(&BaseWorkerControl->lock, LW_EXCLUSIVE);
+		starterEntry->workerPid = 0;
+		starterEntry->state = WORKER_STOPPED;
+		starterEntry->needsRestart = true;
+		LWLockRelease(&BaseWorkerControl->lock);
+
+		ereport(WARNING, (errmsg("pg base extension database starter in database %s "
+								 "did not start",
+								 quote_identifier(databaseName))));
+
+		return DATABASE_STARTER_NEVER_RAN;
+	}
 
 	return DATABASE_STARTER_STARTED;
 }
@@ -1045,6 +1259,13 @@ void
 PgExtensionBaseDatabaseStarterMain(Datum databaseIdDatum)
 {
 	Oid			databaseId = DatumGetObjectId(databaseIdDatum);
+
+	/*
+	 * Lets a test exercise a launch whose child dies before it registers the
+	 * exit handler below, which is the only thing that would otherwise move
+	 * the entry out of WORKER_STARTING.
+	 */
+	INJECTION_POINT_COMPAT("database-starter-before-exit-handler");
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, HandleSighup);
@@ -1420,13 +1641,26 @@ StartAllBaseWorkers(List *workerRegistrationList)
 			StartBaseWorker(registration->workerId, registration->extensionId,
 							registration->entryPointFunctionId);
 
-		if (startResult == BASE_WORKER_START_FAILED)
+		if (startResult == BASE_WORKER_NO_WORKER_SLOT)
 		{
 			ereport(LOG, (errmsg("failed to start base worker %s in database %d",
 								 registration->workerName, MyDatabaseId)),
 					errhint("You may need to increase max_worker_processes."));
 
-			/* failed to start, bail out for now */
+			/* no slots left, so the remaining workers will not start either */
+			return false;
+		}
+		else if (startResult == BASE_WORKER_NEVER_RAN)
+		{
+			ereport(LOG, (errmsg("base worker %s in database %d did not start, "
+								 "will retry",
+								 registration->workerName, MyDatabaseId)));
+
+			/*
+			 * The entry has been reset for a retry. Report that not
+			 * everything is up so we stay alive and come back to it, rather
+			 * than exiting as if all the launches had succeeded.
+			 */
 			return false;
 		}
 		else if (startResult == BASE_WORKER_START_BLOCKED)
@@ -1556,13 +1790,25 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 		 * same effect of the worker not getting started again.
 		 */
 
-		if (workerEntry->workerPid > 0 || workerEntry->state == WORKER_STARTING)
+		if (workerEntry->workerPid > 0)
 		{
 			/* base worker is already running */
 			LWLockRelease(&BaseWorkerControl->lock);
 			return BASE_WORKER_EXISTS;
 		}
-		else if (!workerEntry->needsRestart)
+		else if (workerEntry->state == WORKER_STARTING)
+		{
+			/*
+			 * A launch is in flight. If it never actually runs, the server
+			 * starter's ReclaimStaleBaseWorkerLaunches sweep resets the entry
+			 * after worker_startup_timeout -- it has to be the sweep and not
+			 * us, because we exit as soon as every launch reports success.
+			 */
+			LWLockRelease(&BaseWorkerControl->lock);
+			return BASE_WORKER_EXISTS;
+		}
+
+		if (!workerEntry->needsRestart)
 		{
 			/* base worker is already finished and does not need a restart */
 			LWLockRelease(&BaseWorkerControl->lock);
@@ -1632,7 +1878,7 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 							 MyDatabaseId),
 					  errhint("You may need to increase max_worker_processes.")));
 
-		return BASE_WORKER_START_FAILED;
+		return BASE_WORKER_NO_WORKER_SLOT;
 	}
 
 	/*
@@ -1643,6 +1889,7 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 	workerEntry->needsRestart = false;
 	workerEntry->state = WORKER_STARTING;
 	workerEntry->restartAfter = 0;
+	workerEntry->launchedAt = GetCurrentTimestamp();
 
 	/*
 	 * Clear the last-run start time until the worker actually reaches
@@ -1661,8 +1908,33 @@ StartBaseWorker(int workerId, Oid extensionId, Oid entryPointFunctionId)
 	 * creation. We let the process set its own PID.
 	 */
 	pid_t		workerPid = 0;
+	BgwHandleStatus status = WaitForBackgroundWorkerStartup(handle, &workerPid);
 
-	WaitForBackgroundWorkerStartup(handle, &workerPid);
+	Assert(status != BGWH_NOT_YET_STARTED);
+
+	/* see StartDatabaseStarter */
+	if (IS_INJECTION_POINT_ATTACHED_COMPAT("base-worker-launch-reported-stopped"))
+		status = BGWH_STOPPED;
+
+	if (status != BGWH_STARTED)
+	{
+		/*
+		 * The postmaster never actually ran the child (fork() failure). Reset
+		 * the entry so the next pass retries rather than believing a worker
+		 * is running that never existed.
+		 */
+		LWLockAcquire(&BaseWorkerControl->lock, LW_EXCLUSIVE);
+		workerEntry->workerPid = 0;
+		workerEntry->state = WORKER_STOPPED;
+		workerEntry->needsRestart = true;
+		LWLockRelease(&BaseWorkerControl->lock);
+
+		ereport(WARNING, (errmsg("pg base extension worker %d in database %d "
+								 "did not start",
+								 workerId, MyDatabaseId)));
+
+		return BASE_WORKER_NEVER_RAN;
+	}
 
 	return BASE_WORKER_STARTED;
 }
@@ -1892,6 +2164,13 @@ PgExtensionBaseWorkerMain(Datum arg)
 
 	/* record our worker id in a global */
 	MyBaseWorkerId = workerId;
+
+	/*
+	 * Lets a test exercise a launch whose child dies before it registers the
+	 * exit handler below, which is the only thing that would otherwise move
+	 * the entry out of WORKER_STARTING.
+	 */
+	INJECTION_POINT_COMPAT("base-worker-before-exit-handler");
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, HandleSighup);

--- a/pg_extension_base/src/pg_extension_base.c
+++ b/pg_extension_base/src/pg_extension_base.c
@@ -172,7 +172,7 @@ _PG_init(void)
 							NULL,
 							&WorkerStartupTimeoutMs,
 							DEFAULT_WORKER_STARTUP_TIMEOUT_MS,
-							0,
+							MIN_WORKER_STARTUP_TIMEOUT_MS,
 							INT32_MAX,
 							PGC_SIGHUP,
 							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,

--- a/pg_extension_base/src/pg_extension_base.c
+++ b/pg_extension_base/src/pg_extension_base.c
@@ -165,6 +165,21 @@ _PG_init(void)
 							NULL,
 							NULL);
 
+	DefineCustomIntVariable("pg_extension_base.worker_startup_timeout",
+							"Sets how long a launch may sit in the starting state with "
+							"no pid before it is treated as never having run (e.g. the "
+							"postmaster could not fork the child) and retried.",
+							NULL,
+							&WorkerStartupTimeoutMs,
+							DEFAULT_WORKER_STARTUP_TIMEOUT_MS,
+							0,
+							INT32_MAX,
+							PGC_SIGHUP,
+							GUC_UNIT_MS | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+							NULL,
+							NULL,
+							NULL);
+
 	/*
 	 * Install our ProcessUtility hook for ALTER EXTENSION ... UPDATE
 	 * dependency walking BEFORE preloading other extensions.  Postgres

--- a/pg_extension_base/tests/pytests/test_base_worker_fault_injection.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_fault_injection.py
@@ -5,9 +5,8 @@ import time
 from utils_pytest import *
 
 
-# Long enough that the reclaim cannot fire by accident between two polls, short
-# enough that the test does not wait out the 60s production default.
-STARTUP_TIMEOUT_MS = 400
+# The GUC minimum, so the test does not wait out the 60s production default.
+STARTUP_TIMEOUT_MS = 1000
 
 # Either recovery path may win the race below, so accept both messages: the
 # postmaster publishes the child's pid before the child loads our library, so

--- a/pg_extension_base/tests/pytests/test_base_worker_fault_injection.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_fault_injection.py
@@ -1,0 +1,270 @@
+import os
+import psycopg2
+import pytest
+import time
+from utils_pytest import *
+
+
+# Long enough that the reclaim cannot fire by accident between two polls, short
+# enough that the test does not wait out the 60s production default.
+STARTUP_TIMEOUT_MS = 400
+
+# Either recovery path may win the race below, so accept both messages: the
+# postmaster publishes the child's pid before the child loads our library, so
+# WaitForBackgroundWorkerStartup can report either BGWH_STOPPED (caught by the
+# status check) or BGWH_STARTED (caught by the startup timeout).
+RECOVERY_WARNINGS = ("appears to have never started", "did not start")
+
+
+def wait_until(fn, timeout=15.0, interval=0.05):
+    """Poll fn() until it returns a truthy value or `timeout` seconds elapse;
+    return the last observed value.  Background workers act asynchronously, so a
+    single fixed sleep before asserting their effect is racy under CI load."""
+    value = fn()
+    deadline = time.monotonic() + timeout
+    while not value and time.monotonic() < deadline:
+        time.sleep(interval)
+        value = fn()
+    return value
+
+
+def log_end_offset():
+    with open(f"{server_params.PG_DIR}/logfile", "r") as f:
+        f.seek(0, os.SEEK_END)
+        return f.tell()
+
+
+def read_new_log(offset):
+    with open(f"{server_params.PG_DIR}/logfile", "r") as f:
+        f.seek(offset)
+        return f.read()
+
+
+def set_startup_timeout(conn, value):
+    """Shrink worker_startup_timeout cluster-wide and reload, so the already
+    running server starter picks it up on SIGHUP."""
+    was_autocommit = conn.autocommit
+    conn.rollback()
+    conn.autocommit = True
+    try:
+        if value is None:
+            run_command(
+                "ALTER SYSTEM RESET pg_extension_base.worker_startup_timeout", conn
+            )
+        else:
+            run_command(
+                f"ALTER SYSTEM SET pg_extension_base.worker_startup_timeout = '{value}'",
+                conn,
+            )
+        run_command("SELECT pg_reload_conf()", conn)
+    finally:
+        conn.autocommit = was_autocommit
+
+
+def attach(conn, point):
+    run_command(f"SELECT injection_points_attach('{point}', 'error')", conn)
+    conn.commit()
+
+
+def detach(conn, point):
+    run_command(f"SELECT injection_points_detach('{point}')", conn, raise_error=False)
+    conn.commit()
+
+
+def database_starter_pid(conn, dbname):
+    rows = run_query(
+        f"""
+        SELECT ds.pid
+        FROM extension_base.list_database_starters() ds
+        JOIN pg_database d ON d.oid = ds.database_id
+        WHERE d.datname = '{dbname}'
+        """,
+        conn,
+    )
+    return rows[0]["pid"] if rows else None
+
+
+def base_worker_pid(conn, extname):
+    rows = run_query(
+        f"""
+        SELECT w.pid
+        FROM extension_base.list_base_workers() w
+        JOIN pg_extension e ON e.oid = w.extension_id
+        WHERE e.extname = '{extname}'
+        """,
+        conn,
+    )
+    return rows[0]["pid"] if rows else None
+
+
+def test_database_starter_recovers_from_launch_that_never_ran(
+    superuser_conn, create_injection_extension
+):
+    """
+    A database starter whose child dies before registering its exit handler used
+    to leave list_database_starters() reporting pid=0 forever, with nothing in
+    the log: that handler was the only thing that ever moved the entry out of
+    WORKER_STARTING, so every later pass saw "already starting" and returned
+    without doing anything.
+    """
+    if get_pg_version_num(superuser_conn) < 170000:
+        pytest.skip("Injection points not available (requires PostgreSQL 17+)")
+
+    dbname = "fault_inject_db"
+    point = "database-starter-before-exit-handler"
+
+    # the introspection functions live in the extension's schema, so the
+    # observing connection needs the extension too
+    run_command("CREATE EXTENSION IF NOT EXISTS pg_extension_base", superuser_conn)
+    superuser_conn.commit()
+
+    set_startup_timeout(superuser_conn, f"{STARTUP_TIMEOUT_MS}ms")
+    attach(superuser_conn, point)
+
+    start_offset = log_end_offset()
+    superuser_conn.autocommit = True
+    try:
+        run_command(f"CREATE DATABASE {dbname}", superuser_conn)
+
+        # Give the new database the extension, so its starter has a reason to
+        # exist and announces itself once it finally runs. A starter for a
+        # database without pg_extension_base exits before logging anything.
+        other_conn = psycopg2.connect(
+            f"dbname={dbname} user={server_params.PG_USER} "
+            f"password={server_params.PG_PASSWORD} port={server_params.PG_PORT} "
+            f"host={server_params.PG_HOST}"
+        )
+        run_command("CREATE EXTENSION pg_extension_base", other_conn)
+        other_conn.commit()
+        other_conn.close()
+
+        # confirm we reproduce the wedge: a launch was attempted for the new
+        # database and the child never claimed a pid
+        assert wait_until(
+            lambda: f"starting pg base extension database starter in database {dbname}"
+            in read_new_log(start_offset)
+        ), "no launch was ever attempted for the new database"
+        assert database_starter_pid(superuser_conn, dbname) == 0
+
+        # let the child through, and watch it announce itself once the wedged
+        # entry has been reclaimed and relaunched
+        detach_offset = log_end_offset()
+        superuser_conn.autocommit = False
+        detach(superuser_conn, point)
+        superuser_conn.autocommit = True
+
+        assert wait_until(
+            lambda: f"database starter for database {dbname} started"
+            in read_new_log(detach_offset)
+        ), "the wedged entry was never reclaimed and relaunched"
+
+        log = read_new_log(start_offset)
+        assert any(
+            warning in log for warning in RECOVERY_WARNINGS
+        ), "recovery happened without logging anything"
+    finally:
+        # a relaunched starter may still briefly hold a connection to it
+        assert wait_until(
+            lambda: run_command(
+                f"DROP DATABASE IF EXISTS {dbname}", superuser_conn, raise_error=False
+            )
+            is None
+        ), f"could not drop {dbname}"
+        superuser_conn.autocommit = False
+        detach(superuser_conn, point)
+        set_startup_timeout(superuser_conn, None)
+
+
+def test_base_worker_recovers_from_launch_that_never_ran(
+    superuser_conn, create_injection_extension
+):
+    """
+    Same failure mode for a base worker.  Note this one cannot be fixed inside
+    StartBaseWorker: a database starter exits as soon as every launch it issued
+    reported success, so once it is gone nothing would revisit the entry.  The
+    server starter has to be the one that reclaims it.
+    """
+    if get_pg_version_num(superuser_conn) < 170000:
+        pytest.skip("Injection points not available (requires PostgreSQL 17+)")
+
+    extname = "pg_extension_base_test_scheduler"
+    point = "base-worker-before-exit-handler"
+
+    set_startup_timeout(superuser_conn, f"{STARTUP_TIMEOUT_MS}ms")
+    attach(superuser_conn, point)
+
+    start_offset = log_end_offset()
+    try:
+        run_command(f"CREATE EXTENSION {extname} CASCADE", superuser_conn)
+        superuser_conn.commit()
+
+        # confirm we reproduce the wedge before checking that it recovers
+        assert wait_until(
+            lambda: base_worker_pid(superuser_conn, extname) == 0
+        ), "the worker entry never reached pid=0"
+        assert wait_until(
+            lambda: "starting pg base extension worker" in read_new_log(start_offset)
+        ), "no launch was ever attempted"
+
+        detach(superuser_conn, point)
+
+        assert wait_until(
+            lambda: base_worker_pid(superuser_conn, extname)
+        ), "the wedged entry was never reclaimed and relaunched"
+
+        log = read_new_log(start_offset)
+        assert any(
+            warning in log for warning in RECOVERY_WARNINGS
+        ), "recovery happened without logging anything"
+    finally:
+        detach(superuser_conn, point)
+        run_command(f"DROP EXTENSION IF EXISTS {extname} CASCADE", superuser_conn)
+        superuser_conn.commit()
+        set_startup_timeout(superuser_conn, None)
+
+
+def test_base_worker_recovers_when_postmaster_reports_no_child(
+    superuser_conn, create_injection_extension
+):
+    """
+    The other recovery path, and the one the incident that prompted all this
+    actually took: the postmaster failed to fork the child ("could not fork
+    background worker process: Cannot allocate memory") so
+    WaitForBackgroundWorkerStartup reported it stopped, and the launcher used to
+    throw that status away and leave the entry claiming a launch was in flight.
+
+    A test cannot make fork() fail, so it kills the child and has the launcher
+    report the status the failed fork would have produced. Deliberately leaves
+    worker_startup_timeout at its default, so nothing but the status check can
+    get the entry moving again.
+    """
+    if get_pg_version_num(superuser_conn) < 180000:
+        pytest.skip("IS_INJECTION_POINT_ATTACHED requires PostgreSQL 18+")
+
+    extname = "pg_extension_base_test_scheduler"
+    child_point = "base-worker-before-exit-handler"
+    status_point = "base-worker-launch-reported-stopped"
+
+    attach(superuser_conn, child_point)
+    attach(superuser_conn, status_point)
+
+    start_offset = log_end_offset()
+    try:
+        run_command(f"CREATE EXTENSION {extname} CASCADE", superuser_conn)
+        superuser_conn.commit()
+
+        assert wait_until(
+            lambda: "did not start" in read_new_log(start_offset)
+        ), "the discarded startup status was never noticed"
+
+        detach(superuser_conn, child_point)
+        detach(superuser_conn, status_point)
+
+        assert wait_until(
+            lambda: base_worker_pid(superuser_conn, extname)
+        ), "the entry was never retried after the launch was reported stopped"
+    finally:
+        detach(superuser_conn, child_point)
+        detach(superuser_conn, status_point)
+        run_command(f"DROP EXTENSION IF EXISTS {extname} CASCADE", superuser_conn)
+        superuser_conn.commit()


### PR DESCRIPTION
## Problem

A database starter or base worker whose launch never actually ran could stay wedged **forever**: `extension_base.list_database_starters()` / `list_base_workers()` report `pid = 0`, `needs_restart = true`, and nothing is written to the log.

Both `StartDatabaseStarter` and `StartBaseWorker` set `state = WORKER_STARTING` before registering the background worker, and the only thing that ever cleared that state again was the child's own `before_shmem_exit` handler. If the child never reached that registration, every later pass hit the "already starting" guard and returned `EXISTS`, silently, forever.

A database starter wedged this way takes its base workers down with it, since only a database starter can launch them.

### Confirmed in production

This was found on a cluster whose CDC mirror had been stuck for 3+ days. The server log captures the moment, two consecutive lines:

```
13:20:28 [server starter] LOG:  starting pg base extension database starter in database postgres
13:20:28 [postmaster]     LOG:  could not fork background worker process: Cannot allocate memory
```

`RegisterDynamicBackgroundWorker` succeeded, so a slot was reserved, and then `fork()` failed with ENOMEM. `WaitForBackgroundWorkerStartup` returned `BGWH_STOPPED`, which the old code discarded.

That is the **last** database starter launch attempt in the log. It runs another 10 minutes with no further attempts and no mention of the two stuck workers, while the server starter kept looping and silently getting `EXISTS`.

How it got there: pgduck_server was unhealthy (`could not start query engine` at ~20/min), so the CDC workers crash-looped every ~5s, each restart forking a new process and reviving the database starter; the host then ran out of memory (`out of memory ... in memory context "SPI Exec"`, `could not resize shared memory segment ... No space left on device`); and the relaunch after one of those deaths is the one that could not fork.

## Fix

Both ways the child can fail to run are handled, and both are needed:

**1. Stop discarding `BgwHandleStatus`.** Checked instead of ignored, and the entry reset when the postmaster reports the child never ran. This is the failed-fork case above — the launch is registered but the child never exists. Mirrors what `attached_worker.c` already does.

**2. Startup-timeout reclamation.** Entries record `launchedAt` and are reclaimed once they have sat in `WORKER_STARTING` with no pid for longer than the new `pg_extension_base.worker_startup_timeout` (default 60s, `PGC_SIGHUP`). The status check cannot cover this case: the postmaster publishes the child's pid *before* the child loads our library, so a child that dies in between still reports `BGWH_STARTED`.

Base workers are reclaimed by the **server starter**, not by `StartBaseWorker`: a database starter calls `proc_exit(0)` as soon as every launch it issued reported success, so once it is gone nothing else would ever revisit those entries. The sweep also flags the owning database's starter for restart, since only a database starter can actually relaunch a base worker. This is why the two stuck workers could not recover on their own.

Both recovery paths log a `WARNING`, so this failure mode is no longer silent.

## Naming

The two ways a launch can fail now have distinct result values, because they call for different responses and the old shared `*_START_FAILED` name hid that:

- `NO_WORKER_SLOT` — `RegisterDynamicBackgroundWorker` failed, i.e. `max_worker_processes` is exhausted. Server-wide, so the caller stops for this pass instead of repeating the failure for every remaining database or worker.
- `NEVER_RAN` — registered, but the child never ran. Specific to one launch, so the caller keeps going and retries that entry next pass, without emitting the misleading `max_worker_processes` hint.

## Tests

`tests/pytests/test_base_worker_fault_injection.py`, using injection points rather than any production-visible switch.

- Two tests place an injection point in each worker entry point just before it registers its exit handler, so the child is genuinely forked and genuinely dies before claiming its pid. Both recover via the startup timeout.
- A third covers the failed-fork path, which no test can produce for real: it kills the child and has the launcher report the status a failed fork would have produced, through a new `IS_INJECTION_POINT_ATTACHED_COMPAT`. That primitive only exists in Postgres 18, so the test skips below it; the macro is a constant `false` on older versions and compiles to nothing at all unless the server was built with `--enable-injection-points`.
- Each test fails if the recovery path it covers is removed — verified individually.
- pg17: 65 passed, 5 skipped. pg18: all three fault-injection tests pass.

## Follow-up

#571 fixes a related unit bug in the same file: `ComputeNextWakeTimeMs` treats a seconds value as milliseconds, so the starters poll every 100ms instead of the configured 10s. That made this incident worse — the crash-looping workers were churning forks ~10x a second under already-critical memory pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)