### PR TITLE
Validate the length of an Iceberg binary single value

### DIFF
--- a/pg_lake_iceberg/src/avro/avro_reader.c
+++ b/pg_lake_iceberg/src/avro/avro_reader.c
@@ -581,10 +581,21 @@ AvroExtractNullableFieldFromRecordByIndex(avro_value_t * record, int index,
 	}
 	else if (fieldType == AVRO_BOOLEAN)
 	{
-		/* avro_value_get_boolean requires int */
-		*value = palloc0(sizeof(int));
-		*valueLength = sizeof(int);
-		rc = avro_value_get_boolean(&fieldValue, (int *) *value);
+		/*
+		 * The caller reads the value we hand back as an Iceberg binary single
+		 * value, where a boolean is the one byte 0x00 or 0x01.
+		 * avro_value_get_boolean wants an int, so hand back the one byte
+		 * rather than the 4-byte int: its first byte is the wrong end of it
+		 * on a big-endian host, and a 4-byte boolean is not a length the
+		 * deserializer accepts.
+		 */
+		int			boolValue = 0;
+
+		rc = avro_value_get_boolean(&fieldValue, &boolValue);
+
+		*value = palloc0(1);
+		*valueLength = 1;
+		*((unsigned char *) *value) = (boolValue != 0) ? 0x01 : 0x00;
 	}
 	else
 	{

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
@@ -53,6 +53,14 @@
 
 
 static unsigned char *PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNullTerminator, size_t *binaryLen);
+static int32 ReadLittleEndianInt32(const unsigned char *binaryValue);
+static int64 ReadLittleEndianInt64(const unsigned char *binaryValue);
+static float4 ReadLittleEndianFloat4(const unsigned char *binaryValue);
+static float8 ReadLittleEndianFloat8(const unsigned char *binaryValue);
+static unsigned char *WriteLittleEndianInt32(int32 value);
+static unsigned char *WriteLittleEndianInt64(int64 value);
+static unsigned char *WriteLittleEndianFloat4(float4 value);
+static unsigned char *WriteLittleEndianFloat8(float8 value);
 
 
 /*
@@ -131,33 +139,21 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 		int32		shortValue = DatumGetInt16(datum);
 
 		*binaryLen = sizeof(int32);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &shortValue, *binaryLen);
-
-		binaryValue = ToLittleEndian32(binaryValue);
+		binaryValue = WriteLittleEndianInt32(shortValue);
 	}
 	else if (pgType.postgresTypeOid == INT4OID)
 	{
 		int32		intValue = DatumGetInt32(datum);
 
 		*binaryLen = sizeof(int32);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &intValue, *binaryLen);
-
-		binaryValue = ToLittleEndian32(binaryValue);
+		binaryValue = WriteLittleEndianInt32(intValue);
 	}
 	else if (pgType.postgresTypeOid == INT8OID)
 	{
 		int64		longValue = DatumGetInt64(datum);
 
 		*binaryLen = sizeof(int64);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &longValue, *binaryLen);
-
-		binaryValue = ToLittleEndian64(binaryValue);
+		binaryValue = WriteLittleEndianInt64(longValue);
 	}
 	else if (pgType.postgresTypeOid == FLOAT4OID)
 	{
@@ -183,11 +179,7 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 		}
 
 		*binaryLen = sizeof(float4);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &floatValue, *binaryLen);
-
-		binaryValue = ToLittleEndian32(binaryValue);
+		binaryValue = WriteLittleEndianFloat4(floatValue);
 	}
 	else if (pgType.postgresTypeOid == FLOAT8OID)
 	{
@@ -213,11 +205,7 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 		}
 
 		*binaryLen = sizeof(float8);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &doubleValue, *binaryLen);
-
-		binaryValue = ToLittleEndian64(binaryValue);
+		binaryValue = WriteLittleEndianFloat8(doubleValue);
 	}
 	else if (pgType.postgresTypeOid == DATEOID)
 	{
@@ -226,11 +214,7 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 		dateValue = AdjustDateFromPostgresToUnix(dateValue);
 
 		*binaryLen = sizeof(DateADT);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &dateValue, *binaryLen);
-
-		binaryValue = ToLittleEndian32(binaryValue);
+		binaryValue = WriteLittleEndianInt32(dateValue);
 	}
 	else if (pgType.postgresTypeOid == TIMESTAMPOID)
 	{
@@ -239,11 +223,7 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 		timestampValue = AdjustTimestampFromPostgresToUnix(timestampValue);
 
 		*binaryLen = sizeof(Timestamp);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &timestampValue, *binaryLen);
-
-		binaryValue = ToLittleEndian64(binaryValue);
+		binaryValue = WriteLittleEndianInt64(timestampValue);
 	}
 	else if (pgType.postgresTypeOid == TIMESTAMPTZOID)
 	{
@@ -252,22 +232,14 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 		timestampTzValue = AdjustTimestampFromPostgresToUnix(timestampTzValue);
 
 		*binaryLen = sizeof(TimestampTz);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &timestampTzValue, *binaryLen);
-
-		binaryValue = ToLittleEndian64(binaryValue);
+		binaryValue = WriteLittleEndianInt64(timestampTzValue);
 	}
 	else if (pgType.postgresTypeOid == TIMEOID)
 	{
 		TimeADT		timeValue = DatumGetTimeADT(datum);
 
 		*binaryLen = sizeof(TimeADT);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &timeValue, *binaryLen);
-
-		binaryValue = ToLittleEndian64(binaryValue);
+		binaryValue = WriteLittleEndianInt64(timeValue);
 	}
 	else if (pgType.postgresTypeOid == TIMETZOID)
 	{
@@ -279,11 +251,7 @@ PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNull
 		TimeADT		utcMicros = TimeTzGetUTCMicros(timetz);
 
 		*binaryLen = sizeof(int64);
-
-		binaryValue = palloc0(*binaryLen);
-		memcpy(binaryValue, (unsigned char *) &utcMicros, *binaryLen);
-
-		binaryValue = ToLittleEndian64(binaryValue);
+		binaryValue = WriteLittleEndianInt64(utcMicros);
 	}
 	else if (pgType.postgresTypeOid == TEXTOID)
 	{
@@ -387,80 +355,38 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == INT2OID)
 	{
-		binaryValue = FromLittleEndian32(binaryValue);
-
 		/* iceberg does not have int16 type. we store them as int32. */
