### PR TITLE
[release-3.4] Backport #505, #567, #564: base and attached worker lifecycle hangs

### DIFF
--- a/pg_extension_base/include/pg_extension_base/attached_worker.h
+++ b/pg_extension_base/include/pg_extension_base/attached_worker.h
@@ -38,6 +38,13 @@ typedef struct AttachedWorker
 	/* background worker handle */
 	pid_t		workerPid;
 	BackgroundWorkerHandle *workerHandle;
+
+	/*
+	 * Set once the worker sent ReadyForQuery, which is the last thing it does
+	 * before exiting. Until then, a detached queue means the worker died with
+	 * the command unfinished.
+	 */
+	bool		workerFinished;
 }			AttachedWorker;
 
 extern PGDLLEXPORT AttachedWorker * StartAttachedWorker(char *command);

--- a/pg_extension_base/include/pg_extension_base/injection_points.h
+++ b/pg_extension_base/include/pg_extension_base/injection_points.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Snowflake Inc.
+ * Copyright 2026 Snowflake Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,25 @@
 
 #pragma once
 
-/*
- * INJECTION_POINT_COMPAT moved to pg_extension_base so that extension can use
- * it as well. This header remains as the pg_lake spelling of the same macro.
- */
-#include "pg_extension_base/injection_points.h"
+#include "postgres.h"
+
+#if PG_VERSION_NUM >= 180000
+
+#include "utils/injection_point.h"
+
+#define INJECTION_POINT_COMPAT(name) \
+    INJECTION_POINT(name, NULL)
+
+#elif PG_VERSION_NUM >= 170000
+
+#include "utils/injection_point.h"
+
+#define INJECTION_POINT_COMPAT(name) \
+    INJECTION_POINT(name)
+
+#else
+
+#define INJECTION_POINT_COMPAT(name) \
+    ((void) name)
+
+#endif

--- a/pg_extension_base/src/attached_worker.c
+++ b/pg_extension_base/src/attached_worker.c
@@ -33,6 +33,7 @@
 #include "catalog/pg_authid.h"
 #include "commands/dbcommands.h"
 #include "pg_extension_base/attached_worker.h"
+#include "pg_extension_base/injection_points.h"
 #include "pg_extension_base/pg_compat.h"
 #include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
@@ -87,7 +88,7 @@ static AttachedWorker * StartAttachedWorkerInternal(char *command, char *databas
 static void RunAttachedWorker(char *command, char *databaseName, char *userName, ReturnSetInfo *rsinfo);
 static void RunAttachedWorkerReturning(char *command, char *databaseName,
 									   char *userName, ReturnSetInfo *rsinfo);
-static char *ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
+static char *ProcessProtocolMessages(AttachedWorker * worker, bool nowait,
 									 TupleDesc *resultDesc);
 static void ValidateWorkerTupleDesc(TupleDesc workerDesc, TupleDesc expectedDesc);
 static void ExecuteSqlString(const char *sql, shm_mq_handle *tupleQueue);
@@ -400,8 +401,24 @@ StartAttachedWorkerInternal(char *command, char *databaseName, char *userName,
 						errhint("You might need to increase max_worker_processes.")));
 	}
 
-	/* wait for the background worker to start */
-	pid_t		pid;
+	/*
+	 * Associate the queues with the worker. Without a handle, shm_mq cannot
+	 * tell a worker that has not attached yet from one that will never
+	 * attach, so a blocking receive on the queue of a worker that failed to
+	 * start or died during startup waits forever.
+	 */
+	shm_mq_set_handle(outputQueueHandle, workerHandle);
+	if (tupleQueueHandle != NULL)
+		shm_mq_set_handle(tupleQueueHandle, workerHandle);
+
+	/*
+	 * Wait for the background worker to start. BGWH_STOPPED is not
+	 * necessarily a failure, since a short command can run to completion
+	 * before we get here and its output is still in the queue. It is the
+	 * queue handles set above that catch a worker which exited without
+	 * finishing the command.
+	 */
+	pid_t		pid = 0;
 	BgwHandleStatus status = WaitForBackgroundWorkerStartup(workerHandle, &pid);
 
 	if (status != BGWH_STARTED && status != BGWH_STOPPED)
