### PR TITLE
Don't leak Horizon client secret via psql

### DIFF
--- a/pg_lake_iceberg/include/pg_lake/http/http_client.h
+++ b/pg_lake_iceberg/include/pg_lake/http/http_client.h
@@ -62,4 +62,4 @@ extern PGDLLEXPORT HttpResult SendHttpRequest(HttpMethod method, const char *url
 extern PGDLLEXPORT HttpResult SendHttpRequestWithRetry(HttpMethod method, const char *url, const char *body,
 													   List *headers, HttpRetryFn retryFn, int maxRetry);
 extern PGDLLEXPORT int LinearBackoffSleepMs(int baseMs, int retryNo);
-extern PGDLLEXPORT char *RedactSensitiveText(char *input);
+extern PGDLLEXPORT char *RedactSensitiveText(const char *input);

--- a/pg_lake_iceberg/include/pg_lake/http/http_client.h
+++ b/pg_lake_iceberg/include/pg_lake/http/http_client.h
@@ -62,3 +62,4 @@ extern PGDLLEXPORT HttpResult SendHttpRequest(HttpMethod method, const char *url
 extern PGDLLEXPORT HttpResult SendHttpRequestWithRetry(HttpMethod method, const char *url, const char *body,
 													   List *headers, HttpRetryFn retryFn, int maxRetry);
 extern PGDLLEXPORT int LinearBackoffSleepMs(int baseMs, int retryNo);
+extern PGDLLEXPORT char *RedactSensitiveText(char *input);

--- a/pg_lake_iceberg/src/http/http_client.c
+++ b/pg_lake_iceberg/src/http/http_client.c
@@ -65,7 +65,7 @@ static HttpResult CurlReturnError(CURL *curl, struct curl_slist *headerList,
 								  CURLcode curlCode, const char *errorMsg);
 static const char *HttpRequestMethodToString(HttpMethod method);
 static char *StrCaseStr(char *haystack, const char *needle);
-static bool IsKeyStartBoundary(char c);
+static bool IsKeyStartBoundary(char precedingChar);
 static char *RedactValueInPlace(char *valueStart);
 
 #define CURL_SETOPT(curl, opt, value) do { \
@@ -673,10 +673,10 @@ StrCaseStr(char *haystack, const char *needle)
 {
 	size_t		needleLength = strlen(needle);
 
-	for (char *p = haystack; *p != '\0'; p++)
+	for (char *cursor = haystack; *cursor != '\0'; cursor++)
 	{
-		if (pg_strncasecmp(p, needle, needleLength) == 0)
-			return p;
+		if (pg_strncasecmp(cursor, needle, needleLength) == 0)
+			return cursor;
 	}
 
 	return NULL;
@@ -684,16 +684,18 @@ StrCaseStr(char *haystack, const char *needle)
 
 
 /*
- * IsKeyStartBoundary returns true if c can immediately precede a key name.
- * Requiring a boundary keeps "token" from matching the tail of an unrelated
- * identifier such as "csrf_token_name", while still recognising both
+ * IsKeyStartBoundary returns true if precedingChar can immediately precede a
+ * key name.  Requiring a boundary keeps "token" from matching the tail of an
+ * unrelated identifier such as "csrf_token_name", while still recognising both
  * "token": (JSON) and &token= (form encoding).
  */
 static bool
-IsKeyStartBoundary(char c)
+IsKeyStartBoundary(char precedingChar)
 {
-	return c == '"' || c == '\'' || c == '{' || c == ',' ||
-		c == '&' || c == '?' || c == ';' || isspace((unsigned char) c);
+	return precedingChar == '"' || precedingChar == '\'' ||
+		precedingChar == '{' || precedingChar == ',' ||
+		precedingChar == '&' || precedingChar == '?' ||
+		precedingChar == ';' || isspace((unsigned char) precedingChar);
 }
 
 
@@ -704,25 +706,25 @@ IsKeyStartBoundary(char c)
 static char *
 RedactValueInPlace(char *valueStart)
 {
-	char	   *v = valueStart;
+	char	   *cursor = valueStart;
 
-	while (*v && isspace((unsigned char) *v))
-		v++;
+	while (*cursor && isspace((unsigned char) *cursor))
+		cursor++;
 
-	if (*v == '"')
+	if (*cursor == '"')
 	{
-		v++;					/* first character of the quoted value */
+		cursor++;				/* first character of the quoted value */
 
-		while (*v && *v != '"')
+		while (*cursor && *cursor != '"')
 		{
 			/*
 			 * Mask a backslash escape as a unit so that a value containing \"
 			 * is not mistaken for the closing quote.
 			 */
-			if (*v == '\\' && v[1] != '\0')
-				*v++ = '*';
+			if (*cursor == '\\' && cursor[1] != '\0')
+				*cursor++ = '*';
 
-			*v++ = '*';
+			*cursor++ = '*';
 		}
 	}
 	else
@@ -734,12 +736,12 @@ RedactValueInPlace(char *valueStart)
 		 * is "Bearer <token>", so stopping at the space would leave the token
 		 * in the clear.
 		 */
-		while (*v && *v != ',' && *v != '}' && *v != '&' &&
-			   *v != '\r' && *v != '\n')
-			*v++ = '*';
+		while (*cursor && *cursor != ',' && *cursor != '}' && *cursor != '&' &&
+			   *cursor != '\r' && *cursor != '\n')
+			*cursor++ = '*';
 	}
 
-	return v;
+	return cursor;
 }
 
 
@@ -761,16 +763,16 @@ RedactSensitiveText(char *input)
 	{
 		const char *key = sensitiveKeys[keyIndex];
 		size_t		keyLength = strlen(key);
-		char	   *p = redacted;
+		char	   *match = redacted;
 
-		while ((p = StrCaseStr(p, key)) != NULL)
+		while ((match = StrCaseStr(match, key)) != NULL)
 		{
-			char	   *afterKey = p + keyLength;
+			char	   *afterKey = match + keyLength;
 
 			/* the match has to be a whole key, not the tail of a longer one */
-			if (p > redacted && !IsKeyStartBoundary(p[-1]))
+			if (match > redacted && !IsKeyStartBoundary(match[-1]))
 			{
-				p = afterKey;
+				match = afterKey;
 				continue;
 			}
 
@@ -785,11 +787,11 @@ RedactSensitiveText(char *input)
 			if (*separator != ':' && *separator != '=')
 			{
 				/* not a key-value pair, skip */
-				p = afterKey;
+				match = afterKey;
 				continue;
 			}
 
-			p = RedactValueInPlace(separator + 1);
+			match = RedactValueInPlace(separator + 1);
 		}
 	}
 

--- a/pg_lake_iceberg/src/http/http_client.c
+++ b/pg_lake_iceberg/src/http/http_client.c
@@ -67,6 +67,7 @@ static const char *HttpRequestMethodToString(HttpMethod method);
 static char *StrCaseStr(char *haystack, const char *needle);
 static bool IsKeyStartBoundary(char precedingChar);
 static char *RedactValueInPlace(char *valueStart);
+static void RedactUrlUserinfoInPlace(char *text);
 
 #define CURL_SETOPT(curl, opt, value) do { \
 	curlCode = curl_easy_setopt((curl), (opt), (value)); \
@@ -540,8 +541,14 @@ HttpCommonNoThrows(HttpMethod method, const char *url, const char *postData, con
 			appendStringInfo(postDataInfo, ", body: {%s}", postData);
 		}
 
+		/*
+		 * The URL needs redacting too: oauth_endpoint is used exactly as
+		 * configured, so an IdP that takes the client_secret as a query
+		 * parameter would otherwise put it straight into the trace.
+		 */
 		ereport(INFO, (errmsg("making %s request to URL %s%s",
-							  HttpRequestMethodToString(method), url,
+							  HttpRequestMethodToString(method),
+							  RedactSensitiveText(url),
 							  postDataInfo ? RedactSensitiveText(postDataInfo->data) : "")));
 	}
 
@@ -727,6 +734,46 @@ RedactValueInPlace(char *valueStart)
 			*cursor++ = '*';
 		}
 	}