-		int16		shortValue = (int16) *((int32 *) binaryValue);
+		int16		shortValue = (int16) ReadLittleEndianInt32(binaryValue);
 
 		datum = Int16GetDatum(shortValue);
 	}
 	else if (pgType.postgresTypeOid == INT4OID)
 	{
-		binaryValue = FromLittleEndian32(binaryValue);
-		int32		intValue = *((int32 *) binaryValue);
+		int32		intValue = ReadLittleEndianInt32(binaryValue);
 
 		datum = Int32GetDatum(intValue);
 	}
 	else if (pgType.postgresTypeOid == INT8OID)
 	{
-		/*
-		 * Per the Iceberg spec, column metrics are serialized using the type
-		 * at the time the data file was written. After an int -> long type
-		 * promotion, existing data files retain 4-byte int bounds while the
-		 * current schema expects 8-byte long. Widen on read.
-		 *
-		 * See:
-		 * https://iceberg.apache.org/spec/#binary-single-value-serialization
-		 */
-		if (binaryLen == sizeof(int32))
-		{
-			binaryValue = FromLittleEndian32(binaryValue);
-			int32		intValue = *((int32 *) binaryValue);
+		int64		longValue = ReadLittleEndianInt64(binaryValue);
 
-			datum = Int64GetDatum((int64) intValue);
-		}
-		else
-		{
-			binaryValue = FromLittleEndian64(binaryValue);
-			int64		longValue = *((int64 *) binaryValue);
-
-			datum = Int64GetDatum(longValue);
-		}
+		datum = Int64GetDatum(longValue);
 	}
 	else if (pgType.postgresTypeOid == FLOAT4OID)
 	{
-		binaryValue = FromLittleEndian32(binaryValue);
-		float4		floatValue = *((float4 *) binaryValue);
+		float4		floatValue = ReadLittleEndianFloat4(binaryValue);
 
 		datum = Float4GetDatum(floatValue);
 	}
 	else if (pgType.postgresTypeOid == FLOAT8OID)
 	{
-		/*
-		 * Same as int -> long above: after a float -> double type promotion,
-		 * existing data files retain 4-byte float bounds while the current
-		 * schema expects 8-byte double. Widen on read.
-		 */
-		if (binaryLen == sizeof(float4))
-		{
-			binaryValue = FromLittleEndian32(binaryValue);
-			float4		floatValue = *((float4 *) binaryValue);
+		float8		doubleValue = ReadLittleEndianFloat8(binaryValue);
 
-			datum = Float8GetDatum((float8) floatValue);
-		}
-		else
-		{
-			binaryValue = FromLittleEndian64(binaryValue);
-			float8		doubleValue = *((float8 *) binaryValue);
-
-			datum = Float8GetDatum(doubleValue);
-		}
+		datum = Float8GetDatum(doubleValue);
 	}
 	else if (pgType.postgresTypeOid == DATEOID)
 	{
-		binaryValue = FromLittleEndian32(binaryValue);
-
-		DateADT		dateValue = *((DateADT *) binaryValue);
+		DateADT		dateValue = ReadLittleEndianInt32(binaryValue);
 
 		dateValue = AdjustDateFromUnixToPostgres(dateValue);
 
@@ -468,9 +394,7 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == TIMESTAMPOID)
 	{
-		binaryValue = FromLittleEndian64(binaryValue);
-
-		Timestamp	timestampValue = *((Timestamp *) binaryValue);
+		Timestamp	timestampValue = ReadLittleEndianInt64(binaryValue);
 
 		timestampValue = AdjustTimestampFromUnixToPostgres(timestampValue);
 
@@ -478,9 +402,7 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == TIMESTAMPTZOID)
 	{
-		binaryValue = FromLittleEndian64(binaryValue);
-
-		TimestampTz timestampTzValue = *((TimestampTz *) binaryValue);
+		TimestampTz timestampTzValue = ReadLittleEndianInt64(binaryValue);
 
 		timestampTzValue = AdjustTimestampFromUnixToPostgres(timestampTzValue);
 
@@ -488,9 +410,7 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == TIMEOID)
 	{
-		binaryValue = FromLittleEndian64(binaryValue);
-
-		TimeADT		timeValue = *((TimeADT *) binaryValue);
+		TimeADT		timeValue = ReadLittleEndianInt64(binaryValue);
 
 		datum = TimeADTGetDatum(timeValue);
 	}