@@ -434,10 +451,12 @@ StartAttachedWorkerInternal(char *command, char *databaseName, char *userName,
  * message arrives.
  *
  * Returns the command tag on CommandComplete, or NULL when the queue
- * is exhausted or detached.
+ * is exhausted or detached. A queue that detaches before the worker sent
+ * ReadyForQuery means the worker died with the command unfinished, which is
+ * reported as an error.
  */
 static char *
-ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
+ProcessProtocolMessages(AttachedWorker * worker, bool nowait,
 						TupleDesc *resultDesc)
 {
 	StringInfoData msg;
@@ -450,8 +469,15 @@ ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
 
 		Size		messageLength;
 		void	   *data;
-		shm_mq_result res = shm_mq_receive(queue, &messageLength,
+		shm_mq_result res = shm_mq_receive(worker->outputQueue, &messageLength,
 										   &data, nowait);
+
+		if (res == SHM_MQ_DETACHED && !worker->workerFinished)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("attached worker exited before finishing the command"),
+					 errhint("The worker may have failed to start. Look for its "
+							 "error in the server log.")));
 
 		if (res != SHM_MQ_SUCCESS)
 			break;
@@ -519,12 +545,20 @@ ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
 					}
 					break;
 				}
+			case 'Z':
+				{
+					/*
+					 * ReadyForQuery is the last message the worker sends, so
+					 * from here on a detached queue is an orderly exit.
+					 */
+					worker->workerFinished = true;
+					break;
+				}
 			case 'A':
 			case 'D':
 			case 'G':
 			case 'H':
 			case 'W':
