### PR TITLE
[release-3.4] Backport #514: make Azure append blob writes safe to retry

### DIFF
--- a/duckdb_pglake/Makefile
+++ b/duckdb_pglake/Makefile
@@ -142,11 +142,24 @@ patch_duckdb: $(shell find patches -type f -name '*.patch')
 			git apply --ignore-whitespace "$$patch"; \
 		done;) \
 	done
+	# Out-of-tree extensions are fetched by CMake, which applies the patches it
+	# finds in the DuckDB source tree, so copy ours there before building.
+	for extdir in patches/extensions/*/ ; do \
+		[ -d "$$extdir" ] || continue ; \
+		ext=$$(basename $$extdir) ; \
+		echo "staging patches for extension $$ext" ; \
+		mkdir -p duckdb/.github/patches/extensions/$$ext && \
+		cp $$extdir*.patch duckdb/.github/patches/extensions/$$ext/ ; \
+	done
 
 clean_patches:
 	for patchdir in duckdb duckdb-postgres ; do \
 		(cd $$patchdir && \
 		git checkout -f . ); \
+	done
+	for extdir in patches/extensions/*/ ; do \
+		[ -d "$$extdir" ] || continue ; \
+		rm -rf duckdb/.github/patches/extensions/$$(basename $$extdir) ; \
 	done
 
 format:

--- a/duckdb_pglake/extension_config.cmake
+++ b/duckdb_pglake/extension_config.cmake
@@ -3,7 +3,6 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 13f8a814d41a978c3f19eb1dc76069489652ea6f
     INCLUDE_DIR src/include