@@ -500,9 +420,7 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 		 * Iceberg stores time as UTC microseconds since midnight. Deserialize
 		 * into a TimeTzADT at UTC (zone = 0).
 		 */
-		binaryValue = FromLittleEndian64(binaryValue);
-
-		int64		utcMicros = *((int64 *) binaryValue);
+		int64		utcMicros = ReadLittleEndianInt64(binaryValue);
 
 		TimeTzADT  *timetz = palloc(sizeof(TimeTzADT));
 
@@ -549,4 +467,102 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 
 	return datum;
+}
+
+
+/*
+ * Iceberg serializes fixed-width primitives little-endian. Go through a memcpy
+ * in both directions rather than a cast: the byte swap has to apply to the value
+ * and not to the pointer, and a value read out of an Avro buffer has no
+ * alignment guarantee.
+ */
+static int32
+ReadLittleEndianInt32(const unsigned char *binaryValue)
+{
+	uint32		rawValue;
+
+	memcpy(&rawValue, binaryValue, sizeof(rawValue));
+
+	return (int32) FromLittleEndian32(rawValue);
+}
+
+
+static int64
+ReadLittleEndianInt64(const unsigned char *binaryValue)
+{
+	uint64		rawValue;
+
+	memcpy(&rawValue, binaryValue, sizeof(rawValue));
+
+	return (int64) FromLittleEndian64(rawValue);
+}
+
+
+static float4
+ReadLittleEndianFloat4(const unsigned char *binaryValue)
+{
+	int32		rawValue = ReadLittleEndianInt32(binaryValue);
+	float4		floatValue;
+
+	memcpy(&floatValue, &rawValue, sizeof(floatValue));
+
+	return floatValue;
+}
+
+
+static float8
+ReadLittleEndianFloat8(const unsigned char *binaryValue)
+{
+	int64		rawValue = ReadLittleEndianInt64(binaryValue);
+	float8		doubleValue;
+
+	memcpy(&doubleValue, &rawValue, sizeof(doubleValue));
+
+	return doubleValue;
+}
+
+
+static unsigned char *
+WriteLittleEndianInt32(int32 value)
+{
+	uint32		rawValue = ToLittleEndian32((uint32) value);
+	unsigned char *binaryValue = palloc(sizeof(rawValue));
+
+	memcpy(binaryValue, &rawValue, sizeof(rawValue));
+
+	return binaryValue;
+}
+
+
+static unsigned char *
+WriteLittleEndianInt64(int64 value)
+{
+	uint64		rawValue = ToLittleEndian64((uint64) value);
+	unsigned char *binaryValue = palloc(sizeof(rawValue));
+
+	memcpy(binaryValue, &rawValue, sizeof(rawValue));
+
+	return binaryValue;
+}
+
+
+static unsigned char *
+WriteLittleEndianFloat4(float4 value)
+{
+	int32		rawValue;
+
+	memcpy(&rawValue, &value, sizeof(rawValue));
+
+	return WriteLittleEndianInt32(rawValue);
+}
+
+
+static unsigned char *
+WriteLittleEndianFloat8(float8 value)
+{
+	int64		rawValue;
+
+	memcpy(&rawValue, &value, sizeof(rawValue));
+
+	return WriteLittleEndianInt64(rawValue);
 }

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_binary_serde.c
@@ -34,6 +34,7 @@
 #include "utils/date.h"
 #include "utils/lsyscache.h"
 #include "utils/timestamp.h"
+#include "utils/uuid.h"
 
 #ifdef WORDS_BIGENDIAN
 #define ToLittleEndian32(val) pg_bswap32(val)
@@ -52,7 +53,44 @@
 #endif
 
 
+/*
+ * FixedWidthBinaryLength is the serialized width of one Iceberg primitive.
+ *
+ * promotedFromLen is the narrower width the spec still allows, because column
+ * metrics keep the type the data file was written with: after an int -> long or
+ * float -> double promotion, older files carry 4-byte values for a type that is
+ * now 8 bytes wide. Zero means no narrower form is accepted.
+ *
+ * Types with no fixed width (text, bytea, numeric, and anything Iceberg encodes
+ * as a string) are deliberately absent and bounded by their own branch instead.
+ */
+typedef struct FixedWidthBinaryLength
+{
+	Oid			postgresTypeOid;
+	size_t		expectedLen;
+	size_t		promotedFromLen;
+}			FixedWidthBinaryLength;
+
+static const FixedWidthBinaryLength FixedWidthBinaryLengths[] = {
+	{BOOLOID, 1, 0},
+	/* iceberg does not have int16 type. we store them as int32. */
+	{INT2OID, sizeof(int32), 0},
+	{INT4OID, sizeof(int32), 0},
+	{INT8OID, sizeof(int64), sizeof(int32)},
+	{FLOAT4OID, sizeof(float4), 0},
+	{FLOAT8OID, sizeof(float8), sizeof(float4)},
+	{DATEOID, sizeof(DateADT), 0},
+	{TIMEOID, sizeof(TimeADT), 0},
+	/* timetz is stored as iceberg time, i.e. UTC microseconds */
+	{TIMETZOID, sizeof(int64), 0},
+	{TIMESTAMPOID, sizeof(Timestamp), 0},
+	{TIMESTAMPTZOID, sizeof(TimestampTz), 0},
+	{UUIDOID, UUID_LEN, 0},
+};
+
+
 static unsigned char *PGIcebergBinarySerialize(Datum datum, Field * field, PGType pgType, bool addNullTerminator, size_t *binaryLen);