+	else if (*cursor == '[' || *cursor == '{')
+	{
+		/*
+		 * A composite value such as the storage-credentials array has to be
+		 * masked as one unit, because stopping at the first ',' would leave
+		 * its closing brackets behind and trace as malformed JSON.
+		 */
+		char	   *compositeStart = cursor;
+		int			depth = 0;
+		bool		inString = false;
+
+		while (*cursor != '\0')
+		{
+			if (inString)
+			{
+				if (*cursor == '\\' && cursor[1] != '\0')
+					*cursor++ = '*';
+				else if (*cursor == '"')
+					inString = false;
+			}
+			else if (*cursor == '"')
+				inString = true;
+			else if (*cursor == '[' || *cursor == '{')
+				depth++;
+			else if (*cursor == ']' || *cursor == '}')
+				depth--;
+
+			*cursor++ = '*';
+
+			if (!inString && depth == 0)
+				break;
+		}
+
+		/* re-quote the mask so the traced line stays parseable */
+		if (cursor - compositeStart >= 2)
+		{
+			*compositeStart = '"';
+			cursor[-1] = '"';
+		}
+	}
 	else
 	{
 		/*
@@ -746,18 +793,56 @@ RedactValueInPlace(char *valueStart)
 
 
 /*
+ * RedactUrlUserinfoInPlace masks everything between "://" and the '@' that
+ * closes the authority.  libcurl accepts https://user:password@host/..., a
+ * credential spelling no key=value rule sees.
+ */
+static void
+RedactUrlUserinfoInPlace(char *text)
+{
+	char	   *scheme = text;
+
+	while ((scheme = strstr(scheme, "://")) != NULL)
+	{
+		char	   *authority = scheme + 3;
+		char	   *authorityEnd = authority;
+		char	   *userinfoEnd = authority;
+
+		while (*authorityEnd != '\0' && *authorityEnd != '/' &&
+			   *authorityEnd != '?' && *authorityEnd != '#' &&
+			   !isspace((unsigned char) *authorityEnd))
+			authorityEnd++;
+
+		/* the rightmost '@' is the one that separates userinfo from the host */
+		for (char *cursor = authority; cursor < authorityEnd; cursor++)
+		{
+			if (*cursor == '@')
+				userinfoEnd = cursor;
+		}
+
+		for (char *cursor = authority; cursor < userinfoEnd; cursor++)
+			*cursor = '*';
+
+		scheme = authorityEnd;
+	}
+}
+
+
+/*
  * RedactSensitiveText returns a copy of input in which the value of every
  * sensitiveKeys entry is replaced by '*' characters.  Both "key": value and
  * key=value spellings are recognised.
  */
 char *
-RedactSensitiveText(char *input)
+RedactSensitiveText(const char *input)
 {
 	if (input == NULL)
 		return "NULL";
 
 	/* never touch the original input string, redact a copy */
 	char	   *redacted = pstrdup(input);
+
+	RedactUrlUserinfoInPlace(redacted);
 
 	for (int keyIndex = 0; sensitiveKeys[keyIndex] != NULL; keyIndex++)
 	{

--- a/pg_lake_iceberg/src/http/http_client.c
+++ b/pg_lake_iceberg/src/http/http_client.c
@@ -64,7 +64,9 @@ static void CurlCleanup(CURL *curl, struct curl_slist *headerList);
 static HttpResult CurlReturnError(CURL *curl, struct curl_slist *headerList,
 								  CURLcode curlCode, const char *errorMsg);
 static const char *HttpRequestMethodToString(HttpMethod method);
-static char *RedactSensitiveJson(char *s);
+static char *StrCaseStr(char *haystack, const char *needle);
+static bool IsKeyStartBoundary(char c);
+static char *RedactValueInPlace(char *valueStart);
 
 #define CURL_SETOPT(curl, opt, value) do { \
 	curlCode = curl_easy_setopt((curl), (opt), (value)); \
@@ -540,7 +542,7 @@ HttpCommonNoThrows(HttpMethod method, const char *url, const char *postData, con
 
 		ereport(INFO, (errmsg("making %s request to URL %s%s",
 							  HttpRequestMethodToString(method), url,
-							  postDataInfo ? RedactSensitiveJson(postDataInfo->data) : "")));
+							  postDataInfo ? RedactSensitiveText(postDataInfo->data) : "")));
 	}
 
 	if (!CheckMinCurlVersion(curl_version_info(CURLVERSION_NOW)))
