### PR TITLE
Pushdown interval_um function

### DIFF
--- a/pg_lake_engine/src/pgduck/shippable_builtin_operators.c
+++ b/pg_lake_engine/src/pgduck/shippable_builtin_operators.c
@@ -454,6 +454,7 @@ static const PGDuckShippableOperator PGDuckShippableIntervalOperators[] = {
 	{">=", "pg_catalog", "interval_ge", 2, {"interval", "interval"}, NULL},
 	{"+", "pg_catalog", "interval_pl", 2, {"interval", "interval"}, NULL},
 	{"-", "pg_catalog", "interval_mi", 2, {"interval", "interval"}, NULL},
+	{"-", "pg_catalog", "interval_um", 1, {"interval"}, NULL},
 };
 
 /* UUID operators */

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
@@ -55,6 +55,11 @@ test_cases = [
         "WHERE col_interval - INTERVAL '1 day' = INTERVAL '1 day'",
         "WHERE ((\"col_interval\" - '1 day'::interval) = '1 day'::interval)",
     ),
+    (
+        "interval_um",
+        "WHERE - col_interval = INTERVAL '-1 day'",
+        "WHERE ((- \"col_interval\") = '-1 days'::interval)",
+    ),
 ]
 
 

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
@@ -166,3 +166,199 @@ def create_operator_pushdown_table(pg_conn, s3, request, extension):
 
     run_command("DROP SCHEMA time_operator_pushdown CASCADE", pg_conn)
     pg_conn.commit()
