### PR TITLE
flaky tests: take writable REST catalog metadata from the loadTable response

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/iceberg/metadata_operations.h
+++ b/pg_lake_iceberg/include/pg_lake/iceberg/metadata_operations.h
@@ -19,6 +19,9 @@
 
 #include "nodes/pg_list.h"
 
+#include "pg_lake/iceberg/metadata_spec.h"
+
 extern PGDLLEXPORT List *ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allTransforms, int maxSnapshotAgeInSecs, bool isVerbose);
+extern PGDLLEXPORT IcebergTableMetadata * GetWritableRestCatalogTableMetadata(Oid relationId, char **metadataLocation);
 extern PGDLLEXPORT bool ShouldSkipMetadataChangeToIceberg(List *metadataOperationTypes);
 extern PGDLLEXPORT List *GetMetadataOperationTypes(List *metadataOperations);

--- a/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
+++ b/pg_lake_iceberg/include/pg_lake/rest_catalog/rest_catalog.h
@@ -258,6 +258,7 @@ extern PGDLLEXPORT char *LoadRestCatalogMetadataLocation(RestCatalogOptions * op
 														 const char *relationName);
 extern PGDLLEXPORT RestCatalogLoadTableResult LoadTableFromRestCatalog(RestCatalogOptions * opts, const char *restCatalogName,
 																	   const char *namespaceName, const char *relationName);
+extern PGDLLEXPORT RestCatalogLoadTableResult LoadTableFromRestCatalogForIcebergTable(Oid relationId);
 extern PGDLLEXPORT char *GetMetadataLocationForRestCatalogForIcebergTable(Oid relationId);
 extern PGDLLEXPORT bool RestCatalogVendingEnabledForRelation(Oid relationId);
 

--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -149,6 +149,8 @@ static void AddManifestEntryToHash(HTAB *hash, int32 partitionSpecId,
 								   IcebergManifestEntry * entry);
 static bool HasCreateTableOperation(List *metadataOperations);
 static void DeleteInProgressManifests(Oid relationId, List *manifests);
+static IcebergTableMetadata * GetWritableRestCatalogTableMetadataForUpdate(Oid relationId,
+																		   char **metadataLocation);
 
 
 /*
@@ -205,14 +207,26 @@ ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allT
 	}
 	else
 	{
-		metadataPath = GetIcebergMetadataLocation(relationId, forUpdate);
-
-		/*
-		 * metadata for writable rest catalog is intended to be read-only in
-		 * the remaining of the function, given the authoritative source is
-		 * the rest catalog.
-		 */
-		metadata = ReadIcebergTableMetadata(metadataPath);
+		if (writableRestCatalogTable)
+		{
+			/*
+			 * metadata for writable rest catalog is intended to be read-only
+			 * in the remaining of the function, given the authoritative
+			 * source is the rest catalog. Take it from the loadTable response
+			 * rather than reading metadataPath back from storage: a write
+			 * queues the version it was based on for deletion, so a drain of
+			 * the deletion queue can remove that file while it is still the
+			 * location the catalog reports, and a resolve-then-read would
+			 * fail with a 404.
+			 */
+			metadata = GetWritableRestCatalogTableMetadataForUpdate(relationId,
+																	&metadataPath);
+		}
+		else
+		{
+			metadataPath = GetIcebergMetadataLocation(relationId, forUpdate);
+			metadata = ReadIcebergTableMetadata(metadataPath);
+		}
 
 		/*
 		 * for writable rest catalog tables, the metadata state is on the REST
@@ -1357,6 +1371,39 @@ HasCreateTableOperation(List *metadataOperations)
 	}
 
 	return false;
+}
+
+
+/*
+ * GetWritableRestCatalogTableMetadataForUpdate returns the current iceberg
+ * metadata of a writable rest catalog table, and reports where the catalog
+ * says that metadata lives in *metadataLocation.
+ *
+ * A loadTable response inlines the whole metadata document, so no read from
+ * storage is needed. That matters beyond the saved round-trip: resolving the
+ * location and then fetching it are two steps, and the file can be deleted in
+ * between.
+ *
+ * The catalog row is locked as GetIcebergMetadataLocation(forUpdate = true)
+ * would, to serialize concurrent writers to the same table.
+ */
+static IcebergTableMetadata *
+GetWritableRestCatalogTableMetadataForUpdate(Oid relationId, char **metadataLocation)
+{
+	LockIcebergPgLakeCatalogForUpdate(relationId);
+
+	RestCatalogLoadTableResult result =
+		LoadTableFromRestCatalogForIcebergTable(relationId);
+
+	if (result.metadata == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+				 errmsg("rest catalog did not return the metadata of table %s",
+						get_rel_name(relationId))));
+
+	*metadataLocation = result.metadataLocation;
+
+	return ParseIcebergTableMetadata(result.metadata);
 }
 
 

