### PR TITLE
Anchor object_store tables to the object store catalog's own root

### DIFF
--- a/pg_lake_iceberg/src/init.c
+++ b/pg_lake_iceberg/src/init.c
@@ -56,7 +56,7 @@ int			IcebergAutovacuumLogMinDuration = 600000;
 
 static bool DeprecatedEnableStatsCollectionForNestedTypes;
 
-static bool IcebergDefaultLocationCheckHook(char **newvalue, void **extra, GucSource source);
+static bool IcebergLocationPrefixCheckHook(char **newvalue, void **extra, GucSource source);
 static bool IcebergDefaultCatalogCheckHook(char **newvalue, void **extra, GucSource source);
 
 /* function declarations */
@@ -199,7 +199,7 @@ _PG_init(void)
 							   NULL,
 							   PGC_SUSET,
 							   0,
-							   IcebergDefaultLocationCheckHook, NULL, NULL);
+							   IcebergLocationPrefixCheckHook, NULL, NULL);
 
 	DefineCustomStringVariable("pg_lake_iceberg.default_catalog",
 							   gettext_noop("Specifies the default catalog for "
@@ -214,14 +214,17 @@ _PG_init(void)
 							   IcebergDefaultCatalogCheckHook, NULL, NULL);
 
 	DefineCustomStringVariable("pg_lake_iceberg.object_store_catalog_location_prefix",
-							   gettext_noop("Specifies the location prefix for "
-											"object store catalog files."),
-							   NULL,
+							   gettext_noop("Specifies the storage root of the "
+											OBJECT_STORE_CATALOG_NAME " catalog."),
+							   gettext_noop("Both the catalog files and the tables the catalog "
+											"describes are placed under this prefix, so a reader "
+											"authorized for it can resolve the catalog and read "
+											"every table the catalog references."),
 							   &ObjectStoreCatalogLocationPrefix,
 							   NULL,
 							   PGC_SIGHUP,
 							   0,
-							   NULL, NULL, NULL);
+							   IcebergLocationPrefixCheckHook, NULL, NULL);
 
 	DefineCustomBoolVariable("pg_lake_iceberg.enable_manifest_merge_on_write",
 							 "Enables merging manifest files after each data modification.",
@@ -387,28 +390,37 @@ _PG_init(void)
 }
 
 
+/*
+ * IcebergLocationPrefixCheckHook validates a GUC that pg_lake uses as the base
+ * of a composed table location.  PostgreSQL already names the offending
+ * parameter in the primary error, so the details stay generic.
+ */
 static bool
-IcebergDefaultLocationCheckHook(char **newvalue, void **extra, GucSource source)
+IcebergLocationPrefixCheckHook(char **newvalue, void **extra, GucSource source)
 {
 	char	   *newLocationPrefix = *newvalue;
 
 	if (newLocationPrefix == NULL)
 	{
-		/* default location not set */
+		/* prefix not set */
 		return true;
 	}
 
 	if (!IsSupportedURL(newLocationPrefix))
 	{
-		GUC_check_errdetail("pg_lake_iceberg: unsupported URL for default location prefix: \"%s\"",
+		GUC_check_errdetail("pg_lake_iceberg: unsupported URL for location prefix: \"%s\"",
 							newLocationPrefix);
 		return false;
 	}
 
+	/*
+	 * A '?' would land mid-path once pg_lake appends the table path onto the
+	 * prefix.
+	 */
 	if (strchr(newLocationPrefix, '?') != NULL)
 	{
 		GUC_check_errdetail("pg_lake_iceberg: s3 configuration parameters are not allowed "
-							"in the default location prefix");
+							"in a location prefix");
 		return false;
 	}
 

--- a/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
+++ b/pg_lake_iceberg/src/object_store_catalog/object_store_catalog.c
@@ -550,7 +550,7 @@ GetExternalObjectStoreCatalogFilePath(const char *catalogName)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("pg_lake_iceberg.external_object_store_prefix is not set"),
+				 errmsg("pg_lake_iceberg.external_object_store_catalog_prefix is not set"),
 				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 
@@ -575,7 +575,7 @@ GetInternalObjectStoreCatalogFilePath(const char *catalogName)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("pg_lake_iceberg.internal_object_store_prefix is not set"),
+				 errmsg("pg_lake_iceberg.internal_object_store_catalog_prefix is not set"),
 				 errdetail("Set the GUC to use catalog=" OBJECT_STORE_CATALOG_NAME)));
 	}
 

