### PR TITLE
flaky tests: make the aggressive-autovacuum fixture opt-in

### DIFF
--- a/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
+++ b/pg_lake_table/tests/pytests/test_polaris_catalog_writable.py
@@ -32,6 +32,7 @@ def test_writable_rest_basic_flow(
         return
 
     run_command(f"""CREATE SCHEMA test_writable_rest_basic_flow""", pg_conn)
+
     run_command(
         f"""CREATE TABLE test_writable_rest_basic_flow.writable_rest USING iceberg WITH (catalog='REST') AS SELECT 100 AS a""",
         pg_conn,
@@ -411,6 +412,10 @@ def test_writable_rest_vacuum(
     with_default_location,
     installcheck,
     create_http_helper_functions,
+    # The VACUUM below goes through run_command_outside_tx, which opens its own
+    # connection, so the compaction threshold this test needs has to come from the
+    # cluster-wide setting rather than from the SET on pg_conn.
+    set_auto_vacuum_params,
     vacuum_syntax,
 ):
 
@@ -5025,9 +5030,13 @@ def compare_fields(expected, actual):
         ), f"Value mismatch: expected {expected} but got {actual}"
 
 
-# run tests faster
-@pytest.fixture(autouse=True, scope="function")
-def set_auto_vacuum_params(superuser_conn):
+# Makes the autovacuum worker compact aggressively: a 1 s naptime, and a single
+# input file is enough to compact. Both are ALTER SYSTEM, so they apply to every
+# table in the cluster for as long as the test using this runs -- which is why
+# it is opt-in. A test that does not need it gains nothing from a compaction
+# landing in the middle of its own writes.
+@pytest.fixture(scope="function")
+def set_auto_vacuum_params(pg_conn, superuser_conn):
     run_command_outside_tx(
         [
             "ALTER SYSTEM SET pg_lake_table.vacuum_compact_min_input_files = 1;",
@@ -5036,6 +5045,11 @@ def set_auto_vacuum_params(superuser_conn):
         ],
         superuser_conn,
     )
+    # pg_conn is already connected, so it only picks the new values up once it has
+    # processed its SIGHUP. Wait on the naptime alone: it is PGC_SIGHUP, so no test
+    # can have shadowed it with a session-level SET the way one does with
+    # vacuum_compact_min_input_files, and both arrive in the same reload.
+    wait_for_reloaded_settings([pg_conn], {"pg_lake_iceberg.autovacuum_naptime": "1s"})
     yield
     run_command_outside_tx(
         [


### PR DESCRIPTION
This is the nightly flaky test fix.

`test_polaris_catalog_writable.py::test_writable_rest_basic_flow` fails intermittently — twice on `main` in the last three days — with:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "deletion_queue_pkey"
DETAIL:  Key (path)=(s3://.../test_writable_rest_basic_flow/writable_rest/31976/metadata/00003-38316128-6c2d-4579-8a2b-24f8e82deadb.metadata.json) already exists.
CONTEXT:  SQL statement "insert into lake_engine.deletion_queue (path, table_name, orphaned_at, is_prefix, resolve_metadata) values ($1,$2,$3,$4,$5)"
```

## Root cause

The console log does not name the second party; the postgres log artifact does:

```
17:38:32.893 [137549] LOG:  pg_lake: compacted iceberg table test_writable_rest_basic_flow.writable_rest: rewrote 4 files (756 bytes, 4 rows) into 1 files (201 bytes, 4 rows)
17:38:32.934 [137516] ERROR:  duplicate key value violates unique constraint "deletion_queue_pkey"
17:38:32.934 [137516] DETAIL:  Key (path)=(.../metadata/00003-38316128-....metadata.json) already exists.
17:38:32.934 [137516] STATEMENT:  COMMIT
```

PID 137549 is the pg_lake autovacuum worker, PID 137516 the test's own backend, 41 ms apart. For a writable REST catalog table the authoritative metadata location lives in the catalog, and it is only advanced by the requests posted at `XACT_EVENT_COMMIT`. A compaction and a user transaction that both read that location before either has posted therefore orphan the same `metadata.json`, and the second insert into `lake_engine.deletion_queue` hits the primary key.

The worker was compacting a table this test never asked it to touch because of the `set_auto_vacuum_params` fixture, which was `autouse=True`: it lowers `pg_lake_iceberg.autovacuum_naptime` to `1s` and `pg_lake_table.vacuum_compact_min_input_files` to `1` — both `ALTER SYSTEM`, so cluster-wide — for **every** test in the file. So the worker compacted each table roughly once a second while ~30 tests wrote to their own tables. `test_writable_rest_basic_flow` is just the one that lost the race twice this week; `test_writable_rest_vacuum` and `test_writable_drop_table` avoid it today by passing `autovacuum_enabled=False` on their tables.

## The fix

Make the fixture opt-in. Only `test_rest_autovacuum` needs aggressive autovacuum, and it already requests the fixture by name, so dropping `autouse=True` is enough for it to keep working.

Two hidden dependencies had to be repaired to make that safe.

`test_writable_rest_vacuum` relied on the fixture without saying so: it SETs `vacuum_compact_min_input_files` on `pg_conn`, but runs its `VACUUM` through `run_command_outside_tx`, which opens a connection of its own, so the value that counts is the cluster-wide one (default 5, i.e. no compaction, and its manifest assertion would fail). It now requests the fixture too, which keeps its effective settings exactly as they are today and makes the dependency visible.

`test_rest_autovacuum` relied on fixture ordering. `pg_reload_conf()` returns before an already-connected backend has processed its SIGHUP, and as an `autouse` fixture this one ran before the fixtures that go on to issue statements on `pg_conn`, each of which gave that backend a command boundary to reload at. Requested by name it runs last instead, so the test's first statement can still read the old naptime — which is what the first CI run on this branch did, failing on `assert '5s' == '1s'` on PG 17. The fixture now waits for the reload with `wait_for_reloaded_settings`, the way `apply_polaris_gucs` already does. Only the naptime is polled: it is `PGC_SIGHUP`, so unlike `vacuum_compact_min_input_files` no earlier test can have shadowed it with a session-level `SET`, and both values arrive in the same reload.

No product code changes, no skips, and no test loses coverage.

## Note for maintainers

The sequence itself is reachable outside the tests: with autovacuum enabled, a compaction and concurrent DML against the same writable REST table can both orphan the same `metadata.json`, so a user's `COMMIT` fails with this duplicate key. That is not addressed here. A related detail if you look at it: `pg_lake_table/src/ddl/vacuum.c` consumes tracked Iceberg metadata changes several times inside one transaction (the compaction loop), while the REST catalog requests are only posted at commit, so each pass re-reads the same location.