--- a/pg_lake_iceberg/src/iceberg/metadata_operations.c
+++ b/pg_lake_iceberg/src/iceberg/metadata_operations.c
@@ -149,8 +149,6 @@ static void AddManifestEntryToHash(HTAB *hash, int32 partitionSpecId,
 								   IcebergManifestEntry * entry);
 static bool HasCreateTableOperation(List *metadataOperations);
 static void DeleteInProgressManifests(Oid relationId, List *manifests);
-static IcebergTableMetadata * GetWritableRestCatalogTableMetadataForUpdate(Oid relationId,
-																		   char **metadataLocation);
 
 
 /*
@@ -212,15 +210,12 @@ ApplyIcebergMetadataChanges(Oid relationId, List *metadataOperations, List *allT
 			/*
 			 * metadata for writable rest catalog is intended to be read-only
 			 * in the remaining of the function, given the authoritative
-			 * source is the rest catalog. Take it from the loadTable response
-			 * rather than reading metadataPath back from storage: a write
-			 * queues the version it was based on for deletion, so a drain of
-			 * the deletion queue can remove that file while it is still the
-			 * location the catalog reports, and a resolve-then-read would
-			 * fail with a 404.
+			 * source is the rest catalog. Concurrent writers are already
+			 * serialized by the catalog row lock
+			 * TrackIcebergMetadataChangesInTx() took at DML time, which is
+			 * held until end of transaction.
 			 */
-			metadata = GetWritableRestCatalogTableMetadataForUpdate(relationId,
-																	&metadataPath);
+			metadata = GetWritableRestCatalogTableMetadata(relationId, &metadataPath);
 		}
 		else
 		{
@@ -1375,33 +1370,27 @@ HasCreateTableOperation(List *metadataOperations)
 
 
 /*
- * GetWritableRestCatalogTableMetadataForUpdate returns the current iceberg
- * metadata of a writable rest catalog table, and reports where the catalog
- * says that metadata lives in *metadataLocation.
+ * GetWritableRestCatalogTableMetadata returns the current iceberg metadata of a
+ * writable rest catalog table, and reports where the catalog says that metadata
+ * lives in *metadataLocation, which may be NULL if the caller does not need it.
  *
  * A loadTable response inlines the whole metadata document, so no read from
  * storage is needed. That matters beyond the saved round-trip: resolving the
  * location and then fetching it are two steps, and the file can be deleted in
  * between.
- *
- * The catalog row is locked as GetIcebergMetadataLocation(forUpdate = true)
- * would, to serialize concurrent writers to the same table.
  */
-static IcebergTableMetadata *
-GetWritableRestCatalogTableMetadataForUpdate(Oid relationId, char **metadataLocation)
+IcebergTableMetadata *
+GetWritableRestCatalogTableMetadata(Oid relationId, char **metadataLocation)
 {
-	LockIcebergPgLakeCatalogForUpdate(relationId);
-
 	RestCatalogLoadTableResult result =
 		LoadTableFromRestCatalogForIcebergTable(relationId);
 
-	if (result.metadata == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
-				 errmsg("rest catalog did not return the metadata of table %s",
-						get_rel_name(relationId))));
+	if (metadataLocation != NULL)
+		*metadataLocation = result.metadataLocation;
 
-	*metadataLocation = result.metadataLocation;
+	/* the field is required, but a catalog that omits it still works */
+	if (result.metadata == NULL)
+		return ReadIcebergTableMetadata(result.metadataLocation);
 
 	return ParseIcebergTableMetadata(result.metadata);
 }

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_ops.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_ops.c
@@ -450,10 +450,12 @@ ErrorIfRestNamespaceDoesNotExist(RestCatalogOptions * opts, const char *catalogN
 
 
 /*
-* Gets the metadata location for a relation from the external rest catalog.
-*/
-char *
-GetMetadataLocationForRestCatalogForIcebergTable(Oid relationId)
+ * LoadTableFromRestCatalogForIcebergTable performs a loadTable request for
+ * an existing relation and returns the whole response, including the inlined
+ * metadata document.
+ */
+RestCatalogLoadTableResult
+LoadTableFromRestCatalogForIcebergTable(Oid relationId)
 {
 	const char *restCatalogName = GetRestCatalogName(relationId);
 	const char *relationName = GetRestCatalogTableName(relationId);
@@ -461,7 +463,17 @@ GetMetadataLocationForRestCatalogForIcebergTable(Oid relationId)
 
 	RestCatalogOptions *opts = GetRestCatalogOptionsForRelation(relationId);
 
-	return LoadRestCatalogMetadataLocation(opts, restCatalogName, namespaceName, relationName);
+	return LoadTableFromRestCatalog(opts, restCatalogName, namespaceName, relationName);
+}
+
+
+/*
+* Gets the metadata location for a relation from the external rest catalog.
+*/
+char *
+GetMetadataLocationForRestCatalogForIcebergTable(Oid relationId)
+{
+	return LoadTableFromRestCatalogForIcebergTable(relationId).metadataLocation;
 }
 
 

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1377,8 +1377,18 @@ GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker)
 	if (opTracker->relationCreated)
 		return NULL;
 