@@ -607,7 +609,7 @@ HttpCommonNoThrows(HttpMethod method, const char *url, const char *postData, con
 	if (HttpClientTraceTraffic && message_level_is_interesting(INFO))
 	{
 		ereport(INFO, (errmsg("received response with status code %ld, body: %s",
-							  res.status, res.body ? RedactSensitiveJson(res.body) : "<empty>")));
+							  res.status, res.body ? RedactSensitiveText(res.body) : "<empty>")));
 	}
 
 	return res;
@@ -636,99 +638,160 @@ HttpRequestMethodToString(HttpMethod method)
 
 
 /*
- * RedactSensitiveJson
- *   In-place redaction of token-looking values in JSON-ish text.
+ * Key names whose value must never appear in a trace line or an error
+ * detail.  Matched case-insensitively and without surrounding punctuation,
+ * so one list covers JSON objects ("client_secret": "..."), form-encoded
+ * bodies (client_secret=...) and header-style text (Authorization: ...).
+ *
+ * Anchoring on the bare name rather than on '"<name>"' is deliberate: the
+ * OAuth token request body is application/x-www-form-urlencoded, so a
+ * JSON-only matcher let the client_secret through in cleartext.
+ */
+static const char *const sensitiveKeys[] = {
+	"access_token",
+	"refresh_token",
+	"id_token",
+	"session_token",
+	"token",
+	"client_secret",
+	"password",
+	"authorization",
+	"s3.access-key-id",
+	"s3.secret-access-key",
+	"s3.session-token",
+	"storage-credentials",
+	NULL
+};
+
+
+/*
+ * StrCaseStr is a case-insensitive strstr().  strcasestr() is a GNU
+ * extension, so spell it out to stay portable.
  */
 static char *
