### PR TITLE
flaky tests: run two real concurrent COPYs in test_copy_concurrently

### DIFF
--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -1,4 +1,5 @@
 import os
+import psycopg2
 import pytest
 import socket
 import threading
@@ -1419,25 +1420,41 @@ def test_copy_concurrently(s3, pgduck_conn):
     )
     stage_path_1 = path_1 + ".pgl-stage"
 
-    # first, run the first pg_lake_cache_file
-    # and wait until the stage file shows up
-    t1 = thread_run_command(
-        f"""
-        COPY (SELECT s, 'hello-'||s as h FROM generate_series(1,10000) as g(s)) TO '{url_1}';
-    """,
-        pgduck_conn,
+    # Each COPY needs its own connection: a single connection serializes the
+    # queries sent from both threads, so they would never reach the server at
+    # the same time and either one could end up running last.
+    conn_1 = psycopg2.connect(
+        host=server_params.PGDUCK_UNIX_DOMAIN_PATH, port=server_params.PGDUCK_PORT
+    )
+    conn_2 = psycopg2.connect(
+        host=server_params.PGDUCK_UNIX_DOMAIN_PATH, port=server_params.PGDUCK_PORT
     )
 
-    # copy into the same file will be blocked
-    t2 = thread_run_command(
-        f"""
-        COPY (SELECT s, 'hello-'||s as h FROM generate_series(1,2000) as g(s)) TO '{url_1}';
-    """,
-        pgduck_conn,
-    )
+    try:
+        # first, run the first COPY and wait until the stage file shows up,
+        # which means it holds the cache-on-write lock for this path
+        t1 = thread_run_command(
+            f"""
+            COPY (SELECT s, 'hello-'||s as h FROM generate_series(1,10000) as g(s)) TO '{url_1}';
+        """,
+            conn_1,
+        )
 
-    t1.join()
-    t2.join()
+        assert check_file_exist(stage_path_1), "the first COPY is not staged"
+
+        # copy into the same file will be blocked
+        t2 = thread_run_command(
+            f"""
+            COPY (SELECT s, 'hello-'||s as h FROM generate_series(1,2000) as g(s)) TO '{url_1}';
+        """,
+            conn_2,
+        )
+
+        t1.join()
+        t2.join()
+    finally:
+        conn_1.close()
+        conn_2.close()
 
     assert check_file_exist(path_1), "final file is not showing up as expected"
 


### PR DESCRIPTION
This is the nightly flaky test fix.

## Problem

`pgduck_server/tests/pytests/test_caching.py::test_copy_concurrently` fails
intermittently in `check-pgduck_server`:

```
FAILED tests/pytests/test_caching.py::test_copy_concurrently - assert 10000 == 2000
```

The test starts two threads that each run a `COPY` to the same URL, then
asserts the file holds the 2000 rows written by the second one. Both `COPY`s
are sent over the same `pgduck_conn`. A psycopg2 connection serializes queries
from different threads, so the two statements reach the server one after the
other in whatever order the threads win the connection lock. Which `COPY`
writes last is therefore decided by thread scheduling, and the assertion picks
one of the two outcomes.

Measured on the shipped shape, with only the two `thread_run_command` calls
swapped and nothing else changed:

```
shared connection, start order as shipped:   {2000: 40}
shared connection, start order reversed:     {10000: 10}
```

The same shape also means the test never exercises what its name says. Polling
`pg_lake_stat_activity()` while both threads run reports a peak of **1**
concurrent `COPY`, so the second one is blocked by the client connection, not
by the cache-on-write lock for the path.

The test's own comment says it waits for the staging file before starting the
second `COPY`, but that wait is missing, and `stage_path_1` is computed and
never used.

## Solution

Give each `COPY` its own connection, and wait for the first one's `.pgl-stage`
file before starting the second. That is the wait the comment describes and
what the neighbouring `test_concurrent_cache_uncache_different_files` already
does.

Once the staging file exists, the first `COPY` holds the cache-on-write lock
for that path, so the second one blocks until it finishes and the 2000-row
result is the only possible outcome. The test now fails if that lock stops
serializing writes to the same path, which is the behaviour it is meant to
cover.

## Test plan

* 10 consecutive runs of `test_copy_concurrently` pass.
* The staging file is observed on every round (40/40 in a loop probe); the
  window is around 12 ms for the 10000-row `COPY` and `check_file_exist` polls
  every 1 ms with a 3 s budget, so the wait has room to spare.
* With two connections the second `COPY` measurably waits for the first:
  `big-end 1.525 s`, then `small-end 1.545 s` on a larger pair of `COPY`s,
  against a peak of 1 concurrent `COPY` on the shared connection.
* `black --check` clean.
