### PR TITLE
flaky tests: do not start a database starter into a concurrent DROP

### DIFF
--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -98,6 +98,7 @@
 #include "tcop/utility.h"
 
 #include "pg_extension_base/base_workers.h"
+#include "pg_extension_base/injection_points.h"
 #include "pg_extension_base/pg_extension_base_ids.h"
 #include "pg_extension_base/pg_compat.h"
 #include "pg_extension_base/spi_helpers.h"
@@ -1127,6 +1128,14 @@ PgExtensionBaseDatabaseStarterMain(Datum databaseIdDatum)
 	MemoryContext outerContext = CurrentMemoryContext;
 
 	StartTransactionCommand();
+
+	/*
+	 * Tests park a starter here to get the state that made DROP DATABASE
+	 * fail: connected, so it counts as a session in the database, and not yet
+	 * in the main loop, so only a SIGTERM that terminates immediately gets
+	 * rid of it.
+	 */
+	INJECTION_POINT_COMPAT("database-starter-before-lock");
 
 	/*
 	 * We take the LockDatabaseStarter lock here to wait for any concurrent

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -92,6 +92,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
+#include "utils/resowner.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "tcop/utility.h"
@@ -284,6 +285,7 @@ typedef enum StartDatabaseStarterResult
 	DATABASE_STARTER_STARTED,
 	DATABASE_STARTER_EXISTS,
 	DATABASE_STARTER_DONE,
+	DATABASE_STARTER_BLOCKED,
 	DATABASE_STARTER_FAILED
 }			StartDatabaseStarterResult;
 
@@ -377,7 +379,8 @@ static void DatabaseStarterNeedsRestart(Oid databaseId);
 static void PrepareForDrop(Oid databaseId, Oid extensionId);
 
 /* functions called by transaction end */
-static void BaseWorkerTransactionCallback(XactEvent event, void *arg);
+static void BaseWorkerResourceReleaseCallback(ResourceReleasePhase phase, bool isCommit,
+											  bool isTopLevel, void *arg);
 
 /* SQL-callable functions */
 PG_FUNCTION_INFO_V1(pg_extension_base_register_worker);
@@ -451,7 +454,7 @@ InitializeBaseWorkerLauncher(void)
 	PreviousObjectAccessHook = object_access_hook;
 	object_access_hook = BaseWorkerObjectAccessHook;
 
-	RegisterXactCallback(BaseWorkerTransactionCallback, NULL);
+	RegisterResourceReleaseCallback(BaseWorkerResourceReleaseCallback, NULL);
 
 	StartServerStarter();
 }
@@ -775,9 +778,11 @@ StartDatabaseStarters(List *databaseList)
 		Oid			databaseId = entry->databaseId;
 
 		/*
-		 * StartDatabaseStarter acquires a lock to wait for concurrent DROP
-		 * DATABASE commands to finish. We hold this lock until leaving the
-		 * function and committing below.
+		 * StartDatabaseStarter conditionally acquires a lock that a
+		 * concurrent DROP DATABASE/EXTENSION holds, and skips the database if
+		 * it cannot get it. We hold the lock until leaving the function and
+		 * committing below, which keeps such a DROP out of the way while we
+		 * register the database starter.
 		 */
 		StartTransactionCommand();
 
@@ -915,26 +920,36 @@ StartDatabaseStarter(Oid databaseId, char *databaseName)
 	}
 
 	/*
-	 * In case of a concurrent DROP DATABASE/EXTENSION that affects this
-	 * database (which takes ExclusiveLock), we wait for it to finish.
+	 * A concurrent DROP DATABASE/EXTENSION that affects this database holds
+	 * this lock in ExclusiveLock mode until it commits or aborts, so we back
+	 * off and let the next iteration deal with the database.
 	 *
-	 * Otherwise, in case of DROP DATABASE, we might proceed to create a
-	 * database starter for a database that is gone by the time the worker is
-	 * up and running, which causes an error in the log every time someone
-	 * drops a database.
+	 * In case of DROP DATABASE, proceeding would create a database starter
+	 * that connects to a database the DROP is waiting to become idle. The
+	 * starter then blocks below on this very lock, and since it counts as a
+	 * session in the database, DROP DATABASE fails with "database is being
+	 * accessed by other users" once it gives up waiting -- even with FORCE,
+	 * because a SIGTERM only sets a flag the starter cannot act on while it
+	 * is waiting for the lock.
 	 *
-	 * Or, in case of DROP EXTENSION, we might proceed to restart workers for
-	 * an extension that is about to be dropped.
+	 * In case of DROP EXTENSION, proceeding would restart workers for an
+	 * extension that is about to be dropped.
+	 *
+	 * Backing off is safe because we leave needsRestart set, and the DROP
+	 * signals the server starter when its transaction ends either way.
 	 *
 	 * In case of CREATE EXTENSION (which takes ShareLock), we do not back
 	 * off.
-	 *
-	 * We prefer to block here instead of wait for the next server starter
-	 * iteration to promptly react to DROP+CREATE EXTENSION operations.
 	 */
 	bool		waitForLock = false;
 