-    ADD_PATCHES
 )
 
 duckdb_extension_load(aws
@@ -14,6 +13,7 @@ duckdb_extension_load(aws
 duckdb_extension_load(azure
     GIT_URL https://github.com/duckdb/duckdb-azure
     GIT_TAG 7e1ac3333d946a6bf5b4552722743e03f30a47cd
+    APPLY_PATCHES
 )
 
 # Extension from this repo

--- a/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
+++ b/duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch
@@ -1,0 +1,39 @@
+diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
+index 796d5a2..beb5b4f 100644
+--- a/src/azure_blob_filesystem.cpp
++++ b/src/azure_blob_filesystem.cpp
+@@ -402,9 +402,31 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
+ 	// real. Only with AppendBlobClient is each append committed (sync'd).
+ 	auto append_client = afh.blob_client.AsAppendBlobClient();
+ 	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
+-	auto res = append_client.AppendBlock(body_stream);
+-	afh.last_modified = ToTimestamp(res.Value.LastModified);
+-	D_ASSERT(idx_t(res.Value.AppendOffset) == afh.file_offset);
++
++	// Appending a block is not idempotent by itself, while the SDK does retry transport errors and
++	// 408/5xx responses. An append that reached the service but whose response got lost would then
++	// be applied twice and still report success, silently duplicating a part of the file. Telling
++	// the service which offset we expect to append at makes such a retry fail with 412 instead.
++	Azure::Storage::Blobs::AppendBlockOptions options;
++	options.AccessConditions.IfAppendPositionEqual = static_cast<int64_t>(afh.file_offset);
++
++	try {
++		auto res = append_client.AppendBlock(body_stream, options);
++		afh.last_modified = ToTimestamp(res.Value.LastModified);
++		D_ASSERT(idx_t(res.Value.AppendOffset) == afh.file_offset);
++	} catch (const Azure::Storage::StorageException &e) {
++		if (int(e.StatusCode) != 412) {
++			throw;
++		}
++
++		// The blob does not end where we expect it to. Either this append is a retry of one that did
++		// reach the service, or someone else is writing to the blob. We cannot tell those apart
++		// here, and in both cases the file is not what we think it is, so fail the write.
++		throw IOException("Failed to append %lld bytes at offset %lld of '%s': the blob does not end "
++		                  "at that offset, it is most likely being written to concurrently",
++		                  nr_bytes, static_cast<int64_t>(afh.file_offset), afh.GetPath());
++	}
++
+ 	afh.file_offset += nr_bytes;
+ 	afh.length += nr_bytes;
+ 	DUCKDB_LOG_FILE_SYSTEM_WRITE(handle, nr_bytes, afh.file_offset);

--- a/pgduck_server/tests/pytests/test_s3.py
+++ b/pgduck_server/tests/pytests/test_s3.py
@@ -125,6 +125,49 @@ def test_copy_to_parquet_azure_long_prefix(azure, pgduck_conn):
     pgduck_conn.rollback()
 
 
+def test_copy_to_azure_multiple_appends(azure, pgduck_conn, tmp_path):
+    """A file that does not fit in the write buffer is written as multiple appends,
+    and each append tells Azure the offset it expects to be written at, so check that
+    such a file still ends up with exactly the bytes we wrote."""
+    key = "test_copy_to_azure_multiple_appends/data.csv"
+    local_path = tmp_path / "data.csv"
+
+    perform_query(
+        f"""
+        CREATE TABLE bigtable AS
+        SELECT i, repeat('x', 100) padding FROM generate_series(1,20000) t(i);
+        COPY bigtable TO '{local_path}';
+        COPY bigtable TO 'az://{TEST_BUCKET}/{key}';
+    """,
+        pgduck_conn,
+    )
+
+    properties = azure.get_blob_client(key).get_blob_properties()
+
+    # more than one append went into this blob
+    assert properties.append_blob_committed_block_count > 1
+
+    # and the blob is exactly as long as the same data written locally
+    assert properties.size == os.path.getsize(local_path)
+
+    perform_query(
+        f"""
+        CREATE TABLE roundtrip (i int, padding text);
+        COPY roundtrip FROM 'az://{TEST_BUCKET}/{key}';
+    """,
+        pgduck_conn,
+    )
+
+    results = perform_query_on_cursor(
+        "SELECT count(*), sum(i) FROM roundtrip", pgduck_conn
+    )
+    assert len(results) == 1
+    assert results[0][0] == 20000
+    assert int(results[0][1]) == 200010000
+
+    pgduck_conn.rollback()
+
+
 def test_copy_from_non_existent(s3, pgduck_conn):
     perform_query("CREATE TABLE mytable (x int)", pgduck_conn)
 


### PR DESCRIPTION
Backport of #514 to `release-3.4`.

## Why backport

`release-3.4` pins duckdb-azure at `7e1ac3333d946a6bf5b4552722743e03f30a47cd`, whose `AzureBlobStorageFileSystem` flushes every full write buffer with a bare `AppendBlobClient::AppendBlock` and no `AppendBlobAccessConditions::IfAppendPositionEqual`. Azure Core's `RetryPolicy` retries `TransportException` and 408/500/502/503/504 up to three times, so an append that reached the service but whose response was lost is applied twice and the retry reports success. The only thing that would have caught it, the returned `AppendOffset`, was compared in a `D_ASSERT`, which release builds compile out — so in a release build there was no check at all.

The result is an object with a duplicated block. That is not a benign extra copy when the object is Parquet:

- The footer is written last, from the writer's own byte counter, so its `data_page_offset` values assume each block was appended once.
- A duplication in the **middle** of the file shifts every later byte, while the footer is still found from the last 8 bytes and still parses cleanly. The file opens fine; only the page seeks are wrong.
- A reader then parses data bytes where a page header should be and fails with something like `Couldn't deserialize thrift: don't know what type: \x0f` (thrift compact field types are 1–12, so any byte outside that range means "no header here"). It is deterministic per file, so every retry fails identically and nothing short of rewriting the file recovers.

This has been hit in the field on a workload writing Parquet to an `azure://` volume, where a single corrupted file failed the same read for a week until the file was rewritten. `azure://` and `az://` route to the append-blob filesystem; `abfss://` (`Append(stream, offset)`) and S3 multipart (`partNumber` + `uploadId`) are offset-addressed and were never exposed.

The fix has been on `main` since 2026-08-12 and was never backported, so no `release-3.x` line carries it: the patch file is absent from `release-3.3` and `release-3.4`, and all three branches pin the same duckdb-azure commit, so none of them is safe by accident through a newer storage client either. The DuckDB 1.5.5 upgrade retires this patch — upstream duckdb-azure moved to `StageBlock` plus `CommitBlockList`, and staging with an explicit block id is idempotent by construction — but that upgrade is not on this line and is not a patch-release change.

Verified while preparing this pick, since a vendored patch that no longer applies is dropped rather than reported:

- The patch reverse-applies exactly against a duckdb-azure checkout at `7e1ac333`, which is the commit this branch pins, so it will apply at build time.
- `azure_blob_filesystem.cpp` has exactly one `AppendBlock` call site, so the guard covers the whole append path rather than one caller of it.

## Conflict resolution

None — the pick is clean on `f10ff7e`.

Three of the four files are byte-identical to `main`. `pgduck_server/tests/pytests/test_s3.py` differs only because `main` has later additions past the same insertion point (the `pg_lake_remove_file` glob tests from #509 and the `rollback()` after `test_s3_get_region_invalid`); the test this patch adds is identical, and the fixtures it uses (`azure`, `os`) are already present on this branch.

The five commits of #514 are folded into the single squash commit, as on `main`.

## Diff

Four files, 96 insertions, 1 deletion. No source change to pg_lake itself:

- `duckdb_pglake/patches/extensions/azure/append-blob-idempotency.patch` — new, the whole behaviour change. Sets `IfAppendPositionEqual` to the offset we expect to append at, and turns the resulting 412 into an `IOException` naming the file and offset instead of a silent duplication.
- `duckdb_pglake/extension_config.cmake` — adds `APPLY_PATCHES` to the `azure` entry, and drops `ADD_PATCHES` from `httpfs`. `ADD_PATCHES` is not a keyword the pinned DuckDB's `duckdb_extension_load` accepts (`set(options DONT_LINK DONT_BUILD LOAD_TESTS APPLY_PATCHES)`), so it was silently ignored, and there are no httpfs patches for it to have applied.
- `duckdb_pglake/Makefile` — `patch_duckdb` copies `patches/extensions/<ext>/` into `duckdb/.github/patches/extensions/<ext>/`, because CMake applies the patches it finds in the DuckDB source tree, and `clean_patches` removes them again. This is the only way an out-of-tree extension patch reaches the build.
- `pgduck_server/tests/pytests/test_s3.py` — one test.

No SQL or migration files, no catalog or schema change, no version bump, so this fits the patch-release policy.

Worth noting for review: `duckdb/scripts/apply_extension_patches.py` errors out when `APPLY_PATCHES` is set for an extension with no patches present, so a staging step that silently did nothing would fail the build rather than produce an unpatched binary.

## Test plan

- Clean cherry-pick, and the four files audited against `main` line for line as described above.
- The patch verified against the exact duckdb-azure commit this branch pins, by reverse-applying it to that tree.
- `test_copy_to_azure_multiple_appends` writes a table too large for the write buffer to `az://`, asserts `append_blob_committed_block_count > 1` so the multi-append path is genuinely exercised, asserts the blob length equals the same data written locally, and reads it back and checks the row count and a checksum-ish sum. Against the emulator it is the round-trip that matters: the position condition is now sent on every append, so a stale offset fails the write instead of corrupting the object.
- CI on `release-3.4`.
