### PR TITLE
Pushdown new builtin functions

### DIFF
--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -1943,7 +1943,7 @@ RewriteFuncExprToHex(Node *node, void *context)
 		castExpr->location = -1;
 
 		Node	   *maskExpr = MakeOpExpr((Node *) castExpr, "pg_catalog", "&",
-										   (Node *) MakeInt64Const(INT64CONST(4294967295)));
+										  (Node *) MakeInt64Const(INT64CONST(4294967295)));
 
 		funcExpr->funcid = F_TO_HEX_INT8;
 		funcExpr->args = list_make1(maskExpr);

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -1942,46 +1942,18 @@ RewriteFuncExprToHex(Node *node, void *context)
 		castExpr->args = list_make1(arg);
 		castExpr->location = -1;
 
-		Const	   *maskConst = makeConst(INT8OID, -1, InvalidOid, sizeof(int64),
-										   Int64GetDatum(INT64CONST(4294967295)),
-										   false, true);
-
-		Oid			andOpNo = OpernameGetOprid(list_make1(makeString("&")),
-												INT8OID, INT8OID);
-
-		if (!OidIsValid(andOpNo))
-			return node;
-
-		OpExpr	   *andExpr = makeNode(OpExpr);
-
-		andExpr->opno = andOpNo;
-		andExpr->opfuncid = F_INT8AND;
-		andExpr->opresulttype = INT8OID;
-		andExpr->opretset = false;
-		andExpr->args = list_make2(castExpr, maskConst);
-		andExpr->location = -1;
+		Node	   *maskExpr = MakeOpExpr((Node *) castExpr, "pg_catalog", "&",
+										   (Node *) MakeInt64Const(INT64CONST(4294967295)));
 
 		funcExpr->funcid = F_TO_HEX_INT8;
-		funcExpr->args = list_make1(andExpr);
+		funcExpr->args = list_make1(maskExpr);
 	}
 	else if (funcExpr->funcid != F_TO_HEX_INT8)
 	{
 		elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
 	}
 
-	FuncExpr   *lowerExpr = makeNode(FuncExpr);
-
-	lowerExpr->funcid = F_LOWER_TEXT;
-	lowerExpr->funcresulttype = TEXTOID;
-	lowerExpr->funcretset = false;
-	lowerExpr->funcvariadic = false;
-	lowerExpr->funcformat = COERCE_EXPLICIT_CALL;
-	lowerExpr->funccollid = funcExpr->funccollid;
-	lowerExpr->inputcollid = funcExpr->funccollid;
-	lowerExpr->args = list_make1((Node *) funcExpr);
-	lowerExpr->location = -1;
-
-	return (Node *) lowerExpr;
+	return MakeLowerCaseExpr((Node *) funcExpr);
 }
 
 

--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -177,6 +177,7 @@ static Node *RewriteFuncExprInitcap(Node *node, void *context);
 static Node *RewriteFuncExprJsonbArrayLength(Node *node, void *context);
 static Node *RewriteFuncExprEncode(Node *node, void *context);
 static Node *RewriteFuncExprDecode(Node *node, void *context);
+static Node *RewriteFuncExprToHex(Node *node, void *context);
 static Node *RewriteFuncExprToZeroOrNullConst(Node *node, void *context);
 static Node *RewriteFuncExprPostgisTransform(Node *node, void *context);
 static Node *RewriteFuncExprPostgisTransformGeometry(Node *node, void *context);
@@ -356,6 +357,11 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 	},
 	{
 		"pg_catalog", "decode", RewriteFuncExprDecode, 0
+	},
+
+	/* to_hex */
+	{
+		"pg_catalog", "to_hex", RewriteFuncExprToHex, 0
 	},
 
 };
@@ -1902,6 +1908,80 @@ RewriteFuncExprDecode(Node *node, void *context)
 	funcExpr->args = list_make1(linitial(funcExpr->args));
 
 	return (Node *) funcExpr;