-	LockDatabaseStarter(databaseId, ShareLock, waitForLock);
+	if (LockDatabaseStarter(databaseId, ShareLock, waitForLock) == LOCKACQUIRE_NOT_AVAIL)
+	{
+		ereport(DEBUG2, (errmsg("not starting pg base extension database starter in "
+								"database %s because a drop is in progress",
+								quote_identifier(databaseName))));
+		return DATABASE_STARTER_BLOCKED;
+	}
 
 	LWLockAcquire(&BaseWorkerControl->lock, LW_EXCLUSIVE);
 
@@ -1033,7 +1048,17 @@ PgExtensionBaseDatabaseStarterMain(Datum databaseIdDatum)
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, HandleSighup);
 	pqsignal(SIGINT, SIG_IGN);
-	pqsignal(SIGTERM, HandleSigterm);
+
+	/*
+	 * Until we reach the main loop we cannot react to a SIGTERM flag, because
+	 * we connect to the database and wait for locks along the way. That
+	 * matters for DROP DATABASE, which SIGTERMs the sessions in the database
+	 * and then waits a few seconds for them to go away: a starter that
+	 * connected and is waiting for a lock keeps the database busy and fails
+	 * the DROP. Die immediately instead, like the base workers do, and let
+	 * the server starter bring us back if the DROP does not commit.
+	 */
+	pqsignal(SIGTERM, die);
 
 	/* Set our exit handler before any calls to proc_exit */
 	before_shmem_exit(PgExtensionBaseDatabaseStarterSharedMemoryExit,
@@ -1193,6 +1218,13 @@ PgExtensionBaseDatabaseStarterMain(Datum databaseIdDatum)
 													  ALLOCSET_DEFAULT_MAXSIZE);
 
 	MemoryContextSwitchTo(loopContext);
+
+	/*
+	 * From here on we check TerminationRequested between iterations, so we
+	 * can shut down gracefully and let the server starter tell a SIGTERM
+	 * apart from a graceful exit.
+	 */
+	pqsignal(SIGTERM, HandleSigterm);
 
 	while (!TerminationRequested)
 	{
@@ -3067,33 +3099,33 @@ SignalDatabaseStarterLocked(Oid databaseId)
 
 
 /*
- * BaseWorkerTransactionCallback is a transaction callback that
- * signals the server starter after a transaction completed.
+ * BaseWorkerResourceReleaseCallback signals the server starter after a
+ * transaction completed.
  *
  * This speeds up recovery in cases where we killed a background
  * worker and then rolled back, or created a database from a template
  * that contains a base worker registration.
+ *
+ * We deliberately do this in the after-locks phase rather than in a
+ * transaction callback: the transaction callbacks still run while we hold the
+ * database starter lock, so the server starter would find the database locked
+ * and skip it, and then only get to it on its next regular wake-up.
  */
 static void
-BaseWorkerTransactionCallback(XactEvent event, void *arg)
+BaseWorkerResourceReleaseCallback(ResourceReleasePhase phase, bool isCommit,
+								  bool isTopLevel, void *arg)
 {
-	switch (event)
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS || !isTopLevel)
 	{
-		case XACT_EVENT_COMMIT:
-		case XACT_EVENT_ABORT:
-			{
-				if (SignalServerStarter)
-				{
-					LWLockAcquire(&BaseWorkerControl->lock, LW_SHARED);
-					ProcSendSignal(BaseWorkerControl->serverStarterProcno);
-					LWLockRelease(&BaseWorkerControl->lock);
-					SignalServerStarter = false;
-				}
-				break;
-			}
+		return;
+	}
 
-		default:
-			break;
+	if (SignalServerStarter)
+	{
+		LWLockAcquire(&BaseWorkerControl->lock, LW_SHARED);
+		ProcSendSignal(BaseWorkerControl->serverStarterProcno);
+		LWLockRelease(&BaseWorkerControl->lock);
+		SignalServerStarter = false;
 	}
 }
 

--- a/pg_extension_base/tests/pytests/test_base_worker_launcher.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_launcher.py
@@ -368,6 +368,88 @@ def test_failed_drop_database(superuser_conn):
     superuser_conn.autocommit = False
 
 
