### PR TITLE
[release-3.4] Backport #550, #556: file-cache poisoning and truncated downloads

### DIFF
--- a/avro.patch
+++ b/avro.patch
@@ -21,7 +21,7 @@ index ffbb68dc5..5bb2ee699 100644
  avro_file_reader_get_writer_schema(avro_file_reader_t reader);
  
 diff --git a/lang/c/src/datafile.c b/lang/c/src/datafile.c
-index c9d4dfeb6..a2c9d54b1 100644
+index c9d4dfeb6..4a1fdb25f 100644
 --- a/lang/c/src/datafile.c
 +++ b/lang/c/src/datafile.c
 @@ -73,7 +73,7 @@ static int write_sync(avro_file_writer_t w)
@@ -118,7 +118,72 @@ index c9d4dfeb6..a2c9d54b1 100644
  	if (rval) {
  		avro_codec_reset(w->codec);
  		avro_freet(struct avro_codec_t_, w->codec);
-@@ -541,6 +568,93 @@ int avro_file_reader_fp(FILE *fp, const char *path, int should_close,
+@@ -452,6 +479,36 @@ static int file_read_block_count(avro_file_reader_t r)
+ 	check_prefix(rval, enc->read_long(r->reader, &len),
+ 		     "Cannot read file block size: ");
+ 
++	/*
++	 * Both counts come straight off the wire as zigzag varints, so a corrupt
++	 * or misaligned file can decode them to anything, including negatives.
++	 * Neither is meaningful below zero, and letting them through does real
++	 * damage:
++	 *
++	 *   - a negative len reaches avro_malloc(len) as a size_t, which is a
++	 *     nonsensically huge allocation request (embedders that route
++	 *     avro_malloc to their own allocator see it as such);
++	 *   - or, when current_blockdata is already allocated, a negative len is
++	 *     not greater than current_blocklen, so no buffer is resized, the
++	 *     "len > 0" read and decode below are both skipped, and block_reader
++	 *     is re-pointed at the *previous* block's decompressed bytes. The
++	 *     caller then happily re-reads stale records, silently returning data
++	 *     that is not in the file;
++	 *   - a negative blocks_total makes blocks_read == blocks_total never
++	 *     true, so the sync marker is never checked again.
++	 *
++	 * Fail the read instead, so a damaged file is reported as damaged.
++	 */
++	if (r->blocks_total < 0) {
++		avro_set_error("Invalid file block count %" PRId64, r->blocks_total);
++		return EILSEQ;
++	}
++
++	if (len < 0) {
++		avro_set_error("Invalid file block size %" PRId64, len);
++		return EILSEQ;
++	}
++
+ 	if (r->current_blockdata && len > r->current_blocklen) {
+ 		r->current_blockdata = (char *) avro_realloc(r->current_blockdata, r->current_blocklen, len);
+ 		r->current_blocklen = len;
+@@ -466,6 +523,27 @@ static int file_read_block_count(avro_file_reader_t r)
+ 
+ 		check_prefix(rval, avro_codec_decode(r->codec, r->current_blockdata, len),
+ 			     "Cannot decode file block: ");
++	} else {
++		/*
++		 * Nothing was read, so nothing was decoded, and the codec still holds
++		 * the *previous* block's decompressed bytes. Handing those to
++		 * block_reader below would satisfy this block's record count out of
++		 * stale data, so the caller silently receives records that are not in
++		 * the file. Report an empty block instead, and a count that cannot be
++		 * satisfied from it fails the read.
++		 *
++		 * Only used_size may be cleared here. block_data is owned by codecs
++		 * that allocate an output buffer -- deflate frees it in its reset --
++		 * and it aliases current_blockdata for the null codec, so clearing the
++		 * pointer would either leak or double free.
++		 *
++		 * A zero length is not rejected outright because it is representable in
++		 * a well-formed file: a record schema with no fields encodes to zero
++		 * bytes per record, so with the null codec a block of N such records
++		 * legitimately carries a count of N and a size of 0, and libavro's own
++		 * writer emits exactly that.
++		 */
++		r->codec->used_size = 0;
+ 	}
+ 
+ 	avro_reader_memory_set_source(r->block_reader, (const char *) r->codec->block_data, r->codec->used_size);
+@@ -541,6 +619,93 @@ int avro_file_reader_fp(FILE *fp, const char *path, int should_close,
  	return 0;
  }
  

--- a/duckdb_pglake/src/fs/caching_file_system.cpp
+++ b/duckdb_pglake/src/fs/caching_file_system.cpp
@@ -112,12 +112,42 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 								 openFlags.Lock(),
 								 openFlags.Compression());
 
-		/* create a handle for the file in cache */
-		wrappedHandle = localfs.OpenFile(cacheFilePath, localFlags);
+		/*
+		 * Nothing holds the per-path cache lock across the decision above and
+		 * this open, so the entry can stop being usable in between -- cache
+		 * management evicting it under pressure is the ordinary case, and the
+		 * check itself only establishes that a regular file owned by us was
+		 * there a moment ago. Fall back to the remote file rather than failing
+		 * the statement: a re-read costs a download, whereas propagating the
+		 * open failure kills a query over an object that is perfectly readable
+		 * in storage, and reports it as a bare "Cannot open file" naming an
+		 * internal cache path.
+		 */
+		try
+		{
+			/* create a handle for the file in cache */
+			wrappedHandle = localfs.OpenFile(cacheFilePath, localFlags);
 
-		PGDUCK_SERVER_DEBUG("using local cache for %s", cacheFilePath.c_str());
+			PGDUCK_SERVER_DEBUG("using local cache for %s", cacheFilePath.c_str());
+		}
+		catch (IOException &ex)
+		{
+			/*
+			 * Only IOException: that is what LocalFileSystem::OpenFile raises
+			 * when open() fails, which is the case worth absorbing. Anything
+			 * else out of this call -- an InternalException, an unsupported
+			 * compression type -- is a bug rather than a lost race, and
+			 * quietly turning it into a remote read would hide it.
+			 */
+			ErrorData error(ex);
+
+			PGDUCK_SERVER_DEBUG("cannot use local cache for %s, reading from "
+								"the remote file instead: %s",
+								cacheFilePath.c_str(), error.Message().c_str());
+		}
 	}