+}
+
+
+/*
+ * RewriteFuncExprToHex rewrites to_hex(int4)/to_hex(int8) so the expression
+ * pushed to DuckDB matches Postgres's semantics: DuckDB's to_hex() produces
+ * uppercase hex digits, and has no INTEGER overload, so an int4 argument is
+ * implicitly widened to BIGINT by sign-extension rather than the
+ * zero-extension Postgres's to_hex(int4) performs. We fix the int4 case by
+ * masking off the sign-extended upper bits after widening, and fix the case
+ * mismatch for both overloads by wrapping the result in lower(..).
+ */
+static Node *
+RewriteFuncExprToHex(Node *node, void *context)
+{
+	FuncExpr   *funcExpr = castNode(FuncExpr, node);
+
+	if (list_length(funcExpr->args) != 1)
+		return node;
+
+	if (funcExpr->funcid == F_TO_HEX_INT4)
+	{
+		Node	   *arg = (Node *) linitial(funcExpr->args);
+
+		FuncExpr   *castExpr = makeNode(FuncExpr);
+
+		castExpr->funcid = F_INT8_INT4;
+		castExpr->funcresulttype = INT8OID;
+		castExpr->funcretset = false;
+		castExpr->funcvariadic = false;
+		castExpr->funcformat = COERCE_EXPLICIT_CAST;
+		castExpr->args = list_make1(arg);
+		castExpr->location = -1;
+
+		Const	   *maskConst = makeConst(INT8OID, -1, InvalidOid, sizeof(int64),
+										   Int64GetDatum(INT64CONST(4294967295)),
+										   false, true);
+
+		Oid			andOpNo = OpernameGetOprid(list_make1(makeString("&")),
+												INT8OID, INT8OID);
+
+		if (!OidIsValid(andOpNo))
+			return node;
+
+		OpExpr	   *andExpr = makeNode(OpExpr);
+
+		andExpr->opno = andOpNo;
+		andExpr->opfuncid = F_INT8AND;
+		andExpr->opresulttype = INT8OID;
+		andExpr->opretset = false;
+		andExpr->args = list_make2(castExpr, maskConst);
+		andExpr->location = -1;
+
+		funcExpr->funcid = F_TO_HEX_INT8;
+		funcExpr->args = list_make1(andExpr);
+	}
+	else if (funcExpr->funcid != F_TO_HEX_INT8)
+	{
+		elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
+	}
+
+	FuncExpr   *lowerExpr = makeNode(FuncExpr);
+
+	lowerExpr->funcid = F_LOWER_TEXT;
+	lowerExpr->funcresulttype = TEXTOID;
+	lowerExpr->funcretset = false;
+	lowerExpr->funcvariadic = false;
+	lowerExpr->funcformat = COERCE_EXPLICIT_CALL;
+	lowerExpr->funccollid = funcExpr->funccollid;
+	lowerExpr->inputcollid = funcExpr->funccollid;
+	lowerExpr->args = list_make1((Node *) funcExpr);
+	lowerExpr->location = -1;
+
+	return (Node *) lowerExpr;
 }
 
 

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -333,6 +333,8 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"sqrt", 'f', 1, {"numeric"}, NULL},
 	{"trunc", 'f', 1, {"float8"}, NULL},
 	{"trunc", 'f', 1, {"numeric"}, NULL},
+	{"to_hex", 'f', 1, {"int4"}, NULL},
+	{"to_hex", 'f', 1, {"int8"}, NULL},
 
 	/* Random functions */
 	{"random", 'f', 0, {}, NULL},

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -232,6 +232,9 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"timetz", 'f', 1, {"timestamptz"}, NULL},
 
 	{"length", 'f', 1, {"text"}, NULL},
+	{"char_length", 'f', 1, {"text"}, NULL},
+	{"character_length", 'f', 1, {"text"}, NULL},
+	{"translate", 'f', 3, {"text", "text", "text"}, NULL},
 
 	{"to_date", 'f', 1, {"float8"}, NULL},
 	{"to_timestamp", 'f', 1, {"float8"}, NULL},
@@ -258,6 +261,11 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"date_trunc", 'f', 2, {"text", "timestamptz"}, NULL},
 
 	{"now", 'f', 0, {}, NULL},
+
+	{"age", 'f', 2, {"timestamp", "timestamp"}, NULL},
+	{"isfinite", 'f', 1, {"date"}, NULL},
+	{"isfinite", 'f', 1, {"timestamp"}, NULL},
+	{"isfinite", 'f', 1, {"timestamptz"}, NULL},
 
 	{"to_char", 'f', 2, {"timestamp", "text"}, IsConvertibleToChar},
 	{"to_char", 'f', 2, {"timestamptz", "text"}, IsConvertibleToChar},

--- a/pg_lake_engine/src/pgduck/shippable_builtin_operators.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_operators.c
@@ -376,6 +376,8 @@ static const PGDuckShippableOperator PGDuckShippableTimeOperators[] = {
 	{"<=", "pg_catalog", "time_le", 2, {"time", "time"}, NULL},
 	{">", "pg_catalog", "time_gt", 2, {"time", "time"}, NULL},
 	{">=", "pg_catalog", "time_ge", 2, {"time", "time"}, NULL},
+	{"+", "pg_catalog", "time_pl_interval", 2, {"time", "interval"}, NULL},
+	{"-", "pg_catalog", "time_mi_interval", 2, {"time", "interval"}, NULL},
 };
 
 /* Timetz operators */
