### PR TITLE
docker: drop vcpkg build byproducts from the image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -255,9 +255,14 @@ RUN git clone https://github.com/CrunchyData/pg_incremental.git && \
 # Install vcpkg as postgres user
 ARG VCPKG_VERSION=2025.10.17
 
+# Only installed/ is consumed via VCPKG_TOOLCHAIN_PATH; the rest is build
+# byproducts.  Cleaned in this same RUN so the layer never carries them.
 RUN git clone https://github.com/Microsoft/vcpkg.git -b $VCPKG_VERSION /home/postgres/vcpkg && \
     ./vcpkg/bootstrap-vcpkg.sh && \
-    ./vcpkg/vcpkg install azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl
+    ./vcpkg/vcpkg install --clean-after-build azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl && \
+    rm -rf /home/postgres/vcpkg/downloads \
+           /home/postgres/vcpkg/buildtrees \
+           /home/postgres/vcpkg/packages
 
 ENV VCPKG_TOOLCHAIN_PATH="/home/postgres/vcpkg/scripts/buildsystems/vcpkg.cmake"
 


### PR DESCRIPTION
The CI image carries all of `vcpkg/`, but only `installed/` is ever used — that is what `VCPKG_TOOLCHAIN_PATH` points into. `downloads/`, `buildtrees/` and `packages/` are byproducts. On an equivalent local install:

```
163M  vcpkg/downloads
2.4G  vcpkg/buildtrees
358M  vcpkg/packages
209M  vcpkg/installed
3.2G  vcpkg
```

Every job that pulls one of these images pays for the other 2.9GB, and jobs on the smaller runners have started failing while unpacking that layer:

```
failed to register layer: write .../vcpkg/downloads/awslabs-aws-c-s3-v0.9.2.tar.gz:
no space left on device
```

Two parts:

- `rm -rf` in the *same* `RUN` as the install. A later `RUN` would only add a whitelayer and leave the bytes in the image.
- `vcpkg install --clean-after-build`, which drops each port's buildtree and package as it goes, so the peak during the build is lower too.

Nothing else in the tree reads those directories.