### PR TITLE
Push down to_hex(int4) and to_hex(int8)

### DIFF
--- a/pg_lake_engine/src/pgduck/rewrite_query.c
+++ b/pg_lake_engine/src/pgduck/rewrite_query.c
@@ -180,6 +180,7 @@ static Node *RewriteFuncExprInitcap(Node *node, void *context);
 static Node *RewriteFuncExprJsonbArrayLength(Node *node, void *context);
 static Node *RewriteFuncExprEncode(Node *node, void *context);
 static Node *RewriteFuncExprDecode(Node *node, void *context);
+static Node *RewriteFuncExprToHex(Node *node, void *context);
 static Node *RewriteFuncExprToZeroOrNullConst(Node *node, void *context);
 static Node *RewriteFuncExprPostgisTransform(Node *node, void *context);
 static Node *RewriteFuncExprPostgisTransformGeometry(Node *node, void *context);
@@ -359,6 +360,11 @@ static FunctionCallRewriteRuleByName BuiltinFunctionCallRewriteRulesByName[] =
 	},
 	{
 		"pg_catalog", "decode", RewriteFuncExprDecode, 0
+	},
+
+	/* to_hex */
+	{
+		"pg_catalog", "to_hex", RewriteFuncExprToHex, 0
 	},
 
 };
@@ -1905,6 +1911,52 @@ RewriteFuncExprDecode(Node *node, void *context)
 	funcExpr->args = list_make1(linitial(funcExpr->args));
 
 	return (Node *) funcExpr;
+}
+
+
+/*
+ * RewriteFuncExprToHex rewrites to_hex(int4)/to_hex(int8) so the expression
+ * pushed to DuckDB matches Postgres's semantics: DuckDB's to_hex() produces
+ * uppercase hex digits, and has no INTEGER overload, so an int4 argument is
+ * implicitly widened to BIGINT by sign-extension rather than the
+ * zero-extension Postgres's to_hex(int4) performs. We fix the int4 case by
+ * masking off the sign-extended upper bits after widening, and fix the case
+ * mismatch for both overloads by wrapping the result in lower(..).
+ */
+static Node *
+RewriteFuncExprToHex(Node *node, void *context)
+{
+	FuncExpr   *funcExpr = castNode(FuncExpr, node);
+
+	if (list_length(funcExpr->args) != 1)
+		return node;
+
+	if (funcExpr->funcid == F_TO_HEX_INT4)
+	{
+		Node	   *arg = (Node *) linitial(funcExpr->args);
+
+		FuncExpr   *castExpr = makeNode(FuncExpr);
+
+		castExpr->funcid = F_INT8_INT4;
+		castExpr->funcresulttype = INT8OID;
+		castExpr->funcretset = false;
+		castExpr->funcvariadic = false;
+		castExpr->funcformat = COERCE_EXPLICIT_CAST;
+		castExpr->args = list_make1(arg);
+		castExpr->location = -1;
+
+		Node	   *maskExpr = MakeOpExpr((Node *) castExpr, "pg_catalog", "&",
+										  (Node *) MakeInt64Const(INT64CONST(4294967295)));
+
+		funcExpr->funcid = F_TO_HEX_INT8;
+		funcExpr->args = list_make1(maskExpr);
+	}
+	else if (funcExpr->funcid != F_TO_HEX_INT8)
+	{
+		elog(ERROR, "unexpected function ID in rewrite %d", funcExpr->funcid);
+	}
+
+	return MakeLowerCaseExpr((Node *) funcExpr);
 }
 
 

--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -325,6 +325,8 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"sqrt", 'f', 1, {"numeric"}, NULL},
 	{"trunc", 'f', 1, {"float8"}, NULL},
 	{"trunc", 'f', 1, {"numeric"}, NULL},
+	{"to_hex", 'f', 1, {"int4"}, NULL},
+	{"to_hex", 'f', 1, {"int8"}, NULL},
 
 	/* Random functions */
 	{"random", 'f', 0, {}, NULL},

--- a/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
@@ -89,6 +89,18 @@ test_agg_cases = [
     ),
     ("trunc(double)", "WHERE trunc(col_double) = 1.0", '"trunc"(', True),
     ("trunc(numeric)", "WHERE trunc(col_numeric) = 1.0", '"trunc"(', True),