@@ -386,6 +388,8 @@ static const PGDuckShippableOperator PGDuckShippableTimeTzOperators[] = {
 	{"<=", "pg_catalog", "timetz_le", 2, {"timetz", "timetz"}, NULL},
 	{">", "pg_catalog", "timetz_gt", 2, {"timetz", "timetz"}, NULL},
 	{">=", "pg_catalog", "timetz_ge", 2, {"timetz", "timetz"}, NULL},
+	{"+", "pg_catalog", "timetz_pl_interval", 2, {"timetz", "interval"}, NULL},
+	{"-", "pg_catalog", "timetz_mi_interval", 2, {"timetz", "interval"}, NULL},
 };
 
 /* Timestamp operators */
@@ -454,6 +458,9 @@ static const PGDuckShippableOperator PGDuckShippableIntervalOperators[] = {
 	{">=", "pg_catalog", "interval_ge", 2, {"interval", "interval"}, NULL},
 	{"+", "pg_catalog", "interval_pl", 2, {"interval", "interval"}, NULL},
 	{"-", "pg_catalog", "interval_mi", 2, {"interval", "interval"}, NULL},
+	{"-", "pg_catalog", "interval_um", 1, {"interval"}, NULL},
+	{"*", "pg_catalog", "interval_mul", 2, {"interval", "float8"}, NULL},
+	{"*", "pg_catalog", "mul_d_interval", 2, {"float8", "interval"}, NULL},
 };
 
 /* UUID operators */

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
@@ -55,6 +55,21 @@ test_cases = [
         "WHERE col_interval - INTERVAL '1 day' = INTERVAL '1 day'",
         "WHERE ((\"col_interval\" - '1 day'::interval) = '1 day'::interval)",
     ),
+    (
+        "interval_um",
+        "WHERE - col_interval = INTERVAL '-1 day'",
+        "WHERE ((- \"col_interval\") = '-1 days'::interval)",
+    ),
+    (
+        "interval_mul",
+        "WHERE col_interval * 2 = INTERVAL '2 days'",
+        "WHERE ((\"col_interval\" * (2)::double precision) = '2 days'::interval)",
+    ),
+    (
+        "mul_d_interval",
+        "WHERE 2 * col_interval = INTERVAL '2 days'",
+        "WHERE (((2)::double precision * \"col_interval\") = '2 days'::interval)",
+    ),
 ]
 
 

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_time.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_time.py
@@ -55,6 +55,16 @@ test_cases = [
         "WHERE col_time >= '17:00:00'::time",
         "WHERE (\"col_time\" >= '17:00:00'::time without time zone)",
     ),
+    (
+        "time_pl_interval",
+        "WHERE col_time + col_interval = '13:00:00'::time",
+        "WHERE ((\"col_time\" + \"col_interval\") = '13:00:00'::time without time zone)",
+    ),
+    (
+        "time_mi_interval",
+        "WHERE col_time - col_interval = '23:59:59'::time",
+        "WHERE ((\"col_time\" - \"col_interval\") = '23:59:59'::time without time zone)",
+    ),
 ]
 
 

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_time.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_time.py
@@ -58,12 +58,12 @@ test_cases = [
     (
         "time_pl_interval",
         "WHERE col_time + col_interval = '13:00:00'::time",
-        "WHERE ((\"col_time\" + \"col_interval\") = '13:00:00'::time without time zone)",
+        'WHERE (("col_time" + "col_interval") = \'13:00:00\'::time without time zone)',
     ),
     (
         "time_mi_interval",
         "WHERE col_time - col_interval = '23:59:59'::time",
-        "WHERE ((\"col_time\" - \"col_interval\") = '23:59:59'::time without time zone)",
+        'WHERE (("col_time" - "col_interval") = \'23:59:59\'::time without time zone)',
     ),
 ]
 

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_timetz.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_timetz.py
@@ -35,6 +35,16 @@ test_cases = [
     ("timetz_le", "WHERE col_timetz <= '15:00:00'::timetz", 'WHERE ("col_timetz" <= '),
     ("timetz_gt", "WHERE col_timetz > '16:00:00'::timetz", 'WHERE ("col_timetz" > '),
     ("timetz_ge", "WHERE col_timetz >= '17:00:00'::timetz", 'WHERE ("col_timetz" >= '),
+    (
+        "timetz_pl_interval",
+        "WHERE col_timetz + col_interval = '13:00:00+00'::timetz",
+        'WHERE (("col_timetz" + "col_interval") = ',
+    ),
+    (
+        "timetz_mi_interval",
+        "WHERE col_timetz - col_interval = '23:59:59+00'::timetz",
+        'WHERE (("col_timetz" - "col_interval") = ',
+    ),
 ]
 
 

