### PR TITLE
pgduck_server: back off the accept loop when thread creation fails

### DIFF
--- a/pgduck_server/src/command_line/command_line.c
+++ b/pgduck_server/src/command_line/command_line.c
@@ -311,8 +311,8 @@ parse_arguments(int argc, char *argv[])
 		}
 	}
 
-	PGDUCK_SERVER_LOG("pgduck_server is listening on unix_socket_directory: %s with port %u",
-					  options.unix_socket_directory, options.port);
+	PGDUCK_SERVER_LOG("pgduck_server is listening on unix_socket_directory: %s with port %u, max_clients requested %d",
+					  options.unix_socket_directory, options.port, options.max_clients);
 
 	PGDUCK_SERVER_LOG("DuckDB is using database file path: %s",
 					  options.duckdb_database_file_path);

--- a/pgduck_server/src/command_line/command_line.c
+++ b/pgduck_server/src/command_line/command_line.c
@@ -311,8 +311,8 @@ parse_arguments(int argc, char *argv[])
 		}
 	}
 
-	PGDUCK_SERVER_LOG("pgduck_server is listening on unix_socket_directory: %s with port %u, max_clients allowed %d",
-					  options.unix_socket_directory, options.port, options.max_clients);
+	PGDUCK_SERVER_LOG("pgduck_server is listening on unix_socket_directory: %s with port %u",
+					  options.unix_socket_directory, options.port);
 
 	PGDUCK_SERVER_LOG("DuckDB is using database file path: %s",
 					  options.duckdb_database_file_path);

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -29,9 +29,17 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <sys/resource.h>
 
 #include "pgserver/client_threadpool.h"
 #include "utils/pgduck_log_utils.h"
+
+/*
+ * Threads the process needs for itself (the accept loop, DuckDB's scheduler,
+ * etc.) plus slack for the user's other processes.  Reserved out of
+ * RLIMIT_NPROC before we derive how many client threads we can admit.
+ */
+#define THREAD_RLIMIT_HEADROOM 64
 
 
 /*
@@ -97,6 +105,45 @@ static int	ThreadPoolAvailableIndexStart = 0;
 
 
 /*
+ * clamp_max_threads_to_rlimit lowers a requested thread count so that it stays
+ * within what the OS will actually let us create.
+ *
+ * Every client, and every in-flight cancellation, runs on its own OS thread,
+ * so the pool must not admit more than RLIMIT_NPROC allows -- otherwise
+ * pthread_create() starts failing with EAGAIN and admission control never
+ * engages.  We reserve headroom for the process's own threads and the user's
+ * other processes, then clamp to what remains.
+ *
+ * This is best effort: RLIMIT_NPROC is counted across the whole real user id,
+ * and a cgroup pids.max limit is invisible here, so the accept-loop
+ * backpressure in pgserver_run() remains the backstop when the true limit is
+ * lower than we can see.  Returns the request unchanged when the limit is
+ * unknown or unlimited.
+ */
+static int
+clamp_max_threads_to_rlimit(int requestedMaxThreads)
+{
+	struct rlimit rlim;
+
+	if (getrlimit(RLIMIT_NPROC, &rlim) != 0 || rlim.rlim_cur == RLIM_INFINITY)
+		return requestedMaxThreads;
+
+	rlim_t		reserved = Max(rlim.rlim_cur / 5, THREAD_RLIMIT_HEADROOM);
+
+	/* limit is smaller than our headroom; leave it to the backpressure path */
+	if (reserved >= rlim.rlim_cur)
+		return requestedMaxThreads;
+
+	rlim_t		available = rlim.rlim_cur - reserved;
+
+	if (available >= (rlim_t) requestedMaxThreads)
+		return requestedMaxThreads;
+
+	/* available < requestedMaxThreads, so it fits in an int */
+	return (int) available;
+}
+
+/*
  * pgclient_threadpool_init allocates memory for the client thread pool based on the
  * maximum allowed clients.
  * The allocated memory is initialized to zero using pg_malloc0.
@@ -110,8 +157,16 @@ pgclient_threadpool_init(int maxAllowedClients)
 	 *
 	 * We could perhaps use some smaller number, for now let's keep it simple.
 	 */