-			case 'Z':
 				break;
 			default:
 				elog(WARNING, "unknown message type: %c (%zu bytes)",
@@ -545,7 +579,7 @@ ProcessProtocolMessages(shm_mq_handle *queue, bool nowait,
 char *
 ReadFromAttachedWorker(AttachedWorker * worker, bool wait)
 {
-	return ProcessProtocolMessages(worker->outputQueue, !wait, NULL);
+	return ProcessProtocolMessages(worker, !wait, NULL);
 }
 
 
@@ -610,7 +644,7 @@ ReadResultsFromAttachedWorker(AttachedWorker * worker, Tuplestorestate *store,
 		 */
 		TupleDesc	workerDesc = NULL;
 
-		ProcessProtocolMessages(worker->outputQueue, true, &workerDesc);
+		ProcessProtocolMessages(worker, true, &workerDesc);
 
 		if (workerDesc != NULL)
 		{
@@ -652,7 +686,7 @@ ReadResultsFromAttachedWorker(AttachedWorker * worker, Tuplestorestate *store,
 	DestroyTupleQueueReader(reader);
 
 	/* Final drain to catch any trailing errors or notices */
-	ProcessProtocolMessages(worker->outputQueue, true, NULL);
+	ProcessProtocolMessages(worker, true, NULL);
 }
 
 
@@ -734,6 +768,12 @@ AttachedWorkerMain(Datum mainArg)
 	uint32	   *flagsPtr = shm_toc_lookup(toc, ATTACHED_WORKER_KEY_FLAGS, true);
 	bool		returnResults = (flagsPtr != NULL &&
 								 (*flagsPtr & ATTACHED_WORKER_FLAG_RETURN_RESULTS) != 0);
+
+	/*
+	 * Lets a test exercise a worker that dies before it attaches to the
+	 * queues, which is what the parent cannot see without a queue handle.
+	 */
+	INJECTION_POINT_COMPAT("attached-worker-before-queue-attach");
 
 	/* Attach to the response queue (protocol messages: errors, command tags) */
 	shm_mq_set_sender(messageQueue, MyProc);

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -328,6 +328,8 @@ static StartBaseWorkerResult StartBaseWorker(int workerId, Oid extensionId,
 static LockAcquireResult LockDatabaseStarter(Oid databaseId, LOCKMODE lockMode,
 											 bool waitForLock);
 
+static void WaitForBaseWorkerExit(int32 workerId, pid_t workerPid);
+
 /* functions called by base worker */
 static void PgExtensionBaseWorkerSharedMemoryExit(int code, Datum arg);
 
@@ -1832,7 +1834,19 @@ PgExtensionBaseWorkerMain(Datum arg)
 	 */
 	pqsignal(SIGTERM, die);
 
-	/* reset workerPid on exit */
+	/*
+	 * Reset workerPid on exit.
+	 *
+	 * This must stay registered before
+	 * BackgroundWorkerInitializeConnectionByOid below.  before_shmem_exit
+	 * callbacks fire in reverse registration order, so the connection's own
+	 * callbacks (ShutdownPostgres, ReplicationSlotShmemExit) run first and
+	 * clearing workerPid runs last.  That ordering is what lets
+	 * WaitForBaseWorkerExit treat a cleared workerPid as "locks released and
+	 * slot freed" rather than just "worker on its way out".  Moving this
+	 * below the connection setup, or switching it to on_shmem_exit, would
+	 * make that wait return too early.
+	 */
 	before_shmem_exit(PgExtensionBaseWorkerSharedMemoryExit, arg);
 
 	/*
@@ -2314,6 +2328,7 @@ DeregisterBaseWorker_internal(int32 workerId)
 	/* lock the shared hash, because we might change it */
 	LWLockAcquire(&BaseWorkerControl->lock, LW_EXCLUSIVE);
 
+	pid_t		signalledPid = 0;
 	bool		isFound = false;
 	BaseWorkerEntry *baseWorkerEntry = GetBaseWorkerEntry(MyDatabaseId, workerId, &isFound);
 
@@ -2336,13 +2351,91 @@ DeregisterBaseWorker_internal(int32 workerId)
 			 * PgExtensionBaseWorkerMain when it sees needsRestart is true.
 			 */
 			if (baseWorkerEntry->workerPid > 0)
+			{
+				signalledPid = baseWorkerEntry->workerPid;
 				kill(baseWorkerEntry->workerPid, SIGTERM);
+			}
 		}
 	}
 
 	LWLockRelease(&BaseWorkerControl->lock);
 
+	/*
+	 * Wait for a worker we just signalled to actually exit before returning.
+	 *
+	 * A caller typically deregisters a worker so it can then drop or alter
+	 * the resources the worker was using (a replication slot, a connection, a
+	 * table).  If we returned while the worker were still alive, that
+	 * follow-up work could block on -- or deadlock against -- locks the
+	 * worker still holds.
+	 *
+	 * SIGTERM is asynchronous, so signalling above does not guarantee the
+	 * worker is gone yet.  The worker clears its own workerPid under
+	 * BaseWorkerControl->lock in PgExtensionBaseWorkerSharedMemoryExit as it
+	 * exits, so waiting for that is race-free.  We do it after releasing the
+	 * lock so we do not block the worker's own shmem-exit cleanup.
+	 */
+	if (signalledPid > 0)
+		WaitForBaseWorkerExit(workerId, signalledPid);
+
 	PG_RETURN_VOID();
+}
+
+
+/*
+ * Bound on how long DeregisterBaseWorker_internal waits for a signalled
+ * worker to exit, and how often it re-checks.  The wait is best-effort: on
+ * timeout we log and proceed rather than error, matching the launcher's
+ * tolerant handling elsewhere.
+ */
+#define BASE_WORKER_EXIT_TIMEOUT_MS 30000
+#define BASE_WORKER_EXIT_POLL_MS 50
+
+/*
+ * WaitForBaseWorkerExit waits for the base worker (workerId, workerPid) to
+ * clear its workerPid in shared memory -- the signal, set under
+ * BaseWorkerControl->lock by PgExtensionBaseWorkerSharedMemoryExit, that the
+ * process has exited.  Comparing against the specific pid we signalled means
+ * a restart that reuses the entry with a fresh pid also ends the wait: our
+ * worker is gone either way.  Bounded by BASE_WORKER_EXIT_TIMEOUT_MS.
+ */
+static void
+WaitForBaseWorkerExit(int32 workerId, pid_t workerPid)
+{
+	TimestampTz deadline =
+		TimestampTzPlusMilliseconds(GetCurrentTimestamp(),
+									BASE_WORKER_EXIT_TIMEOUT_MS);
+
+	for (;;)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * GetBaseWorkerPid returns 0 once the entry is gone, so an entry that
+		 * disappeared entirely also ends the wait.
+		 */
+		if (GetBaseWorkerPid(workerId) != workerPid)
+			return;
+
+		if (GetCurrentTimestamp() >= deadline)
+		{
+			ereport(WARNING,
+					(errmsg("base worker %d (pid %d) did not exit within %d ms "
+							"of SIGTERM; proceeding without waiting",
+							workerId, (int) workerPid,
+							BASE_WORKER_EXIT_TIMEOUT_MS)));
+			return;
+		}
+
+		int			waitResult =
+			WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					  BASE_WORKER_EXIT_POLL_MS, WAIT_EVENT_PG_SLEEP);
+
+		if (waitResult & WL_POSTMASTER_DEATH)
+			proc_exit(1);
+
+		ResetLatch(MyLatch);
+	}
 }
 
 

