### PR TITLE
[release-3.4] Backport #390, #561: two pgduck_server crashes

### DIFF
--- a/duckdb_pglake/src/include/pg_lake/query_listener.hpp
+++ b/duckdb_pglake/src/include/pg_lake/query_listener.hpp
@@ -17,30 +17,68 @@
 
 #pragma once
 
+#include <mutex>
+
 namespace duckdb {
 
 /*
- * PgLakeQueryListener can be used to safely get the query
- * string from a ClientContext. GetCurrentQuery is only safe to call
- * while a query is active.
+ * PgLakeQueryListener tracks the active query for one DuckDB ClientContext
+ * so that pg_lake_stat_activity (and similar inspection functions) can
+ * report it from a different connection.
+ *
+ * QueryBegin / QueryEnd run on the session's own thread.  GetActiveQuery
+ * runs on whatever thread the caller is on -- typically a different
+ * session iterating ConnectionManager::GetConnectionList().  The query
+ * string and start timestamp are mutated on every QueryBegin / QueryEnd,
+ * so a concurrent direct read is a data race; std::string in particular
+ * is undefined behaviour to read while another thread writes to it.
+ *
+ * The mutex protects the (is_active, active_query, active_start) triple.
+ * connectionId is set once during duckdb_pglake_init_connection and
+ * never modified afterwards, so it is safe to read directly.
  */
 struct PgLakeQueryListener : public ClientContextState {
-	int64_t connectionId;
-
-	bool isQueryActive;
-	string queryString;
-	timestamp_t queryStart;
+	int64_t connectionId = 0;
 
 	void QueryBegin(ClientContext &context) override {
-		isQueryActive = true;
-		queryString = context.GetCurrentQuery();
-		queryStart = Timestamp::GetCurrentTimestamp();
+		std::lock_guard<std::mutex> lock(active_mutex);
+		is_active = true;
+		active_query = context.GetCurrentQuery();
+		active_start = Timestamp::GetCurrentTimestamp();
 	}
 
 	void QueryEnd(ClientContext &context) override {
-		isQueryActive = false;
-		queryString = "";
+		std::lock_guard<std::mutex> lock(active_mutex);
+		is_active = false;
+		active_query.clear();
 	}
+
+	//! Snapshot the active query state under the listener's mutex.
+	//! Returns true and fills out_query / out_start when a query is
+	//! currently running; returns false otherwise.  Safe to call from
+	//! any thread.
+	bool GetActiveQuery(string &out_query, timestamp_t &out_start) const {
+		std::lock_guard<std::mutex> lock(active_mutex);
+		if (!is_active) {
+			return false;
+		}
+		out_query = active_query;
+		out_start = active_start;
+		return true;
+	}
+
+	//! Cheap probe of the active flag without copying the query string.
+	//! Held briefly under the same mutex as GetActiveQuery.
+	bool IsQueryActive() const {
+		std::lock_guard<std::mutex> lock(active_mutex);
+		return is_active;
+	}
+
+private:
+	mutable std::mutex active_mutex;
+	bool is_active = false;
+	string active_query;
+	timestamp_t active_start = timestamp_t(0);
 };
 
 

--- a/duckdb_pglake/src/utility_functions.cpp
+++ b/duckdb_pglake/src/utility_functions.cpp
@@ -33,8 +33,8 @@ struct StatActivityFunctionData : public TableFunctionData
 {
 	/* Function state */
 	vector<shared_ptr<ClientContext>> connections;
-	int offset;
-	bool finished = false;
+	idx_t		offset = 0;
+	bool		finished = false;
 };
 
 
@@ -63,6 +63,26 @@ static unique_ptr<FunctionData> StatActivityBind(ClientContext &context,
 
 /*
  * StatActivityExecute implements the execution for pg_lake_stat_activity.
+ *
+ * We are iterating connections from a thread that is not the one running
+ * any of the inspected sessions.  Two pieces of inspected state need
+ * care:
+ *
+ * 1. The PgLakeQueryListener's query string and start timestamp are
+ *    mutated on every QueryBegin / QueryEnd on the session's own thread.
+ *    GetActiveQuery reads them under the listener's mutex and returns
+ *    false when no query is active, so sessions that start or end a
+ *    query mid-iteration are simply skipped.
+ *
+ * 2. ClientContext::ExecutionIsFinished is not safe to call from another
+ *    thread: it reads the ClientContext's active_query unique_ptr, which
+ *    the owning session resets in QueryEnd.  We previously used it as a
+ *    cheap "is a query running" probe; the listener's GetActiveQuery
+ *    already answers that question safely, so the ExecutionIsFinished
+ *    call is removed.
+ *
+ * connectionId is set once at session initialization and never modified
+ * afterwards, so it is safe to read directly.
  */
 static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &functionData = (StatActivityFunctionData &)*data_p.bind_data;
@@ -81,16 +101,19 @@ static void StatActivityExec(ClientContext &context, TableFunctionInput &data_p,
 	while (functionData.offset< functionData.connections.size() && rowsInChunk < STANDARD_VECTOR_SIZE) {
 		shared_ptr<ClientContext> connection = functionData.connections[functionData.offset];
 
-		if (connection && !connection->ExecutionIsFinished())
+		if (connection)
 		{
 			shared_ptr<PgLakeQueryListener> queryListener =
 				connection->registered_state->Get<PgLakeQueryListener>("pg_lake_query_listener");
 
-			if (queryListener && queryListener->isQueryActive)
+			string activeQuery;
+			timestamp_t activeStart;
+
+			if (queryListener && queryListener->GetActiveQuery(activeQuery, activeStart))
 			{
 				output.SetValue(0, rowsInChunk, Value::BIGINT(queryListener->connectionId));
-				output.SetValue(1, rowsInChunk, Value(queryListener->queryString));
-				output.SetValue(2, rowsInChunk, Value::TIMESTAMP(queryListener->queryStart));
+				output.SetValue(1, rowsInChunk, Value(activeQuery));
+				output.SetValue(2, rowsInChunk, Value::TIMESTAMP(activeStart));
 
 				rowsInChunk++;
 			}

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -55,7 +55,14 @@ typedef struct PgClientThreadState
 	int32		cancellationToken;
 #endif
 
-	/* DuckDB connection to interrupt */
+	/*
+	 * DuckDB connection to interrupt.
+	 *
+	 * The cancel paths call duckdb_interrupt() on this pointer, so it must be
+	 * NULL whenever the connection behind it is not alive.  The thread owning
+	 * the slot has to clear it (set_duckdb_conn with NULL) *before* it
+	 * disconnects, not when it frees the slot.
+	 */
 	duckdb_connection duckdbConnection;
 
 }			PgClientThreadState;

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -1132,6 +1132,16 @@ static int
 pgsession_destroy(PGSession * pgSession)
 {
 	pg_free(pgSession->pqSendBuffer);
+
+	/*
+	 * Clear the connection in the thread pool before disconnecting it, so
+	 * that a concurrent cancellation cannot call duckdb_interrupt() on a
+	 * freed connection. Setting it under the write lock means a cancel either
+	 * runs before this and finds a live connection, or after it and finds
+	 * NULL.
+	 */
+	pgclient_threadpool_set_duckdb_conn(pgSession->pgClient->threadIndex, NULL);
+
 	duckdb_session_destroy(&pgSession->duckSession);
 	return OK;
 }

--- a/pgduck_server/tests/pytests/test_stat_activity.py
+++ b/pgduck_server/tests/pytests/test_stat_activity.py
@@ -59,3 +59,116 @@ def wait_for_connection(conn):
             select.select([conn.fileno()], [], [])
         else:
             raise psycopg2.OperationalError("poll() returned %s" % state)
+
+
+# Regression test for https://github.com/Snowflake-Labs/pg_lake/issues/148:
+# running pg_lake_stat_activity() concurrently from several pgbench clients
+# used to crash pgduck_server because StatActivityExec read another
+# session's PgLakeQueryListener fields and called ClientContext::
+# ExecutionIsFinished() across threads. Both reads now go through
+# thread-safe paths, and the test fails if pgduck_server crashes (pgbench
+# starts reporting connection errors and exits non-zero).
+def test_stat_activity_concurrent_pgbench(s3, pgduck_server):
+    file_path = "/tmp/stat_activity_concurrent.sql"
+    with open(file_path, "w") as f:
+        f.write("SELECT count(*) FROM pg_lake_stat_activity();\n")
+
+    returncode, stdout, stderr = run_pgbench_command(
+        [
+            "-n",
+            "-c",
+            "4",
+            "-j",
+            "2",
+            "-T",
+            "5",
+            "-f",
+            file_path,
+            "-h",
+            server_params.PGDUCK_UNIX_DOMAIN_PATH,
+            "-p",
+            str(server_params.PGDUCK_PORT),
+        ]
+    )
+
+    assert returncode == 0, (
+        f"pgbench against pg_lake_stat_activity() failed; "
+        f"stdout=\n{stdout}\nstderr=\n{stderr}"
+    )
+    assert "number of transactions actually processed" in stdout, stdout
+    # All transactions must succeed; a crashed pgduck_server shows up as
+    # "number of failed transactions" > 0 or a non-zero return code.
+    assert "number of failed transactions: 0" in stdout, stdout
+
+    # The server must still be reachable after the stress run.
+    run_simple_command(server_params.PGDUCK_UNIX_DOMAIN_PATH, server_params.PGDUCK_PORT)
+
+
+# Companion repro for the second scenario described in issue #148: a
+# single client looping over pg_lake_stat_activity() while a wider fleet
+# of pgbench clients hammers pgduck_server with cheap queries. The
+# stat_activity caller iterates ConnectionManager::GetConnectionList()
+# while many sessions are racing through QueryBegin / QueryEnd, which
+# was the original trigger okalaci observed.
+def test_stat_activity_under_background_load(s3, pgduck_server):
+    import subprocess
+
+    background_sql = "/tmp/stat_activity_background.sql"
+    foreground_sql = "/tmp/stat_activity_foreground.sql"
+    with open(background_sql, "w") as f:
+        f.write("SELECT 1;\n")
+    with open(foreground_sql, "w") as f:
+        f.write("SELECT count(*) FROM pg_lake_stat_activity();\n")
+
+    background = subprocess.Popen(
+        [
+            "pgbench",
+            "-n",
+            "-c",
+            "16",
+            "-j",
+            "4",
+            "-T",
+            "5",
+            "-f",
+            background_sql,
+            "-h",
+            server_params.PGDUCK_UNIX_DOMAIN_PATH,
+            "-p",
+            str(server_params.PGDUCK_PORT),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    returncode, stdout, stderr = run_pgbench_command(
+        [
+            "-n",
+            "-c",
+            "1",
+            "-j",
+            "1",
+            "-T",
+            "5",
+            "-f",
+            foreground_sql,
+            "-h",
+            server_params.PGDUCK_UNIX_DOMAIN_PATH,
+            "-p",
+            str(server_params.PGDUCK_PORT),
+        ]
+    )
+
+    bg_stdout, bg_stderr = background.communicate()
+    bg_returncode = background.returncode
+
+    assert (
+        returncode == 0
+    ), f"foreground pgbench failed; stdout=\n{stdout}\nstderr=\n{stderr}"
+    assert "number of failed transactions: 0" in stdout, stdout
+    assert bg_returncode == 0, (
+        f"background pgbench failed; stdout=\n{bg_stdout.decode()}\n"
+        f"stderr=\n{bg_stderr.decode()}"
+    )
+
+    run_simple_command(server_params.PGDUCK_UNIX_DOMAIN_PATH, server_params.PGDUCK_PORT)


### PR DESCRIPTION
## Why backport

Two `pgduck_server` crashes, both reachable from ordinary operation, neither needing
special configuration. A `pgduck_server` crash takes every session's query engine
connection with it.

- **#390** — `pg_lake_stat_activity` read `PgLakeQueryListener`'s `queryString` and
  `queryStart` from a thread that is not the one running the query, while `QueryBegin` /
  `QueryEnd` assign to them on every query boundary. For `std::string` that is undefined
  behaviour: the small-string-optimised buffer can be read mid-write. The same loop called
  `connection->ExecutionIsFinished()` across threads, which derefs the `active_query`
  `unique_ptr` that the owning session resets in `QueryEnd` — that deref is the crash in
  the stack trace on #148, `Attempted to dereference unique_ptr that is NULL!`. Trigger is
  just querying `pg_lake_stat_activity` while other sessions are running queries.
- **#561** — a client thread registers its DuckDB connection in the thread pool so
  cancellations can `duckdb_interrupt()` it, then disconnects it in `pgsession_destroy()`
  while the pool still holds the pointer and still marks the slot started. The pool only
  learns on the later `pgclient_thread_cleanup()`. In that window a concurrent cancellation
  interrupts freed memory. Reachable two ways: `pgclient_threadpool_cancel_all()` on
  shutdown, and `pgclient_threadpool_cancel_thread()` when a cancel arrives while another
  session is tearing down. The cancel paths do take the pool lock, but the disconnect
  happens outside it, so the lock does not help.

#561 is also the cause of the `test_server_pidfile_signal` flake: the server dies from
`SIGSEGV` inside `pgserver_destroy()`, so the `atexit` handler never unlinks the pidfile.
So this backport removes a known CI flake as well as a crash.

Fixes #148 on this branch.

## Conflict resolution

None. Both picks are clean on `f10ff7e`, in upstream order (#390 then #561).

## Verification

- Each pick applies a change set **byte-identical to its upstream commit** — diffing the
  `+`/`-` lines of `9b0ba82e` against `cc9c97e` and of `4867f38b` against `dcc6f04` gives no
  differences. So no hunk was dropped or adapted.
- 3 of the 5 files are **byte-identical to `main`**: `query_listener.hpp`,
  `client_threadpool.c`, `test_stat_activity.py`.
- The two that differ are both explained by later work that is not on this branch and is
  not part of either fix:
  - `duckdb_pglake/src/utility_functions.cpp` — `main` has 231 more lines, all of them
    #389 (`Expose query progress and connection id as SQL functions`), a feature adding
    `pg_lake_query_progress` and `pg_lake_connection_id`. Not patch-release material.
  - `pgduck_server/src/pgsession/pgsession.c` — `main` has 13 more lines, all of them
    `3ca48c5` (`keep secret values out of statement logs`), which routes three log call
    sites through `QueryStringForLog()`. Unrelated to either fix.
- No new source files, so no build-glue change to check.

## Diff

| Commit | Upstream | Files |
|---|---|---|
| `Fix data races in pg_lake_stat_activity across-thread reads` | #390 | `query_listener.hpp`, `utility_functions.cpp`, `test_stat_activity.py` |
| `pgduck_server: stop interrupting a disconnected DuckDB connection` | #561 | `client_threadpool.c`, `pgsession.c` |

No SQL, no migration, no catalog change, no version bump, so this fits the patch-release
policy.

## Test plan

pg_lake CI on this branch. #390 comes with two pgbench-based regression tests in
`test_stat_activity.py`: concurrent `stat_activity` callers against each other (the
original #148 repro), and one `stat_activity` caller alongside many `SELECT 1` clients (the
follow-up repro). #561's coverage is `test_server_pidfile_signal`, which flakes without the
fix.

Not built locally on this branch: `utility_functions.cpp` and `query_listener.hpp` are
`duckdb_pglake`, where a from-scratch DuckDB build is the long pole, so the six
`build-and-install` jobs are the compile check. The C files are byte-identical to `main`
apart from the two divergences audited above.