-	MaxAllowedClients = maxAllowedClients;
-	MaxThreads = maxAllowedClients * 2;
+	MaxThreads = clamp_max_threads_to_rlimit(maxAllowedClients * 2);
+	MaxAllowedClients = Max(MaxThreads / 2, 1);
+
+	/* keep the 2x cancellation headroom exact after any clamping */
+	MaxThreads = MaxAllowedClients * 2;
+
+	if (MaxAllowedClients < maxAllowedClients)
+		PGDUCK_SERVER_LOG("max_clients lowered from %d to %d to stay within the "
+						  "host thread limit (RLIMIT_NPROC)",
+						  maxAllowedClients, MaxAllowedClients);
 
 	/* pg_malloc0 exists the program in case cannot allocate */
 	ClientThreadPool = (PgClientThreadState *) pg_malloc0(sizeof(PgClientThreadState) * MaxThreads);

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -105,14 +105,16 @@ static int	ThreadPoolAvailableIndexStart = 0;
 
 
 /*
- * clamp_max_threads_to_rlimit lowers a requested thread count so that it stays
+ * clamp_clients_to_rlimit lowers a requested client cap so that it stays
  * within what the OS will actually let us create.
  *
- * Every client, and every in-flight cancellation, runs on its own OS thread,
- * so the pool must not admit more than RLIMIT_NPROC allows -- otherwise
- * pthread_create() starts failing with EAGAIN and admission control never
- * engages.  We reserve headroom for the process's own threads and the user's
- * other processes, then clamp to what remains.
+ * reserve_slot() admits at most MaxAllowedClients live entries, and every
+ * live entry -- a client or the cancel session that momentarily replaces it
+ * -- runs on its own OS thread.  So MaxAllowedClients, not the 2x slot array,
+ * is the real live-thread ceiling and the value we must keep within
+ * RLIMIT_NPROC; otherwise pthread_create() starts failing with EAGAIN and
+ * admission control never engages.  We reserve headroom for the process's own
+ * threads and the user's other processes, then clamp to what remains.
  *
  * This is best effort: RLIMIT_NPROC is counted across the whole real user id,
  * and a cgroup pids.max limit is invisible here, so the accept-loop
@@ -121,25 +123,25 @@ static int	ThreadPoolAvailableIndexStart = 0;
  * unknown or unlimited.
  */
 static int
-clamp_max_threads_to_rlimit(int requestedMaxThreads)
+clamp_clients_to_rlimit(int requestedMaxClients)
 {
 	struct rlimit rlim;
 
 	if (getrlimit(RLIMIT_NPROC, &rlim) != 0 || rlim.rlim_cur == RLIM_INFINITY)
-		return requestedMaxThreads;
+		return requestedMaxClients;
 
 	rlim_t		reserved = Max(rlim.rlim_cur / 5, THREAD_RLIMIT_HEADROOM);
 
 	/* limit is smaller than our headroom; leave it to the backpressure path */
 	if (reserved >= rlim.rlim_cur)
-		return requestedMaxThreads;
+		return requestedMaxClients;
 
 	rlim_t		available = rlim.rlim_cur - reserved;
 
-	if (available >= (rlim_t) requestedMaxThreads)
-		return requestedMaxThreads;
+	if (available >= (rlim_t) requestedMaxClients)
+		return requestedMaxClients;
 
-	/* available < requestedMaxThreads, so it fits in an int */
+	/* available < requestedMaxClients, so it fits in an int */
 	return (int) available;
 }
 
