### PR TITLE
[release-3.4] Backport #568: make releasing a pgduck connection idempotent

### DIFF
--- a/pg_lake_copy/src/test/pgduck_connection.c
+++ b/pg_lake_copy/src/test/pgduck_connection.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * User-defined functions for testing the pgduck_server connection lifecycle.
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+
+#include "pg_lake/pgduck/client.h"
+
+
+PG_FUNCTION_INFO_V1(release_pgduck_connection_twice);
+
+
+/*
+ * release_pgduck_connection_twice releases the same connection twice, which is
+ * what a caller does when it releases both in an error path and in the
+ * PG_FINALLY block that follows. The second release must be a no-op.
+ */
+Datum
+release_pgduck_connection_twice(PG_FUNCTION_ARGS)
+{
+	PGDuckConnection *pgDuckConnection = GetPGDuckConnection();
+
+	ReleasePGDuckConnection(pgDuckConnection);
+	ReleasePGDuckConnection(pgDuckConnection);
+
+	PG_RETURN_VOID();
+}

--- a/pg_lake_copy/tests/pytests/test_pgduck_connection.py
+++ b/pg_lake_copy/tests/pytests/test_pgduck_connection.py
@@ -1,0 +1,54 @@
+"""Regression test: releasing the same pgduck_server connection twice.
+
+ReleasePGDuckConnection() used to dereference the entry returned by
+HASH_REMOVE, and on the !found path it closed the connection through the
+caller's own handle. A second release therefore passed the same PGconn to
+PQfinish() twice, which aborts the backend and restarts the whole cluster,
+or closed a newer connection that had reused the hash entry.
+
+See https://github.com/Snowflake-Labs/pg_lake/issues/557.
+"""
+
+import pytest
+from utils_pytest import *
+
+
+@pytest.fixture()
+def release_pgduck_connection_twice(superuser_conn):
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION release_pgduck_connection_twice()
+        RETURNS void LANGUAGE C
+        AS 'pg_lake_copy', $$release_pgduck_connection_twice$$;
+    """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    yield
+
+    run_command("DROP FUNCTION release_pgduck_connection_twice()", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_double_release_is_a_noop(superuser_conn, release_pgduck_connection_twice):
+    superuser_conn.notices.clear()
+
+    run_command("SELECT release_pgduck_connection_twice()", superuser_conn)
+    superuser_conn.commit()
+
+    # The second release must recognize the connection as already released
+    # instead of taking the untracked path that closed the handle again.
+    assert not any(
+        "untracked connection" in notice for notice in superuser_conn.notices
+    )
+
+    # The first release must still have removed the hash entry, or the
+    # end-of-transaction sweep would have found a connection to close.
+    assert not any(
+        "connections on transaction commit" in notice
+        for notice in superuser_conn.notices
+    )
+
+    # The backend is still alive, so PQfinish() was not called twice.
+    assert run_query("SELECT 1 AS ok", superuser_conn)[0]["ok"] == 1

--- a/pg_lake_engine/src/pgduck/client.c
+++ b/pg_lake_engine/src/pgduck/client.c
@@ -170,30 +170,48 @@ GetPGDuckConnection(void)
 
 /*
  * ReleasePGDuckConnection closes the current connection to the
- * pgduck_server, if any.
+ * pgduck_server, if any. Releasing a connection that was already released
+ * is a no-op.
  */
 void
 ReleasePGDuckConnection(PGDuckConnection * pgDuckConnection)
 {
+	/*
+	 * GetPGDuckConnection never hands out an entry with a NULL conn, so a
+	 * NULL here means this connection was already released.
+	 */
+	if (pgDuckConnection->conn == NULL)
+		return;
+
 	uint32		connectionId = pgDuckConnection->connectionId;
 	bool		found = false;
 	PgDuckServerConnectionHashEntry *entry =
-		hash_search(PgDuckConnectionHash, &connectionId, HASH_REMOVE, &found);
+		hash_search(PgDuckConnectionHash, &connectionId, HASH_FIND, &found);
 
 	if (!found)
 	{
-		elog(WARNING, "closing untracked connection to query engine");
-
-		if (pgDuckConnection->conn != NULL)
-			PQfinish(pgDuckConnection->conn);
-
-		pgDuckConnection->conn = NULL;
-
+		/*
+		 * A released entry goes back to dynahash's freelist while the caller
+		 * still points into it, so a handle we cannot find in the hash may
+		 * already be closed or may belong to a newer connection that reused
+		 * the entry. Leak it rather than risk closing the wrong connection.
+		 */
+		elog(WARNING, "ignoring release of untracked connection to query engine");
 		return;
 	}
 
-	if (entry->pgDuckConnection.conn != NULL)
-		PQfinish(entry->pgDuckConnection.conn);
+	PGconn	   *conn = entry->pgDuckConnection.conn;
+
+	/*
+	 * Clear the handle before removing the entry: HASH_REMOVE returns a
+	 * dangling pointer, so this is the last point at which the entry, and
+	 * with it the caller's PGDuckConnection, can be marked as released.
+	 */
+	entry->pgDuckConnection.conn = NULL;
+
+	hash_search(PgDuckConnectionHash, &connectionId, HASH_REMOVE, NULL);
+
+	PQfinish(conn);
 }
 
 


### PR DESCRIPTION
## Why backport

`ReleasePGDuckConnection()` removed the hash entry with `HASH_REMOVE` and then read the
returned pointer, which dynahash documents as dangling — the entry is on the freelist and
the next connection reuses it. On the `!found` path it closed the connection through the
caller's own handle instead, so releasing the same `PGDuckConnection` twice passed the same
`PGconn` to `PQfinish()` twice. That aborts the backend inside glibc, and an aborted backend
**restarts the whole cluster**, taking every other session with it.

Callers hold an interior pointer into the hash entry, so they have no way to tell whether
they already released it. That is why this is reachable from ordinary operation rather than
from a contrived sequence.

Fixes #557. For a managed release line I would rank this directly behind #514: whole-cluster
impact, no special configuration needed to reach it, and the pick is clean.

## Conflict resolution

None — the pick is clean on `f10ff7e`.

## Diff

| File | What |
|---|---|
| `pg_lake_engine/src/pgduck/client.c` | Clear the handle first, then remove the entry; treat a NULL handle as already released; `HASH_FIND` instead of `HASH_REMOVE`-then-read; a release that cannot be found in the hash leaks the connection rather than closing what may now be a newer connection's `PGconn` |
| `pg_lake_copy/src/test/pgduck_connection.c` | New test-only SQL-callable helper that acquires and double-releases a connection |
| `pg_lake_copy/tests/pytests/test_pgduck_connection.py` | New test |

Byte-identical to `main` in all three files. No SQL, no migration, no catalog change, no
version bump, so this fits the patch-release policy.

`pg_lake_copy/Makefile` builds `$(wildcard src/*/*.c)`, so the new `src/test/` file is
compiled without a build-file change.

## Test plan

pg_lake CI on this branch. `test_pgduck_connection.py` double-releases a connection through
the new helper; before the fix that crashes the backend and takes the cluster down, which is
what the test asserts does not happen.