+def count_other_backends_in_database(conn, datname, own_pid):
+    query = f"""
+        SELECT count(*) FROM pg_stat_activity
+        WHERE datname = '{datname}' AND pid <> {own_pid}
+    """
+    return run_query(query, conn)[0]["count"]
+
+
+def test_no_starter_connects_while_a_drop_holds_the_lock(superuser_conn):
+    """A DROP that stops the workers of a database also blocks new database
+    starters for it until it is done.
+
+    Otherwise the server starter connects a database starter to a database that
+    a concurrent DROP DATABASE is waiting to become idle. The starter then
+    blocks on the same lock the DROP holds, and because it counts as a session
+    in the database, the DROP fails with "database is being accessed by other
+    users" once it stops waiting -- FORCE does not help, since the SIGTERM it
+    sends only sets a flag that a starter waiting for a lock cannot act on.
+
+    We hold the lock with an uncommitted DROP EXTENSION rather than with a
+    DROP DATABASE, which cannot run inside a transaction block.
+    """
+    superuser_conn.autocommit = True
+
+    run_command("CREATE DATABASE other", superuser_conn)
+
+    other_conn_str = f"dbname=other user={server_params.PG_USER} password={server_params.PG_PASSWORD} port={server_params.PG_PORT} host={server_params.PG_HOST}"
+    other_conn = psycopg2.connect(other_conn_str)
+    run_command("CREATE EXTENSION pg_extension_base_test_scheduler CASCADE", other_conn)
+    other_conn.commit()
+
+    assert (
+        wait_until_equal(lambda: count_pg_extension_base_workers(superuser_conn), 1)
+        == 1
+    )
+
+    other_pid = run_query("SELECT pg_backend_pid()", other_conn)[0]["pg_backend_pid"]
+
+    # take the lock and mark the database starter for restart, without
+    # committing, which is the state a DROP DATABASE is in while it waits
+    run_command("DROP EXTENSION pg_extension_base_test_scheduler CASCADE", other_conn)
+
+    # CREATE DATABASE wakes up the server starter, so it iterates over the
+    # databases while we hold the lock rather than at its own pace
+    run_command("CREATE DATABASE other_wakeup", superuser_conn)
+
+    # no database starter may connect to other for as long as we hold the lock
+    assert (
+        wait_until_equal(
+            lambda: count_other_backends_in_database(
+                superuser_conn, "other", other_pid
+            ),
+            1,
+            timeout=3.0,
+        )
+        == 0
+    )
+
+    # rolling back has to bring the worker back, so the back-off above may not
+    # simply drop the pending restart
+    other_conn.rollback()
+
+    assert (
+        wait_until_equal(lambda: count_pg_extension_base_workers(superuser_conn), 1)
+        == 1
+    )
+
+    run_command("DROP EXTENSION pg_extension_base_test_scheduler CASCADE", other_conn)
+    other_conn.commit()
+    other_conn.close()
+
+    run_command("DROP DATABASE other", superuser_conn)
+    run_command("DROP DATABASE other_wakeup", superuser_conn)
+
+    assert (
+        wait_until_equal(lambda: count_pg_extension_base_workers(superuser_conn), 0)
+        == 0
+    )
+
+    superuser_conn.autocommit = False
+
+
 def test_oneshot_worker_completes(superuser_conn):
     run_command("LISTEN oneshot", superuser_conn)
     superuser_conn.commit()

--- a/pg_extension_base/tests/pytests/test_base_worker_launcher.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_launcher.py
@@ -450,6 +450,70 @@ def test_no_starter_connects_while_a_drop_holds_the_lock(superuser_conn):
     superuser_conn.autocommit = False
 
 
+def test_drop_database_force_removes_a_starting_starter(
+    superuser_conn, create_injection_extension
+):
+    # A starter that already connected but has not reached its main loop counts
+    # as a session in the database and cannot act on a SIGTERM flag, so
+    # DROP DATABASE ... WITH (FORCE) used to fail with "database is being
+    # accessed by other users". It should terminate the starter instead.
+
+    if get_pg_version_num(superuser_conn) < 170000:
+        pytest.skip("Injection points not available (requires PostgreSQL 17+)")
+
+    superuser_conn.rollback()
+    superuser_conn.autocommit = True
+
+    run_command(
+        "SELECT injection_points_attach('database-starter-before-lock', 'wait')",
+        superuser_conn,
+    )
+
+    own_pid = run_query("SELECT pg_backend_pid()", superuser_conn)[0]["pg_backend_pid"]
+
+    try:
+        # the server starter starts a database starter for every new database,
+        # which then parks in the injection point
+        run_command("CREATE DATABASE other", superuser_conn)
+
+        assert (
+            wait_until_equal(
+                lambda: count_other_backends_in_database(
+                    superuser_conn, "other", own_pid
+                ),
+                1,
+            )
+            == 1
+        )
+
+        run_command("DROP DATABASE other WITH (FORCE)", superuser_conn)
+    finally:
+        # release any starter still parked, so a failure above does not leave
+        # one behind for the next test
+        run_command(
+            "SELECT injection_points_wakeup('database-starter-before-lock')",
+            superuser_conn,
+            raise_error=False,
+        )
+        run_command(
+            "SELECT injection_points_detach('database-starter-before-lock')",
+            superuser_conn,
+            raise_error=False,
+        )
+        run_command(
+            "DROP DATABASE IF EXISTS other WITH (FORCE)",
+            superuser_conn,
+            raise_error=False,
+        )
+
+    assert (
+        wait_until_equal(lambda: count_pg_extension_base_workers(superuser_conn), 0)
+        == 0
+    )
+
+    superuser_conn.autocommit = False
+
+
 def test_oneshot_worker_completes(superuser_conn):
     run_command("LISTEN oneshot", superuser_conn)
     superuser_conn.commit()