-RedactSensitiveJson(char *input)
+StrCaseStr(char *haystack, const char *needle)
+{
+	size_t		needleLength = strlen(needle);
+
+	for (char *p = haystack; *p != '\0'; p++)
+	{
+		if (pg_strncasecmp(p, needle, needleLength) == 0)
+			return p;
+	}
+
+	return NULL;
+}
+
+
+/*
+ * IsKeyStartBoundary returns true if c can immediately precede a key name.
+ * Requiring a boundary keeps "token" from matching the tail of an unrelated
+ * identifier such as "csrf_token_name", while still recognising both
+ * "token": (JSON) and &token= (form encoding).
+ */
+static bool
+IsKeyStartBoundary(char c)
+{
+	return c == '"' || c == '\'' || c == '{' || c == ',' ||
+		c == '&' || c == '?' || c == ';' || isspace((unsigned char) c);
+}
+
+
+/*
+ * RedactValueInPlace overwrites the value starting at valueStart with '*'
+ * and returns the first character past it.
+ */
+static char *
+RedactValueInPlace(char *valueStart)
+{
+	char	   *v = valueStart;
+
+	while (*v && isspace((unsigned char) *v))
+		v++;
+
+	if (*v == '"')
+	{
+		v++;					/* first character of the quoted value */
+
+		while (*v && *v != '"')
+		{
+			/*
+			 * Mask a backslash escape as a unit so that a value containing \"
+			 * is not mistaken for the closing quote.
+			 */
+			if (*v == '\\' && v[1] != '\0')
+				*v++ = '*';
+
+			*v++ = '*';
+		}
+	}
+	else
+	{
+		/*
+		 * Unquoted: stop only at what genuinely ends a value -- ',' or '}' in
+		 * JSON, '&' in a form-encoded body, end of line in header-style text.
+		 * Whitespace is deliberately not a terminator: an Authorization value
+		 * is "Bearer <token>", so stopping at the space would leave the token
+		 * in the clear.
+		 */
+		while (*v && *v != ',' && *v != '}' && *v != '&' &&
+			   *v != '\r' && *v != '\n')
+			*v++ = '*';
+	}
+
+	return v;
+}
+
+
+/*
+ * RedactSensitiveText returns a copy of input in which the value of every
+ * sensitiveKeys entry is replaced by '*' characters.  Both "key": value and
+ * key=value spellings are recognised.
+ */
+char *
+RedactSensitiveText(char *input)
 {
 	if (input == NULL)
 		return "NULL";
 
-	/*
-	 * Never touch the original input string, make a copy to redact.
-	 */
-	char	   *copyOfinput = pstrdup(input);
+	/* never touch the original input string, redact a copy */
+	char	   *redacted = pstrdup(input);
 
-	const char *keys[] = {
-		"\"access_token\"",
-		"\"refresh_token\"",
-		"\"id_token\"",
-		"\"session_token\"",
-		"\"token\"",
-		"\"client_secret\"",
-		"\"authorization\"",
-		"\"Authorization\"",
-		"\"s3.access-key-id\"",
-		"\"s3.secret-access-key\"",
-		"\"s3.session-token\"",
-		"\"storage-credentials\""
-	};
-	const int	keyCount = sizeof(keys) / sizeof(keys[0]);
-
-	for (int i = 0; i < keyCount; i++)
+	for (int keyIndex = 0; sensitiveKeys[keyIndex] != NULL; keyIndex++)
 	{
-		const char *key = keys[i];
-		char	   *p = copyOfinput;
+		const char *key = sensitiveKeys[keyIndex];
+		size_t		keyLength = strlen(key);
+		char	   *p = redacted;
 
-		while ((p = strstr(p, key)) != NULL)
+		while ((p = StrCaseStr(p, key)) != NULL)
 		{
-			/* Move to the colon after the key */
-			char	   *colon = strchr(p + strlen(key), ':');
+			char	   *afterKey = p + keyLength;
 
-			if (colon == NULL)
+			/* the match has to be a whole key, not the tail of a longer one */
+			if (p > redacted && !IsKeyStartBoundary(p[-1]))
 			{
-				/* No colon? then this isn't a key-value pair, skip */
-				p += strlen(key);
+				p = afterKey;
 				continue;
 			}
 
-			char	   *v = colon + 1;	/* start of value (maybe spaces /
-										 * quote) */
+			char	   *separator = afterKey;
 
-			/* Skip whitespace */
-			while (*v && isspace((unsigned char) *v))
-				v++;
+			if (*separator == '"')
+				separator++;	/* closing quote of a JSON key */
 
-			int			quoted = 0;
+			while (*separator && isspace((unsigned char) *separator))
+				separator++;
 
-			if (!v)
-				return copyOfinput;
-
-			if (*v == '"')
+			if (*separator != ':' && *separator != '=')
 			{
-				quoted = 1;
-				v++;			/* move to first character of value */
+				/* not a key-value pair, skip */
+				p = afterKey;
+				continue;
 			}
 
-			char	   *q = v;
-
-			if (quoted)
-			{
-				/* Redact until the closing quote */
-				while (*q && *q != '"')
-				{
-					*q = '*';
-					q++;
-				}
-			}
-			else
-			{
-				/* Redact until comma, closing brace, or whitespace */
-				while (*q &&
-					   *q != ',' &&
-					   *q != '}' &&
-					   !isspace((unsigned char) *q))
-				{
-					*q = '*';
-					q++;
-				}
-			}
-
-			/* Continue search after the value we just redacted */
-			p = q;
+			p = RedactValueInPlace(separator + 1);
 		}
 	}
 
-	return copyOfinput;
+	return redacted;
 }