-	else
+
+	if (wrappedHandle == nullptr)
 	{
 		/* create a handle for the remote file */
 		try
@@ -173,9 +203,32 @@ PGLakeCachingFileSystem::OpenFile(const string &fullUrl,
 				{
 					try
 					{
+						/*
+						 * FILE_FLAGS_FILE_CREATE_NEW (O_CREAT|O_TRUNC), not
+						 * FILE_FLAGS_FILE_CREATE (O_CREAT): a staging file
+						 * orphaned by an earlier write may still sit at this
+						 * exact path, and the path is fully deterministic.
+						 * Without O_TRUNC we write the new contents over its
+						 * prefix and leave whatever of the older, longer file
+						 * extends past them, then rename that hybrid in as a
+						 * complete cache entry. Readers trust a finalized cache
+						 * file without revalidating it against object storage,
+						 * so that poisons every later read of this URL until
+						 * the entry is evicted.
+						 *
+						 * Do not assume orphans are rare. ~CachingFSFileHandle()
+						 * only removes one when it actually runs, so a hard
+						 * crash or kill escapes it -- and before that cleanup
+						 * existed, so did every ordinary caught abort: a
+						 * runtime error mid-write, a cancellation, or an ENOSPC
+						 * that DuckDB throws and pgduck_server catches. That
+						 * leaves an orphan with the process still running and
+						 * its pid unchanged, which is what was observed in the
+						 * field.
+						 */
 						cacheOnWriteHandle =
 							localfs.OpenFile(cacheFilePath + cacheManager->STAGING_SUFFIX,
-											 FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+											 FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
 
 						cacheOnWritePath = cacheFilePath;
 					}

--- a/duckdb_pglake/src/fs/file_cache_manager.cpp
+++ b/duckdb_pglake/src/fs/file_cache_manager.cpp
@@ -341,7 +341,12 @@ FileCacheManager::CacheFileInternal(ClientContext &context, string url, bool for
 	/* prefix the URL with nocache to prevent copying an already-cached file to itself */
 	string sourceUrl = NO_CACHE_PREFIX + url;
 
-	/* first, copy the file from the URL into a staging file */
+	/*
+	 * First, copy the file from the URL into a staging file. A failure here
+	 * leaves the staging file behind on purpose: unwinding releases the cache
+	 * lock, so the sweep at the top of ManageCache reclaims it on its next run,
+	 * and cleaning up here would only duplicate that.
+	 */
 	string stagingCacheFilePath = finalCacheFilePath + STAGING_SUFFIX;
 	int64_t size = FileUtils::CopyFile(context, sourceUrl, stagingCacheFilePath);
 
@@ -697,6 +702,15 @@ FileCacheManager::ManageCache(ClientContext &context, int64_t maxCacheSize)
 		}
 		catch (std::exception &ex)
 		{
+			/*
+			 * The summary below only counts these, and the same counter ticks
+			 * for an ordinary timeout, so without the reason a fill that was
+			 * rejected because it did not match the object looks like any other
+			 * transient failure.
+			 */
+			PGDUCK_SERVER_WARN("could not add %s to cache: %.500s",
+							   cacheFile.url.c_str(), ex.what());
+
 			actions.push_back({
 				.url = cacheFile.url,
 				.fileSize = cacheFile.fileSize,

--- a/duckdb_pglake/src/fs/file_utils.cpp
+++ b/duckdb_pglake/src/fs/file_utils.cpp
@@ -142,6 +142,14 @@ FileUtils::CopyFile(ClientContext &context,
 
 	int64_t totalBytesWritten = 0L;
 
+	/*
+	 * Taken before the copy so it can be compared against what we actually
+	 * transferred. Zero means the source does not report a size -- an http
+	 * server that sends no Content-Length, for instance -- in which case there
+	 * is nothing to compare against.
+	 */
+	idx_t sourceSize = sourceHandle->GetFileSize();
+
 	if (sourceHandle->file_system.GetName() == "HTTPFileSystem")
 	{
 		/* when opening http(s), we go through CachedFileSystem */
@@ -199,6 +207,31 @@ FileUtils::CopyFile(ClientContext &context,
 		{
 			totalBytesWritten += destinationHandle->Write(buffer.get(), bytesRead);
 		}
+	}
+
+	/*
+	 * A transfer that reports success is not the same as one that delivered
+	 * everything: a retried http/s3 body can leave a partial attempt followed by
+	 * a complete one, and the generic loop stops at the first zero-length read.
+	 * Since the result may be renamed into the cache, and nothing revalidates a
+	 * cache entry afterwards, either shape would be served from then on.
+	 *
+	 * Checked before finalizing, so nothing bad is published: a cache fill
+	 * leaves its staging file for the sweep in ManageCache, and an upload never
+	 * appears because Sync() is what completes the multipart upload.
+	 */
+	if (sourceSize > 0 && (idx_t) totalBytesWritten != sourceSize)
+	{
+		/* a cache fill asks for nocache<url>, which is no use to the reader */
+		string reportedPath =
+			StringUtil::StartsWith(sourcePath, NO_CACHE_PREFIX)
+			? sourcePath.substr(NO_CACHE_PREFIX.length())
+			: sourcePath;
+
+		throw IOException("Copied %llu bytes of '%s' but it is %llu bytes; the "
+						  "transfer was incomplete or was retried",
+						  (unsigned long long) totalBytesWritten, reportedPath,
+						  (unsigned long long) sourceSize);
 	}
 
 	destinationHandle->Sync();

--- a/duckdb_pglake/src/fs/httpfs_extended.cpp
+++ b/duckdb_pglake/src/fs/httpfs_extended.cpp
@@ -81,6 +81,12 @@ PgLakeHTTPFileSystem::Download(ClientContext &context, FileHandle &inputHandle, 
 
 	hfh.StoreClient(std::move(http_client));
 
+	/*
+	 * The byte count is verified by FileUtils::CopyFile, which does it for every
+	 * transfer rather than only the ones that come through here. Note that a
+	 * request reporting success does not mean the whole body arrived: see the
+	 * comment there.
+	 */
 	return total_request_bytes;
 }
 

--- a/pg_lake_engine/src/storage/local_storage.c
+++ b/pg_lake_engine/src/storage/local_storage.c
@@ -135,7 +135,18 @@ WriteStringToFile(char *content, FILE *file)
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("failed to write to file")));
 	}
-	fflush(file);
+
+	/*
+	 * fwrite may have only filled the stdio buffer, so the flush is where a
+	 * write error surfaces. ferror() is sticky, so it also reports one whose
+	 * flush already consumed the buffer.
+	 */
+	if (fflush(file) != 0 || ferror(file))
+	{
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("failed to write to file: %m")));
+	}
 }
 
 
@@ -155,5 +166,10 @@ WriteStringToFilePath(char *content, char *localFilePath)
 	}
 
 	WriteStringToFile(content, localFile);
-	FreeFile(localFile);
+
+	/* the final fclose() can still fail, e.g. out of space */
+	if (FreeFile(localFile) != 0)
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not close file \"%s\": %m",
+							   localFilePath)));
 }