--- a/pg_extension_base/src/base_worker_launcher.c
+++ b/pg_extension_base/src/base_worker_launcher.c
@@ -3022,10 +3022,22 @@ BaseWorkerTransactionCallback(XactEvent event, void *arg)
 /*
  * GetBaseWorkerPid returns the PID of a running base worker given its worker
  * ID, or 0 if the worker is not found in the current database.
+ *
+ * Never raises, so it is safe from an XACT_EVENT_COMMIT callback where an error
+ * would become a PANIC.  Hence an uninitialized hash reads as "not found" here
+ * rather than raising the way StartBaseWorker does.
+ *
+ * Use the PID for reporting or to compare against one observed earlier (see
+ * WaitForBaseWorkerExit), not to find the worker's PGPROC: the worker can exit
+ * and an unrelated backend can be handed the same PID before BackendPidGetProc
+ * runs.
  */
 pid_t
 GetBaseWorkerPid(int32 workerId)
 {
+	if (BaseWorkerHash == NULL)
+		return 0;
+
 	pid_t		workerPid = 0;
 
 	LWLockAcquire(&BaseWorkerControl->lock, LW_SHARED);

--- a/pg_extension_base/tests/pytests/test_attached_workers.py
+++ b/pg_extension_base/tests/pytests/test_attached_workers.py
@@ -447,3 +447,46 @@ def test_returning_more_columns_expected(superuser_conn, pg_extension_base):
     # session should still be alive
     result = run_query("SELECT 1 as alive", superuser_conn)
     assert result[0]["alive"] == 1
+
+
+def test_worker_dies_before_attaching(
+    superuser_conn, pg_extension_base, create_injection_extension
+):
+    # A worker that exits before it attaches to the queues used to leave the
+    # caller waiting forever, since shm_mq cannot see the worker die without a
+    # queue handle. The caller should get an error instead.
+
+    if get_pg_version_num(superuser_conn) < 170000:
+        pytest.skip("Injection points not available (requires PostgreSQL 17+)")
+
+    run_command(
+        "SELECT injection_points_attach('attached-worker-before-queue-attach', 'error')",
+        superuser_conn,
+    )
+
+    try:
+        for command in [
+            "SELECT * FROM extension_base.run_attached($$SELECT 1$$)",
+            "SELECT * FROM extension_base.run_attached_returning($$SELECT 1$$) AS t(x int)",
+        ]:
+            # bound the wait so a regression fails the test instead of hanging
+            run_command("SET statement_timeout = '60s'", superuser_conn)
+
+            error = run_command(command, superuser_conn, raise_error=False)
+            superuser_conn.rollback()
+
+            assert error is not None
+            assert "attached worker exited before finishing the command" in error
+    finally:
+        run_command(
+            "SELECT injection_points_detach('attached-worker-before-queue-attach')",
+            superuser_conn,
+            raise_error=False,
+        )
+        superuser_conn.commit()
+
+    # session should still be alive, and workers should work again
+    result = run_query(
+        "SELECT * FROM extension_base.run_attached($$SELECT 1$$)", superuser_conn
+    )
+    assert result[0]["command_tag"] == "SELECT 1"


### PR DESCRIPTION
## Why backport

Three base/attached worker lifecycle fixes. Two are hangs or stalls reachable from ordinary
operation with no special configuration; the third removes a crash and a potential PANIC.

- **#505 — a deregistered worker is not waited for.** `DeregisterBaseWorker_internal`
  `SIGTERM`s a running base worker and returned immediately. `SIGTERM` is asynchronous, so a
  caller that deregisters a worker precisely in order to drop the objects that worker was
  using races a still-live process, and those `DROP`s then block on or deadlock against
  locks the worker still holds. This is one of the ways a point-in-time-recovery fork's
  recovery finalize stalls and the fork fails to open — which makes it the highest-impact
  item in this PR for a managed release line. The fix waits for the signalled worker to
  clear `workerPid` in shared memory, bounded to 30s and best-effort: on timeout it logs a
  `WARNING` and proceeds, matching the launcher's tolerant handling elsewhere.
- **#567 — a caller waits forever for a worker that never attaches.**
  `StartAttachedWorkerInternal` attached to the output and tuple queues without ever calling
  `shm_mq_set_handle()`. Without a handle, `shm_mq` cannot distinguish a worker that has not
  attached yet from one that never will, so if the background worker failed to start or died
  during startup, the caller's blocking `shm_mq_receive()` hung indefinitely — holding its
  transaction open, pinning `backend_xmin` and blocking autovacuum, recoverable only by
  `pg_terminate_backend()`. The fix sets the handle on both queues right after registering
  the worker, as core `parallel.c` does, and tracks whether the worker sent
  `ReadyForQuery` so that a detach *before* that is the error and a detach after a
  short command completes is not. It also initialises `pid`, which
  `WaitForBackgroundWorkerStartup` only writes on `BGWH_STARTED`, so the `BGWH_STOPPED`
  path no longer stores an uninitialised value in `workerPid`. Fixes #565.
- **#564 — `GetBaseWorkerPid` had no shared-memory guard.** It went straight to
  `BaseWorkerControl->lock` and the worker hash without checking that shared memory was
  initialised, so a call before initialisation crashed instead of reporting "not found".
  Its xact-commit caller must not raise, because an error after the commit record is
  promoted to `PANIC`, so the fix returns 0 rather than raising the way `StartBaseWorker`
  does on the same check. Refs #555.

They want to land together and in this order: #567 is what makes the attached-worker
failure path reportable at all, and #564 hardens the accessor that #505's new wait depends
on.

## Conflict resolution

None. All three picks are clean on `f10ff7e`, in upstream order (#505, #567, #564).

## Verification

- Each pick applies a change set **byte-identical to its upstream commit** —
  `f71da22d` vs `3cfd719`, `94413e98` vs `a8c8ff4`, `f9830de1` vs `1ce11bb`, all three
  with no differences in the `+`/`-` lines. No hunk was dropped or adapted.
- `attached_worker.h` and `pg_lake_engine/include/pg_lake/util/injection_points.h` are
  **byte-identical to `main`**.
- The four that differ are all explained by later work absent from this branch, principally
  #570 and the base-worker launcher work that followed it: `base_worker_launcher.c`
  (`main` has 541 more lines), `test_attached_workers.py` (156), `attached_worker.c` (38),
  and the new `pg_extension_base/include/pg_extension_base/injection_points.h` (19).
  Nothing from #505, #567 or #564 is missing on either side. **#570 is deliberately
  excluded**: it conflicts in four files and needs injection-point plumbing this branch does
  not have, which is more risk than a patch release should take.
- **Compile-verified locally against PG 18.6**, which matters here because #567 moves
  `INJECTION_POINT_COMPAT` down from `pg_lake_engine` to `pg_extension_base` and leaves the
  `pg_lake` header forwarding to it. Built clean, no errors and no warnings:
  `pg_extension_base`, plus all four modules that include the forwarding header —
  `pg_lake_engine`, `pg_lake_iceberg`, `pg_lake_table` (and `client.c`, `vacuum.c`,
  `find_referenced_files.c`, `track_iceberg_metadata_changes.c` among them). The new header
  is version-gated: `INJECTION_POINT(name, NULL)` on PG≥18, `INJECTION_POINT(name)` on
  PG≥17, `((void) name)` below.
- The new header needs no build-glue change, and no new `.c` file was added.

## Diff

| Commit | Upstream | Files |
|---|---|---|
| `pg_extension_base: wait for a deregistered base worker to exit` | #505 | `base_worker_launcher.c` |
| `pg_extension_base: do not wait forever for a worker that never attaches` | #567 | `attached_worker.{c,h}`, `pg_extension_base/injection_points.h` (new), `pg_lake/util/injection_points.h`, `test_attached_workers.py` |
| `pg_extension_base: guard GetBaseWorkerPid and document its pid contract` | #564 | `base_worker_launcher.c` |

No SQL, no migration, no catalog change, no version bump, so this fits the patch-release
policy.

## Test plan

pg_lake CI on this branch. #567 comes with `test_worker_dies_before_attaching`, which uses a
new injection point to make the worker exit before it attaches; without the fix the caller
hangs and only the statement timeout ends the test. It skips where injection points are
unavailable (`requires PostgreSQL 17+`), so on the older matrix legs it is the compile that
carries the weight — hence the local compile check above.