--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -178,10 +178,13 @@ _PG_init(void)
 	DefineCustomBoolVariable(
 							 "pg_lake_iceberg.http_client_trace_traffic",
 							 gettext_noop("When set to true, HTTP client logging is enabled."),
-							 NULL,
+							 gettext_noop("The trace reports request URLs and bodies of catalog "
+										  "traffic to the client, so it is restricted to "
+										  "superusers.  Delegate it with GRANT SET ON PARAMETER "
+										  "if a non-superuser needs to debug catalog calls."),
 							 &HttpClientTraceTraffic,
 							 false,
-							 PGC_USERSET,
+							 PGC_SUSET,
 							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 

--- a/pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c
+++ b/pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c
@@ -306,10 +306,17 @@ FetchRestCatalogAccessToken(RestCatalogOptions * opts, char **accessToken, int *
 	HttpResult	httpResponse = SendRequestToRestCatalog(NULL, HTTP_POST, accessTokenUrl,
 														body.data, headers);
 
+	/*
+	 * The upstream body goes to the client, so it has to be redacted even
+	 * though tracing is off: an endpoint that echoes the request, or that
+	 * returns a token inside an error envelope, would otherwise disclose
+	 * credentials to whoever ran the statement.
+	 */
 	if (httpResponse.status != 200)
 		ereport(ERROR,
 				(errmsg("Rest Catalog OAuth token request failed (HTTP %ld)", httpResponse.status),
-				 httpResponse.body ? errdetail_internal("%s", httpResponse.body) : 0));
+				 httpResponse.body ?
+				 errdetail_internal("%s", RedactSensitiveText(httpResponse.body)) : 0));
 
 	if (!httpResponse.body || !*httpResponse.body)
 		ereport(ERROR, (errmsg("Rest Catalog OAuth token response body is empty")));

--- a/pg_lake_iceberg/src/test/test_http_client.c
+++ b/pg_lake_iceberg/src/test/test_http_client.c
@@ -30,6 +30,7 @@ PG_FUNCTION_INFO_V1(test_http_delete);
 PG_FUNCTION_INFO_V1(test_http_post);
 PG_FUNCTION_INFO_V1(test_http_put);
 PG_FUNCTION_INFO_V1(test_http_with_retry);
+PG_FUNCTION_INFO_V1(test_redact_sensitive_text);
 
 
 static Datum build_http_result(FunctionCallInfo fcinfo, const HttpResult * r);
@@ -135,6 +136,19 @@ test_http_with_retry(PG_FUNCTION_ARGS)
 											 MAX_HTTP_RETRY_FOR_REST_CATALOG);
 
 	PG_RETURN_DATUM(build_http_result(fcinfo, &r));
+}
+
+
+/*
+ * test_redact_sensitive_text exposes the trace redaction helper so that the
+ * masking of credentials can be tested without a live catalog.
+ */
+Datum
+test_redact_sensitive_text(PG_FUNCTION_ARGS)
+{
+	char	   *input = text_to_cstring(PG_GETARG_TEXT_PP(0));
+
+	PG_RETURN_TEXT_P(cstring_to_text(RedactSensitiveText(input)));
 }
 
 