+    (
+        "to_hex(col_int4)",
+        "WHERE to_hex(col_int4) = to_hex(col_int4)",
+        '"lower"("to_hex"(',
+        True,
+    ),
+    (
+        "to_hex(col_int8)",
+        "WHERE to_hex(col_int8) = to_hex(col_int8)",
+        '"lower"("to_hex"(',
+        True,
+    ),
     # Trigonometry operators, input must be in the range [-1,1]
     (
         "acos",
@@ -367,4 +379,62 @@ def test_hyperbolic_functions_specific_values(
         pg_conn,
         f"(SELECT {func}(col_val) FROM hyperbolic_vals.fdw_tbl) fdw",
         f"(SELECT {func}(col_val) FROM hyperbolic_vals.heap_tbl) heap",
+    )
+
+
+@pytest.fixture(scope="module")
+def create_to_hex_values_table(pg_conn, s3, extension):
+    url = f"s3://{TEST_BUCKET}/to_hex_values_test/data.parquet"
+    run_command(
+        f"""
+        COPY (
+            SELECT NULL::int4 AS col_int4, NULL::int8 AS col_int8
+            UNION ALL SELECT 0, 0
+            UNION ALL SELECT 1, 1
+            UNION ALL SELECT -1, -1
+            UNION ALL SELECT -2147483648, -9223372036854775808
+            UNION ALL SELECT 2147483647, 9223372036854775807
+        ) TO '{url}' WITH (FORMAT 'parquet');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        CREATE SCHEMA to_hex_vals;
+        CREATE FOREIGN TABLE to_hex_vals.fdw_tbl (col_int4 int4, col_int8 int8)
+        SERVER pg_lake OPTIONS (format 'parquet', path '{url}');
+        CREATE TABLE to_hex_vals.heap_tbl (col_int4 int4, col_int8 int8);
+        COPY to_hex_vals.heap_tbl FROM '{url}';
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    yield
+
+    run_command("DROP SCHEMA to_hex_vals CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize(
+    "col",
+    ["col_int4", "col_int8"],
+)
+def test_to_hex_specific_values(create_to_hex_values_table, pg_conn, col):
+    """Verify to_hex(int4)/to_hex(int8) pushdown returns the same results as
+    Postgres for NULL, 0, 1, -1, and both the int4 and int8 extremes.
+
+    Covers the two correctness fixes the pushdown rewrite applies: DuckDB's
+    to_hex() is uppercase where Postgres's is lowercase, and DuckDB has no
+    INTEGER overload so an int4 argument is otherwise sign-extended to
+    BIGINT rather than zero-extended as Postgres does.
+    """
+    query = f"SELECT to_hex({col}) FROM to_hex_vals.fdw_tbl"
+    assert_remote_query_contains_expression(query, '"lower"("to_hex"(', pg_conn)
+    assert_table_contents_match(
+        pg_conn,
+        f"(SELECT to_hex({col}) FROM to_hex_vals.fdw_tbl) fdw",
+        f"(SELECT to_hex({col}) FROM to_hex_vals.heap_tbl) heap",
     )

--- a/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_mathematical_functions_pushdown.py
@@ -392,6 +392,10 @@ def create_to_hex_values_table(pg_conn, s3, extension):
             UNION ALL SELECT 0, 0
             UNION ALL SELECT 1, 1
             UNION ALL SELECT -1, -1
+            UNION ALL SELECT 15, 15
+            UNION ALL SELECT 16, 16
+            UNION ALL SELECT 255, 255
+            UNION ALL SELECT 256, 256
             UNION ALL SELECT -2147483648, -9223372036854775808
             UNION ALL SELECT 2147483647, 9223372036854775807
         ) TO '{url}' WITH (FORMAT 'parquet');
@@ -424,7 +428,8 @@ def create_to_hex_values_table(pg_conn, s3, extension):
 )
 def test_to_hex_specific_values(create_to_hex_values_table, pg_conn, col):
     """Verify to_hex(int4)/to_hex(int8) pushdown returns the same results as
-    Postgres for NULL, 0, 1, -1, and both the int4 and int8 extremes.
+    Postgres for NULL, 0, 1, -1, the values either side of the nibble and byte
+    boundaries (15/16, 255/256), and both the int4 and int8 extremes.
 
     Covers the two correctness fixes the pushdown rewrite applies: DuckDB's
     to_hex() is uppercase where Postgres's is lowercase, and DuckDB has no


### PR DESCRIPTION
Split out of #601, which bundled several unrelated pushdown families.

DuckDB has to_hex() but two things differ from Postgres, so the plain function cannot be shipped as-is:

  - DuckDB returns uppercase hex digits, Postgres lowercase.
  - DuckDB has no INTEGER overload, so an int4 argument is widened to BIGINT by sign extension, while Postgres's to_hex(int4) treats the value as 32 unsigned bits. to_hex(-1::int4) is ffffffff in Postgres and would become ffffffffffffffff.

A rewrite rule fixes both. For int4 the argument is cast to int8 and masked with 4294967295 to clear the sign-extended upper bits, the call switches to the int8 overload, and both overloads are wrapped in lower():

  SELECT to_hex(col_int4) FROM t;
  -- sent as: lower(to_hex((col_int4)::bigint & 4294967295))

Tests cover NULL, 0, 1, -1 and both the int4 and int8 extremes against a heap-table baseline, plus pushdown assertions for both overloads.

Verified separately against a standalone PostgreSQL 18.4 and DuckDB 1.4.4: the rewritten expression matches Postgres for all 12 of those values.

## Description
Please explain what this PR changes and why.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
