### PR TITLE
[release-3.4] Backport #526: preserve numeric precision and scale inside composite types

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/parse_struct.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/parse_struct.h
@@ -42,6 +42,9 @@ typedef struct CompositeCol
 {
 	char	   *colName;		/* the column name */
 	Oid			colType;		/* our oid type, or 0 if not yet allocated  */
+	int32		colTypeMod;		/* typmod of colType, or -1 if none; for an
+								 * array field this is the element typmod, as
+								 * in pg_attribute.atttypmod */
 	char	   *colTypeName;	/* string version of the type */
 	CompositeType *subStruct;	/* for a non-composite type, NULL; for
 								 * composite, pointer to that type's struct */

--- a/pg_lake_engine/src/pgduck/parse_struct.c
+++ b/pg_lake_engine/src/pgduck/parse_struct.c
@@ -296,10 +296,14 @@ ParseStructColumn(StructParserState * parse)
 	/*
 	 * If we are not a supported builting type, this should be InvalidOid,
 	 * which will later be assigned in the createUncreatedTypes() routine
+	 *
+	 * GetPGTypeForDuckDBTypeNameBuiltin only assigns typeMod for types that
+	 * carry one, so seed it with "no modifier" first.
 	 */
-	int			typeMod;
+	int			typeMod = -1;
 
 	myCol->colType = GetPGTypeForDuckDBTypeNameBuiltin(fieldType, &typeMod, isArray);
+	myCol->colTypeMod = typeMod;
 	myCol->colTypeName = fieldType;
 	myCol->isArray = isArray;
 	myCol->colName = fieldName;
@@ -1091,10 +1095,13 @@ GetDuckDBStructDefinitionForCompositeType(CompositeType * type,
 		{
 			/*
 			 * Now add our simple type string -- array handling added later,
-			 * so use underlying element type.
+			 * so use underlying element type.  The typmod has to travel with
+			 * the oid, otherwise a numeric(p,s) field would render as a bare
+			 * DECIMAL and DuckDB would resolve it to its own default.
 			 */
 
-			PGType		baseColumnType = MakePGTypeOid(GetRelatedTypeOid(col->colType, false));
+			PGType		baseColumnType = MakePGType(GetRelatedTypeOid(col->colType, false),
+													col->colTypeMod);
 			DuckDBType	duckDBType = GetDuckDBTypeForPGType(baseColumnType);
 
 			if (duckDBType)
@@ -1215,6 +1222,12 @@ GetCompositeTypeForPGType(Oid postgresType)
 
 		col->colType = GetRelatedTypeOid(rawTypid, false);
 		col->isArray = rawTypid != col->colType;
+
+		/*
+		 * atttypmod already refers to the element type for an array
+		 * attribute, so it pairs with the unwrapped colType either way.
+		 */
+		col->colTypeMod = attr->atttypmod;
 
 		/*
 		 * We need more info about this type than just the name, so already

--- a/pg_lake_engine/src/pgduck/type.c
+++ b/pg_lake_engine/src/pgduck/type.c
@@ -22,6 +22,7 @@
 #include "pg_lake/pgduck/parse_struct.h"
 #include "pg_lake/pgduck/type.h"
 #include "pg_lake/pgduck/map.h"
+#include "pg_lake/pgduck/numeric.h"
 #include "pg_extension_base/extension_ids.h"
 #include "pg_lake/extensions/pg_map.h"
 #include "pg_lake/extensions/postgis.h"
@@ -532,7 +533,14 @@ GetFullDuckDBTypeNameForPGType(PGType postgresType, CopyDataFormat format)
 		/* get the element type and return [] after */
 		Oid			elementType = get_element_type(postgresType.postgresTypeOid);
 
-		return psprintf("%s[]", GetFullDuckDBTypeNameForPGType(MakePGTypeOid(elementType), format));
+		/*
+		 * A typmod on an array type always describes its element (that is how
+		 * pg_attribute.atttypmod stores it), so hand it to the element.
+		 */
+		return psprintf("%s[]",
+						GetFullDuckDBTypeNameForPGType(MakePGType(elementType,
+																  postgresType.postgresTypeMod),
+													   format));
 	}
 
 	if (myType == DUCKDB_TYPE_STRUCT)
@@ -547,15 +555,30 @@ GetFullDuckDBTypeNameForPGType(PGType postgresType, CopyDataFormat format)
 
 	const char *typeName = GetDuckDBTypeName(myType);
 
-	if (myType == DUCKDB_TYPE_DECIMAL && postgresType.postgresTypeMod != -1)
+	if (myType == DUCKDB_TYPE_DECIMAL)
 	{
-		StringInfo	typeNameWithMod = makeStringInfo();
+		/*
+		 * Decide the DECIMAL width exactly as the top-level column path does
+		 * (see ChooseDuckDBEngineTypeForWrite), so a numeric nested in a
+		 * struct, list or map is stored the same way as the same numeric in a
+		 * table column, and matches the decimal type the Iceberg schema
+		 * declares for it.  Notably, an unbounded numeric gets the configured
+		 * default precision/scale rather than DuckDB's own DECIMAL default,
+		 * which is narrower than what the CSV writer already lets through.
+		 */
+		int			precision = -1;
+		int			scale = -1;
 
-		appendStringInfo(typeNameWithMod, "%s(%d,%d)", typeName,
-						 numeric_typmod_precision(postgresType.postgresTypeMod),
-						 numeric_typmod_scale(postgresType.postgresTypeMod));
+		GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(postgresType.postgresTypeMod,
+															 &precision, &scale);
 
-		return typeNameWithMod->data;
+		if (!CanPushdownNumericToDuckdb(precision, scale))
+		{
+			/* too wide for DuckDB; fall back to text, as we do elsewhere */
+			return GetDuckDBTypeName(DUCKDB_TYPE_VARCHAR);
+		}
+
+		return psprintf("%s(%d,%d)", typeName, precision, scale);
 	}
 
 	return typeName;

--- a/pg_lake_table/tests/pytests/test_complex_types.py
+++ b/pg_lake_table/tests/pytests/test_complex_types.py
@@ -274,3 +274,105 @@ def test_map_escaping(pg_conn, superuser_conn, extension, s3, with_default_locat
     assert res[0][0] == ["[", "'", "]"]
 
     pg_conn.rollback()
+
+
+def _parquet_decimal_leaves(superuser_conn, pgduck_conn, qualified_table):
+    """
+    Return ``{leaf_name: (precision, scale)}`` for every DECIMAL leaf physically
+    present in the table's data files, read straight from the Parquet footer.
+    """
+    files = run_query(
+        f"SELECT path FROM lake_table.files "
+        f"WHERE table_name = '{qualified_table}'::regclass",
+        superuser_conn,
+    )
+    assert files, f"expected at least one data file for {qualified_table}"
+
+    leaves = {}
+    for (path,) in files:
+        rows = run_query(
+            "SELECT name, precision, scale FROM parquet_schema("
+            f"'{path}') WHERE converted_type = 'DECIMAL'",
+            pgduck_conn,
+        )
+        for name, precision, scale in rows:
+            leaves[name] = (precision, scale)
+
+    return leaves
+
+
+def test_numeric_typmod_inside_composite(
+    pg_conn, superuser_conn, pgduck_conn, extension, s3, with_default_location
+):
+    """
+    A numeric(p,s) field of a composite type must be written with its own
+    precision and scale, not DuckDB's default DECIMAL(18,3), which rounded the
+    value and disagreed with the decimal type declared in the Iceberg schema.
+    """
+    run_command(
+        """
+        CREATE SCHEMA numeric_typmod;
+        SET search_path TO numeric_typmod;
+        CREATE TYPE nested_slot AS (deep numeric(10,4));
+        CREATE TYPE slot AS (amount numeric(10,4),
+                             amounts numeric(10,4)[],
+                             sub nested_slot,
+                             label text);
+        CREATE TABLE slots (
+            id integer,
+            top numeric(10,4),
+            arr numeric(10,4)[],
+            nested slot,
+            nested_arr slot[]
+        ) USING iceberg;
+        INSERT INTO slots VALUES (
+            1,
+            1.2345,
+            ARRAY[1.2345::numeric(10,4)],
+            ROW(1.2345, ARRAY[1.2345::numeric(10,4)], ROW(1.2345)::nested_slot, 'x')::slot,
+            ARRAY[ROW(1.2345, ARRAY[1.2345::numeric(10,4)], ROW(1.2345)::nested_slot, 'y')::slot]
+        );
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    # Every numeric must keep all four fractional digits, wherever it is nested.
+    res = run_query(
+        """
+        SELECT top, arr,
+               (nested).amount, (nested).amounts, ((nested).sub).deep,
+               (nested_arr[1]).amount, (nested_arr[1]).amounts,
+               ((nested_arr[1]).sub).deep
+        FROM slots WHERE id = 1
+        """,
+        pg_conn,
+    )
+    expected = Decimal("1.2345")
+    assert res[0] == [
+        expected,
+        [expected],
+        expected,
+        [expected],
+        expected,
+        expected,
+        [expected],
+        expected,
+    ]
+
+    # The Parquet footer must agree with the numeric(10,4) declared in Postgres
+    # (and hence with the decimal(10,4) in the Iceberg schema) for every leaf.
+    leaves = _parquet_decimal_leaves(
+        superuser_conn, pgduck_conn, "numeric_typmod.slots"
+    )
+    assert leaves == {
+        "top": (10, 4),
+        "element": (10, 4),
+        "amount": (10, 4),
+        "deep": (10, 4),
+    }, leaves
+
+    pg_conn.rollback()
+    run_command("DROP SCHEMA IF EXISTS numeric_typmod CASCADE;", pg_conn)
+    run_command("RESET search_path;", pg_conn)
+    pg_conn.commit()


### PR DESCRIPTION
## Why backport

Silent data loss on write. A `numeric(p,s)` field inside a composite type was written to
Parquet as DuckDB's default `DECIMAL(18,3)`, so values were rounded to three fractional
digits — and the data file then disagreed with the `decimal(p,s)` the Iceberg schema declares
for that same field. No error at write time, no error at read time; the digits are simply
gone, and the file and its schema disagree for any other reader of the table.

The composite representation had nowhere to keep a field's typmod:
`GetCompositeTypeForPGType()` dropped `pg_attribute.atttypmod`, and the `STRUCT` string built
for the CSV-to-Parquet write handed DuckDB a bare `DECIMAL`. The fix keeps the typmod on
`CompositeCol` and passes it with the oid in both directions, and does the same for an array
reached through a container, where the `LIST` branch of `GetFullDuckDBTypeNameForPGType()`
also dropped it.

Affected a struct field, an array inside a struct, a nested struct, and all of those inside
an array of structs. A top-level column or array was already correct, because the top-level
write path keeps the typmod when it unwraps the array — which is why this went unnoticed.

The same commit also renders the nested `DECIMAL` width with the rule the top-level path
uses (`GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod` plus
`CanPushdownNumericToDuckdb`) rather than the raw typmod, so an unbounded `numeric` nested in
a composite gets the configured default precision and scale instead of DuckDB's narrower
default. That matters because the CSV writer already lets 29 integral digits through for an
unbounded numeric at any nesting depth, which `DECIMAL(18,3)` cannot hold.

Fixes #524 on this branch.

## Conflict resolution

The pick conflicted only in `pg_lake_table/tests/pytests/test_complex_types.py`, and only
because `main` has two later test additions at the same place. Upstream's contribution there
is a pure append at end of file (`@@ -444,3 +444,105 @@`), so the resolution takes this
branch's version of the file and appends that hunk verbatim. The resulting commit's change
set is byte-identical to upstream's — see below.

The three source files picked clean.

## Verification

- The pick applies a change set **byte-identical to upstream `34696708`** — diffing the
  `+`/`-` lines gives no differences, conflict resolution included.
- `parse_struct.h` and `parse_struct.c` are **byte-identical to `main`**.
- The two that differ are both explained by later work absent from this branch, and neither
  belongs to this fix:
  - `pg_lake_engine/src/pgduck/type.c` — `main` has exactly one extra hunk, #500's
    `ResolveDomainBaseTypeAndTypmod` call at the top of
    `GetFullDuckDBTypeNameForPGType`. Verified as an exact match for #500's hunk and
    nothing else. **#500 is deliberately excluded** — see below.
  - `pg_lake_table/tests/pytests/test_complex_types.py` — `main` has 170 more lines, being
    #501's and #504's dropped-attribute tests. Both are genuinely absent from this branch and
    are separate candidates for the release owner, not part of this fix.
- `#443` shows up in a naive `HEAD..main` log for `type.c` but is **already on this branch**
  as backport commit `c2611a6`; the log entry is just the sha difference between the two
  copies.
- **Compile-verified locally against PG 18.6**: `pg_lake_engine` builds and links clean, no
  errors, no warnings. The new test file compiles (`py_compile`), and its fixtures
  `superuser_conn` / `pgduck_conn` both exist on this branch in
  `test_common/helpers/core_fixtures.py`.
- No new source files, so no build-glue change to check.

## Why #500 is not in this PR

#500 fixes the same family — a domain loses the numeric typmod — and it picks cleanly on top
of this commit. It is left out on purpose: it also changes the written DuckDB type for a
domain over an array from `VARCHAR` to `LIST`. Since the storage type is re-derived per
query rather than recorded, that reinterprets the files of tables that already exist, which
is not something a patch release should do. Worth shipping, but it wants a minor release and
an explicit decision, not this PR.

## Diff

| File | What |
|---|---|
| `include/pg_lake/pgduck/parse_struct.h` | Carry the typmod on `CompositeCol` |
| `src/pgduck/parse_struct.c` | Keep `atttypmod` when building and consuming the composite representation |
| `src/pgduck/type.c` | Pass the typmod through the `STRUCT`/`LIST` name builders; use the top-level precision/scale rule for a nested `DECIMAL` |
| `tests/pytests/test_complex_types.py` | `test_numeric_typmod_inside_composite` plus a `_parquet_decimal_leaves` helper |

No SQL, no migration, no catalog change, no version bump.

**One caveat the release owner should see:** this changes the Parquet type written for a
nested `numeric` field, from `DECIMAL(18,3)` to the declared `decimal(p,s)`. New files are
correct and match the Iceberg schema. Files already written with the wrong width are not
migrated and stay as they are — they were already rounded, and the schema already disagreed
with them, so this neither fixes nor worsens them. A table with a mix of old and new files
has leaves of two widths; Iceberg readers resolve that per file against the table schema, and
the new files are the ones that agree with it.

## Test plan

pg_lake CI on this branch. `test_numeric_typmod_inside_composite` reads the actual Parquet
decimal leaves through `pgduck_conn` and asserts the precision and scale, so it fails on the
old `DECIMAL(18,3)` behaviour rather than only on a value comparison.
