### PR TITLE
flaky tests: do not abort a statement when a deletion-queue path is already queued

### DIFF
--- a/pg_lake_engine/src/cleanup/deletion_queue.c
+++ b/pg_lake_engine/src/cleanup/deletion_queue.c
@@ -579,6 +579,21 @@ InsertMetadataResolveRecord(char *metadataPath, Oid relationId, TimestampTz orph
 * a record into the deletion queue. is_prefix marks a whole-prefix delete and
 * resolve_metadata marks a metadata.json to be resolved into referenced files
 * by VACUUM; the two are mutually exclusive.
+*
+* The queue is a set of paths, so queueing a path that is already queued has
+* to be a no-op rather than a primary key violation: the callers run inside
+* user DML and DDL, and a duplicate would abort the user's statement (an
+* INSERT into a writable REST catalog table, a DROP TABLE) over a file that is
+* already scheduled for deletion. Paths repeat for several reasons -- the
+* metadata location a write is based on can still be the location the catalog
+* reports afterwards, previous_metadata rotation can queue a path a later drop
+* queues again, and two dropped tables can share a file.
+*
+* ON CONFLICT (path) DO UPDATE ... WHERE excluded.resolve_metadata keeps the
+* existing row's retention in every ordinary case, and upgrades it to a
+* resolve_metadata row when that is what the caller is queueing: a deferred
+* drop must still have VACUUM resolve the metadata.json into the files it
+* references, and silently dropping that intent would leak them.
 */
 void
 InsertDeletionQueueRecordExtended(char *path, Oid relationId, TimestampTz orphanedAt,
@@ -587,7 +602,10 @@ InsertDeletionQueueRecordExtended(char *path, Oid relationId, TimestampTz orphan
 	char	   *query =
 		"insert into " DELETION_QUEUE_TABLE " "
 		"(path, table_name, orphaned_at, is_prefix, resolve_metadata) "
-		"values ($1,$2,$3,$4,$5)";
+		"values ($1,$2,$3,$4,$5) "
+		"on conflict (path) do update "
+		"set resolve_metadata = true, table_name = excluded.table_name "
+		"where excluded.resolve_metadata";
 
 	DECLARE_SPI_ARGS(5);
 	SPI_ARG_VALUE(1, TEXTOID, path, false);

--- a/pg_lake_table/tests/pytests/test_drop_table.py
+++ b/pg_lake_table/tests/pytests/test_drop_table.py
@@ -1164,6 +1164,117 @@ def test_flush_deletion_queue_drains_dropped_table_files(
     pg_conn.commit()
 
 
+def _metadata_location(conn, namespace, table):
+    """The metadata.json the iceberg catalog currently points at."""
+    return run_query(
+        f"SELECT metadata_location FROM lake_iceberg.tables "
+        f"WHERE table_namespace = '{namespace}' AND table_name = '{table}'",
+        conn,
+    )[0][0]
+
+
+def _queue_path(superuser_conn, path):
+    """Put a path in the deletion queue the way an earlier write would have."""
+    run_command(
+        f"INSERT INTO lake_engine.deletion_queue "
+        f"(path, table_name, orphaned_at, is_prefix, resolve_metadata) "
+        f"VALUES ('{path}', NULL, pg_catalog.now(), false, false)",
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+
+def _count_path_records(superuser_conn, path):
+    return run_query(
+        f"SELECT count(*) FROM lake_engine.deletion_queue WHERE path = '{path}'",
+        superuser_conn,
+    )[0][0]
+
+
+def test_drop_when_a_referenced_file_is_already_queued(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    """A DROP must not fail because a file it queues is queued already.
+
+    The queue is a set of paths, and paths legitimately repeat: the metadata
+    location a write is based on can still be the location the catalog reports
+    afterwards, previous_metadata rotation queues a path a later drop queues
+    again, and two dropped tables can share a file. A plain INSERT hit the
+    primary key and aborted the user's DROP."""
+    run_command("CREATE SCHEMA IF NOT EXISTS drop_requeue", pg_conn)
+    run_command(
+        """
+        CREATE TABLE drop_requeue.t USING iceberg
+        WITH (autovacuum_enabled='false')
+        AS SELECT i AS id, 'pg_lake' AS name FROM generate_series(1, 10) i
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    location = _writable_location(pg_conn, "drop_requeue.t")
+    metadata_location = _metadata_location(pg_conn, "drop_requeue", "t")
+
+    # the drop enumerates the referenced files and queues each of them, the
+    # metadata.json included -- so queue that one up front
+    _queue_path(superuser_conn, metadata_location)
+
+    run_command("DROP TABLE drop_requeue.t", pg_conn)
+    pg_conn.commit()
+
+    # one row for the path, not a second one, and the eager per-file rows for
+    # the rest of the table are there as usual
+    assert _count_path_records(superuser_conn, metadata_location) == 1
+    assert _count_data_file_records(superuser_conn, location) > 0
+    assert _count_prefix_records(superuser_conn, location) == 0
+    superuser_conn.commit()
+
+    # VACUUM still deletes the referenced files and drains the queue
+    _assert_vacuum_drains(superuser_conn, location)
+
+    run_command("DROP SCHEMA IF EXISTS drop_requeue CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def test_deferred_drop_upgrades_an_already_queued_metadata(
+    s3, pg_conn, superuser_conn, extension, with_default_location
+):
+    """A deferred drop of a metadata.json that is already queued as a plain
+    file row must upgrade that row to a resolve_metadata row, not leave it as
+    is: VACUUM has to resolve the metadata into the files it references, and
+    losing that intent would leak every one of them."""
+    run_command("CREATE SCHEMA IF NOT EXISTS defer_drop_requeue", pg_conn)
+    run_command(
+        """
+        CREATE TABLE defer_drop_requeue.t USING iceberg
+        WITH (autovacuum_enabled='false')
+        AS SELECT i AS id, 'pg_lake' AS name FROM generate_series(1, 10) i
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    location = _writable_location(pg_conn, "defer_drop_requeue.t")
+    metadata_location = _metadata_location(pg_conn, "defer_drop_requeue", "t")
+
+    _queue_path(superuser_conn, metadata_location)
+
+    _drop_deferred(pg_conn, "DROP TABLE defer_drop_requeue.t")
+
+    # still a single row for the metadata.json, now flagged for resolution
+    assert _count_path_records(superuser_conn, metadata_location) == 1
+    assert _count_resolve_records(superuser_conn, location) == 1
+    assert _count_data_file_records(superuser_conn, location) == 0
+    assert _count_prefix_records(superuser_conn, location) == 0
+    superuser_conn.commit()
+
+    # and resolution happens, so the data files are deleted rather than leaked
+    _assert_vacuum_drains(superuser_conn, location)
+
+    run_command("DROP SCHEMA IF EXISTS defer_drop_requeue CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 @pytest.fixture(scope="module")
 def create_test_helper_functions(superuser_conn, s3, extension):
     # lake_iceberg.find_all_referenced_files is installed by pg_lake_iceberg,


### PR DESCRIPTION
This is the nightly flaky test fix.

Two different CI failures, one root cause:

- [run 32732142779](https://github.com/Snowflake-Labs/pg_lake/actions/runs/32732142779) — `test_different_table_types.py`, where a `DROP SCHEMA ... CASCADE` aborted
- [run 32473112918](https://github.com/Snowflake-Labs/pg_lake/actions/runs/32473112918) — `test_writable_rest.py::test_writable_rest_basic_flow`, where a plain `COMMIT` after an `INSERT` aborted

Both with:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "deletion_queue_pkey"
```

Each passed on a re-run of the same commit.

### Root cause

`InsertDeletionQueueRecordExtended()` does a plain `INSERT` into `lake_engine.deletion_queue`, whose primary key is `path`. But the queue is a *set* of paths, and paths legitimately repeat:

- the metadata location a write is based on can still be the location the catalog reports afterwards, so the same `metadata.json` gets queued twice
- `previous_metadata` rotation queues a path that a later `DROP` queues again
- two dropped tables can share a file

Because every caller runs inside user DML and DDL, the duplicate doesn't just fail the enqueue — it aborts the user's statement, over a file that is *already* scheduled for deletion. That's the `DROP SCHEMA CASCADE` failure and the `COMMIT` failure above.

It's timing-dependent (hence flaky) because whether the two paths collide depends on whether a catalog interaction landed between the two enqueues.

`ExpandMetadataResolveRecord()` in the same file already hit this and already handles it with `ON CONFLICT (path)`, with a comment saying a plain `INSERT` would hit the primary key and abort. The other path never got the same treatment.

### Fix

Make the enqueue idempotent with `ON CONFLICT (path) DO UPDATE ... WHERE excluded.resolve_metadata`:

- an ordinary duplicate is a no-op, keeping the existing row's `orphaned_at` (its retention window is already partly served, so this is the conservative choice)
- when the caller is queueing a `resolve_metadata` row, the existing row is *upgraded* to one. A deferred drop must still have VACUUM resolve the `metadata.json` into the files it references; silently discarding that intent would leak every one of them.

### Testing

Two regression tests in `test_drop_table.py`:

- `test_drop_when_a_referenced_file_is_already_queued` — a `DROP` whose `metadata.json` is already queued as a plain row
- `test_deferred_drop_upgrades_an_already_queued_metadata` — a deferred drop that has to upgrade an already-queued plain row, and still resolves and deletes the data files rather than leaking them

Both reproduce the CI signature without the fix (`duplicate key value violates unique constraint "deletion_queue_pkey"`) and pass with it. Full local runs against PG 18: `test_drop_table.py` 24 passed, plus `test_deletion_queue_batching.py`, `test_vacuum_failure.py`, `test_iceberg_remove_unreferenced_files.py` and `test_writable_iceberg.py` green.

Nothing skipped or weakened — the tests still assert the files are queued and that VACUUM drains them.