+static void ErrorIfUnexpectedBinaryLength(size_t binaryLen, Field * field, PGType pgType);
 static int32 ReadLittleEndianInt32(const unsigned char *binaryValue);
 static int64 ReadLittleEndianInt64(const unsigned char *binaryValue);
 static float4 ReadLittleEndianFloat4(const unsigned char *binaryValue);
@@ -326,6 +364,8 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	Assert(field && field->type == FIELD_TYPE_SCALAR);
 	Assert(binaryValue);
 
+	ErrorIfUnexpectedBinaryLength(binaryLen, field, pgType);
+
 	Datum		datum = 0;
 
 	if (PGTypeRequiresConversionToIcebergString(field, pgType))
@@ -368,9 +408,27 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == INT8OID)
 	{
-		int64		longValue = ReadLittleEndianInt64(binaryValue);
+		/*
+		 * Per the Iceberg spec, column metrics are serialized using the type
+		 * at the time the data file was written. After an int -> long type
+		 * promotion, existing data files retain 4-byte int bounds while the
+		 * current schema expects 8-byte long. Widen on read.
+		 *
+		 * See:
+		 * https://iceberg.apache.org/spec/#binary-single-value-serialization
+		 */
+		if (binaryLen == sizeof(int32))
+		{
+			int32		intValue = ReadLittleEndianInt32(binaryValue);
 
-		datum = Int64GetDatum(longValue);
+			datum = Int64GetDatum((int64) intValue);
+		}
+		else
+		{
+			int64		longValue = ReadLittleEndianInt64(binaryValue);
+
+			datum = Int64GetDatum(longValue);
+		}
 	}
 	else if (pgType.postgresTypeOid == FLOAT4OID)
 	{
@@ -380,9 +438,23 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 	else if (pgType.postgresTypeOid == FLOAT8OID)
 	{
-		float8		doubleValue = ReadLittleEndianFloat8(binaryValue);
+		/*
+		 * Same as int -> long above: after a float -> double type promotion,
+		 * existing data files retain 4-byte float bounds while the current
+		 * schema expects 8-byte double. Widen on read.
+		 */
+		if (binaryLen == sizeof(float4))
+		{
+			float4		floatValue = ReadLittleEndianFloat4(binaryValue);
 
-		datum = Float8GetDatum(doubleValue);
+			datum = Float8GetDatum((float8) floatValue);
+		}
+		else
+		{
+			float8		doubleValue = ReadLittleEndianFloat8(binaryValue);
+
+			datum = Float8GetDatum(doubleValue);
+		}
 	}
 	else if (pgType.postgresTypeOid == DATEOID)
 	{
@@ -467,6 +539,45 @@ PGIcebergBinaryDeserialize(unsigned char *binaryValue, size_t binaryLen, Field *
 	}
 
 	return datum;
+}
+
+
+/*
+ * ErrorIfUnexpectedBinaryLength rejects a fixed-width value that is not exactly
+ * as wide as its type. The bytes are Avro "bytes" of arbitrary length taken from
+ * a manifest we did not necessarily write, so without this every fixed-width
+ * read in PGIcebergBinaryDeserialize is an out-of-bounds read waiting for a
+ * short value.
+ */
+static void
+ErrorIfUnexpectedBinaryLength(size_t binaryLen, Field * field, PGType pgType)
+{
+	/* string-encoded types carry a value of any length, e.g. geometry */
+	if (PGTypeRequiresConversionToIcebergString(field, pgType))
+		return;
+
+	for (int i = 0; i < lengthof(FixedWidthBinaryLengths); i++)
+	{
+		if (FixedWidthBinaryLengths[i].postgresTypeOid != pgType.postgresTypeOid)
+			continue;
+
+		size_t		expectedLen = FixedWidthBinaryLengths[i].expectedLen;
+		size_t		promotedFromLen = FixedWidthBinaryLengths[i].promotedFromLen;
+
+		if (binaryLen == expectedLen ||
+			(promotedFromLen > 0 && binaryLen == promotedFromLen))
+			return;
+
+		char	   *expectedLengths = promotedFromLen > 0 ?
+			psprintf("%zu or %zu", promotedFromLen, expectedLen) :
+			psprintf("%zu", expectedLen);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("Iceberg value of type %s has invalid serialized length %zu",
+						format_type_be(pgType.postgresTypeOid), binaryLen),
+				 errdetail("Expected %s bytes.", expectedLengths)));
+	}
 }
 
 