+	Oid			relationId = opTracker->relationId;
+
+	/*
+	 * A writable rest catalog inlines the metadata in its loadTable response,
+	 * which is the same request we would resolve the location with, so take
+	 * it from there instead of reading the file back from storage.
+	 */
+	if (GetIcebergCatalogType(relationId) == REST_CATALOG_READ_WRITE)
+		return GetWritableRestCatalogTableMetadata(relationId, NULL);
+
 	/* read the most recently pushed iceberg metadata for the table */
-	char	   *metadataPath = GetIcebergMetadataLocation(opTracker->relationId, false);
+	char	   *metadataPath = GetIcebergMetadataLocation(relationId, false);
 
 	return ReadIcebergTableMetadata(metadataPath);
 }

--- a/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
+++ b/pg_lake_table/src/transaction/track_iceberg_metadata_changes.c
@@ -1380,9 +1380,10 @@ GetLastPushedIcebergMetadata(const TableMetadataOperationTracker * opTracker)
 	Oid			relationId = opTracker->relationId;
 
 	/*
-	 * A writable rest catalog inlines the metadata in its loadTable response,
-	 * which is the same request we would resolve the location with, so take
-	 * it from there instead of reading the file back from storage.
+	 * Any rest catalog inlines the metadata in its loadTable response, and
+	 * resolving the location takes that same request, so take it from there
+	 * rather than reading the file back from storage. Only writable tables
+	 * reach this write-tracking path.
 	 */
 	if (GetIcebergCatalogType(relationId) == REST_CATALOG_READ_WRITE)
 		return GetWritableRestCatalogTableMetadata(relationId, NULL);


### PR DESCRIPTION
This is the nightly flaky test fix.

`test_polaris_catalog_writable.py::test_writable_rest_basic_flow` fails intermittently on `main`, most recently in run [32725825613](https://github.com/Snowflake-Labs/pg_lake/actions/runs/32725825613) (`test-check-pg-lake-table (17, check-pg_lake_table, 4)`), at the positional-delete `INSERT`:

```
E   psycopg2.errors.FeatureNotSupported: HTTP Error: Unable to connect to URL
    ".../test_writable_rest_basic_flow/writable_rest/30628/metadata/00004-625cd739-....metadata.json": 404 (NOT FOUND).
```

### Root cause

For a writable REST catalog table, a pre-commit reads the current `metadata.json` back from object storage more than once, and each read is two steps: resolve the location from the catalog (a `loadTable` request), then fetch that file. The two call sites are `GetLastPushedIcebergMetadata()`, which diffs the transaction's data files against the last pushed version, and `ApplyIcebergMetadataChanges()`, which builds the new version. The file can disappear between the resolve and the fetch.

A write queues the version it was based on for deletion, and that queue row commits before the catalog is told about the successor version — the REST request is posted at `XACT_EVENT_COMMIT`. The deletion queue is drained by a different backend (pg_lake's autovacuum worker), and the pytest server runs with `orphaned_file_retention_period=0`, so the row is eligible the moment it is visible. The moto access log from the failing run shows exactly that ordering:

```
PUT  .../00004-....metadata.json  200      <- version 4 written
GET  .../00004-....metadata.json  206      <- the diff read
PUT  .../00005-....metadata.json  200      <- version 5 written
GET  .../00004-....metadata.json  206
HEAD .../00004-....metadata.json  404      <- 00004 deleted under a reader that resolved it
```

with the drain visible as a batched delete of `00001`–`00004` in the same second.

### Fix

A `loadTable` response inlines the whole metadata document, and it is the same document that lives at the reported location, so parse that (`ParseIcebergTableMetadata()`, already used by `CREATE TABLE`) instead of fetching it. Both call sites now go through one helper, so resolve and read collapse into a single call and there is no window to lose the file in. Neither path pays for it: both already issued a `loadTable` to resolve the location, so this is the same number of catalog requests and one fewer storage read each.

Nothing else changes: the metadata location reported to the rest of `ApplyIcebergMetadataChanges()` is the one the catalog returned, so what gets queued for deletion, and the deletion accounting `test_writable_rest_vacuum` asserts on, are untouched. If a catalog omits the `metadata` field the helper falls back to reading the location, which is what happened before.

### Not fixed here

The write path still releases the catalog row lock before posting the REST request at `XACT_EVENT_COMMIT`, so a queue row for the version the catalog is still pointing at is visible and drainable before its successor exists. This change removes the storage reads that lose that race, but not the ordering gap itself: a concurrent writer can still resolve a base version the drain then deletes, and have the catalog reject its update. It is a transaction-ordering gap rather than a test flake, and worth a separate look.

### Testing

No new test: the race is a timing window between two HTTP calls and there is no injection point to pin it open. Verified no regression by running the REST catalog pytests against a local Polaris (`test_polaris_catalog_writable.py`, `test_polaris_catalog.py`, `test_modify_iceberg_rest_table.py`, `test_vended_credentials_polaris.py`, `test_vended_credentials_enforced.py`, `test_iceberg_catalog_server.py`) — all pass.