--- a/pg_lake_iceberg/tests/pytests/test_security.py
+++ b/pg_lake_iceberg/tests/pytests/test_security.py
@@ -2,6 +2,7 @@
 Security regression tests for pg_lake_iceberg Avro parsing vulnerabilities.
 """
 
+import json
 import tempfile
 import pytest
 from utils_pytest import *
@@ -443,3 +444,75 @@ def test_redaction_covers_form_encoded_credentials(
     redacted = redact('{"token_type": "Bearer", "not_a_password": "plain"}')
     assert "Bearer" in redacted, redacted
     assert "plain" in redacted, redacted
+
+
+def test_redaction_covers_credentials_carried_in_a_url(
+    superuser_conn, extension, create_redact_helper_function
+):
+    """
+    Regression test for: the request trace printed the URL verbatim, so any
+    credential carried in the URL rather than in the body went out in the
+    clear.  oauth_endpoint is used exactly as configured, so an IdP that takes
+    the client_secret as a query parameter, or a URL written with libcurl's
+    https://user:password@host/ form, both reach the trace.
+    """
+    secret = "URL-BORNE-SECRET"
+
+    def redact(text):
+        cursor = superuser_conn.cursor()
+        try:
+            cursor.execute("SELECT lake_iceberg.redact_sensitive_text(%s)", (text,))
+            return cursor.fetchone()[0]
+        finally:
+            cursor.close()
+
+    redacted = redact(f"https://idp.example/v1/tokens?client_secret={secret}&scope=ALL")
+    assert secret not in redacted, redacted
+    # The host and the harmless parameters stay legible.
+    assert "https://idp.example/v1/tokens" in redacted, redacted
+    assert "scope=ALL" in redacted, redacted
+
+    redacted = redact(f"https://client-id:{secret}@catalog.example/v1/config")
+    assert secret not in redacted, redacted
+    assert "client-id" not in redacted, redacted
+    assert "@catalog.example/v1/config" in redacted, redacted
+
+    # A URL without userinfo must survive untouched, otherwise every traced
+    # request line loses its host.
+    plain_url = "https://catalog.example:8181/v1/namespaces"
+    assert redact(plain_url) == plain_url
+
+
+def test_redaction_masks_a_composite_value_as_one_unit(
+    superuser_conn, extension, create_redact_helper_function
+):
+    """
+    A loadTable response carries storage-credentials as an array of objects.
+    Masking only up to the first comma left the closing brackets behind, so the
+    traced line was malformed JSON.
+    """
+    key_id = "AKIAEXAMPLEKEYID"
+    secret = "COMPOSITE-SECRET"
+
+    cursor = superuser_conn.cursor()
+    try:
+        cursor.execute(
+            "SELECT lake_iceberg.redact_sensitive_text(%s)",
+            (
+                '{"storage-credentials": [{"prefix": "s3://bucket", "config": '
+                f'{{"s3.access-key-id": "{key_id}", '
+                f'"s3.secret-access-key": "{secret}"}}}}], "expires": 60}}',
+            ),
+        )
+        redacted = cursor.fetchone()[0]
+    finally:
+        cursor.close()
+
+    assert key_id not in redacted, redacted
+    assert secret not in redacted, redacted
+    # Nothing of the array structure may survive the mask.
+    assert "prefix" not in redacted, redacted
+    assert "}]" not in redacted, redacted
+    # Fields after the array are still readable, and the line still parses.
+    assert '"expires": 60' in redacted, redacted
+    json.loads(redacted)

--- a/pg_lake_iceberg/tests/pytests/test_security.py
+++ b/pg_lake_iceberg/tests/pytests/test_security.py
@@ -329,3 +329,117 @@ def test_data_file_local_path_in_manifest_is_rejected(pg_conn, superuser_conn, s
     assert "root:" not in str(error) and "nobody:" not in str(
         error
     ), "SECURITY REGRESSION: /etc/passwd content leaked in the error message."
+
+
+@pytest.fixture(scope="module")
+def create_redact_helper_function(superuser_conn):
+    run_command(
+        """
+        CREATE OR REPLACE FUNCTION lake_iceberg.redact_sensitive_text(input TEXT)
+        RETURNS text
+         LANGUAGE C
+         IMMUTABLE STRICT
+        AS 'pg_lake_iceberg', $function$test_redact_sensitive_text$function$;
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+    yield
+    run_command("DROP FUNCTION lake_iceberg.redact_sensitive_text;", superuser_conn)
+    superuser_conn.commit()
+
+
+def test_http_client_trace_traffic_is_superuser_only(pg_conn, extension):
+    """
+    Regression test for: any role could turn on the HTTP client trace and read
+    the REST catalog OAuth credentials out of its own client notices.
+
+    pg_lake_iceberg.http_client_trace_traffic was PGC_USERSET, and the trace is
+    emitted at INFO, which PostgreSQL delivers to the client.  A plain role
+    could therefore SET the GUC, touch any Iceberg REST table, and collect the
+    client_secret from the traced OAuth token request body -- credentials that
+    are otherwise readable only by a superuser (the GUCs that hold them are all
+    GUC_SUPERUSER_ONLY).
+
+    Fix: the GUC is PGC_SUSET.  A superuser can still delegate it with
+    GRANT SET ON PARAMETER when a non-superuser needs to debug catalog calls.
+    """
+    error = run_command(
+        "SET pg_lake_iceberg.http_client_trace_traffic TO on",
+        pg_conn,
+        raise_error=False,
+    )
+    pg_conn.rollback()
+
+    assert error is not None, (
+        "SECURITY REGRESSION: a non-superuser was allowed to SET "
+        "pg_lake_iceberg.http_client_trace_traffic. The trace is reported to "
+        "the client at INFO and contains the REST catalog OAuth request body, "
+        "so the GUC must be PGC_SUSET."
+    )
+    assert (
+        "permission denied" in str(error).lower()
+    ), f"Expected a permission error, got: {error}"
+
+
+def test_redaction_covers_form_encoded_credentials(
+    superuser_conn, extension, create_redact_helper_function
+):
+    """
+    Regression test for: the trace redaction only understood JSON, so the OAuth
+    client_secret went out in cleartext.
+
+    The old RedactSensitiveJson() anchored on '"client_secret"' -- a quoted JSON
+    key followed by ':'.  The OAuth token request body that carries the secret
+    is application/x-www-form-urlencoded (client_secret=<secret>), so it matched
+    nothing and the secret was traced verbatim.
+
+    Fix: RedactSensitiveText() matches the bare key name case-insensitively and
+    accepts both ':' and '=' as the separator, so JSON bodies, form-encoded
+    bodies and header-style text are all covered.
+    """
+    secret = "SUPER-SECRET-CLIENT-VALUE"
+
+    def redact(text):
+        cur = superuser_conn.cursor()
+        try:
+            cur.execute("SELECT lake_iceberg.redact_sensitive_text(%s)", (text,))
+            return cur.fetchone()[0]
+        finally:
+            cur.close()
+
+    # The exact shape of the body built by FetchRestCatalogAccessToken() for
+    # the horizon auth type.
+    form_body = (
+        f"grant_type=client_credentials&scope=PRINCIPAL_ROLE%3AALL"
+        f"&client_secret={secret}"
+    )
+    redacted = redact(form_body)
+    assert secret not in redacted, (
+        "SECURITY REGRESSION: the form-encoded client_secret survived "
+        f"redaction: {redacted}"
+    )
+    # Non-sensitive parameters must still be legible, otherwise the trace is
+    # useless for debugging.
+    assert "grant_type=client_credentials" in redacted, redacted
+    assert "scope=PRINCIPAL_ROLE%3AALL" in redacted, redacted
+
+    # JSON spelling must keep working (no regression on the original behaviour).
+    json_body = f'{{"client_secret": "{secret}", "grant_type": "client_credentials"}}'
+    redacted = redact(json_body)
+    assert secret not in redacted, redacted
+    assert "client_credentials" in redacted, redacted
+
+    # A bearer token in a response body, and a header-style Authorization line.
+    redacted = redact(f'{{"access_token": "{secret}", "expires_in": 3600}}')
+    assert secret not in redacted, redacted
+    assert "3600" in redacted, redacted
+
+    redacted = redact(f"Authorization: Bearer {secret}")
+    assert secret not in redacted, redacted
+
+    # Keys that merely end in a sensitive name must not swallow their value:
+    # over-redaction would hide the fields a trace is read for.
+    redacted = redact('{"token_type": "Bearer", "not_a_password": "plain"}')
+    assert "Bearer" in redacted, redacted
+    assert "plain" in redacted, redacted