### PR DESCRIPTION
This is the nightly flaky test fix.

[Run 32712707500](https://github.com/Snowflake-Labs/pg_lake/actions/runs/32712707500), job `18_test-check-pg-lake-table (17, check-pg_lake_table, 4)`:

```
psycopg2.errors.ObjectInUse: database "sec_dollar_dst_db" is being accessed by other users
DETAIL:  There is 1 other session using the database.
STATEMENT:  DROP DATABASE IF EXISTS sec_dollar_dst_db WITH (FORCE);
```

It passed on a re-run of the same commit. Any test that drops a database can hit this; the failing test just happened to be the one.

### Root cause

The server starter's log for that job says who the "1 other session" was:

```
09:57:21.916 [141921] FATAL:  terminating background worker "pg base extension worker" due to administrator command
09:57:21.916 [491]    LOG:  starting pg base extension database starter in database sec_dollar_dst_db
09:57:26.922 [141856] ERROR:  database "sec_dollar_dst_db" is being accessed by other users
09:57:26.923 [141974] LOG:  pg_extension_base database starter for database sec_dollar_dst_db started
```

A database starter, launched *into* the `DROP DATABASE` that was already running.

`StartDatabaseStarter()` takes the database starter lock conditionally (`waitForLock = false`) before launching one, but discarded the result and proceeded either way — and then cleared `needsRestart`. `DROP DATABASE` holds that same lock in `ExclusiveLock` mode for the duration of its transaction, i.e. while it SIGTERMs the sessions in the database and waits ~5s for them to go away. So:

1. the drop's `PrepareForDrop()` stops the base workers, sets `needsRestart`, and signals the server starter
2. the server starter launches a database starter for the database being dropped
3. that starter connects to the database — it is now one of the sessions the drop is waiting for — and blocks on the lock the drop holds
4. `WITH (FORCE)` does not break the deadlock: the starter connected after the SIGTERM sweep, and even if it had not, `HandleSigterm` only sets a flag that a process waiting for a lock never gets to look at
5. the drop gives up after 5s with `ObjectInUse`

Timing-dependent, hence flaky: the starter has to connect inside the drop's wait window.

### Fix

Three parts, all in `base_worker_launcher.c`:

- **Honour the conditional lock.** Return early when it is not available, *before* touching the shared entry, which leaves `needsRestart` set for the next iteration. A drop signals the server starter when its transaction ends either way, so nothing is lost. `CREATE EXTENSION` takes `ShareLock` and so still does not make us back off.
- **`die` on a SIGTERM received during startup**, and only switch to the flag-based `HandleSigterm` once the main loop (which checks the flag every iteration) is reached. Base workers already do exactly this. This closes the window where a starter that connected just before the SIGTERM sweep keeps the database busy anyway.
- **Wake the server starter after the transaction's locks are released**, from the after-locks resource release phase rather than from a transaction callback. `XACT_EVENT_COMMIT`/`ABORT` fire before `ProcReleaseLocks()`, so the wake-up a drop sends there arrives while it still holds the lock — with the first change in place that wake-up would be wasted and recovery would wait for the next regular poll instead.

### Testing

`test_no_starter_connects_while_a_drop_holds_the_lock` in `test_base_worker_launcher.py` holds the lock with an uncommitted `DROP EXTENSION` (a `DROP DATABASE` cannot run in a transaction block), forces a server starter iteration with a `CREATE DATABASE`, and asserts no backend appears in the locked database. Without the fix it reproduces the bug — a starter connects (`assert 1 == 0`); with it, the count stays 0. It then rolls back and asserts the worker comes back, so backing off cannot be "fixed" by dropping the pending restart.

`pg_extension_base` pytests: 67 passed on unmodified `main`, 68 passed with the change, four consecutive runs.

Nothing was skipped or weakened. One thing I deliberately left alone: `ComputeNextWakeTimeMs()` seeds `minSleepMs` from `WorkerStarterSleepTimeSec` without converting seconds to milliseconds, so the server starter polls every 100 ms instead of every 10 s. That is why this race was reachable at all, but the poll interval is not the bug and changing it would only make the window smaller.
