### PR TITLE
Bump extension versions to 3.6

### DIFF
--- a/pg_extension_base/pg_extension_base--3.5--3.6.sql
+++ b/pg_extension_base/pg_extension_base--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_extension_base from 3.5 to 3.6

--- a/pg_extension_base/pg_extension_base.control
+++ b/pg_extension_base/pg_extension_base.control
@@ -1,5 +1,5 @@
 comment = 'Extension development kit by Snowflake'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_extension_base'
 relocatable = false
 schema = pg_catalog

--- a/pg_extension_updater/pg_extension_updater--3.5--3.6.sql
+++ b/pg_extension_updater/pg_extension_updater--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_extension_updater from 3.5 to 3.6

--- a/pg_extension_updater/pg_extension_updater.control
+++ b/pg_extension_updater/pg_extension_updater.control
@@ -1,5 +1,5 @@
 comment = 'Automatic extension updater'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_extension_updater'
 requires = 'pg_extension_base'
 relocatable = false

--- a/pg_lake/pg_lake--3.5--3.6.sql
+++ b/pg_lake/pg_lake--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake from 3.5 to 3.6

--- a/pg_lake/pg_lake.control
+++ b/pg_lake/pg_lake.control
@@ -1,6 +1,6 @@
 # pg_lake extension
 comment = 'Data lake extension by Snowflake'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_lake'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_benchmark/pg_lake_benchmark--3.5--3.6.sql
+++ b/pg_lake_benchmark/pg_lake_benchmark--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_benchmark from 3.5 to 3.6

--- a/pg_lake_benchmark/pg_lake_benchmark.control
+++ b/pg_lake_benchmark/pg_lake_benchmark.control
@@ -1,6 +1,6 @@
 # pg_lake_benchmark extension
 comment = 'Benchmark for PgLake and Iceberg tables'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_lake_benchmark'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_copy/pg_lake_copy--3.5--3.6.sql
+++ b/pg_lake_copy/pg_lake_copy--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_copy from 3.5 to 3.6

--- a/pg_lake_copy/pg_lake_copy.control
+++ b/pg_lake_copy/pg_lake_copy.control
@@ -1,5 +1,5 @@
 comment = 'Copy to/from data lake files'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_lake_copy'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_engine/pg_lake_engine--3.5--3.6.sql
+++ b/pg_lake_engine/pg_lake_engine--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_engine from 3.5 to 3.6

--- a/pg_lake_engine/pg_lake_engine.control
+++ b/pg_lake_engine/pg_lake_engine.control
@@ -1,5 +1,5 @@
 comment = 'Query engine for data lake queries'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_lake_engine'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_iceberg/pg_lake_iceberg--3.5--3.6.sql
+++ b/pg_lake_iceberg/pg_lake_iceberg--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_iceberg from 3.5 to 3.6

--- a/pg_lake_iceberg/pg_lake_iceberg.control
+++ b/pg_lake_iceberg/pg_lake_iceberg.control
@@ -1,5 +1,5 @@
 comment = 'Iceberg implementation in Postgres'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_lake_iceberg'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_spatial/pg_lake_spatial--3.5--3.6.sql
+++ b/pg_lake_spatial/pg_lake_spatial--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_spatial from 3.5 to 3.6

--- a/pg_lake_spatial/pg_lake_spatial.control
+++ b/pg_lake_spatial/pg_lake_spatial.control
@@ -1,6 +1,6 @@
 # pg_lake_spatial extension
 comment = 'Geospatial file format support'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_lake_spatial'
 relocatable = false
 schema = pg_catalog

--- a/pg_lake_table/pg_lake_table--3.5--3.6.sql
+++ b/pg_lake_table/pg_lake_table--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_lake_table from 3.5 to 3.6

--- a/pg_lake_table/pg_lake_table.control
+++ b/pg_lake_table/pg_lake_table.control
@@ -1,6 +1,6 @@
 # pg_lake_table extension
 comment = 'Data lake tables and Iceberg tables'
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_lake_table'
 relocatable = false
 schema = pg_catalog

--- a/pg_map/pg_map--3.5--3.6.sql
+++ b/pg_map/pg_map--3.5--3.6.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_map from 3.5 to 3.6

--- a/pg_map/pg_map.control
+++ b/pg_map/pg_map.control
@@ -1,4 +1,4 @@
-default_version = '3.5'
+default_version = '3.6'
 module_pathname = '$libdir/pg_map'
 relocatable = false
 schema = pg_catalog


### PR DESCRIPTION
## Summary
- Bump all 10 PostgreSQL extensions from 3.5 to 3.6 via `tools/bump_extension_versions.py`
- Update `default_version` in each `.control` file
- Add stub upgrade SQL scripts (`extname--3.5--3.6.sql`) for each extension

## Test plan
- [x] Ran `python tools/bump_extension_versions.py 3.6` and verified all 10 extensions were bumped
- [x] Re-ran the script to confirm idempotency (all extensions skipped as already at 3.6)
- [x] Verified 20 files changed (10 `.control` + 10 upgrade stubs), matching the 3.5 bump pattern (#450)


Made with [Cursor](https://cursor.com)