### PR TITLE
Map Iceberg fixed[L] to BLOB when reading parquet

### DIFF
--- a/pg_lake_engine/src/pgduck/read_data.c
+++ b/pg_lake_engine/src/pgduck/read_data.c
@@ -57,6 +57,7 @@ static char *ReadDataSourceFunction(List *sourcePaths,
 									bool emitRowId);
 static char *BuildParquetSchema(DataFileSchema * schema, bool emitRowId);
 static char *GetSchemaType(Field * mapping);
+static const char *IcebergScalarTypeNameToDuckDBTypeName(const char *icebergTypeName);
 static char *ReadEmptyDataSource(TupleDesc tupleDesc, CopyDataFormat format,
 								 bool preferVarchar,
 								 ReadRowLocationMode emitRowLocation);
@@ -639,9 +640,13 @@ GetSchemaType(Field * field)
 	switch (field->type)
 	{
 		case FIELD_TYPE_SCALAR:
-			/* For scalar types, simply append the type name */
-			appendStringInfoString(&str, field->field.scalar.typeName);
-			break;
+			{
+				const char *typeName =
+					IcebergScalarTypeNameToDuckDBTypeName(field->field.scalar.typeName);
+
+				appendStringInfoString(&str, typeName);
+				break;
+			}
 
 		case FIELD_TYPE_LIST:
 			{
@@ -695,6 +700,24 @@ GetSchemaType(Field * field)
 
 	/* Return the constructed type string */
 	return str.data;
+}
+
+
+/*
+ * IcebergScalarTypeNameToDuckDBTypeName maps an Iceberg scalar type name to the
+ * DuckDB type name used in the read_parquet() schema option.
+ *
+ * The Iceberg names we store double as DuckDB type names, so they are passed
+ * through as-is. The exception is fixed[L], which DuckDB parses as an array of
+ * L "fixed" values instead of a fixed-length binary.
+ */
+static const char *
+IcebergScalarTypeNameToDuckDBTypeName(const char *icebergTypeName)
+{
+	if (strncmp(icebergTypeName, "fixed", strlen("fixed")) == 0)
+		return "BLOB";
+
+	return icebergTypeName;
 }
 
 

--- a/pg_lake_table/tests/pytests/test_iceberg_read_only.py
+++ b/pg_lake_table/tests/pytests/test_iceberg_read_only.py
@@ -98,6 +98,15 @@ def test_iceberg_nested_types(pg_conn, bids_table, extension):
     assert result[0]["created_by"] == "joe"
     assert result[1]["created_by"] == "john"
 
+    # binary and fixed-length binary columns must be projectable, not just
+    # visible in the table definition
+    result = run_query("select data, fixed_data from bids order by bid", pg_conn)
+    assert len(result) == 4
+    assert bytes(result[0]["data"]) == b"tt5678"
+    assert bytes(result[0]["fixed_data"]) == b"bbbbbbbbbbbbbbbb"
+    assert bytes(result[1]["data"]) == b"1"
+    assert bytes(result[1]["fixed_data"]) == b"aaaaaaaaaaaaaaaa"
+
     pg_conn.rollback()
 
 
@@ -253,7 +262,7 @@ def bids_table(iceberg_catalog):
                 "ask": 1.0,
                 "details": {"created_by": "john"},
                 "data": b"1",
-                "fixed_data": b"1234567890123456",
+                "fixed_data": b"aaaaaaaaaaaaaaaa",
             },
             {
                 "datetime": datetime(2024, 1, 2),
@@ -262,7 +271,7 @@ def bids_table(iceberg_catalog):
                 "ask": 1.1,
                 "details": {"created_by": "joe"},
                 "data": b"tt5678",
-                "fixed_data": b"1234567890123456",
+                "fixed_data": b"bbbbbbbbbbbbbbbb",
             },
             {
                 "datetime": datetime(2024, 1, 3),
@@ -271,7 +280,7 @@ def bids_table(iceberg_catalog):
                 "ask": 1.2,
                 "details": {"created_by": "jack"},
                 "data": b"90f12",
-                "fixed_data": b"1234567890123456",
+                "fixed_data": b"cccccccccccccccc",
             },
             {
                 "datetime": datetime(2024, 1, 4),
@@ -280,7 +289,7 @@ def bids_table(iceberg_catalog):
                 "ask": 1.3,
                 "details": {"created_by": "jim"},
                 "data": b"34asd56",
-                "fixed_data": b"1234567890123456",
+                "fixed_data": b"dddddddddddddddd",
             },
         ],
         schema=arrow_schema,


### PR DESCRIPTION
## Problem

Selecting an Iceberg column declared as `fixed[L]` fails. The read never
reaches the data files:

```
Invalid Input Error: Value "fixed[67108864]" can not be converted to a DuckDB Type
```

For small `L` the same query fails with `Type with name fixed does not exist`
or an internal error about type `UNKNOWN`. Writers that use `fixed[L]` for
binary columns (a common choice when the column has a declared max length)
produce tables that pg_lake registers correctly, reports as `bytea` in
`pg_attribute`, and then cannot read.

## Solution

`GetSchemaType()` puts the Iceberg type name straight into the
`read_parquet(.., schema=map {..})` option. That works for every other
Iceberg primitive because their names double as DuckDB type names (`long`,
`string`, `binary`, `timestamptz`, ...). `fixed[L]` is the exception: DuckDB
parses `X[N]` as a fixed-size array, so it either rejects the length or
resolves an element type named `fixed` that does not exist. Translate it to
`BLOB`, which is already what the column is read as everywhere else
(`IcebergTypeNameToDuckdbTypeName()` maps `fixed` to `BLOB`, and the
projection the planner builds is `CAST(.. AS BLOB)`).

The schema option covers every field in the table, not just the projected
ones, so a single unread `fixed[L]` column breaks all reads of that table.

## Test plan

- [x] `test_iceberg_nested_types` now projects the `fixed[16]` column that the
      `bids` fixture already had, plus the plain `binary` column next to it.
      The fixture used one repeated value, so the rows now differ.
- [x] Verified the new assertion fails without the fix
      (`Type with name fixed does not exist!`) and passes with it.
- [x] `pytest tests/pytests/test_iceberg_read_only.py` and the iceberg types,
      field-id, DDL and changelog test files pass locally.