--- a/pg_lake_table/src/ddl/create_table.c
+++ b/pg_lake_table/src/ddl/create_table.c
@@ -1028,7 +1028,7 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		{
 			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 							errmsg(OBJECT_STORE_CATALOG_NAME " catalog iceberg tables require "
-								   "pg_lake_iceberg.internal_iceberg_storage_prefix "
+								   "pg_lake_iceberg.internal_object_store_catalog_prefix "
 								   "to be set")));
 		}
 
@@ -1036,11 +1036,16 @@ ProcessCreateIcebergTableFromForeignTableStmt(ProcessUtilityParams * params)
 		Assert(!HasReadOnlyOption(createStmt->options));
 
 		/*
-		 * For hasObjectStoreCatalogOption, we also append
-		 * InternalObjectStorePrefix/tables to the location
+		 * Anchor the table under the object store catalog's own root rather
+		 * than pg_lake_iceberg.default_location_prefix.  catalog.json is
+		 * composed from this root and records absolute metadata locations, so
+		 * any other anchor publishes a catalog that points outside its own
+		 * storage, and a reader authorized for the catalog's root then fails
+		 * on every data read.  The "tables" segment keeps the tables siblings
+		 * of the "catalog" segment.
 		 */
 		defaultLocationPrefix = psprintf("%s/%s/%s",
-										 defaultLocationPrefix,
+										 objectStoreCatalogLocationPrefix,
 										 InternalObjectStorePrefix,
 										 "tables");
 	}

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -947,11 +947,45 @@ def test_create_table_with_default_location_object_store(
 
 # Every other fixture points both candidate anchors at the same bucket, which
 # makes them indistinguishable. These pull them apart. Both stay writable, so a
-# regression fails on the recorded location rather than on S3 permissions.
+# regression fails on the recorded location rather than on S3 permissions. The
+# internal and external catalog prefixes are distinct too, so resolving either
+# path through the wrong one is caught rather than hidden by a shared value.
 OBJECT_STORE_MANAGED_PATH = "object_store_managed_root"
 OBJECT_STORE_MANAGED_ROOT = f"s3://{TEST_BUCKET}/{OBJECT_STORE_MANAGED_PATH}"
 OBJECT_STORE_DIVERTED_ROOT = f"s3://{TEST_BUCKET}/object_store_diverted_root"
-OBJECT_STORE_DIVERTED_CATALOG_PREFIX = "tmp_divert"
+OBJECT_STORE_INTERNAL_CATALOG_PREFIX = "tmp_divert_internal"
+OBJECT_STORE_EXTERNAL_CATALOG_PREFIX = "tmp_divert_external"
+
+
+def wait_for_internal_catalog_entry(s3, key, table_name, timeout=15.0):
+    """Poll the internal catalog.json in storage until it lists table_name.
+
+    Deliberately reads storage rather than going through
+    lake_iceberg.list_object_store_tables(), which gates even an internal
+    listing on the external catalog file existing and so cannot be used while
+    the two catalog prefixes differ.
+    """
+    deadline = time.monotonic() + timeout
+    last_seen = None
+
+    while time.monotonic() < deadline:
+        try:
+            last_seen = json.loads(
+                s3.get_object(Bucket=TEST_BUCKET, Key=key)["Body"].read()
+            )
+        except s3.exceptions.NoSuchKey:
+            time.sleep(0.1)
+            continue
+
+        for table in last_seen.get("tables", []):
+            if table["table-name"] == table_name:
+                return table
+
+        time.sleep(0.1)
+
+    raise AssertionError(
+        f"{table_name} never appeared in {key}; last read: {last_seen}"
+    )
 
 
 @pytest.fixture(scope="function")
@@ -959,8 +993,8 @@ def diverted_default_location_prefix(pg_conn, superuser_conn, s3, extension):
     superuser_conn.autocommit = True
     for guc, value in (
         ("object_store_catalog_location_prefix", OBJECT_STORE_MANAGED_ROOT),
-        ("internal_object_store_catalog_prefix", OBJECT_STORE_DIVERTED_CATALOG_PREFIX),
-        ("external_object_store_catalog_prefix", OBJECT_STORE_DIVERTED_CATALOG_PREFIX),
+        ("internal_object_store_catalog_prefix", OBJECT_STORE_INTERNAL_CATALOG_PREFIX),
+        ("external_object_store_catalog_prefix", OBJECT_STORE_EXTERNAL_CATALOG_PREFIX),
     ):
         run_command(
             f"ALTER SYSTEM SET pg_lake_iceberg.{guc} = '{value}'", superuser_conn
@@ -1013,7 +1047,15 @@ def test_object_store_table_ignores_diverted_default_location_prefix(
     )
     run_command(f"INSERT INTO {schema}.tbl VALUES (1),(2),(3)", pg_conn)
     pg_conn.commit()
-    wait_until_object_store_writable_table_pushed(pg_conn, schema, "tbl")
+
+    # The catalog file and the table it points at must share a root, so read
+    # the catalog from the managed root and require the published entry to be
+    # the location asserted below.
+    catalog_key = (
+        f"{OBJECT_STORE_MANAGED_PATH}/{OBJECT_STORE_INTERNAL_CATALOG_PREFIX}"
+        f"/catalog/{dbname}/catalog.json"
+    )
+    entry = wait_for_internal_catalog_entry(s3, catalog_key, "tbl")
 
     table_oid = run_query(
         f"SELECT oid FROM pg_class WHERE oid = '{schema}.tbl'::regclass", pg_conn
@@ -1025,7 +1067,7 @@ def test_object_store_table_ignores_diverted_default_location_prefix(
     )[0][0]
 
     expected_prefix = (
-        f"{OBJECT_STORE_MANAGED_ROOT}/{OBJECT_STORE_DIVERTED_CATALOG_PREFIX}/tables/"
+        f"{OBJECT_STORE_MANAGED_ROOT}/{OBJECT_STORE_INTERNAL_CATALOG_PREFIX}/tables/"
         f"{dbname}/{schema}/tbl/{table_oid}/"
     )
     assert metadata_location.startswith(expected_prefix), (
@@ -1033,17 +1075,6 @@ def test_object_store_table_ignores_diverted_default_location_prefix(
         f"{expected_prefix}, got {metadata_location}"
     )
     assert OBJECT_STORE_DIVERTED_ROOT not in metadata_location
-
-    # The catalog file and the table it points at must share a root, and the
-    # published entry has to be the location asserted above.
-    catalog_key = (
-        f"{OBJECT_STORE_MANAGED_PATH}/{OBJECT_STORE_DIVERTED_CATALOG_PREFIX}"
-        f"/catalog/{dbname}/catalog.json"
-    )
-    catalog = json.loads(
-        s3.get_object(Bucket=TEST_BUCKET, Key=catalog_key)["Body"].read()
-    )
-    entry = next(t for t in catalog["tables"] if t["table-name"] == "tbl")
     assert entry["metadata-location"] == metadata_location
 
     assert run_query(f"SELECT count(*) FROM {schema}.tbl", pg_conn) == [[3]]
@@ -1116,6 +1147,12 @@ def test_object_store_table_without_default_location_prefix(
     dbname = run_query("SELECT current_database()", pg_conn)[0][0]
 
     run_command("RESET pg_lake_iceberg.default_location_prefix", pg_conn)
+    # RESET restores the reset value, not necessarily NULL, so confirm the GUC
+    # really is unset -- otherwise this asserts nothing about the unset case.
+    assert (
+        run_query("SHOW pg_lake_iceberg.default_location_prefix", pg_conn)[0][0] == ""
+    )
+
     run_command(f"CREATE SCHEMA {schema}", pg_conn)
     run_command(
         f"CREATE TABLE {schema}.tbl(a int) USING iceberg WITH (catalog='object_store')",

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -945,6 +945,209 @@ def test_create_table_with_default_location_object_store(
     pg_conn.commit()
 
 
+# Every other fixture points both candidate anchors at the same bucket, which
+# makes them indistinguishable. These pull them apart. Both stay writable, so a
+# regression fails on the recorded location rather than on S3 permissions.
+OBJECT_STORE_MANAGED_PATH = "object_store_managed_root"
+OBJECT_STORE_MANAGED_ROOT = f"s3://{TEST_BUCKET}/{OBJECT_STORE_MANAGED_PATH}"
+OBJECT_STORE_DIVERTED_ROOT = f"s3://{TEST_BUCKET}/object_store_diverted_root"
+OBJECT_STORE_DIVERTED_CATALOG_PREFIX = "tmp_divert"
+
+
+@pytest.fixture(scope="function")
+def diverted_default_location_prefix(pg_conn, superuser_conn, s3, extension):
+    superuser_conn.autocommit = True
+    for guc, value in (
+        ("object_store_catalog_location_prefix", OBJECT_STORE_MANAGED_ROOT),
+        ("internal_object_store_catalog_prefix", OBJECT_STORE_DIVERTED_CATALOG_PREFIX),
+        ("external_object_store_catalog_prefix", OBJECT_STORE_DIVERTED_CATALOG_PREFIX),
+    ):
+        run_command(
+            f"ALTER SYSTEM SET pg_lake_iceberg.{guc} = '{value}'", superuser_conn
+        )
+    run_command("SELECT pg_reload_conf()", superuser_conn)
+    # bg workers need a moment to pick up the reload
+    run_command("SELECT pg_sleep(0.2)", superuser_conn)
+    superuser_conn.autocommit = False
+
+    for conn in (pg_conn, superuser_conn):
+        run_command(
+            f"SET pg_lake_iceberg.default_location_prefix TO '{OBJECT_STORE_DIVERTED_ROOT}'",
+            conn,
+        )
+        conn.commit()
+
+    yield
+
+    for conn in (pg_conn, superuser_conn):
+        conn.rollback()
+        run_command("RESET pg_lake_iceberg.default_location_prefix", conn)
+        conn.commit()
+
+    superuser_conn.autocommit = True
+    for guc in (
+        "object_store_catalog_location_prefix",
+        "internal_object_store_catalog_prefix",
+        "external_object_store_catalog_prefix",
+    ):
+        run_command(f"ALTER SYSTEM RESET pg_lake_iceberg.{guc}", superuser_conn)
+    run_command("SELECT pg_reload_conf()", superuser_conn)
+    run_command("SELECT pg_sleep(0.2)", superuser_conn)
+    superuser_conn.autocommit = False
+
+
+# catalog.json records absolute metadata locations, so an object_store table has
+# to land under the catalog's own root. Were it to follow
+# default_location_prefix, the published catalog would hand out pointers to
+# storage its readers are not authorized for.
+def test_object_store_table_ignores_diverted_default_location_prefix(
+    pg_conn, superuser_conn, s3, extension, diverted_default_location_prefix
+):
+    schema = "object_store_sc1"
+    dbname = run_query("SELECT current_database()", pg_conn)[0][0]
+
+    run_command(f"CREATE SCHEMA {schema}", pg_conn)
+    run_command(
+        f"CREATE TABLE {schema}.tbl(a int) USING iceberg WITH (catalog='object_store')",
+        pg_conn,
+    )
+    run_command(f"INSERT INTO {schema}.tbl VALUES (1),(2),(3)", pg_conn)
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, schema, "tbl")
+
+    table_oid = run_query(
+        f"SELECT oid FROM pg_class WHERE oid = '{schema}.tbl'::regclass", pg_conn
+    )[0][0]
+    metadata_location = run_query(
+        f"""SELECT metadata_location FROM iceberg_tables
+            WHERE table_namespace = '{schema}' AND table_name = 'tbl'""",
+        pg_conn,
+    )[0][0]
+
+    expected_prefix = (
+        f"{OBJECT_STORE_MANAGED_ROOT}/{OBJECT_STORE_DIVERTED_CATALOG_PREFIX}/tables/"
+        f"{dbname}/{schema}/tbl/{table_oid}/"
+    )
+    assert metadata_location.startswith(expected_prefix), (
+        f"object_store table should be anchored to the catalog root "
+        f"{expected_prefix}, got {metadata_location}"
+    )
+    assert OBJECT_STORE_DIVERTED_ROOT not in metadata_location
+
+    # The catalog file and the table it points at must share a root, and the
+    # published entry has to be the location asserted above.
+    catalog_key = (
+        f"{OBJECT_STORE_MANAGED_PATH}/{OBJECT_STORE_DIVERTED_CATALOG_PREFIX}"
+        f"/catalog/{dbname}/catalog.json"
+    )
+    catalog = json.loads(
+        s3.get_object(Bucket=TEST_BUCKET, Key=catalog_key)["Body"].read()
+    )
+    entry = next(t for t in catalog["tables"] if t["table-name"] == "tbl")
+    assert entry["metadata-location"] == metadata_location
+
+    assert run_query(f"SELECT count(*) FROM {schema}.tbl", pg_conn) == [[3]]
+
+    run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+# Control for the test above: the postgres catalog has no object-store root to
+# anchor to, so default_location_prefix stays the right base there. This test
+# can only pass if the fixture genuinely diverted the GUC, which is what keeps
+# the assertion above from being vacuously green.
+def test_postgres_catalog_table_follows_default_location_prefix(
+    pg_conn, superuser_conn, s3, extension, diverted_default_location_prefix
+):
+    schema = "object_store_sc2"
+
+    run_command(f"CREATE SCHEMA {schema}", pg_conn)
+    # Name the catalog rather than relying on pg_lake_iceberg.default_catalog,
+    # which another test in this module may have left pointing elsewhere.
+    run_command(
+        f"CREATE TABLE {schema}.tbl(a int) USING iceberg WITH (catalog='postgres')",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    metadata_location = run_query(
+        f"""SELECT metadata_location FROM iceberg_tables
+            WHERE table_namespace = '{schema}' AND table_name = 'tbl'""",
+        pg_conn,
+    )[0][0]
+
+    assert metadata_location.startswith(f"{OBJECT_STORE_DIVERTED_ROOT}/")
+    assert OBJECT_STORE_MANAGED_ROOT not in metadata_location
+
+    run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+# The object store root is the base of every composed table location, so it is
+# validated like default_location_prefix: a '?' would otherwise land mid-path.
+@pytest.mark.parametrize(
+    "location", ["invalid_loc/", f"s3://{TEST_BUCKET}/managed/?region=us-west-2"]
+)
+def test_object_store_catalog_location_prefix_is_validated(
+    superuser_conn, s3, extension, location
+):
+    superuser_conn.autocommit = True
+    try:
+        error = run_command(
+            f"ALTER SYSTEM SET pg_lake_iceberg.object_store_catalog_location_prefix = '{location}'",
+            superuser_conn,
+            raise_error=False,
+        )
+        assert (
+            'invalid value for parameter "pg_lake_iceberg.object_store_catalog_location_prefix"'
+            in str(error)
+        )
+    finally:
+        superuser_conn.autocommit = False
+
+
+# The object store root is the only prefix an object_store table needs; the
+# create path used to compose the location from default_location_prefix and so
+# produced a garbage base whenever that GUC was unset.
+def test_object_store_table_without_default_location_prefix(
+    pg_conn, superuser_conn, s3, extension, adjust_object_store_settings
+):
+    schema = "object_store_sc1"
+    dbname = run_query("SELECT current_database()", pg_conn)[0][0]
+
+    run_command("RESET pg_lake_iceberg.default_location_prefix", pg_conn)
+    run_command(f"CREATE SCHEMA {schema}", pg_conn)
+    run_command(
+        f"CREATE TABLE {schema}.tbl(a int) USING iceberg WITH (catalog='object_store')",
+        pg_conn,
+    )
+    run_command(f"INSERT INTO {schema}.tbl VALUES (1),(2)", pg_conn)
+    pg_conn.commit()
+    wait_until_object_store_writable_table_pushed(pg_conn, schema, "tbl")
+
+    catalog_prefix = run_query(
+        "SHOW pg_lake_iceberg.internal_object_store_catalog_prefix", superuser_conn
+    )[0][0]
+    superuser_conn.commit()
+
+    table_oid = run_query(
+        f"SELECT oid FROM pg_class WHERE oid = '{schema}.tbl'::regclass", pg_conn
+    )[0][0]
+    metadata_location = run_query(
+        f"""SELECT metadata_location FROM iceberg_tables
+            WHERE table_namespace = '{schema}' AND table_name = 'tbl'""",
+        pg_conn,
+    )[0][0]
+
+    assert metadata_location.startswith(
+        f"s3://{TEST_BUCKET}/{catalog_prefix}/tables/{dbname}/{schema}/tbl/{table_oid}/"
+    ), metadata_location
+    assert run_query(f"SELECT count(*) FROM {schema}.tbl", pg_conn) == [[2]]
+
+    run_command(f"DROP SCHEMA {schema} CASCADE", pg_conn)
+    pg_conn.commit()
+
+
 def test_complex_types_object_store(
     pg_conn, s3, extension, with_default_location, adjust_object_store_settings
 ):

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1134,6 +1134,13 @@ def test_object_store_catalog_location_prefix_is_validated(
             in str(error)
         )
     finally:
+        # A rejected ALTER SYSTEM writes nothing, so this is only here to keep a
+        # regression in the check hook from leaving the bad value behind and
+        # failing every later test in the module instead of just this one.
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.object_store_catalog_location_prefix",
+            superuser_conn,
+        )
         superuser_conn.autocommit = False
 
 
@@ -1162,10 +1169,17 @@ def test_object_store_table_without_default_location_prefix(
     pg_conn.commit()
     wait_until_object_store_writable_table_pushed(pg_conn, schema, "tbl")
 
+    # Read both halves of the expected anchor from the server rather than
+    # restating what adjust_object_store_settings happens to set, so the
+    # assertion keeps testing the composition if that fixture ever moves.
+    catalog_root = run_query(
+        "SHOW pg_lake_iceberg.object_store_catalog_location_prefix", superuser_conn
+    )[0][0]
     catalog_prefix = run_query(
         "SHOW pg_lake_iceberg.internal_object_store_catalog_prefix", superuser_conn
     )[0][0]
     superuser_conn.commit()
+    assert catalog_root and catalog_prefix
 
     table_oid = run_query(
         f"SELECT oid FROM pg_class WHERE oid = '{schema}.tbl'::regclass", pg_conn
@@ -1177,7 +1191,7 @@ def test_object_store_table_without_default_location_prefix(
     )[0][0]
 
     assert metadata_location.startswith(
-        f"s3://{TEST_BUCKET}/{catalog_prefix}/tables/{dbname}/{schema}/tbl/{table_oid}/"
+        f"{catalog_root}/{catalog_prefix}/tables/{dbname}/{schema}/tbl/{table_oid}/"
     ), metadata_location
     assert run_query(f"SELECT count(*) FROM {schema}.tbl", pg_conn) == [[2]]
 


### PR DESCRIPTION
Fixes #603.

## The inconsistency

For `catalog=object_store` tables, the catalog file and the table data are composed from **different** base prefixes, even though the rest of their paths are deliberately parallel:

| | base prefix | composition |
|---|---|---|
| internal `catalog.json` | `GetObjectStoreDefaultLocationPrefix()` (`object_store_catalog.c:564`) | `<base>/<InternalObjectStorePrefix>/catalog/<name>/catalog.json` (`:582`) |
| external `catalog.json` | `GetObjectStoreDefaultLocationPrefix()` (`:539`) | `<base>/<ExternalObjectStorePrefix>/catalog/<name>/catalog.json` (`:557`) |
| **table location** | `GetIcebergDefaultLocationPrefix()` (`create_table.c:1013`) | `<base>/<InternalObjectStorePrefix>/tables` (`:1042`) |

Neither getter falls back to the other — both are just `StripTrailingSlash` of their own GUC — so when the two GUCs differ the tree genuinely splits. The `catalog/` and `tables/` segments sit under the same `InternalObjectStorePrefix`, so they are designed as siblings in one tree, which only holds if the base agrees.

## Why it matters

`PushMetadataLocationToObjectStoreCatalog` writes `metadata-location` straight out of `lake_iceberg.tables_internal`, i.e. an **absolute** URI. So the published catalog hands out pointers outside its own storage. A consumer that resolves the catalog and then reads tables with credentials scoped to the catalog's storage resolves the pointer successfully and gets `403 AccessDenied` on every data read, which no retry clears.

Since `default_location_prefix` is the documented knob for pointing pg_lake at your own bucket (`README.md`, `docs/iceberg-tables.md`, the dbt guide), setting it for an ordinary reason is enough to split the tree.

## The fix

Compose the table location from `objectStoreCatalogLocationPrefix` — the value the branch already fetches at `create_table.c:1017` and requires to be non-NULL at `:1019`.

This is consistent with how the `rest` catalog already behaves rather than a new rule: `RestCatalogOptions.locationPrefix` is a per-server `location_prefix` option (`rest_catalog_options.c:108`) that seeds from `default_location_prefix` only as a *fallback* (`rest_catalog.c:100`) and composes the table location at `rest_catalog_ops.c:282`. The established pattern is "a catalog owns its storage root, `default_location_prefix` is the fallback"; `object_store` was the one catalog that had its own storage-root GUC and ignored it for placement.

### Scope

`create_table.c:1013-1045` is the only site composing object_store table locations, and the location is persisted into `ftoptions` at the post-create hook, so nothing is ever recomposed. Tables on the `postgres` and `rest` catalogs are untouched, and this is a no-op on any deployment where the two prefixes already agree. Existing tables are **not** relocated, so anything already created under a diverted prefix needs recreating.

### Two consequences worth review

**`default_location_prefix` is now irrelevant for object_store tables.** Previously, leaving it unset meant `psprintf` formatted a NULL pointer into the base, yielding `(null)/frompg/tables/...`, which is non-NULL and so passed the guard at `:1069` before `IsSupportedURL` rejected it downstream. That was reachable in exactly the configuration the branch's own validation implies is sufficient — object-store prefix set, default unset — and is masked today because every object_store fixture pairs `adjust_object_store_settings` with `with_default_location`. (`test_writable_object_store_without_default_location_guc` omits the default but also omits the object-store prefix, so the earlier guard fires first; its `# make sure nothing crashes` comment suggests this was already suspected.) There is a new test for it.

**`object_store_catalog_location_prefix` gets a check hook.** It now anchors every table location rather than one fixed catalog path, so it needs the same validation `default_location_prefix` has — a `?` in the base would otherwise land mid-path on composed URLs, which is precisely why that check exists. `IcebergDefaultLocationCheckHook` is renamed to `IcebergLocationPrefixCheckHook` and shared. Its description, which said "location prefix for object store catalog **files**", is updated to cover table data too — that wording is the one piece of evidence the split may have been intentional, so it should not be left standing either way.

## Tests

The inconsistency survived because every fixture and the documented dev setup point both prefixes at the same bucket, making the two candidate anchors indistinguishable. The new fixture pulls them apart, keeping both writable so a regression fails on the recorded location rather than on storage permissions.

- `test_object_store_table_ignores_diverted_default_location_prefix` — asserts the recorded location *and* that the entry published in `catalog.json` matches it, so the catalog and the table it references are checked to share a root.
- `test_postgres_catalog_table_follows_default_location_prefix` — the control. The postgres catalog has no object-store root to anchor to, so `default_location_prefix` stays correct there. It can only pass if the fixture genuinely diverted the GUC, which is what keeps the assertion above from being vacuously green.
- `test_object_store_table_without_default_location_prefix` — covers the NULL-prefix case described above.
- `test_object_store_catalog_location_prefix_is_validated` — the new check hook rejects a bad URL and a `?`.

**Verified the tests bite.** With the anchor line reverted, the two behavior tests fail (landing under the diverted root) while the control and the validation tests still pass.

## Test plan

- [x] `make check-indent` clean
- [x] `test_object_store_catalog.py`, `test_create_table.py`, `test_security.py`: 62 passed, 0 failed
- [x] `test_iceberg_catalog_server.py` green
- [x] New tests confirmed to fail with the fix reverted
- [ ] CI on PG16/17/18


---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---