+
+
+@pytest.fixture(scope="module")
+def create_interval_um_table(pg_conn, s3, extension):
+    url = f"s3://{TEST_BUCKET}/create_interval_um_table/data.parquet"
+    run_command(
+        f"""
+        COPY (
+            SELECT 1 AS id, NULL::interval AS col_interval
+            UNION ALL SELECT 2, INTERVAL '0 seconds'
+            UNION ALL SELECT 3, INTERVAL '1 second'
+            UNION ALL SELECT 4, INTERVAL '1 minute'
+            UNION ALL SELECT 5, INTERVAL '1 hour'
+            UNION ALL SELECT 6, INTERVAL '1 day'
+            UNION ALL SELECT 7, INTERVAL '1 month'
+            UNION ALL SELECT 8, INTERVAL '1 year'
+            UNION ALL SELECT 9, INTERVAL '3 days 4 hours'
+            UNION ALL SELECT 10, INTERVAL '1 month 2 days 03:04:05'
+        ) TO '{url}' WITH (FORMAT 'parquet');
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        CREATE SCHEMA interval_um;
+        CREATE FOREIGN TABLE interval_um.tbl (id int, col_interval interval)
+        SERVER pg_lake OPTIONS (format 'parquet', path '{url}');
+        CREATE TABLE interval_um.heap_tbl (LIKE interval_um.tbl);
+        COPY interval_um.heap_tbl FROM '{url}';
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    yield
+
+    run_command("DROP SCHEMA interval_um CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def _um_tables():
+    return ["interval_um.tbl"], ["interval_um.heap_tbl"]
+
+
+interval_um_queries = [
+    (
+        "project",
+        "SELECT id, - col_interval FROM interval_um.tbl",
+        '(- "col_interval")',
+    ),
+    (
+        "double_negation",
+        "SELECT id, - (- col_interval) FROM interval_um.tbl",
+        '(- (- "col_interval"))',
+    ),
+    (
+        "is_null",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval IS NULL",
+        '(- "col_interval")',
+    ),
+    (
+        "eq_zero",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = INTERVAL '0 seconds'",
+        '(- "col_interval")',
+    ),
+    (
+        "eq_neg_day",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = INTERVAL '-1 day'",
+        '(- "col_interval")',
+    ),
+    (
+        "eq_neg_month",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = INTERVAL '-1 month'",
+        '(- "col_interval")',
+    ),
+    (
+        "eq_neg_year",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = INTERVAL '-1 year'",
+        '(- "col_interval")',
+    ),
+    (
+        "eq_neg_second",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = INTERVAL '-1 second'",
+        '(- "col_interval")',
+    ),
+    (
+        "eq_neg_mixed_hms",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = INTERVAL '-3 days -04:00:00'",
+        '(- "col_interval")',
+    ),
+    (
+        "filter_on_negated_column",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval < INTERVAL '0 seconds'",
+        '(- "col_interval")',
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_id, query, expected_expression",
+    interval_um_queries,
+    ids=[c[0] for c in interval_um_queries],
+)
+def test_interval_um_pushdown_matches_heap(
+    create_interval_um_table, pg_conn, test_id, query, expected_expression
+):
+    assert_query_pushdownable(query, pg_conn)
+    assert_remote_query_contains_expression(query, expected_expression, pg_conn)
+    fdw, heap = _um_tables()
+    assert_query_results_on_tables(query, pg_conn, fdw, heap)
+
+
+def test_interval_um_infinite_const_not_pushed(create_interval_um_table, pg_conn):
+    if get_pg_version_num(pg_conn) < 170000:
+        pytest.skip("infinity intervals require PostgreSQL 17+")
+
+    query = (
+        "SELECT id FROM interval_um.tbl "
+        "WHERE - col_interval IS DISTINCT FROM INTERVAL 'infinity'"
+    )
+    assert_query_not_pushdownable(query, pg_conn)
+    fdw, heap = _um_tables()
+    assert_query_results_on_tables(query, pg_conn, fdw, heap)
+
+
+def test_interval_um_neg_infinite_const_not_pushed(create_interval_um_table, pg_conn):
+    if get_pg_version_num(pg_conn) < 170000:
+        pytest.skip("infinity intervals require PostgreSQL 17+")
+
+    query = (
+        "SELECT id FROM interval_um.tbl "
+        "WHERE - col_interval IS DISTINCT FROM INTERVAL '-infinity'"
+    )
+    assert_query_not_pushdownable(query, pg_conn)
+    fdw, heap = _um_tables()
+    assert_query_results_on_tables(query, pg_conn, fdw, heap)
+
+
+interval_const_deparse_errors = [
+    (
+        "eq_mixed_sign",
+        "SELECT id FROM interval_um.tbl WHERE col_interval = '-1 mons +2 days'::interval",
+    ),
+    (
+        "eq_mixed_sign_years",
+        "SELECT id FROM interval_um.tbl WHERE col_interval = '-1 years +2 days -03:04:05'::interval",
+    ),
+    (
+        "eq_wide_hour",
+        "SELECT id FROM interval_um.tbl WHERE col_interval = '2562047788:00:54.775807'::interval",
+    ),
+    (
+        "pl_mixed_sign",
+        "SELECT id FROM interval_um.tbl WHERE col_interval + '-1 mons +2 days'::interval = INTERVAL '1 day'",
+    ),
+    (
+        "mi_mixed_sign",
+        "SELECT id FROM interval_um.tbl WHERE col_interval - '-1 mons +2 days'::interval = INTERVAL '1 day'",
+    ),
+    (
+        "um_mixed_sign",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = '-1 mons +2 days'::interval",
+    ),
+    (
+        "um_wide_hour",
+        "SELECT id FROM interval_um.tbl WHERE - col_interval = '2562047788:00:54.775807'::interval",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_id, query",
+    interval_const_deparse_errors,
+    ids=[c[0] for c in interval_const_deparse_errors],
+)
+def test_interval_const_deparse_errors_on_fdw(
+    create_interval_um_table, pg_conn, test_id, query
+):
+    with pytest.raises(Exception, match="Could not convert string"):
+        run_query(query, pg_conn)
+    pg_conn.rollback()
+    heap_query = query.replace("interval_um.tbl", "interval_um.heap_tbl")
+    run_query(heap_query, pg_conn)
+    pg_conn.rollback()
+
+
+def test_interval_const_deparse_ok_without_plus(create_interval_um_table, pg_conn):
+    query = (
+        "SELECT id FROM interval_um.tbl "
+        "WHERE col_interval <> '1 mon -2 days'::interval"
+    )
+    assert_query_pushdownable(query, pg_conn)
+    fdw, heap = _um_tables()
+    assert_query_results_on_tables(query, pg_conn, fdw, heap)

--- a/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
+++ b/pg_lake_table/tests/pytests/operator_pushdown/test_interval.py
@@ -362,3 +362,97 @@ def test_interval_const_deparse_ok_without_plus(create_interval_um_table, pg_con
     assert_query_pushdownable(query, pg_conn)
     fdw, heap = _um_tables()
     assert_query_results_on_tables(query, pg_conn, fdw, heap)
+
+
+# Parquet cannot store a negative interval, so the fixture above only has
+# non-negative values. Iceberg can, so negating an already-negative interval
+# and negating mixed-sign fields are only reachable through an iceberg table.
+interval_um_iceberg_rows = """
+    (1, NULL),
+    (2, INTERVAL '-1 day'),
+    (3, INTERVAL '1 mon -2 days'),
+    (4, INTERVAL '-1 year -6 months'),
+    (5, INTERVAL '-3 days -04:00:00'),
+    (6, INTERVAL '1 mon -2 days -03:04:05')
+"""
+
+
+@pytest.fixture(scope="module")
+def create_interval_um_iceberg_table(pg_conn, s3, extension):
+    url = f"s3://{TEST_BUCKET}/create_interval_um_iceberg_table"
+    run_command(
+        f"""
+        CREATE SCHEMA interval_um_iceberg;
+        CREATE TABLE interval_um_iceberg.tbl (id int, col_interval interval)
+        USING iceberg WITH (location = '{url}');
+        CREATE TABLE interval_um_iceberg.heap_tbl (id int, col_interval interval);
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    run_command(
+        f"""
+        INSERT INTO interval_um_iceberg.tbl VALUES {interval_um_iceberg_rows};
+        INSERT INTO interval_um_iceberg.heap_tbl VALUES {interval_um_iceberg_rows};
+        """,
+        pg_conn,
+    )
+    pg_conn.commit()
+
+    yield
+
+    run_command("DROP SCHEMA interval_um_iceberg CASCADE", pg_conn)
+    pg_conn.commit()
+
+
+def _um_iceberg_tables():
+    return ["interval_um_iceberg.tbl"], ["interval_um_iceberg.heap_tbl"]
+
+
+interval_um_iceberg_queries = [
+    (
+        "project_negative_and_mixed_sign",
+        "SELECT id, - col_interval FROM interval_um_iceberg.tbl",
+        '(- "col_interval")',
+    ),
+    (
+        "double_negation",
+        "SELECT id, - (- col_interval) FROM interval_um_iceberg.tbl",
+        '(- (- "col_interval"))',
+    ),
+    (
+        "negate_already_negative",
+        "SELECT id FROM interval_um_iceberg.tbl WHERE - col_interval = INTERVAL '1 day'",
+        '(- "col_interval")',
+    ),
+    (
+        "negate_already_negative_ym",
+        "SELECT id FROM interval_um_iceberg.tbl WHERE - col_interval = INTERVAL '1 year 6 months'",
+        '(- "col_interval")',
+    ),
+    (
+        "negate_already_negative_mixed_hms",
+        "SELECT id FROM interval_um_iceberg.tbl WHERE - col_interval = INTERVAL '3 days 04:00:00'",
+        '(- "col_interval")',
+    ),
+    (
+        "negated_column_is_positive",
+        "SELECT id FROM interval_um_iceberg.tbl WHERE - col_interval > INTERVAL '0 seconds'",
+        '(- "col_interval")',
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_id, query, expected_expression",
+    interval_um_iceberg_queries,
+    ids=[c[0] for c in interval_um_iceberg_queries],
+)
+def test_interval_um_pushdown_matches_heap_on_iceberg(
+    create_interval_um_iceberg_table, pg_conn, test_id, query, expected_expression
+):
+    assert_query_pushdownable(query, pg_conn)
+    assert_remote_query_contains_expression(query, expected_expression, pg_conn)
+    fdw, heap = _um_iceberg_tables()
+    assert_query_results_on_tables(query, pg_conn, fdw, heap)


### PR DESCRIPTION
  ## Problem

  Unary minus on an interval (- col_interval) is still run in Postgres after the lake scan, even though interval + and interval - already ship and DuckDB matches on finite lake values.

  ## Solution

  Add interval_um to the shippable operator list. Do not ship interval * float8: a parquet double can be Inf, Postgres returns an infinite interval, and DuckDB errors with overflow.

  -- Push unary minus into the remote scan.
  SELECT * FROM lake_tbl WHERE - col_interval = INTERVAL '-1 day';

  Infinite interval constants are already refused. Strings such as '-1 mons +2 days' still fail in DuckDB (Postgres interval_out); that is the same const-deparse issue as interval_pl / interval_mi.

  Split from #601.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