--- a/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
@@ -89,6 +89,18 @@ test_agg_cases = [
     ),
     ("trunc(double)", "WHERE trunc(col_double) = 1.0", '"trunc"(', True),
     ("trunc(numeric)", "WHERE trunc(col_numeric) = 1.0", '"trunc"(', True),
+    (
+        "to_hex(col_int4)",
+        "WHERE to_hex(col_int4) = to_hex(col_int4)",
+        '"lower"("to_hex"(',
+        True,
+    ),
+    (
+        "to_hex(col_int8)",
+        "WHERE to_hex(col_int8) = to_hex(col_int8)",
+        '"lower"("to_hex"(',
+        True,
+    ),
     # Trigonometry operators, input must be in the range [-1,1]
     (
         "acos",
@@ -367,4 +379,62 @@ def test_hyperbolic_functions_specific_values(
         pg_conn,
         f"(SELECT {func}(col_val) FROM hyperbolic_vals.fdw_tbl) fdw",
         f"(SELECT {func}(col_val) FROM hyperbolic_vals.heap_tbl) heap",
+    )
+
+
+@pytest.fixture(scope="module")
+def create_to_hex_values_table(pg_conn, s3, extension):
+    url = f"s3://{TEST_BUCKET}/to_hex_values_test/data.parquet"
+    run_command(
+        f"""
+        COPY (
+            SELECT NULL::int4 AS col_int4, NULL::int8 AS col_int8
+            UNION ALL SELECT 0, 0
+            UNION ALL SELECT 1, 1
+            UNION ALL SELECT -1, -1
+            UNION ALL SELECT -2147483648, -9223372036854775808
+            UNION ALL SELECT 2147483647, 9223372036854775807
+        ) TO '{url}' WITH (FORMAT 'parquet');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        CREATE SCHEMA to_hex_vals;
+        CREATE FOREIGN TABLE to_hex_vals.fdw_tbl (col_int4 int4, col_int8 int8)
+        SERVER pg_lake OPTIONS (format 'parquet', path '{url}');
+        CREATE TABLE to_hex_vals.heap_tbl (col_int4 int4, col_int8 int8);
+        COPY to_hex_vals.heap_tbl FROM '{url}';
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    yield
+
+    run_command("DROP SCHEMA to_hex_vals CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col",
+    ["col_int4", "col_int8"],
+)
+def test_to_hex_specific_values(create_to_hex_values_table, pg_conn, col):
+    """Verify to_hex(int4)/to_hex(int8) pushdown returns the same results as
+    Postgres for NULL, 0, 1, -1, and both the int4 and int8 extremes.
+
+    Covers the two correctness fixes the pushdown rewrite applies: DuckDB's
+    to_hex() is uppercase where Postgres's is lowercase, and DuckDB has no
+    INTEGER overload so an int4 argument is otherwise sign-extended to
+    BIGINT rather than zero-extended as Postgres does.
+    """
+    query = f"SELECT to_hex({col}) FROM to_hex_vals.fdw_tbl"
+    assert_remote_query_contains_expression(query, '"lower"("to_hex"(', pg_conn)
+    assert_table_contents_match(
+        pg_conn,
+        f"(SELECT to_hex({col}) FROM to_hex_vals.fdw_tbl) fdw",
+        f"(SELECT to_hex({col}) FROM to_hex_vals.heap_tbl) heap",
     )

--- a/pg_lake_table/tests/pytests/test_text_function_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_text_function_pushdown.py
@@ -179,6 +179,19 @@ test_cases = [
     # initcap
     ("initcap_text", "WHERE initcap(col_text) = 'Test'", "initcap_pg", True),
     ("initcap_varchar", "WHERE initcap(col_varchar) = 'Test'", "initcap_pg", True),
+    (
+        "translate",
+        "WHERE translate(col_text, 'lo', 'LO') <> col_text",
+        "translate",
+        True,
+    ),
+    ("char_length", "WHERE char_length(col_text) >= 0", "char_length", True),
+    (
+        "character_length",
+        "WHERE character_length(col_text) >= 0",
+        "character_length",
+        True,
+    ),
 ]
 
 

--- a/pg_lake_table/tests/pytests/test_time_functions.py
+++ b/pg_lake_table/tests/pytests/test_time_functions.py
@@ -92,6 +92,29 @@ test_cases += [
     for ex in date_trunc_cases
 ]
 
+test_cases += [
+    (
+        "age(timestamp,timestamp)",
+        "WHERE age(col_timestamp, '2019-01-01'::timestamp) IS NOT NULL",
+        "age",
+    ),
+    (
+        "isfinite(date)",
+        "WHERE isfinite(col_date)",
+        "isfinite",
+    ),
+    (
+        "isfinite(timestamp)",
+        "WHERE isfinite(col_timestamp)",
+        "isfinite",
+    ),
+    (
+        "isfinite(timestamptz)",
+        "WHERE isfinite(col_timestamptz)",
+        "isfinite",
+    ),
+]
+
 
 # Use the first element of each tuple for the ids parameter by extracting it with a list comprehension
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Extend the pushdown allow-lists for built-in functions and operators (follow-up to #372):

- **Unconditional pushdown candidates** — functions/operators DuckDB already exposes under the same name with identical semantics, so no rewrite is needed:
  - text: `char_length`, `character_length`, `translate`
  - time/timetz ± interval: `time_pl_interval`, `time_mi_interval`, `timetz_pl_interval`, `timetz_mi_interval`
  - interval: unary minus (`interval_um`), multiply by float8 (`interval_mul`, `mul_d_interval`)
  - timestamp/date: `age(timestamp, timestamp)`, `isfinite(date/timestamp/timestamptz)`
- **Correctness-fixing rewrite** — `to_hex(int4)`/`to_hex(int8)`: DuckDB's `to_hex()` returns uppercase hex and has no `INTEGER` overload, so an `int4` argument is sign-extended to `BIGINT` rather than zero-extended as Postgres does (e.g. `to_hex(-1::int4)` would come back `ffffffffffffffff` instead of `ffffffff`). Rather than reject this candidate, we added a rewrite rule that masks `int4` inputs to 32 bits before widening and wraps the result in `lower(...)` to match Postgres output exactly.

Regression tests were added in `pg_lake_table` covering pushdown detection and result equivalence against a heap-table baseline for all of the above.

## Correctness verification

Rather than relying on source-reading alone, we ran an empirical pass: a standalone PostgreSQL 18.4 instance and a standalone `pgduck_server` (DuckDB v1.4.4) side by side, comparing results for the same SQL expressions directly. Every function/operator here was confirmed matching across normal values, NULL, and edge cases — including `to_hex` across NULL, 0, ±1, and the `int4`/`int8` extremes (`INT32_MIN/MAX`, `INT64_MIN/MAX`).

One caveat, not disqualifying: DuckDB's `interval` type can't represent infinity, while PostgreSQL 18 does and propagates it through arithmetic — so `interval_um`/`interval_mul`/`mul_d_interval` would diverge if a caller constructed an infinite interval (PostgreSQL returns `infinity`, DuckDB errors). This isn't new risk — the existing shipped `interval + interval`/`interval - interval` operators already have the same gap. `time`/`timetz` arithmetic errors on both engines for an infinite interval operand (different messages), so that failure mode stays consistent rather than a silent wrong answer.

## Benchmark results

Manual timing over a 500,000-row Parquet-backed foreign table, one `count(*)` per predicate. "Before" is unmodified `main` (predicate evaluated as a local `Filter`); "after" is this branch (predicate pushed into the remote DuckDB scan, confirmed via `EXPLAIN VERBOSE`).

| Function/operator | Before (main) | After (pushdown) | Speedup |
|---|---|---|---|
| `age(timestamp,timestamp)` | 1048.5 ms | 12.4 ms | ~85x |
| `isfinite(date/timestamp/timestamptz)` | ~900–1170 ms | ~5.5–6.8 ms | ~140–180x |
| `char_length`/`character_length` | ~1163 ms | ~5.6 ms | ~206x |
| `translate(text,text,text)` | 1116.9 ms | 33.6 ms | ~33x |
| `interval_mul`/`mul_d_interval` | ~1290–1300 ms | ~44.9–45.1 ms | ~29x |
| `interval_um` (unary `-`) | 1126.3 ms | 43.2 ms | ~26x |
| `time`/`timetz` ± `interval` (4 variants) | ~1280–1330 ms | ~44.5–45.4 ms | ~28–30x |

`to_hex` was correctness-tested (see above) but not separately benchmarked — it's a `lower(to_hex(...))` rewrite of the same shape as the other pushed-down scalar functions above, not a new pushdown mechanism.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**
