### PR TITLE
flaky tests: keep the database starter lock out of a database's lock space

### DIFF
--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -139,9 +139,17 @@
                          (uint32) workerId, \
                          (uint32) 0, \
                          ADV_LOCKTAG_CLASS_BASE_WORKER)
-#define SET_LOCKTAG_DATABASE_STARTER(tag, db, databaseId) \
+
+/*
+ * The database starter lock is not part of any database's advisory lock space:
+ * the server starter takes it while connected to no database at all, so the
+ * database it is about goes in the second field and the first stays InvalidOid.
+ * Putting the database in the first field instead would list the lock in that
+ * database's pg_locks, where sessions expect to see only their own.
+ */
+#define SET_LOCKTAG_DATABASE_STARTER(tag, databaseId) \
     SET_LOCKTAG_ADVISORY(tag, \
-                         db, \
+                         InvalidOid, \
                          (uint32) databaseId, \
                          (uint32) 0, \
                          ADV_LOCKTAG_CLASS_DATABASE_STARTER)
@@ -1973,7 +1981,7 @@ LockDatabaseStarter(Oid databaseId, LOCKMODE lockMode, bool waitForLock)
 	LOCKTAG		tag;
 	const bool	sessionLock = false;
 
-	SET_LOCKTAG_DATABASE_STARTER(tag, databaseId, databaseId);
+	SET_LOCKTAG_DATABASE_STARTER(tag, databaseId);
 
 	return LockAcquire(&tag, lockMode, sessionLock, !waitForLock);
 }

--- a/pg_extension_base/tests/pytests/test_base_worker_launcher.py
+++ b/pg_extension_base/tests/pytests/test_base_worker_launcher.py
@@ -854,3 +854,43 @@ def test_worker_restart_backoff_resets_after_healthy_uptime(superuser_conn):
         )
         superuser_conn.commit()
         reset_backoff_gucs(superuser_conn)
+
+
+def test_database_starter_lock_is_outside_the_database_lock_space(superuser_conn):
+    """
+    The server starter takes the database starter lock while connected to no
+    database, so the lock belongs to no database's advisory lock space.  A
+    session listing the advisory locks of its own database has to find only the
+    ones it took itself, because that is what PostgreSQL's own advisory_lock
+    regression test asserts about the database it runs in.
+    """
+    run_command(
+        "CREATE EXTENSION pg_extension_base_test_scheduler CASCADE", superuser_conn
+    )
+    superuser_conn.commit()
+
+    # deregister_worker takes the same lock and holds it until the transaction
+    # ends, so there is no need to catch a starter in the act
+    run_command(
+        "SELECT extension_base.deregister_worker('pg_extension_base_test_scheduler_main_worker')",
+        superuser_conn,
+    )
+
+    assert [[1, 0]] == run_query(
+        """
+        SELECT count(*),
+               count(*) FILTER (
+                   WHERE database = (SELECT oid FROM pg_database
+                                     WHERE datname = current_database()))
+        FROM pg_locks
+        WHERE locktype = 'advisory' AND pid = pg_backend_pid()
+        """,
+        superuser_conn,
+    )
+
+    superuser_conn.rollback()
+
+    run_command(
+        "DROP EXTENSION pg_extension_base_test_scheduler CASCADE", superuser_conn
+    )
+    superuser_conn.commit()


### PR DESCRIPTION
This is the nightly flaky test fix.

`test-installcheck-postgres` fails intermittently on core PostgreSQL's own
`advisory_lock` test, with one extra row that nothing in the test took:

```
diff -U3 .../expected/advisory_lock.out .../results/advisory_lock.out
@@ -157,7 +157,8 @@
 advisory |       0 |     2 |        1 | ShareLock     | t
 advisory |       1 |     1 |        2 | ExclusiveLock | t
 advisory |       2 |     2 |        2 | ShareLock     | t
-(4 rows)
+ advisory |   17748 |     0 |       21 | ShareLock     | t
+(5 rows)
```

The query behind it is

```sql
SELECT locktype, classid, objid, objsubid, mode, granted
  FROM pg_locks WHERE locktype = 'advisory' AND database = :datoid;
```

so the test asserts that the advisory locks visible in its own database are
exactly the ones it took. `objsubid = 21` is the database starter locktag class,
and `classid = 17748` is the oid of the database the test is running in.

## Where the row comes from

The server starter connects to no database at all, but it takes one advisory
lock per database. `StartDatabaseStarters()` loops over every non-template
database on every wake-up and calls `StartDatabaseStarter()`, which takes the
lock at the top:

```c
if (LockDatabaseStarter(databaseId, ShareLock, waitForLock) == LOCKACQUIRE_NOT_AVAIL)
```

That happens *before* the steady-state check further down that finds the entry
already done and returns:

```c
if (!starterEntry->needsRestart)
{
	LWLockRelease(&BaseWorkerControl->lock);
	return DATABASE_STARTER_DONE;
}
```

The lock is transaction-scoped and `StartDatabaseStarters()` wraps each call in
its own transaction, so the window is short — but it is taken for every
database on every pass, whether or not there is anything to launch, and it stays
held for ~870 µs when a starter actually is launched.

The locktag put the *target* database in `locktag_field1`, which `pg_locks`
reports as `database`, so the lock landed in that database's advisory lock space
even though the process holding it is connected to no database:

```c
SET_LOCKTAG_ADVISORY(tag, db, (uint32) databaseId, (uint32) 0,
                     ADV_LOCKTAG_CLASS_DATABASE_STARTER)
```

## The fix

The database this lock is *about* moves to the second field and the first stays
`InvalidOid`, which is what a lock held while connected to no database should
look like. Nothing else changes: it is the same lock, taken at the same points,
with the same mode and scope, so `LockDatabaseStarter()` callers still exclude
each other and still exclude `CREATE`/`DROP EXTENSION`. It just no longer shows
up in any database's `pg_locks`.

A read-only pre-check before taking the lock would have narrowed the window but
not closed it, since the launch path has to hold the lock for real work.

## Verified

A tight `pg_locks` poll from inside `regression` (a database with no extensions
created), for 30 s, counting advisory locks reported in the polling session's own
database:

```
===== BEFORE (main) =====
samples=565629 hits=10
  all hits: classid=16384 objid=0 objsubid=21 mode=ShareLock
===== AFTER (fix) =====
samples=583906 hits=0
```

The lock is still taken just as often afterwards — the same poll widened to all
advisory locks regardless of database found 11 hits in 636185 samples, now
reported as `database=0`.

Deterministic A/B on the tag itself, using `BEGIN; DROP EXTENSION
pg_extension_base;` to hold the same lock open:

```
===== BEFORE (main) =====
 advisory |    16384 |   16384 |       21 | ExclusiveLock | in_this_database=t
===== AFTER (fix) =====
 advisory |        0 |   16384 |       21 | ExclusiveLock | in_this_database=f
```

`test_database_starter_lock_is_outside_the_database_lock_space` asserts exactly
that, via `deregister_worker()`, which takes the same lock and holds it to the
end of the transaction so the test does not have to catch a starter in the act.
A/B of its assertion query:

```
===== BEFORE (main) =====   advisory_locks=1 | in_this_database=1
===== AFTER (fix) =====     advisory_locks=1 | in_this_database=0
```
