### PR TITLE
[release-3.4] Backport #584: drop vcpkg build byproducts from the image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -255,9 +255,14 @@ RUN git clone https://github.com/CrunchyData/pg_incremental.git && \
 # Install vcpkg as postgres user
 ARG VCPKG_VERSION=2025.10.17
 
+# Only installed/ is consumed via VCPKG_TOOLCHAIN_PATH; the rest is build
+# byproducts.  Cleaned in this same RUN so the layer never carries them.
 RUN git clone https://github.com/Microsoft/vcpkg.git -b $VCPKG_VERSION /home/postgres/vcpkg && \
     ./vcpkg/bootstrap-vcpkg.sh && \
-    ./vcpkg/vcpkg install azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl
+    ./vcpkg/vcpkg install --clean-after-build azure-identity-cpp azure-storage-blobs-cpp azure-storage-files-datalake-cpp openssl && \
+    rm -rf /home/postgres/vcpkg/downloads \
+           /home/postgres/vcpkg/buildtrees \
+           /home/postgres/vcpkg/packages
 
 ENV VCPKG_TOOLCHAIN_PATH="/home/postgres/vcpkg/scripts/buildsystems/vcpkg.cmake"
 


### PR DESCRIPTION
Backport of #584 to release-3.4. Applies cleanly (the vcpkg install step is identical on this branch).

The CI image carried all of `vcpkg/`, but only `installed/` is ever consumed — that is where `VCPKG_TOOLCHAIN_PATH` points. `downloads/`, `buildtrees/` and `packages/` are build byproducts, ~2.9GB of a 3.2GB tree. Jobs on the smaller runners had started failing while unpacking that layer (`no space left on device`).

- `rm -rf` the byproduct dirs in the *same* `RUN` as the install, so the layer never carries them.
- `vcpkg install --clean-after-build`, which also lowers the peak during the build.