--- a/pg_lake_iceberg/src/avro/avro_writer.c
+++ b/pg_lake_iceberg/src/avro/avro_writer.c
@@ -35,7 +35,8 @@ typedef struct ExtraMetadata
 }			ExtraMetadata;
 
 static AvroWriter * AvroWriterCreate(const char *filePath, avro_schema_t schema, avro_value_t * meta);
-static void AvroFileWriterClose(AvroWriter * writer);
+static bool AvroFileWriterClose(AvroWriter * writer);
+static void AvroFileWriterCloseCallback(void *arg);
 static void AvroPrepareSetNullable(avro_value_t * record, char *fieldName, avro_value_t * innerValue, bool isSet);
 static void WriteExtraMetadataToAvro(avro_value_t * record, ExtraMetadata * metadata);
 static avro_value_t * CreateAvroExtraMetadata(const char *schemaJson);
@@ -116,7 +117,7 @@ AvroWriterCreate(const char *filePath, avro_schema_t schema, avro_value_t * meta
 	MemoryContextCallback *cb = MemoryContextAllocZero(CurrentMemoryContext,
 													   sizeof(MemoryContextCallback));
 
-	cb->func = (MemoryContextCallbackFunction) AvroFileWriterClose;
+	cb->func = AvroFileWriterCloseCallback;
 	cb->arg = writer;
 	MemoryContextRegisterResetCallback(CurrentMemoryContext, cb);
 
@@ -146,20 +147,48 @@ GetSchemaFromJson(const char *schemaJson)
 
 
 /*
- * AvroFileWriterClose is called via a MemoryContextCallback to make sure we
- * close the Avro file writer. Even though we use a custom allocator, it
- * does not propagate to some the libraries that libavro calls (e.g. libz).
+ * AvroFileWriterClose closes the Avro file writer, and returns whether it
+ * managed to. It is also called via a MemoryContextCallback to make sure we
+ * close the writer. Even though we use a custom allocator, it does not
+ * propagate to some the libraries that libavro calls (e.g. libz).
  */
-static void
+static bool
 AvroFileWriterClose(AvroWriter * writer)
 {
+	bool		succeeded = true;
+
 	if (writer->initializedDataWriter)
 	{
-		avro_file_writer_flush(writer->dataWriter);
-		avro_file_writer_close(writer->dataWriter);
+		/* clear first, so the callback does not touch a half-closed writer */
+		writer->initializedDataWriter = false;
+
+		/*
+		 * Do not close after a failed flush: avro_file_writer_close() flushes
+		 * again, and file_write_block() does not reset the pending block when
+		 * it fails, so the retry appends a second copy of it. Either way the
+		 * writer's own allocations go with its memory context.
+		 */
+		if (avro_file_writer_flush(writer->dataWriter) != 0)
+			succeeded = false;
+		else if (avro_file_writer_close(writer->dataWriter) != 0)
+			succeeded = false;
 	}
 
-	writer->initializedDataWriter = false;
+	return succeeded;
+}
+
+
+/*
+ * AvroFileWriterCloseCallback closes the writer from a memory context reset.
+ *
+ * The result is ignored: a reset callback must not throw, and this only runs
+ * ahead of AvroWriterClose() when the transaction is failing anyway, in which
+ * case the file is discarded with it.
+ */
+static void
+AvroFileWriterCloseCallback(void *arg)
+{
+	(void) AvroFileWriterClose((AvroWriter *) arg);
 }
 
 
@@ -251,12 +280,36 @@ AvroWriterWriteRecord(AvroWriter * writer, AvroSerializeFunction serializeFn, vo
 
 /*
  * AvroWriterClose releases all Avro-related resources.
+ *
+ * Nothing here may fail quietly. Records are buffered until a block fills and
+ * the block goes through stdio, so for a manifest of ordinary size none of it
+ * has reached the file system until now, and the caller takes the file's length
+ * with GetLocalFileSize() once we return -- so a short file yields a
+ * manifest_length that agrees with it and nothing downstream can tell.
  */
 void
 AvroWriterClose(AvroWriter * writer)
 {
-	AvroFileWriterClose(writer);
-	FreeFile(writer->avroFile);
+	bool		succeeded = AvroFileWriterClose(writer);
+
+	if (!succeeded)
+		ereport(ERROR, (errmsg("could not write avro file: %s",
+							   avro_strerror())));
+
+	/*
+	 * libavro's avro_writer_flush() is declared void and discards fflush()'s
+	 * result, so the flush above can fail while still reporting success, and
+	 * once it has consumed the buffer fclose() succeeds too. ferror() reports
+	 * it regardless, because the stream's error indicator is sticky.
+	 */
+	if (fflush(writer->avroFile) != 0 || ferror(writer->avroFile))
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not write avro file: %m")));
+
+	if (FreeFile(writer->avroFile) != 0)
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not close avro file: %m")));
+
 	MemoryContextDelete(writer->memoryContext);
 }
 

--- a/pg_lake_iceberg/src/iceberg/api/table_metadata.c
+++ b/pg_lake_iceberg/src/iceberg/api/table_metadata.c
@@ -395,7 +395,18 @@ WriteMetadataJsonToTemporaryFile(IcebergTableMetadata * metadata, FILE *file)
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("Failed to write metadata file to temporary file")));
 	}