--- a/pg_lake_table/tests/pytests/test_iceberg_catalog_server.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_catalog_server.py
@@ -941,6 +941,62 @@ def test_create_table_with_server_catalog(
     superuser_conn.commit()
 
 
+def test_trace_redacts_a_credential_in_the_request_url(
+    superuser_conn, s3, extension, with_default_location
+):
+    """The HTTP trace reports the request URL, and oauth_endpoint is used
+    exactly as configured, so an IdP that takes the client_secret as a query
+    parameter must not end up with it in the client's notices."""
+    secret = "url-sentinel-secret"
+    run_command(
+        f"""
+        CREATE SERVER test_trace_url_srv TYPE 'rest'
+            FOREIGN DATA WRAPPER iceberg_catalog
+            OPTIONS (rest_endpoint 'http://127.0.0.1:1',
+                     rest_auth_type 'OAuth2',
+                     oauth_endpoint
+                         'http://127.0.0.1:1/oauth/tokens?client_secret={secret}')
+        """,
+        superuser_conn,
+    )
+    run_command(
+        """
+        CREATE USER MAPPING FOR PUBLIC SERVER test_trace_url_srv
+            OPTIONS (client_id 'id', client_secret 'body-sentinel-secret')
+        """,
+        superuser_conn,
+    )
+    superuser_conn.commit()
+
+    try:
+        run_command(
+            "SET pg_lake_iceberg.http_client_trace_traffic TO on", superuser_conn
+        )
+        superuser_conn.notices.clear()
+        # The endpoint is a dead port, so the token POST fails -- but it is
+        # traced before libcurl ever connects, which is all this test needs.
+        run_command(
+            """
+            CREATE TABLE test_trace_url_tbl ()
+                USING iceberg
+                WITH (catalog = 'test_trace_url_srv', read_only = 'true',
+                      catalog_namespace = 'ns', catalog_table_name = 'tbl')
+            """,
+            superuser_conn,
+            raise_error=False,
+        )
+        notices = "\n".join(superuser_conn.notices)
+        superuser_conn.rollback()
+
+        # Without the traced token request the secret assertion is vacuous.
+        assert "/oauth/tokens?client_secret=" in notices, notices
+        assert secret not in notices, notices
+        assert "body-sentinel-secret" not in notices, notices
+    finally:
+        run_command("DROP SERVER IF EXISTS test_trace_url_srv CASCADE", superuser_conn)
+        superuser_conn.commit()
+
+
 def test_create_table_requires_usage_on_catalog_server(
     pg_conn, superuser_conn, s3, extension, with_default_location
 ):

--- a/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
+++ b/pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py
@@ -1105,7 +1105,6 @@ def test_multi_table_single_transaction_on_same_server(
 def test_token_cache_reuses_token_across_catalog_ops(
     installcheck,
     superuser_conn,
-    pg_conn,
     s3,
     extension,
     with_default_location,
@@ -1128,45 +1127,45 @@ def test_token_cache_reuses_token_across_catalog_ops(
     SCHEMA_NAME = TABLE_NAMESPACE
     TABLE_NAME = "token_cache_test"
 
-    run_command(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA_NAME}", pg_conn)
-    pg_conn.commit()
+    run_command(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA_NAME}", superuser_conn)
+    superuser_conn.commit()
 
     run_command(
         "SET pg_lake_iceberg.http_client_trace_traffic TO on",
-        pg_conn,
+        superuser_conn,
     )
-    pg_conn.notices.clear()
+    superuser_conn.notices.clear()
 
     run_command(
         f"CREATE TABLE {SCHEMA_NAME}.{TABLE_NAME} (id bigint, value text) "
         f"USING iceberg WITH (catalog='rest')",
-        pg_conn,
+        superuser_conn,
     )
-    pg_conn.commit()
+    superuser_conn.commit()
 
     for i in range(3):
         run_command(
             f"INSERT INTO {SCHEMA_NAME}.{TABLE_NAME} VALUES ({i}, 'v')",
-            pg_conn,
+            superuser_conn,
         )
-        pg_conn.commit()
+        superuser_conn.commit()
 
     token_fetches = sum(
-        1 for n in pg_conn.notices if "oauth/tokens" in n and "POST" in n
+        1 for n in superuser_conn.notices if "oauth/tokens" in n and "POST" in n
     )
     assert token_fetches == 1, (
         f"Expected exactly 1 OAuth token fetch (cached), got {token_fetches}. "
-        f"Notices:\n" + "\n".join(pg_conn.notices)
+        f"Notices:\n" + "\n".join(superuser_conn.notices)
     )
 
     run_command(
         "RESET pg_lake_iceberg.http_client_trace_traffic",
-        pg_conn,
+        superuser_conn,
     )
 
-    pg_conn.rollback()
-    run_command(f"DROP SCHEMA {SCHEMA_NAME} CASCADE", pg_conn)
-    pg_conn.commit()
+    superuser_conn.rollback()
+    run_command(f"DROP SCHEMA {SCHEMA_NAME} CASCADE", superuser_conn)
+    superuser_conn.commit()
 
 
 def test_alter_user_mapping_credentials_invalidates_token_cache(


### PR DESCRIPTION
## The problem

`pg_lake_iceberg.http_client_trace_traffic` was `PGC_USERSET`, and the trace is emitted with `ereport(INFO, ...)`, which PostgreSQL delivers **to the client**. So any role could turn the trace on in its own session, touch an Iceberg REST table, and read the OAuth token request body out of its own notices.

For the `horizon` auth type that body is built in `FetchRestCatalogAccessToken()` as:

```
grant_type=client_credentials&scope=<scope>&client_secret=<secret>
```

which means the `client_secret` came back in cleartext — a credential that is otherwise readable only by a superuser, since every GUC that can hold one (`rest_catalog_client_secret` and friends) is `GUC_SUPERUSER_ONLY`. The `oauth2` auth type is not affected the same way: it puts the secret in an `Authorization: Basic` header, and headers are not traced.

The redaction that was already there did not stop it. `RedactSensitiveJson()` anchored on a quoted JSON key — `"client_secret"` followed by `:` — but the token request is `application/x-www-form-urlencoded`, so the matcher found nothing at all and the body was traced verbatim. Redacting by pattern-matching a serialised payload is fragile in exactly this way: the key list looked right, the encoding was wrong.

## The fix

Three changes, so that neither the privilege check nor the redaction is the only thing standing between a secret and a client:

**1. The GUC is now `PGC_SUSET`** (`pg_lake_iceberg/src/init.c`). It stays visible and readable — the boolean's own value is not sensitive, so no `GUC_SUPERUSER_ONLY` — and a superuser can still delegate it with `GRANT SET ON PARAMETER pg_lake_iceberg.http_client_trace_traffic TO <role>` when someone needs to debug catalog calls. That is spelled out in the GUC's long description.

**2. `RedactSensitiveJson()` becomes `RedactSensitiveText()`** (`pg_lake_iceberg/src/http/http_client.c`), matching the bare key name case-insensitively at a key boundary and accepting either `:` or `=` as the separator. One key list now covers JSON objects, form-encoded bodies, and header-style text. Two details that matter:

- An unquoted value ends at `,`, `}`, `&`, or end of line — deliberately **not** at whitespace. An `Authorization` value is `Bearer <token>`; stopping at the space would mask the word `Bearer` and leave the token in the clear. (It did, in my first draft.)
- A quoted value masks a backslash escape as a unit, so a value containing `\"` is not mistaken for the closing quote.

Non-sensitive fields stay legible — `grant_type`, `scope`, `expires_in`, `token_type` all survive — because a trace nobody can read is a trace nobody will keep enabled.

**3. The non-200 OAuth error detail routes the upstream body through the redactor** (`pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c`). This path does not depend on the trace GUC at all: an endpoint that echoes the request back, or that returns a token inside an error envelope, would otherwise disclose it to whoever ran the statement.

## Scope decision

The cleanest version of this would redact by construction — carry a separate "safe to trace" body from `SendRequestToRestCatalog` down through `HttpCommonNoThrows` so the secret never reaches the trace formatter in the first place. I did not do that here: it touches every HTTP entry point for a gain the redactor already covers, and it would make this change much harder to review as a security fix. Worth doing separately if the trace grows more call sites.

## Tests

`pg_lake_iceberg/tests/pytests/test_security.py` gains two regression tests:

- `test_http_client_trace_traffic_is_superuser_only` — a non-superuser `SET` must be refused. The `extension` fixture grants `SET ON PARAMETER` for five other pg_lake GUCs but not this one, so the denial is real rather than an artifact of fixture ordering.
- `test_redaction_covers_form_encoded_credentials` — drives the redactor through a new SQL-callable wrapper (`test_redact_sensitive_text` in `src/test/test_http_client.c`) over the exact form-encoded body shape, the JSON spelling, a bearer token in a response body, an `Authorization` header line, and two keys that merely *end* in a sensitive name (`token_type`, `not_a_password`) to pin down that over-redaction is a failure too.

`pg_lake_table/tests/pytests/test_modify_iceberg_rest_table.py`: `test_token_cache_reuses_token_across_catalog_ops` was the only existing test that set the trace GUC on a non-superuser connection, so it now runs on `superuser_conn` throughout. Its `set_polaris_gucs` fixture configures both connections identically, so the notice-counting assertions are unchanged in meaning.

## Verification

`make check-indent` clean (pgindent + black). Built warning-free and exercised end-to-end against an isolated PostgreSQL 18 instance: non-superuser `SET` refused, superuser `SET` accepted, `GRANT SET ON PARAMETER` delegation works, and the redactor masks form-encoded, JSON, header-style, escaped-quote and multi-line inputs while leaving the non-sensitive fields readable. The two new pytests were validated by driving the same SQL against that instance rather than through the full pytest harness, which wants `pgduck_server` and moto — CI covers that.