--- a/pg_lake_iceberg/src/iceberg/iceberg_type_numeric_binary_serde.c
+++ b/pg_lake_iceberg/src/iceberg/iceberg_type_numeric_binary_serde.c
@@ -90,6 +90,19 @@ PGNumericIcebergBinaryDeserialize(unsigned char *numericBinary, size_t binaryLen
 	GetDuckdbAdjustedPrecisionAndScaleFromNumericTypeMod(pgType.postgresTypeMod,
 														 &precision, &scale);
 
+	/*
+	 * Iceberg stores a decimal as the minimum number of two's complement
+	 * bytes, so any length up to the 16 bytes of a decimal(38,s) is valid.
+	 * Reject the rest: an empty value reads a byte that is not there, and a
+	 * longer one makes SignExtendNumericBinary write before its 16-byte
+	 * buffer.
+	 */
+	if (binaryLen == 0 || binaryLen > 16)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("Iceberg decimal has invalid serialized length %zu", binaryLen),
+				 errdetail("Expected 1 to 16 bytes.")));
+
 	bool		isNegative = (numericBinary[0] & 0x80) != 0;
 
 	unsigned char *adjustedNumericBinary = SignExtendNumericBinary(numericBinary, binaryLen);

--- a/pg_lake_iceberg/src/test/test_iceberg_binary_serde.c
+++ b/pg_lake_iceberg/src/test/test_iceberg_binary_serde.c
@@ -38,10 +38,12 @@ static List *DeserializeDataFileColumnBounds(List *leafFields, ColumnBound * col
 static List *SerializeDataFileColumnBounds(List *leafFields, List *columnIdDatums, List *boundDatums, List **columnTypes);
 static Datum DeserializeColumnBound(ColumnBound * bound, LeafField * leafField);
 static Datum DataFileColumnBoundsToJsonDatum(List *boundDatums, List *columnIdDatums, List *columnTypes);
+static Field * MakeScalarFieldAndPGType(const char *icebergScalarTypeName, Oid typoid, PGType * pgType);
 
 PG_FUNCTION_INFO_V1(pg_lake_read_data_file_stats);
 PG_FUNCTION_INFO_V1(pg_lake_reserialize_data_file_stats);
 PG_FUNCTION_INFO_V1(pg_lake_serde_value);
+PG_FUNCTION_INFO_V1(pg_lake_deserialize_value);
 
 /*
  * FindColumnBoundByColumnId finds ColumnBound by column id.
@@ -406,47 +408,10 @@ pg_lake_serde_value(PG_FUNCTION_ARGS)
 	const char *icebergScalarTypeName = text_to_cstring(PG_GETARG_TEXT_P(1));
 
 	Oid			typoid = get_fn_expr_argtype(fcinfo->flinfo, 0);
-	int32		typmod = -1;
 
-	Field	   *field = palloc0(sizeof(Field));
-
-	field->type = FIELD_TYPE_SCALAR;
-	field->field.scalar.typeName = pstrdup(icebergScalarTypeName);
-
-	PGType		pgType = MakePGType(typoid, typmod);
-
-	if (pgType.postgresTypeOid == NUMERICOID)
-	{
-		/* set typmod properly for numeric types */
-		int			precision = 0;
-		int			scale = 0;
-
-		if (sscanf(icebergScalarTypeName, "decimal(%d,%d)", &precision, &scale) == 2)
-		{
-			pgType.postgresTypeMod = make_numeric_typmod(precision, scale);
-		}
-	}
-
-	/* check if iceberg type and pg type matches */
-	PGType		pgTypeFromIceberg = IcebergFieldToPostgresType(field);
-
-	/*
-	 * TimeTZ is stored as Iceberg "time" (UTC-normalized), so the Iceberg
-	 * type resolves to TIMEOID while the input is TIMETZOID.  Allow this
-	 * expected mismatch.
-	 */
-	bool		isTimeTzToTime = (pgType.postgresTypeOid == TIMETZOID &&
-								  pgTypeFromIceberg.postgresTypeOid == TIMEOID);
-
-	if (pgTypeFromIceberg.postgresTypeOid != pgType.postgresTypeOid &&
-		!isTimeTzToTime &&
-		!PGTypeRequiresConversionToIcebergString(field, pgType))
-	{
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("expected %s type, got %s type",
-							   format_type_be(pgTypeFromIceberg.postgresTypeOid),
-							   format_type_be(pgType.postgresTypeOid))));
-	}
+	PGType		pgType;
+	Field	   *field = MakeScalarFieldAndPGType(icebergScalarTypeName, typoid,
+												 &pgType);
 
 	size_t		binaryLen = 0;
 
@@ -458,4 +423,82 @@ pg_lake_serde_value(PG_FUNCTION_ARGS)
 	}
 
 	return PGIcebergBinaryDeserialize(binaryValue, binaryLen, field, pgType);