-	fflush(file);
+
+	/*
+	 * fwrite may have only filled the stdio buffer, so the flush is where a
+	 * write error surfaces. ferror() is sticky, so it also reports one whose
+	 * flush already consumed the buffer.
+	 */
+	if (fflush(file) != 0 || ferror(file))
+	{
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write metadata file to temporary file: %m")));
+	}
 }
 
 /*
@@ -423,7 +434,14 @@ UploadTableMetadataToURI(IcebergTableMetadata * tableMetadata, char *metadataURI
 
 	ScheduleFileCopyToS3WithCleanup(localFilePath, metadataURI, autoDeleteRecord);
 
-	FreeFile(localFile);
+	/*
+	 * The final fclose() can still fail; unchecked, a truncated metadata.json
+	 * would be uploaded and committed as the table's current metadata.
+	 */
+	if (FreeFile(localFile) != 0)
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not close file \"%s\": %m",
+							   localFilePath)));
 }
 
 /*

--- a/pg_lake_iceberg/tests/pytests/test_avro_block_header.py
+++ b/pg_lake_iceberg/tests/pytests/test_avro_block_header.py
@@ -1,0 +1,267 @@
+"""
+Regression tests for Avro container block-header validation.
+
+An Avro container file stores, before each data block, a record count and a
+compressed byte length, both as zigzag varints. libavro's
+file_read_block_count() used them without checking their sign, so a corrupt or
+misaligned file could steer the reader in two bad directions:
+
+  * a negative length reached avro_malloc(len), and pg_lake routes libavro's
+    allocator to palloc (see AvroPostgresAllocator in avro_init.c), so the
+    negative value arrived as a size_t -- surfacing as
+    "invalid memory alloc request size 18446744073709551563" for len == -53,
+    an error that names neither the file nor the real problem;
+
+  * or, once a block buffer already existed, a negative length is not greater
+    than current_blocklen, so nothing was resized, the read and the codec
+    decode were both skipped, and the block reader was left pointing at the
+    *previous* block's decompressed bytes. The reader then re-emitted stale
+    records and returned data that is not in the file, with no error at all.
+
+Both are now rejected up front, so a damaged manifest is reported as damaged.
+"""
+
+import tempfile
+
+import pytest
+from utils_pytest import *
+
+
+def _encode_zigzag_long(value):
+    """Encode an int64 the way Avro's binary encoding does: zigzag + varint."""
+    zigzag = (value << 1) ^ (value >> 63)
+    zigzag &= (1 << 64) - 1
+
+    out = bytearray()
+    while True:
+        chunk = zigzag & 0x7F
+        zigzag >>= 7
+        if zigzag:
+            out.append(chunk | 0x80)
+        else:
+            out.append(chunk)
+            return bytes(out)
+
+
+def _decode_zigzag_long(data, offset):
+    result = 0
+    shift = 0
+    while True:
+        byte = data[offset]
+        offset += 1
+        result |= (byte & 0x7F) << shift
+        shift += 7
+        if not byte & 0x80:
+            break
+    return (result >> 1) ^ -(result & 1), offset
+
+
+def _first_block_header_offset(data):
+    """Return the offset just past the container header, where the first block
+    header (count, length) begins: magic, the metadata map, then a 16-byte sync
+    marker."""
+    assert data[:4] == b"Obj\x01", "not an Avro container file"
+
+    offset = 4
+    while True:
+        count, offset = _decode_zigzag_long(data, offset)
+        if count == 0:
+            break
+        if count < 0:
+            # a negative map block count is followed by its byte size
+            _, offset = _decode_zigzag_long(data, offset)
+            count = -count
+        for _ in range(count):
+            key_len, offset = _decode_zigzag_long(data, offset)
+            offset += key_len
+            value_len, offset = _decode_zigzag_long(data, offset)
+            offset += value_len
+
+    return offset + 16  # skip the sync marker
+
+
+def _sync_marker(data):
+    start = _first_block_header_offset(data) - 16
+    return data[start : start + 16]
+
+
+def _sample_manifest_bytes():
+    with open(sample_avro_filepath("equality-ids-manifest.avro"), "rb") as f:
+        return f.read()
+
+
+def _read_manifest_error(manifest_url, superuser_conn):
+    """Reserialize the manifest and return the error text, or None if it worked.
+
+    run_query returns result rows on success and the error string on failure, so
+    the type is what distinguishes the two.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".avro") as out_file:
+        result = run_query(
+            f"SELECT lake_iceberg.reserialize_iceberg_manifest("
+            f"'{manifest_url}', '{out_file.name}')",
+            superuser_conn,
+            raise_error=False,
+        )
+
+    return result if isinstance(result, str) else None
+
+
+@pytest.fixture(scope="module")
+def reserialize_functions(create_reserialize_helper_functions, superuser_conn):
+    """Commit the helper function DDL.
+
+    create_reserialize_helper_functions leaves it uncommitted, and every test
+    here has to roll back after the failure it provokes, which would otherwise
+    take the CREATE FUNCTION statements with it.
+    """
+    superuser_conn.commit()
+
+
+def _count_records(data):
+    """Sum the record counts of every block header in a container file."""
+    offset = _first_block_header_offset(data)
+    total = 0
+
+    while offset < len(data):
+        count, offset = _decode_zigzag_long(data, offset)
+        size, offset = _decode_zigzag_long(data, offset)
+        assert size >= 0, f"unreadable output: negative block size {size}"
+        offset += size + 16  # payload plus the sync marker
+        total += count
+
+    return total
+
+
+def _reserialize(manifest_url, out_path, superuser_conn):
+    """Reserialize into out_path; return the error text, or None if it worked."""
+    result = run_query(
+        f"SELECT lake_iceberg.reserialize_iceberg_manifest("
+        f"'{manifest_url}', '{out_path}')",
+        superuser_conn,
+        raise_error=False,
+    )
+
+    return result if isinstance(result, str) else None
+
+
+def _upload(tmp_path, s3, key, payload):
+    local = tmp_path / "manifest.avro"
+    local.write_bytes(payload)
+    s3.upload_file(str(local), TEST_BUCKET, key)
+    return f"s3://{TEST_BUCKET}/{key}"
+
+
+@pytest.mark.parametrize(
+    "label,block_count,block_size",
+    [
+        ("negative_size", 1, -53),
+        ("negative_count", -7, 84),
+    ],
+)
+def test_first_block_header_with_negative_field_is_rejected(
+    label,
+    block_count,
+    block_size,
+    tmp_path,
+    superuser_conn,
+    s3,
+    reserialize_functions,
+):
+    """A negative count or length in the *first* block header must fail the read.
+
+    The first block is the case where no block buffer exists yet, so before the
+    fix a negative length went straight to avro_malloc() and the statement died
+    with "invalid memory alloc request size 18446744073709551563" instead of
+    anything that identifies the file as corrupt.
+    """
+    original = _sample_manifest_bytes()
+    header_end = _first_block_header_offset(original)
+
+    corrupt = bytearray(original[:header_end])
+    corrupt += _encode_zigzag_long(block_count)
+    corrupt += _encode_zigzag_long(block_size)
+    # Keep a plausible amount of trailing data so the failure has to come from
+    # the block header itself and not from hitting end-of-file.
+    corrupt += original[header_end:]
+
+    url = _upload(tmp_path, s3, f"avro_block_header/{label}.avro", bytes(corrupt))
+    error = _read_manifest_error(url, superuser_conn)
+    superuser_conn.rollback()
+
+    assert error is not None, (
+        f"{label}: reading a manifest with a negative block header field "
+        f"succeeded; file_read_block_count() must reject it"
+    )
+    assert "invalid memory alloc request size" not in str(
+        error
+    ), f"{label}: unvalidated block length reached the allocator: {error}"
+    assert "Invalid file block" in str(
+        error
+    ), f"{label}: expected a block-header validation error, got: {error}"
+
+
+@pytest.mark.parametrize("label,block_size", [("negative", -53), ("zero", 0)])
+def test_trailing_block_header_does_not_add_phantom_records(
+    label, block_size, tmp_path, superuser_conn, s3, reserialize_functions
+):
+    """Garbage after the final sync marker must not be read as extra records.
+
+    A trailing block header whose length is not positive used to reach the
+    stale-buffer path: no buffer is resized, the "len > 0" read and decode are
+    both skipped, and block_reader is left pointing at the previous block's
+    decompressed bytes, so the declared record count is satisfied out of them.
+
+    The count matters for whether that is even visible. Claim more records than
+    the stale buffer holds and the reader overruns it and errors, which looks
+    like correct behaviour for the wrong reason. Claim exactly one and it fits,
+    so the read succeeds and the manifest comes back with an extra entry that is
+    not in the file -- in Iceberg terms a phantom data file -- reported as
+    success. So this asserts on the record count, not merely that an error
+    occurred.
+
+    Zero is the likelier length of the two in practice: the fields are
+    independent zigzag varints, so a single 0x00 decodes to it, and zero is what
+    a misaligned read into a zero-filled region finds.
+    """
+    original = _sample_manifest_bytes()
+    expected = _count_records(original)
+
+    # The trailing bytes are a bare block header, with no sync marker in front:
+    # the reader consumed the file's own final sync while finishing the last
+    # block, so it is already positioned where a block header would start.
+    #
+    # Closing with a sync marker is what makes the failure silent rather than
+    # merely wrong: after the phantom record the reader looks for a sync marker,
+    # finds a valid one, then hits end-of-file and stops cleanly. End the file
+    # any other way and it reports "Incorrect sync bytes" *after* having already
+    # handed the extra record to the caller.
+    trailing = (
+        _encode_zigzag_long(1)
+        + _encode_zigzag_long(block_size)
+        + _sync_marker(original)
+    )
+
+    url = _upload(
+        tmp_path,
+        s3,
+        f"avro_block_header/phantom_records_{label}.avro",
+        original + trailing,
+    )
+    out_path = tmp_path / f"out_{label}.avro"
+    error = _reserialize(url, str(out_path), superuser_conn)
+    superuser_conn.rollback()
+
+    if error is not None:
+        # Failing the read outright is the acceptable outcome; it just must not
+        # be the unvalidated-length allocation error.
+        assert "invalid memory alloc request size" not in str(
+            error
+        ), f"{label}: unvalidated block length reached the allocator: {error}"
+        return
+
+    actual = _count_records(out_path.read_bytes())
+    assert actual == expected, (
+        f"{label}: read {actual} records from a manifest holding {expected}; the "
+        f"trailing block header was satisfied from the previous block's bytes"
+    )

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -1,8 +1,10 @@
 import os
 import pytest
+import socket
 import threading
 import time
 from decimal import Decimal
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from utils_pytest import *
 
 CACHE_FILE_PREFIX = "pgl-cache."
@@ -86,6 +88,173 @@ def test_cache_rejects_non_regular_file(s3, pgduck_conn, tmp_path):
     assert cached_path.is_file() and not cached_path.is_symlink()
     assert cached_path.stat().st_size == real_size
     assert (cached_path.stat().st_mode & 0o777) == 0o600
+
+    run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
+    pgduck_conn.rollback()
+
+
+TRUNCATED_BODY_SIZE = 64 * 1024
+TRUNCATED_BODY_SENT = 4 * 1024
+
+
+@pytest.fixture(scope="module")
+def flaky_http_server():
+    """Truncate the first GET of the body, then serve it in full.
+
+    This is the case that corrupts silently. A body that is *always* short ends
+    up failing anyway, because HTTPUtil::SendRequest runs out of retries and
+    throws -- so it proves nothing about the download path. Truncating only the
+    first attempt lets the retry succeed, and a successful retry is what leaves
+    the partial attempt and the complete one both in the output file.
+
+    The handler keeps its own state so that a re-run does not inherit a counter.
+    """
+
+    state = {"gets": 0}
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _headers(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(TRUNCATED_BODY_SIZE))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+
+        def do_HEAD(self):
+            self._headers()
+
+        def do_GET(self):
+            state["gets"] += 1
+            first = state["gets"] == 1
+            self._headers()
+            self.wfile.write(
+                b"x" * (TRUNCATED_BODY_SENT if first else TRUNCATED_BODY_SIZE)
+            )
+            self.wfile.flush()
+            if first:
+                self.close_connection = True
+
+        def log_message(self, *args):
+            pass
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield port, state
+
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=10)
+
+
+def test_retried_download_is_not_cached(flaky_http_server, pgduck_conn):
+    """A download whose retry succeeded must still match the object.
+
+    HTTPUtil::SendRequest retries a request error by re-running the content
+    handler from the start of the body, and the handler appends to an output
+    file that still holds whatever the previous attempt delivered. So a retry
+    that succeeds leaves a partial copy followed by a complete one: longer than
+    the object, with no exception, and reported as success.
+
+    Nothing revalidates a finalized cache entry against object storage, so that
+    entry would be served for every later read of the URL. For an Avro manifest
+    the second copy begins exactly where the reader looks for the next block
+    header, which is the shape that produces the corruption in #550.
+    """
+    port, state = flaky_http_server
+    url = f"http://127.0.0.1:{port}/flaky.bin"
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/http/127.0.0.1:{port}"
+        f"/{CACHE_FILE_PREFIX}flaky.bin"
+    )
+    stage_path = Path(f"{cached_path}.pgl-stage")
+
+    error = run_query(
+        f"CALL pg_lake_cache_file('{url}');", pgduck_conn, raise_error=False
+    )
+    pgduck_conn.rollback()
+
+    # Guards against the test passing for the wrong reason: the request has to
+    # have been retried, otherwise this is just a plain failed download.
+    assert state["gets"] >= 2, (
+        f"the download was not retried ({state['gets']} GET(s)), so the "
+        f"accumulation this test is about never happened"
+    )
+
+    cached_size = cached_path.stat().st_size if cached_path.exists() else None
+    assert isinstance(error, str), (
+        f"a retried download was cached as {cached_size} bytes for a "
+        f"{TRUNCATED_BODY_SIZE}-byte object"
+    )
+    assert not cached_path.exists(), f"over-long download was published: {cached_path}"
+
+    # The rejected download stays staged, which is deliberate: the sweep at the
+    # top of ManageCache reclaims it. Nothing races us for it here -- this suite
+    # talks to pgduck_server directly, so there is no cache worker running, and
+    # unwinding out of CacheFile released the lock the sweep needs.
+    assert stage_path.exists(), (
+        f"expected the rejected download to stay staged for the sweep to "
+        f"reclaim: {stage_path}"
+    )
+
+    # A budget far above the cache contents, so this only exercises the staging
+    # sweep and does not evict anything another test cached.
+    run_command("SELECT count(*) FROM pg_lake_manage_cache(21474836480);", pgduck_conn)
+    pgduck_conn.rollback()
+
+    assert (
+        not stage_path.exists()
+    ), f"sweep did not reclaim the staging file: {stage_path}"
+
+
+def test_azure_download_is_length_checked(azure, pgduck_conn):
+    """Azure goes through the same length check, and is not tripped up by it.
+
+    The check lives in FileUtils::CopyFile rather than in the http/s3 download
+    helper, because CopyFile dispatches on the file system name and only
+    HTTPFileSystem and RegionAwareS3FileSystem use that helper. Azure registers
+    as AzureBlobStorageFileSystem / AzureDfsStorageFileSystem, so it takes the
+    generic Read/Write loop and would otherwise be left unverified.
+
+    A truncated Azure body cannot be provoked here -- azurite serves what it is
+    given -- so the truncation case is covered by the http test above, where the
+    server is ours. What this pins down is that the generic branch is subject to
+    the check and that a healthy transfer satisfies it, byte for byte, which is
+    what a wrong expected-size would break.
+    """
+    key = "test_azure_download_is_length_checked/data.csv"
+    url = f"az://{TEST_BUCKET}/{key}"
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/az/{TEST_BUCKET}"
+        f"/test_azure_download_is_length_checked/{CACHE_FILE_PREFIX}data.csv"
+    )
+
+    run_command(
+        f"COPY (SELECT * FROM generate_series(1,5000)) TO '{url}' WITH (header false);",
+        pgduck_conn,
+    )
+
+    remote_size = pg_lake_file_size(f"nocache{url}", pgduck_conn)
+
+    # Writing the blob populated the cache on the way out, so drop that entry
+    # first. Without this, pg_lake_cache_file finds the file already cached and
+    # returns without copying anything, and the check would never be reached.
+    run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
+    assert not cached_path.exists(), "cache entry survived the uncache"
+
+    run_command(f"CALL pg_lake_cache_file('{url}');", pgduck_conn)
+
+    assert cached_path.exists(), f"azure blob was not cached: {cached_path}"
+    assert local_file_size(str(cached_path)) == remote_size, (
+        f"cache entry is {local_file_size(str(cached_path))} bytes for a "
+        f"{remote_size}-byte blob"
+    )
 
     run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
     pgduck_conn.rollback()

--- a/pgduck_server/tests/pytests/test_caching.py
+++ b/pgduck_server/tests/pytests/test_caching.py
@@ -91,6 +91,69 @@ def test_cache_rejects_non_regular_file(s3, pgduck_conn, tmp_path):
     pgduck_conn.rollback()
 
 
+@pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="mode 0 does not deny root, so the cache open succeeds and this "
+    "would pass with or without the fallback",
+)
+def test_unusable_cache_file_falls_back_to_remote(s3, pgduck_conn):
+    """A cache entry that cannot be opened must not fail the read.
+
+    OpenFile() decides to read from the cache with IsOwnedByCurrentUser() and
+    then opens the file, and nothing holds the per-path cache lock across those
+    two steps. So the entry can stop being usable in between -- cache management
+    evicting it under pressure is the ordinary case, and the check only
+    establishes that a regular file owned by us was there a moment ago. The open
+    used to propagate, killing the statement with a bare
+    "IO Error: Cannot open file <cache path>" for an object that is still
+    perfectly readable in object storage.
+
+    A cache file owned by us but with no read permission reaches the same open
+    failure deterministically, without having to win a race: lstat() still
+    reports a regular file owned by the effective UID, so the cache branch is
+    taken, and only then does the open fail.
+    """
+    key = "test_unusable_cache_file_falls_back_to_remote/data.csv"
+    url = f"s3://{TEST_BUCKET}/{key}"
+    cached_path = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/s3/{TEST_BUCKET}"
+        f"/test_unusable_cache_file_falls_back_to_remote/{CACHE_FILE_PREFIX}data.csv"
+    )
+
+    run_command(
+        f"COPY (SELECT * FROM generate_series(1,10)) TO '{url}' WITH (header false);",
+        pgduck_conn,
+    )
+    run_command(f"CALL pg_lake_cache_file('{url}');", pgduck_conn)
+    assert cached_path.is_file(), "file was not cached, nothing to exercise"
+
+    remote_size = pg_lake_file_size(f"nocache{url}", pgduck_conn)
+    original_mode = cached_path.stat().st_mode & 0o777
+
+    cached_path.chmod(0o000)
+    try:
+        result = run_query(
+            f"SELECT octet_length(content) AS size FROM read_blob('{url}')",
+            pgduck_conn,
+            raise_error=False,
+        )
+    finally:
+        cached_path.chmod(original_mode)
+
+    # run_query hands back the error string rather than rows when it fails.
+    assert not isinstance(result, str), (
+        f"an unusable cache entry failed the read instead of falling back to "
+        f"object storage: {result}"
+    )
+    assert int(result[0]["size"]) == remote_size, (
+        f"fell back but returned {result[0]['size']} bytes for a "
+        f"{remote_size}-byte object"
+    )
+
+    run_query(f"CALL pg_lake_uncache_file('{url}');", pgduck_conn)
+    pgduck_conn.rollback()
+
+
 def test_pg_lake_cache_file(s3, gcs, azure, pgduck_conn):
     run_pg_lake_cache_file_test_for_protocol("s3", TEST_BUCKET, pgduck_conn, s3)
     run_pg_lake_cache_file_test_for_protocol("gs", TEST_BUCKET_GCS, pgduck_conn, gcs)
@@ -943,6 +1006,69 @@ def test_cache_on_write_abort_removes_stage_file(s3, pgduck_conn):
         # After the abort neither the finalized file nor the staging file remain.
         assert not cached_path.exists(), f"{ext}: unexpected finalized cache file"
         assert not stage_path.exists(), f"{ext}: orphaned staging file not cleaned up"
+
+
+def test_cache_on_write_truncates_orphaned_stage_file(s3, pgduck_conn):
+    """Reusing a .pgl-stage file left by a crash must truncate it first.
+
+    ~CachingFSFileHandle() removes the staging file on a caught abort, but a
+    hard crash or kill skips the destructor entirely and leaves one on disk at a
+    fully deterministic path. Opening that file with O_CREAT alone writes the new
+    contents over its prefix and leaves whatever of the older, longer file
+    extends past them; FileSync()/Close() then renames the hybrid in as a
+    finalized cache entry. Nothing revalidates a finalized entry against object
+    storage, so every later read of that URL gets the wrong bytes until it is
+    evicted -- for an Avro manifest, a trailing fragment past the final sync
+    marker is read as another block header.
+
+    The orphan is written directly here because that is precisely the on-disk
+    state a crash leaves behind, and the one state the destructor cannot cover.
+    """
+    test_dir = Path(
+        f"{server_params.PGDUCK_CACHE_DIR}/s3/{TEST_BUCKET}"
+        f"/test_cache_on_write_truncates_orphaned_stage_file"
+    )
+
+    # A small limit left over from another test would disable write-through
+    # caching, so pin it back to the 1GB default.
+    run_command(
+        "SET GLOBAL pg_lake_cache_on_write_max_size TO '1073741824';", pgduck_conn
+    )
+
+    # Far larger than the file about to be written, so a surviving tail is
+    # unmistakable rather than a handful of bytes.
+    filler = b"ORPHAN.." * (128 * 1024)
+
+    for ext in ("parquet", "csv"):
+        url = (
+            f"s3://{TEST_BUCKET}"
+            f"/test_cache_on_write_truncates_orphaned_stage_file/data.{ext}"
+        )
+        cached_path = test_dir / f"{CACHE_FILE_PREFIX}data.{ext}"
+        stage_path = test_dir / f"{CACHE_FILE_PREFIX}data.{ext}.pgl-stage"
+
+        test_dir.mkdir(parents=True, exist_ok=True)
+        cached_path.unlink(missing_ok=True)
+        stage_path.write_bytes(filler)
+
+        run_command(
+            f"COPY (SELECT s AS s, s * 2 AS d FROM generate_series(1, 100) g(s)) "
+            f"TO '{url}' (format '{ext}');",
+            pgduck_conn,
+        )
+
+        assert cached_path.exists(), f"{ext}: write-through cache file is missing"
+        assert not stage_path.exists(), f"{ext}: staging file was not finalized"
+
+        cached_bytes = cached_path.read_bytes()
+        assert b"ORPHAN" not in cached_bytes, (
+            f"{ext}: content of the orphaned staging file survived into the "
+            f"finalized cache entry ({len(cached_bytes)} bytes cached)"
+        )
+        assert len(cached_bytes) == pg_lake_file_size(f"nocache{url}", pgduck_conn), (
+            f"{ext}: finalized cache entry ({len(cached_bytes)} bytes) disagrees "
+            f"with the object in storage"
+        )
 
 
 # we cannot cache the same file concurrently


### PR DESCRIPTION
## Why backport

Two fixes for one failure class: an entry lands in the pgduck_server file cache holding
bytes that are not the object's, nothing ever revalidates a finalized entry against
storage, and every later read of that URL gets the wrong data until eviction. It is the
same shape as #514 — the write reports success, and the damage surfaces much later as an
unreadable Iceberg manifest or Parquet file, at which point the cause is long gone.

`release-3.4` has neither.

- **#550 is the corruption, and the detection.** Write-through caching staged into
  `<cache path>.pgl-stage` opened with `O_CREAT` instead of `O_CREAT|O_TRUNC`, so an
  orphan at that fully deterministic path was written into from offset 0 without being
  truncated, and whatever of the longer previous file extended past the new contents
  survived into the rename and was published as a finalized entry. Orphans are not
  crash-only: any caught abort mid-write leaves one. Separately, libavro used the block
  header's count and size without validating either, so the damage surfaced as
  `invalid memory alloc request size 18446744073709551563`, or worse, as silently serving
  the previous block's bytes for a zero-length block — phantom records reported as success.
- **#556 is a second route to a poisoned entry**, needing neither a crash nor a full disk.
  `PgLakeHTTPFileSystem::Download` never compared the bytes it wrote against the object,
  and `HTTPUtil::SendRequest` retries a request error by re-running the content handler
  from the start of the body while the output handle keeps the partial attempt. So a
  successful retry leaves partial-then-complete: longer than the object, no exception,
  reported as success, then renamed into the cache.

## Why one PR

#550 has to land first: #556 touches `file_cache_manager.cpp` and `test_caching.py` at
points #550 moves, so picking #556 alone conflicts. Two stacked PRs would have to merge in
that order anyway and each rebase would re-resolve the same conflict. Each commit keeps its
`(cherry picked from commit …)` provenance, so they are still reviewable one at a time.

## #513 removed

An earlier revision of this PR also carried #513 (inode-aware cache accounting). Dropped at
review: it is 933 insertions including a new 422-line `cache_inode_budget.cpp`, which is a
feature and not patch-release material.

It was originally included because it is the trigger condition for one route into #550 —
cache management counted only bytes, so many small files exhaust the inodes of a
fixed-inode-table volume long before `max_cache_size`, every cache write then fails with
`ENOSPC`, and an `ENOSPC` mid-write is one way to leave the orphan #550 publishes. Removing
#513 leaves that route open, but #550 still fixes the corruption on it — the orphan is
truncated whatever created it, and a `ENOSPC`-damaged entry now falls back to remote rather
than being served. So the fix is not weakened by dropping #513; only one way of *provoking*
it stays unaddressed. #513 is worth its own decision on a minor release.

For the record, my earlier claim that #556 needed #513 in front of it to pick cleanly was
wrong: rebuilt as #550 then #556, both pick clean with no conflict at all.

## Conflict resolution

- **#550** — conflict in `duckdb_pglake/src/fs/pg_lake_s3fs.cpp`. Its
  `fix RemoveFiles batch loop build on macOS/arm64` hunk fixes `MinValue` template
  deduction inside `PgLakeS3FileSystem::RemoveFilesFromS3`, which is #509's function and is
  not on this branch — so there is nothing here to fix. The hunk is dropped rather than
  backporting #509, which is a batching feature and not patch-release material. That file
  is left byte-identical to `release-3.4`.
- **#556** — clean.

## Verification

- Each pick applies a change set **byte-identical to its upstream commit** (`adba0f7` vs
  `21bc327`, `ccdd0e6` vs `94dbb87`), conflict resolution included. No hunk was dropped or
  adapted.
- 7 of the 10 files this branch touches are **byte-identical to `main`**. The three that
  differ are each explained by work absent from this branch:
  - `caching_file_system.cpp` — #509's batched-removal work.
  - `file_cache_manager.cpp` — #513, now deliberately excluded.
  - `test_caching.py` — exactly #513's 169-line test hunk, verified line for line.
- `avro.patch` is byte-identical to `main`'s and applies cleanly
  (`git apply --check --ignore-whitespace`) to an `avro` checkout at `2b11dba4`, which is
  the submodule commit `release-3.4` pins — and the same one `main` pins. So the libavro
  half of #550 will actually apply at build time rather than being silently skipped, which
  is the failure mode a vendored patch has.
- **Compile-verified locally against PG 18.6**, clean with no warnings: `pg_lake_engine`
  and `pg_lake_iceberg`, which covers #550's `local_storage.c`, `avro_writer.c` and
  `table_metadata.c`. The `duckdb_pglake` C++ files are left to the six
  `build-and-install` jobs — a from-scratch DuckDB build is the long pole locally — and
  every one of them except the two audited above is byte-identical to `main`.

## Diff

Two cherry-picks, 10 files.

| Commit | Upstream | Files |
|---|---|---|
| `Fix write-through cache poisoning and unvalidated Avro block headers` | #550 | `avro.patch`, `caching_file_system.cpp`, `local_storage.c`, `avro_writer.c`, `table_metadata.c`, + 2 test files |
| `duckdb_pglake: verify a copy delivered the whole source before caching it` | #556 | `file_cache_manager.cpp`, `file_utils.cpp`, `httpfs_extended.cpp`, + test |

No SQL, no migration files, no catalog or schema change, no version bump, and now no new
settings either, so this fits the patch-release policy.

## Test plan

pg_lake CI on this branch. Tests come with the picks and each was written to fail without
its fix:

- #550: `test_cache_on_write_truncates_orphaned_stage_file`,
  `test_unusable_cache_file_falls_back_to_remote`,
  `test_first_block_header_with_negative_field_is_rejected`,
  `test_trailing_block_header_does_not_add_phantom_records`.
- #556: `test_retried_download_is_not_cached`, `test_azure_download_is_length_checked`
  (the latter needs `azurite`, so it skips where that is unavailable).