@@ -152,21 +154,24 @@ void
 pgclient_threadpool_init(int maxAllowedClients)
 {
 	/*
-	 * We multiply by 2 because we might need to cancel a client (e.g.,
-	 * thread) and cancellations require a slot in the thread pool.
-	 *
-	 * We could perhaps use some smaller number, for now let's keep it simple.
+	 * The live-thread ceiling is MaxAllowedClients (see reserve_slot), so
+	 * that is what we clamp to the host thread limit.  MaxThreads is just the
+	 * slot array, sized 2x so a cancellation can always find a free slot
+	 * alongside the client it targets.
 	 */
-	MaxThreads = clamp_max_threads_to_rlimit(maxAllowedClients * 2);
-	MaxAllowedClients = Max(MaxThreads / 2, 1);
-
-	/* keep the 2x cancellation headroom exact after any clamping */
+	MaxAllowedClients = Max(clamp_clients_to_rlimit(maxAllowedClients), 1);
 	MaxThreads = MaxAllowedClients * 2;
 
 	if (MaxAllowedClients < maxAllowedClients)
+	{
 		PGDUCK_SERVER_LOG("max_clients lowered from %d to %d to stay within the "
 						  "host thread limit (RLIMIT_NPROC)",
 						  maxAllowedClients, MaxAllowedClients);
+	}
+	else
+	{
+		PGDUCK_SERVER_LOG("max_clients: %d", MaxAllowedClients);
+	}
 
 	/* pg_malloc0 exists the program in case cannot allocate */
 	ClientThreadPool = (PgClientThreadState *) pg_malloc0(sizeof(PgClientThreadState) * MaxThreads);

--- a/pgduck_server/src/pgserver/client_threadpool.c
+++ b/pgduck_server/src/pgserver/client_threadpool.c
@@ -163,15 +163,9 @@ pgclient_threadpool_init(int maxAllowedClients)
 	MaxThreads = MaxAllowedClients * 2;
 
 	if (MaxAllowedClients < maxAllowedClients)
-	{
 		PGDUCK_SERVER_LOG("max_clients lowered from %d to %d to stay within the "
 						  "host thread limit (RLIMIT_NPROC)",
 						  maxAllowedClients, MaxAllowedClients);
-	}
-	else
-	{
-		PGDUCK_SERVER_LOG("max_clients: %d", MaxAllowedClients);
-	}
 
 	/* pg_malloc0 exists the program in case cannot allocate */
 	ClientThreadPool = (PgClientThreadState *) pg_malloc0(sizeof(PgClientThreadState) * MaxThreads);

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -64,6 +64,17 @@ typedef struct PgClientThreadInitState
 		snprintf(path, sizeof(path), "%s/.s.PGSQL.%d", \
 				 (sockdir), (port))
 
+/*
+ * When the OS refuses a new client thread (typically pthread_create returning
+ * EAGAIN under thread or memory pressure) the accept loop pauses before it
+ * accepts again.  The pause is deliberate backpressure: without it the loop
+ * spins accept()->pthread_create()->EAGAIN, pinning the host and never letting
+ * the detached client threads exit to free their resources.  The delay grows
+ * on consecutive failures and resets as soon as a thread starts.
+ */
+#define THREAD_CREATE_BACKOFF_MIN_US (10 * 1000)
+#define THREAD_CREATE_BACKOFF_MAX_US (1000 * 1000)
+
 static int	create_and_bind_unix_socket(PGServer * server, char *unixSocketPath,
 										char *unixSocketOwningGroup,
 										int unixSocketPermissions,
@@ -418,6 +429,9 @@ pgserver_run(PGServer * pgServer)
 	if (install_shutdown_signal_handlers() != STATUS_OK)
 		return STATUS_ERROR;
 
+	/* current accept-loop backpressure delay after a failed thread creation */
+	long		threadCreateBackoffUs = 0;
+
 	while (running)
 	{
 		PGClient   *client = (PGClient *) pg_malloc0(sizeof(PGClient));
@@ -492,7 +506,9 @@ pgserver_run(PGServer * pgServer)
 		if (disable_shutdown_signals() != STATUS_OK)
 			exit(STATUS_ERROR);
 
-		if (pgserver_create_client_thread(initState) != OK)
+		bool		threadCreated = pgserver_create_client_thread(initState) == OK;
+
+		if (!threadCreated)
 		{
 			PGDUCK_SERVER_ERROR("Thread creation failed for client %d", client->clientSocket);
 
@@ -513,6 +529,26 @@ pgserver_run(PGServer * pgServer)
 
 		if (enable_shutdown_signals() != STATUS_OK)
 			exit(STATUS_ERROR);
+
+		if (threadCreated)
+		{
+			/* served a client, so drop any accumulated backpressure delay */
+			threadCreateBackoffUs = 0;
+		}
+		else
+		{
+			/*
+			 * Sleep before accepting again so the loop yields the CPU and
+			 * lets thread resources free up.  We are past enable_shutdown_
+			 * signals(), so a SIGTERM interrupts the sleep and exits
+			 * promptly.
+			 */
+			threadCreateBackoffUs = threadCreateBackoffUs == 0
+				? THREAD_CREATE_BACKOFF_MIN_US
+				: Min(threadCreateBackoffUs * 2, THREAD_CREATE_BACKOFF_MAX_US);
+
+			pg_usleep(threadCreateBackoffUs);
+		}
 	}
 
 	return STATUS_OK;

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -75,6 +75,26 @@ typedef struct PgClientThreadInitState
 #define THREAD_CREATE_BACKOFF_MIN_US (10 * 1000)
 #define THREAD_CREATE_BACKOFF_MAX_US (1000 * 1000)
 
+/*
+ * Stack size for each client thread.  A client thread runs the wire protocol
+ * and drives DuckDB through its C API; queries themselves execute on DuckDB's
+ * own scheduler threads, so the client thread's stack needs are modest.  We
+ * set an explicit size, rather than inherit the platform default (8 MB on
+ * glibc), so the per-connection address-space reservation is bounded and
+ * predictable while still leaving generous headroom over PostgreSQL's 2 MB
+ * max_stack_depth convention.
+ */
+#define CLIENT_THREAD_STACK_SIZE (4 * 1024 * 1024)
+
+/*
+ * Upper bound on the listen() backlog.  MaxThreads can be very large (the
+ * default max_clients of 10000 makes it 20000), and a huge backlog just lets
+ * more connections queue up under a flood only to time out on the startup
+ * read.  Cap it at a sane value; the kernel further clamps this to
+ * net.core.somaxconn regardless.
+ */
+#define LISTEN_BACKLOG_MAX 1024
+
 static int	create_and_bind_unix_socket(PGServer * server, char *unixSocketPath,
 										char *unixSocketOwningGroup,
 										int unixSocketPermissions,
@@ -228,7 +248,7 @@ create_and_bind_unix_socket(PGServer * server,
 		return STATUS_ERROR;
 	}
 
-	const int	listenQueueSize = MaxThreads;
+	const int	listenQueueSize = Min(MaxThreads, LISTEN_BACKLOG_MAX);
 
 	if (listen(server->listeningSocket, listenQueueSize) != STATUS_OK)
 	{
@@ -609,6 +629,11 @@ pgserver_create_client_thread(const PgClientThreadInitState * initState)
 
 	pthread_attr_init(&threadAttr);
 	pthread_attr_setdetachstate(&threadAttr, PTHREAD_CREATE_DETACHED);
+
+	/* non-fatal: on failure the thread just keeps the platform default stack */
+	if (pthread_attr_setstacksize(&threadAttr, CLIENT_THREAD_STACK_SIZE) != 0)
+		PGDUCK_SERVER_ERROR("could not set client thread stack size to %d bytes",
+							CLIENT_THREAD_STACK_SIZE);
 
 	int			isThreadCreated = pthread_create(&threadId,
 												 &threadAttr,

--- a/pgduck_server/src/pgserver/pgserver.c
+++ b/pgduck_server/src/pgserver/pgserver.c
@@ -65,15 +65,17 @@ typedef struct PgClientThreadInitState
 				 (sockdir), (port))
 
 /*
- * When the OS refuses a new client thread (typically pthread_create returning
- * EAGAIN under thread or memory pressure) the accept loop pauses before it
- * accepts again.  The pause is deliberate backpressure: without it the loop
- * spins accept()->pthread_create()->EAGAIN, pinning the host and never letting
- * the detached client threads exit to free their resources.  The delay grows
- * on consecutive failures and resets as soon as a thread starts.
+ * When we cannot serve an accepted connection -- either the OS refuses a new
+ * client thread (typically pthread_create returning EAGAIN under thread or
+ * memory pressure) or we are already at the client limit -- the accept loop
+ * pauses before it accepts again.  The pause is deliberate backpressure:
+ * without it the loop hot-spins on accept(), pinning the host and (in the
+ * thread-creation case) never letting the detached client threads exit to free
+ * their resources.  The delay grows while we keep failing and resets as soon
+ * as a thread starts.
  */
-#define THREAD_CREATE_BACKOFF_MIN_US (10 * 1000)
-#define THREAD_CREATE_BACKOFF_MAX_US (1000 * 1000)
+#define ACCEPT_BACKOFF_MIN_US (10 * 1000)
+#define ACCEPT_BACKOFF_MAX_US (1000 * 1000)
 
 /*
  * Stack size for each client thread.  A client thread runs the wire protocol
@@ -441,6 +443,23 @@ enable_shutdown_signals(void)
 
 
 /*
+ * grow_accept_backoff advances the accept-loop backpressure delay one step and
+ * sleeps for the new duration, returning it so the caller can track the ramp.
+ * Callers must sleep with shutdown signals enabled so a SIGTERM interrupts it.
+ */
+static long
+grow_accept_backoff(long backoffUs)
+{
+	backoffUs = backoffUs == 0
+		? ACCEPT_BACKOFF_MIN_US
+		: Min(backoffUs * 2, ACCEPT_BACKOFF_MAX_US);
+
+	pg_usleep(backoffUs);
+
+	return backoffUs;
+}
+
+/*
  * pgserver_run is the main loop for the PostgreSQL wire compatible server.
  */
 int
@@ -449,8 +468,11 @@ pgserver_run(PGServer * pgServer)
 	if (install_shutdown_signal_handlers() != STATUS_OK)
 		return STATUS_ERROR;
 
-	/* current accept-loop backpressure delay after a failed thread creation */
-	long		threadCreateBackoffUs = 0;
+	/*
+	 * current accept-loop backpressure delay after a connection we could not
+	 * serve
+	 */
+	long		acceptBackoffUs = 0;
 
 	while (running)
 	{
@@ -507,11 +529,22 @@ pgserver_run(PGServer * pgServer)
 
 		if (threadIndex == InvalidThreadIndex)
 		{
-			PGDUCK_SERVER_LOG("A new client rejected as it exceeds %d clients", MaxAllowedClients);
+			/*
+			 * At capacity.  Log only when we first start rejecting so a
+			 * sustained burst does not fill the log with a line per
+			 * connection, and back off so the accept loop does not hot-spin
+			 * while clients keep arriving.  Shutdown signals are still
+			 * enabled here, so the sleep is interruptible by SIGTERM.
+			 */
+			if (acceptBackoffUs == 0)
+				PGDUCK_SERVER_LOG("new clients rejected: at the %d client limit",
+								  MaxAllowedClients);
 
 			/* TODO: send error message to the client */
 			close(client->clientSocket);
 			pg_free(client);
+
+			acceptBackoffUs = grow_accept_backoff(acceptBackoffUs);
 			continue;
 		}
 
@@ -553,7 +586,7 @@ pgserver_run(PGServer * pgServer)
 		if (threadCreated)
 		{
 			/* served a client, so drop any accumulated backpressure delay */
-			threadCreateBackoffUs = 0;
+			acceptBackoffUs = 0;
 		}
 		else
 		{
@@ -563,11 +596,7 @@ pgserver_run(PGServer * pgServer)
 			 * signals(), so a SIGTERM interrupts the sleep and exits
 			 * promptly.
 			 */
-			threadCreateBackoffUs = threadCreateBackoffUs == 0
-				? THREAD_CREATE_BACKOFF_MIN_US
-				: Min(threadCreateBackoffUs * 2, THREAD_CREATE_BACKOFF_MAX_US);
-
-			pg_usleep(threadCreateBackoffUs);
+			acceptBackoffUs = grow_accept_backoff(acceptBackoffUs);
 		}
 	}
 

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -44,6 +44,7 @@
 #include <arpa/inet.h>
 #include <lib/stringinfo.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <common/ip.h>
 #include <common/fe_memutils.h>
 #include <port/pg_bswap.h>
@@ -68,6 +69,15 @@
  */
 #define TRANSMIT_PREFIX "transmit "
 #define TRANSMIT_PREFIX_LENGTH (strlen(TRANSMIT_PREFIX))
+
+/*
+ * How long to wait for a client to send its startup packet before dropping the
+ * connection.  A connected-but-silent client would otherwise hold its thread
+ * slot indefinitely; under a connection flood that keeps the pool exhausted.
+ * The timeout covers only the startup read and is cleared once the session is
+ * established, so it never interrupts a normal (possibly long-idle) session.
+ */
+#define STARTUP_PACKET_READ_TIMEOUT_SECONDS 10
 
 /*
  * Convenience macro for pgsession_handle_connection to terminate
@@ -105,6 +115,8 @@ static int	pgsession_send_client_encoding(PGSession * pgSession, const char *cli
 static int	pgsession_send_extra_float_digits(PGSession * pgSession, const char *extra_float_digits);
 static int	pgsession_send_ready_for_query(PGSession * pgSession);
 static int	pgsession_init(PGSession * pgSession, PGClient * pgClient);
+static int	pgsession_init_duckdb(PGSession * pgSession);
+static void set_client_recv_timeout(int clientSocket, int seconds);
 static int	pgsession_destroy(PGSession * pgSession);
 static void pgsession_prepared_statement_deallocate(PGSession * pgSession);
 static void pgsession_log_client_info(PGClient * pgClient);
@@ -150,11 +162,8 @@ pgsession_handle_connection(void *input)
 	/* follow through the protocol setup */
 	check(pgsession_init(&pgSession, pgClient), pgSession, "failed to initialize connection");
 
-	/*
-	 * Tell the thread pool about our DuckDB connection, such that it can do
-	 * duckdb_interrupt() to cancel a query on a thread.
-	 */
-	pgclient_threadpool_set_duckdb_conn(pgClient->threadIndex, pgSession.duckSession.connection);
+	/* reap clients that connect but never send their startup packet */
+	set_client_recv_timeout(pgClient->clientSocket, STARTUP_PACKET_READ_TIMEOUT_SECONDS);
 
 	check(pgsession_read_startup_packet(&pgSession), pgSession, "failed to read startup packet");
 
@@ -164,10 +173,27 @@ pgsession_handle_connection(void *input)
 	 * request to cancel an ongoing client.
 	 *
 	 * If this session is one of those cancellation sessions, we should not
-	 * proceed with the normal protocol.
+	 * proceed with the normal protocol.  It has done its work in
+	 * pgsession_read_startup_packet() and never needs a DuckDB connection.
 	 */
 	if (pgSession.isCancelSession)
 		goto finally;
+
+	/* established session: drop the startup timeout for its whole lifetime */
+	set_client_recv_timeout(pgClient->clientSocket, 0);
+
+	/*
+	 * Only now, for a real client, connect to DuckDB.  Deferring it past the
+	 * startup packet keeps cancel probes and half-open sockets from
+	 * allocating a DuckDB connection they never use.
+	 */
+	check(pgsession_init_duckdb(&pgSession), pgSession, "failed to initialize DuckDB session");
+
+	/*
+	 * Tell the thread pool about our DuckDB connection, such that it can do
+	 * duckdb_interrupt() to cancel a query on a thread.
+	 */
+	pgclient_threadpool_set_duckdb_conn(pgClient->threadIndex, pgSession.duckSession.connection);
 
 	check(pgsession_send_auth_ok(&pgSession), pgSession, "failed to send authentication info");
 #if PG_VERSION_NUM >= 180000
@@ -1133,12 +1159,40 @@ pgsession_init(PGSession * pgSession, PGClient * pgClient)
 	pgSession->lastReportedSendErrno = 0;
 	pgSession->clientConnectionLost = false;
 
+	return OK;
+}
+
+
+/*
+ * pgsession_init_duckdb opens the DuckDB connection for an established session.
+ *
+ * Kept separate from pgsession_init so the connection is only created once we
+ * know the client is a real (non-cancel) session; see
+ * pgsession_handle_connection.
+ */
+static int
+pgsession_init_duckdb(PGSession * pgSession)
+{
 	if (duckdb_session_init(&pgSession->duckSession, pgSession) != DUCKDB_SUCCESS)
-	{
 		return INIT_ERROR;
-	}
 
 	return OK;
+}
+
+
+/*
+ * set_client_recv_timeout sets (seconds > 0) or clears (seconds == 0) a receive
+ * timeout on the client socket.  Best effort: a missing timeout only weakens
+ * the startup-read guard, so failure is logged and otherwise ignored.
+ */
+static void
+set_client_recv_timeout(int clientSocket, int seconds)
+{
+	struct timeval tv = {.tv_sec = seconds,.tv_usec = 0};
+
+	if (setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0)
+		PGDUCK_SERVER_DEBUG("could not set receive timeout on connection %d: %m",
+							clientSocket);
 }
 
 

--- a/pgduck_server/src/pgsession/pgsession.c
+++ b/pgduck_server/src/pgsession/pgsession.c
@@ -1182,17 +1182,31 @@ pgsession_init_duckdb(PGSession * pgSession)
 
 /*
  * set_client_recv_timeout sets (seconds > 0) or clears (seconds == 0) a receive
- * timeout on the client socket.  Best effort: a missing timeout only weakens
- * the startup-read guard, so failure is logged and otherwise ignored.
+ * timeout on the client socket.
+ *
+ * Setting is best effort: a missing startup timeout only weakens the
+ * startup-read guard.  Clearing is not -- if it fails the established session
+ * keeps the startup timeout for its whole lifetime and starts dropping clients
+ * that sit idle longer than it, so that failure is logged at a higher level.
  */
 static void
 set_client_recv_timeout(int clientSocket, int seconds)
 {
 	struct timeval tv = {.tv_sec = seconds,.tv_usec = 0};
 
-	if (setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0)
+	if (setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == 0)
+		return;
+
+	if (seconds == 0)
+	{
+		PGDUCK_SERVER_WARN("could not clear receive timeout on connection %d; "
+						   "idle clients may be dropped: %m", clientSocket);
+	}
+	else
+	{
 		PGDUCK_SERVER_DEBUG("could not set receive timeout on connection %d: %m",
 							clientSocket);
+	}
 }
 
 

--- a/pgduck_server/src/pgsession/pgsession_io.c
+++ b/pgduck_server/src/pgsession/pgsession_io.c
@@ -522,6 +522,13 @@ pgsession_receive(PGSession * pgSession)
 				continue;		/* Ok if interrupted */
 			}
 
+			/* SO_RCVTIMEO fired (e.g. startup packet never arrived) */
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+			{
+				PGDUCK_SERVER_DEBUG("timed out receiving data from client");
+				return EOF;
+			}
+
 			PGDUCK_SERVER_ERROR("could not receive data from client");
 			return EOF;
 		}

--- a/pgduck_server/tests/pytests/test_cli.py
+++ b/pgduck_server/tests/pytests/test_cli.py
@@ -27,7 +27,7 @@ def assert_common_output(
 ):
     print(stderr)
     assert (
-        f"pgduck_server is listening on unix_socket_directory: {unix_socket_directory} with port {port}, max_clients allowed {max_clients}"
+        f"pgduck_server is listening on unix_socket_directory: {unix_socket_directory} with port {port}, max_clients requested {max_clients}"
         in stderr
     )
     assert f"DuckDB is using database file path: {duckdb_database_file_path}" in stderr


### PR DESCRIPTION
Fixes #607.

Under a burst of connections `pgduck_server` can exhaust the host's OS
threads: `pthread_create()` starts returning `EAGAIN`, the accept loop
hot-spins, and legitimate clients can no longer connect
(`could not start query engine`). This hardens the server against that on
several fronts.

**Recover from thread-creation failure.** The accept loop pauses after a
failed thread creation, with a delay that grows on consecutive failures
(10 ms up to 1 s) and resets as soon as a client thread starts. Previously
it looped straight back to `accept()`, pinning the host and never letting
the detached client threads exit. The sleep runs after shutdown signals are
re-enabled, so a `SIGTERM` still interrupts it.

**Make the client cap protective.** Each client (and each in-flight
cancellation) needs its own OS thread, so the real ceiling is
`RLIMIT_NPROC`, not the default `max_clients` of 10000. The cap is now
derived from `RLIMIT_NPROC` at startup, reserving headroom, so admission
control engages before `pthread_create()` fails. Best effort — a cgroup
`pids.max` is invisible here — so the backpressure above stays the backstop.

**Bound per-connection footprint.** Client threads get an explicit 4 MB
stack instead of the glibc 8 MB default, and the `listen()` backlog is
capped rather than sized at `MaxThreads` (20000).

**Stop wasting resources on non-clients.** The DuckDB connection is deferred
until after the startup packet is read and the session is known to be a real
(non-cancel) client, so cancel probes and half-open sockets no longer
allocate a connection they never use. A startup-read timeout (`SO_RCVTIMEO`,
cleared once the session is established) reaps clients that connect but never
send anything, so they don't hold a thread slot indefinitely.

### Testing

- `make -C pgduck_server` compiles the changes under the project's
  `-Werror` flags; `make check-indent` is clean.