+}
+
+
+/*
+ * pg_lake_deserialize_value deserializes a raw binary value into the type of its
+ * first argument, which is ignored. Serialization always produces a value of the
+ * right width, so this is the only way for a test to hand the deserializer the
+ * arbitrary-length bytes a manifest can actually contain.
+ */
+Datum
+pg_lake_deserialize_value(PG_FUNCTION_ARGS)
+{
+	const char *icebergScalarTypeName = text_to_cstring(PG_GETARG_TEXT_P(1));
+	bytea	   *binary = PG_GETARG_BYTEA_PP(2);
+
+	Oid			typoid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+
+	PGType		pgType;
+	Field	   *field = MakeScalarFieldAndPGType(icebergScalarTypeName, typoid,
+												 &pgType);
+
+	return PGIcebergBinaryDeserialize((unsigned char *) VARDATA_ANY(binary),
+									  VARSIZE_ANY_EXHDR(binary), field, pgType);
+}
+
+
+/*
+ * MakeScalarFieldAndPGType builds the scalar Field and the PGType that the
+ * single value binary serde takes for the given Iceberg type name and Postgres
+ * type, and errors if the two do not describe the same type.
+ */
+static Field *
+MakeScalarFieldAndPGType(const char *icebergScalarTypeName, Oid typoid,
+						 PGType * pgType)
+{
+	int32		typmod = -1;
+
+	Field	   *field = palloc0(sizeof(Field));
+
+	field->type = FIELD_TYPE_SCALAR;
+	field->field.scalar.typeName = pstrdup(icebergScalarTypeName);
+
+	*pgType = MakePGType(typoid, typmod);
+
+	if (pgType->postgresTypeOid == NUMERICOID)
+	{
+		/* set typmod properly for numeric types */
+		int			precision = 0;
+		int			scale = 0;
+
+		if (sscanf(icebergScalarTypeName, "decimal(%d,%d)", &precision, &scale) == 2)
+		{
+			pgType->postgresTypeMod = make_numeric_typmod(precision, scale);
+		}
+	}
+
+	/* check if iceberg type and pg type matches */
+	PGType		pgTypeFromIceberg = IcebergFieldToPostgresType(field);
+
+	/*
+	 * TimeTZ is stored as Iceberg "time" (UTC-normalized), so the Iceberg
+	 * type resolves to TIMEOID while the input is TIMETZOID.  Allow this
+	 * expected mismatch.
+	 */
+	bool		isTimeTzToTime = (pgType->postgresTypeOid == TIMETZOID &&
+								  pgTypeFromIceberg.postgresTypeOid == TIMEOID);
+
+	if (pgTypeFromIceberg.postgresTypeOid != pgType->postgresTypeOid &&
+		!isTimeTzToTime &&
+		!PGTypeRequiresConversionToIcebergString(field, *pgType))
+	{
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("expected %s type, got %s type",
+							   format_type_be(pgTypeFromIceberg.postgresTypeOid),
+							   format_type_be(pgType->postgresTypeOid))));
+	}
+
+	return field;
 }

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
@@ -379,6 +379,9 @@ def test_pg_lake_deserialize_value_rejects_invalid_length(
     # if it were the full width.
     invalid_lengths = [
         ("boolean", "false::boolean", "\\x"),
+        # the 4 byte int libavro hands us for an Avro boolean is not a boolean;
+        # AvroExtractNullableFieldFromRecordByIndex narrows it to one byte
+        ("boolean", "false::boolean", "\\x01000000"),
         ("int", "0::int", "\\x0102"),
         ("long", "0::bigint", "\\x0102"),
         ("float", "0::float4", "\\x0102"),
@@ -408,6 +411,7 @@ def test_pg_lake_deserialize_value_rejects_invalid_length(
     # promotion, and likewise float -> double
     valid_lengths = [
         ("boolean", "false::boolean", "\\x01", True),
+        ("boolean", "false::boolean", "\\x00", False),
         ("int", "0::int", "\\x01000000", 1),
         ("long", "0::bigint", "\\x0100000000000000", 1),
         ("long", "0::bigint", "\\x01000000", 1),

--- a/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
+++ b/pg_lake_iceberg/tests/pytests/test_iceberg_binary_serde.py
@@ -369,6 +369,68 @@ def test_pg_lake_serde_timetz(
     superuser_conn.rollback()
 
 
+def test_pg_lake_deserialize_value_rejects_invalid_length(
+    superuser_conn,
+    iceberg_extension,
+    create_helper_functions,
+):
+    # Bounds and partition values are Avro "bytes", so their length comes from the
+    # manifest and not from us. A value narrower than its type used to be read as
+    # if it were the full width.
+    invalid_lengths = [
+        ("boolean", "false::boolean", "\\x"),
+        ("int", "0::int", "\\x0102"),
+        ("long", "0::bigint", "\\x0102"),
+        ("float", "0::float4", "\\x0102"),
+        ("double", "0::float8", "\\x0102"),
+        ("date", "'1970-01-01'::date", "\\x0102"),
+        ("time", "'00:00:00'::time", "\\x0102"),
+        ("timestamp", "'1970-01-01'::timestamp", "\\x0102"),
+        ("timestamptz", "'1970-01-01+00'::timestamptz", "\\x0102"),
+        ("uuid", "'00000000-0000-0000-0000-000000000000'::uuid", "\\x0102"),
+        # a longer value is just as wrong, and for decimal it would have made the
+        # sign extension write before its 16 byte buffer
+        ("int", "0::int", "\\x0102030405060708"),
+        ("decimal(10,2)", "0::numeric(10,2)", "\\x"),
+        ("decimal(10,2)", "0::numeric(10,2)", "\\x000102030405060708090a0b0c0d0e0f10"),
+    ]
+
+    for iceberg_type, target, binary_value in invalid_lengths:
+        pg_query = f"SELECT lake_iceberg.deserialize_value({target}, '{iceberg_type}', '{binary_value}'::bytea);"
+
+        with pytest.raises(Exception, match="invalid serialized length"):
+            run_query(pg_query, superuser_conn)
+
+        superuser_conn.rollback()
+
+    # the accepted widths still deserialize, including the two type promotions the
+    # spec allows: an int bound left behind in a file written before an int -> long
+    # promotion, and likewise float -> double
+    valid_lengths = [
+        ("boolean", "false::boolean", "\\x01", True),
+        ("int", "0::int", "\\x01000000", 1),
+        ("long", "0::bigint", "\\x0100000000000000", 1),
+        ("long", "0::bigint", "\\x01000000", 1),
+        ("float", "0::float4", "\\x0000803f", 1.0),
+        ("double", "0::float8", "\\x000000000000f03f", 1.0),
+        ("double", "0::float8", "\\x0000803f", 1.0),
+        ("decimal(10,2)", "0::numeric(10,2)", "\\x01", Decimal("0.01")),
+        (
+            "decimal(10,2)",
+            "0::numeric(10,2)",
+            "\\x00000000000000000000000000000001",
+            Decimal("0.01"),
+        ),
+    ]
+
+    for iceberg_type, target, binary_value, expected in valid_lengths:
+        pg_query = f"SELECT lake_iceberg.deserialize_value({target}, '{iceberg_type}', '{binary_value}'::bytea);"
+        result = run_query(pg_query, superuser_conn)
+        assert result[0][0] == expected, pg_query
+
+    superuser_conn.rollback()
+
+
 @pytest.fixture(scope="module")
 def create_helper_functions(superuser_conn, s3, iceberg_extension):
 
@@ -378,6 +440,16 @@ def create_helper_functions(superuser_conn, s3, iceberg_extension):
         RETURNS anyelement
         LANGUAGE C STRICT
         AS 'pg_lake_iceberg', $$pg_lake_serde_value$$;
+""",
+        superuser_conn,
+    )
+
+    run_command(
+        f"""
+        CREATE OR REPLACE FUNCTION lake_iceberg.deserialize_value(target anyelement, iceberg_scalar_type text, binary_value bytea)
+        RETURNS anyelement
+        LANGUAGE C STRICT
+        AS 'pg_lake_iceberg', $$pg_lake_deserialize_value$$;
 """,
         superuser_conn,
     )
@@ -392,6 +464,13 @@ def create_helper_functions(superuser_conn, s3, iceberg_extension):
     run_command(
         f"""
         DROP FUNCTION IF EXISTS lake_iceberg.serde_value
+""",
+        superuser_conn,
+    )
+
+    run_command(
+        f"""
+        DROP FUNCTION IF EXISTS lake_iceberg.deserialize_value
 """,
         superuser_conn,
     )

--- a/pg_lake_table/src/fdw/partition_transform.c
+++ b/pg_lake_table/src/fdw/partition_transform.c
@@ -1088,9 +1088,25 @@ PartitionValueToDatum(IcebergPartitionTransformType transformType, void *value, 
 			 transformType == PARTITION_TRANSFORM_HOUR ||
 			 transformType == PARTITION_TRANSFORM_BUCKET)
 	{
+		/*
+		 * These transforms all produce an Iceberg int, and the value comes
+		 * from a manifest as Avro "bytes" of arbitrary length, so a shorter
+		 * value would read past the end of it.
+		 */
+		if (valueLength != sizeof(int32))
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("partition value for transform %d has invalid serialized "
+							"length %zu", transformType, valueLength),
+					 errdetail("Expected %zu bytes.", sizeof(int32))));
+
 		*isNull = false;
 
-		return Int32GetDatum(*(int32_t *) value);
+		int32		intValue;
+
+		memcpy(&intValue, value, sizeof(intValue));
+
+		return Int32GetDatum(intValue);
 	}
 	else
 	{

--- a/pg_lake_table/src/transaction/external_heavy_asserts.c
+++ b/pg_lake_table/src/transaction/external_heavy_asserts.c
@@ -504,34 +504,24 @@ AssertInternalAndExternalIcebergStatsMatchForAllDataFiles(Oid relationId, bool d
 										 externalPartitionField->value_length,
 										 &normalizedValue, &normalizedLen);
 
-			/*
-			 * we serialize boolean 1 byte per spec but spark serializes it as
-			 * 4 bytes (int)
-			 */
-			bool		mismatchBoolLength = internalPartitionField->value_type.physical_type == ICEBERG_AVRO_PHYSICAL_TYPE_BOOL &&
-				internalPartitionField->value_length == 1 && externalPartitionField->value_length == 4;
-
-			if (!mismatchBoolLength)
+			if (internalPartitionField->value_length != normalizedLen)
 			{
-				if (internalPartitionField->value_length != normalizedLen)
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_INTERNAL_ERROR),
-							 errmsg("internal and external iceberg data file partition field value length mismatch %zu %zu for %s",
-									internalPartitionField->value_length,
-									normalizedLen,
-									internalPartitionField->field_name)));
-				}
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("internal and external iceberg data file partition field value length mismatch %zu %zu for %s",
+								internalPartitionField->value_length,
+								normalizedLen,
+								internalPartitionField->field_name)));
+			}
 
-				if (memcmp(internalPartitionField->value,
-						   normalizedValue,
-						   internalPartitionField->value_length) != 0)
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_INTERNAL_ERROR),
-							 errmsg("internal and external iceberg data file partition field value mismatch for %s",
-									internalPartitionField->field_name)));
-				}
+			if (memcmp(internalPartitionField->value,
+					   normalizedValue,
+					   internalPartitionField->value_length) != 0)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("internal and external iceberg data file partition field value mismatch for %s",
+								internalPartitionField->field_name)));
 			}
 		}
 	}


### PR DESCRIPTION
Bound values, partition summaries and partition field values are Avro `bytes` in
a manifest, so their length is whatever the writer put there. `PGIcebergBinaryDeserialize`
and `PartitionValueToDatum` read them at the width of the *current schema* type
instead, so a value narrower than its type is an out-of-bounds read of the Avro
buffer, and the bytes that follow it end up in a query result.

Probed on a build without this change, through a test-only SQL entry point that
hands the deserializer raw bytes:

| type | bytes given | value returned |
| --- | --- | --- |
| `int` | `\x0102` (2) | `2138964481` |
| `uuid` | `\x0102` (2) | `01027e7f-3400-0000-0000-000063000000` |
| `boolean` | `\x` (0) | `False` |
| `decimal(10,2)` | 17 bytes | `ERROR: numeric field overflow` |

The `uuid` row is the clearest one: 14 of the 16 bytes in that value are
adjacent heap.

The `decimal` row is a write, not a read. `SignExtendNumericBinary` pads into a
16-byte `palloc0`, copying `binaryLen` bytes to the end of it, so a 17-byte
value writes one byte in front of the buffer. A 0-byte value reads
`numericBinary[0]` for the sign before that.

## What this changes

* `ErrorIfUnexpectedBinaryLength` rejects a fixed-width value whose length is
  not the width of its type, from a table of the widths. Two narrower forms stay
  legal, because the spec keeps column metrics at the type the data file was
  written with: a 4-byte `int` bound on a column that has since been promoted to
  `long`, and likewise `float` to `double`. Those are now widened on read
  instead of read as 8 bytes.
* Variable-width types (`string`, `binary`, and anything Iceberg encodes as a
  string, e.g. geometry) keep taking any length. `decimal` is bounded in its own
  path to 1..16 bytes, the range the spec's minimum-two's-complement encoding
  can produce for `decimal(38,s)`.
* `PartitionValueToDatum` checks the 4 bytes it reads for the `year`/`month`/
  `day`/`hour`/`bucket` transforms.
* The fixed-width reads and writes go through `Read*`/`Write*LittleEndian*`
  helpers that `memcpy`. The previous code byte-swapped the *pointer* rather
  than the value (`binaryValue = ToLittleEndian32(binaryValue)`), which is a
  no-op on a little-endian host and reads a swapped address on a big-endian
  one; and a value taken out of an Avro buffer has no alignment guarantee, so
  `*(int32 *) binaryValue` was undefined there.
* `AvroExtractNullableFieldFromRecordByIndex` now hands back a boolean as the
  one byte Iceberg encodes it in. It is the only producer of the manifest
  partition field values we read as Iceberg binary single values, and
  `avro_value_get_boolean` writes into an `int`, so it used to hand back all
  four bytes of that `int` — a width the spec does not have, whose first byte
  is also the wrong end of the value on a big-endian host. Nothing noticed
  while the deserializer read a boolean as "the first byte of whatever you gave
  me". Narrowing it at the producer is what keeps the new length check strict
  rather than teaching it that booleans come in two widths.

  That also retires the workaround in
  `AssertInternalAndExternalIcebergStatsMatchForAllDataFiles`, which attributed
  the four bytes to Spark rather than to us and skipped both the length and the
  value comparison for every boolean partition field as a result.

## Testing

`test_pg_lake_deserialize_value_rejects_invalid_length` in
`test_iceberg_binary_serde.py` covers every fixed-width type at a wrong length,
both narrower and wider, plus the accepted widths and the two promotions. It
drives a new test-only `pg_lake_deserialize_value`, because serialization always
produces the correct width and there is otherwise no way to hand the
deserializer the arbitrary-length bytes a manifest can contain. The test fails
on the unfixed build with `DID NOT RAISE`. It also pins the 4-byte boolean as
rejected and both one-byte forms as accepted.

The `PartitionValueToDatum` bucket/temporal branch has no unit test: reaching it
needs a crafted manifest, and `LookupTransformType` in
`pg_lake_table/src/fdw/partitioning/partition_by_parser.c` is `static`, so there
is no in-process entry point to call it through. That check is by inspection.

Local: 104 passed across `test_iceberg_binary_serde.py`,
`test_iceberg_data_file_stats.py` and `test_iceberg_representation.py`, and 79
passed across `test_bucket_partitioned_writes.py`,
`test_date_partitioned_writes.py` and `test_data_file_pruning.py`. For the
boolean narrowing, the three files that read a real manifest partition field:
`test_partitioned_pushdown.py` and `test_identity_partitioned_writes.py` (81
passed), `test_iceberg_metadata_via_spark.py` (2) and
`test_pg_lake_iceberg_apply_partition_transform.py` (7).
