### PR TITLE
Push down char_length, character_length and translate

### DIFF
--- a/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_functions.c
@@ -232,6 +232,9 @@ static const PGDuckShippableFunction ShippableBuiltinProcs[] =
 	{"timetz", 'f', 1, {"timestamptz"}, NULL},
 
 	{"length", 'f', 1, {"text"}, NULL},
+	{"char_length", 'f', 1, {"text"}, NULL},
+	{"character_length", 'f', 1, {"text"}, NULL},
+	{"translate", 'f', 3, {"text", "text", "text"}, NULL},
 
 	{"to_date", 'f', 1, {"float8"}, NULL},
 	{"to_timestamp", 'f', 1, {"float8"}, NULL},

--- a/pg_lake_table/tests/pytests/test_text_function_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_text_function_pushdown.py
@@ -554,11 +554,13 @@ def test_initcap_on_pg_vs_duck(create_initcap_edge_case_tables, pg_conn):
 # strings where a naive implementation diverges -- trailing blanks (which
 # count for text but not for bpchar), multi-byte UTF-8, an emoji plus skin
 # tone modifier and a ZWJ sequence (multiple codepoints that render as one
-# grapheme), and a combining accent.
+# grapheme), and a combining accent. Plain "abc" is here for the translate
+# cases below, where it keeps the expected output readable.
 TEXT_EDGE_VALUES = [
     None,
     "",
     "     ",
+    "abc",
     "abc  ",
     "  abc",
     "h\u00e9llo",
@@ -649,12 +651,21 @@ def test_length_bpchar_is_not_pushed_down(create_text_edge_values_table, pg_conn
 # longer than to, extra to characters ignored, duplicate from characters
 # (first wins), no cascading replacement, and multi-byte characters on
 # either side.
+#
+# no_cascade_overlap is the important one: from and to overlap, so a
+# character produced by the mapping is itself in from.
+#
+#     SELECT translate('abc', 'ab', 'bc');  -- bcc, not ccc
+#
+# Both engines scan the input once, so the "b" that came from "a" is not
+# translated again. A second pass over the output would give "ccc".
 translate_cases = [
     ("delete_all", "abc", ""),
     ("delete_extra", "abcd", "AB"),
     ("to_longer_than_from", "ab", "ABCDEF"),
     ("duplicate_in_from", "aa", "XY"),
     ("no_cascade", "abc", "cba"),
+    ("no_cascade_overlap", "ab", "bc"),
     ("empty_from", "", "XY"),
     ("multibyte_from", "\u00e9\u65e5", "eX"),
     ("multibyte_to", "ab", "\u00e9\u65e5"),

--- a/pg_lake_table/tests/pytests/test_text_function_pushdown.py
+++ b/pg_lake_table/tests/pytests/test_text_function_pushdown.py
@@ -179,6 +179,41 @@ test_cases = [
     # initcap
     ("initcap_text", "WHERE initcap(col_text) = 'Test'", "initcap_pg", True),
     ("initcap_varchar", "WHERE initcap(col_varchar) = 'Test'", "initcap_pg", True),
+    # translate
+    (
+        "translate_text",
+        "WHERE translate(col_text, 'lo', 'LO') <> col_text",
+        "translate",
+        True,
+    ),
+    (
+        "translate_varchar",
+        "WHERE translate(col_varchar, 'lo', 'LO') <> col_varchar",
+        "translate",
+        True,
+    ),
+    # char_length / character_length. A varchar argument resolves to the same
+    # text overload (Postgres plans it as char_length(col_varchar::text)), so
+    # both are pushed down.
+    ("char_length_text", "WHERE char_length(col_text) >= 0", "char_length", True),
+    (
+        "char_length_varchar",
+        "WHERE char_length(col_varchar) >= 0",
+        "char_length",
+        True,
+    ),
+    (
+        "character_length_text",
+        "WHERE character_length(col_text) >= 0",
+        "character_length",
+        True,
+    ),
+    (
+        "character_length_varchar",
+        "WHERE character_length(col_varchar) >= 0",
+        "character_length",
+        True,
+    ),
 ]
 
 
@@ -512,4 +547,137 @@ def test_initcap_on_pg_vs_duck(create_initcap_edge_case_tables, pg_conn):
         pg_conn,
         ["initcap_pushdown.tbl"],
         ["initcap_pushdown.heap_tbl"],
+    )
+
+
+# Values chosen for the equivalence check below: NULL, the empty string, and
+# strings where a naive implementation diverges -- trailing blanks (which
+# count for text but not for bpchar), multi-byte UTF-8, an emoji plus skin
+# tone modifier and a ZWJ sequence (multiple codepoints that render as one
+# grapheme), and a combining accent.
+TEXT_EDGE_VALUES = [
+    None,
+    "",
+    "     ",
+    "abc  ",
+    "  abc",
+    "h\u00e9llo",
+    "he\u0301llo",
+    "\u65e5\u672c\u8a9e",
+    "\U0001f44d",
+    "\U0001f44d\U0001f3fd",
+    "\U0001f468\u200d\U0001f469\u200d\U0001f467",
+]
+
+
+@pytest.fixture(scope="module")
+def create_text_edge_values_table(pg_conn, s3, extension):
+    """A table whose text, varchar and bpchar columns all hold TEXT_EDGE_VALUES.
+
+    The bpchar column is char(10) so Postgres blank-pads every value, which is
+    what makes the char_length(bpchar) negative test below meaningful.
+    """
+    url = f"s3://{TEST_BUCKET}/text_edge_values_test/data.parquet"
+    rows = " UNION ALL ".join(
+        "SELECT {v}::text AS col_text, {v}::varchar AS col_varchar, "
+        "{v}::char(10) AS col_bpchar".format(
+            v="NULL" if value is None else "'" + value + "'"
+        )
+        for value in TEXT_EDGE_VALUES
+    )
+    run_command(
+        f"COPY ({rows}) TO '{url}' WITH (FORMAT 'parquet');",
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        CREATE SCHEMA text_edge_vals;
+        CREATE FOREIGN TABLE text_edge_vals.fdw_tbl
+            (col_text text, col_varchar varchar, col_bpchar char(10))
+        SERVER pg_lake OPTIONS (format 'parquet', path '{url}');
+        CREATE TABLE text_edge_vals.heap_tbl
+            (col_text text, col_varchar varchar, col_bpchar char(10));
+        COPY text_edge_vals.heap_tbl FROM '{url}';
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    yield
+
+    run_command("DROP SCHEMA text_edge_vals CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+@pytest.mark.parametrize("func", ["char_length", "character_length"])
+@pytest.mark.parametrize("col", ["col_text", "col_varchar"])
+def test_length_specific_values(create_text_edge_values_table, pg_conn, func, col):
+    """char_length/character_length pushdown agrees with Postgres on NULL, the
+    empty string, trailing blanks and multi-codepoint UTF-8 sequences."""
+    query = f"SELECT {func}({col}) FROM text_edge_vals.fdw_tbl"
+    assert_remote_query_contains_expression(query, func, pg_conn)
+    assert_table_contents_match(
+        pg_conn,
+        f"(SELECT {func}({col}) FROM text_edge_vals.fdw_tbl) fdw",
+        f"(SELECT {func}({col}) FROM text_edge_vals.heap_tbl) heap",
+    )
+
+
+@pytest.mark.parametrize("func", ["char_length", "character_length"])
+def test_length_bpchar_is_not_pushed_down(create_text_edge_values_table, pg_conn, func):
+    """char_length(bpchar) is a different function (bpcharlen) and has to stay
+    local. Postgres ignores the blank padding, DuckDB counts it:
+
+        SELECT char_length('abc'::char(10));  -- pg: 3, DuckDB: 10
+
+    Only the text overload is on the shippable list, so this is already what
+    happens. Pin it here, so that adding a bpchar entry later cannot silently
+    start returning the padded length.
+    """
+    query = f"SELECT {func}(col_bpchar) FROM text_edge_vals.fdw_tbl"
+    assert_remote_query_not_contains_expression(query, func, pg_conn)
+    assert_table_contents_match(
+        pg_conn,
+        f"(SELECT {func}(col_bpchar) FROM text_edge_vals.fdw_tbl) fdw",
+        f"(SELECT {func}(col_bpchar) FROM text_edge_vals.heap_tbl) heap",
+    )
+
+
+# from/to pairs where a naive translate() diverges: deletion when from is
+# longer than to, extra to characters ignored, duplicate from characters
+# (first wins), no cascading replacement, and multi-byte characters on
+# either side.
+translate_cases = [
+    ("delete_all", "abc", ""),
+    ("delete_extra", "abcd", "AB"),
+    ("to_longer_than_from", "ab", "ABCDEF"),
+    ("duplicate_in_from", "aa", "XY"),
+    ("no_cascade", "abc", "cba"),
+    ("empty_from", "", "XY"),
+    ("multibyte_from", "\u00e9\u65e5", "eX"),
+    ("multibyte_to", "ab", "\u00e9\u65e5"),
+    ("blanks", " ", ""),
+]
+
+
+@pytest.mark.parametrize("col", ["col_text", "col_varchar"])
+@pytest.mark.parametrize(
+    "test_id, from_chars, to_chars",
+    translate_cases,
+    ids=[case[0] for case in translate_cases],
+)
+def test_translate_specific_values(
+    create_text_edge_values_table, pg_conn, col, test_id, from_chars, to_chars
+):
+    """translate() pushdown agrees with Postgres for the character-set edge
+    cases, over NULL and multi-byte input."""
+    expr = f"translate({col}, '{from_chars}', '{to_chars}')"
+    query = f"SELECT {expr} FROM text_edge_vals.fdw_tbl"
+    assert_remote_query_contains_expression(query, "translate", pg_conn)
+    assert_table_contents_match(
+        pg_conn,
+        f"(SELECT {expr} FROM text_edge_vals.fdw_tbl) fdw",
+        f"(SELECT {expr} FROM text_edge_vals.heap_tbl) heap",
     )


### PR DESCRIPTION
Split out of #601, which bundled several unrelated pushdown families. This one only adds the three text functions DuckDB exposes under the same name with the same semantics, so no rewrite rule is needed:

  char_length(text), character_length(text), translate(text, text, text)

A varchar argument resolves to the same text overload (Postgres plans it as char_length(col::text)), so varchar is covered too.

The bpchar overloads are deliberately left out. char_length(bpchar) is a different function (bpcharlen) and Postgres ignores the blank padding where DuckDB counts it:

  SELECT char_length('abc'::char(10));  -- pg: 3, DuckDB: 10

That already stays local because only the text overload is on the list, but nothing pinned it, so a later bpchar entry would silently start returning the padded length. There is now a test asserting char_length(col_bpchar) does not appear in the remote SQL.

Tests start from the values where the two engines are most likely to disagree rather than from the happy path: NULL, the empty string, blanks only, leading and trailing blanks, 2- and 3-byte UTF-8, an emoji, an emoji plus skin tone modifier, a ZWJ sequence, and a combining accent. For translate they also cover deletion when from is longer than to, extra to characters being ignored, duplicate characters in from, no cascading replacement, an empty from, and multi-byte characters on either side. Each case is compared against a heap-table baseline.

Verified separately against a standalone PostgreSQL 18.4 and DuckDB 1.4.4: all 121 expression comparisons matched, including every case above.

## Description
Please explain what this PR changes and why.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
