### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -20,7 +20,7 @@ runs:
         echo "PATH=/home/postgres/pgsql-${{ inputs.pg_version }}/bin:$PATH" >> $GITHUB_ENV
         echo "PG_REGRESS_DIR=/home/postgres/pgsql-${{ inputs.pg_version }}/regress" >> $GITHUB_ENV
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache_pipenv
       name: Cache pipenv
       with:
@@ -36,7 +36,7 @@ runs:
     - name: Check for typos # ;)
       uses: ./.github/actions/check-typos
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache_libduckdb
       name: Cache libduckdb
       with:
@@ -48,7 +48,7 @@ runs:
           ${{ env.PG_INCLUDEDIR }}/duckdb.hpp
           ${{ env.PG_INCLUDEDIR }}/duckdb_extension.h
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache_polaris
       name: Cache Polaris
       with:
@@ -86,7 +86,7 @@ runs:
         make -C pg_lake_table prepare-check
 
     - name: Upload postgres-${{ inputs.pg_version }} artifacts for ${{ inputs.container_os }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: postgres-${{ inputs.pg_version }}-${{ inputs.container_os }}-artifacts
         path: /home/postgres/pgsql-${{ inputs.pg_version }}/
@@ -94,7 +94,7 @@ runs:
     # need to upload once, same for all pg versions
     - name: Upload avro artifacts for ${{ inputs.container_os }}
       if: ${{ inputs.pg_version == 18 }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: avro-${{ inputs.container_os }}-artifacts
         path: ./avro/lang/c/build/avrolib

--- a/.github/actions/build-and-push-image/action.yml
+++ b/.github/actions/build-and-push-image/action.yml
@@ -40,7 +40,7 @@ runs:
         fi
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -57,14 +57,14 @@ runs:
         echo "PG_REGRESS_DIR=/home/postgres/pgsql-${{ inputs.pg_version }}/regress" >> $GITHUB_ENV
 
     - name: Download postgres-${{ inputs.pg_version }} artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: postgres-${{ inputs.pg_version }}-${{ inputs.container_os }}-artifacts
         path: /home/postgres/pgsql-${{ inputs.pg_version }}/
 
     - name: Download postgres (from_pg_version) artifacts
       if: ${{ inputs.upgrade == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: postgres-${{ inputs.from_pg_version }}-${{ inputs.container_os }}-artifacts
         path: /home/postgres/pgsql-${{ inputs.from_pg_version }}/
@@ -72,7 +72,7 @@ runs:
     # avro tests needs a clean environment
     - name: Download avro artifacts for ${{ inputs.container_os }}
       if: ${{ inputs.test_make_target != 'check-avro' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: avro-${{ inputs.container_os }}-artifacts
         path: |
@@ -90,7 +90,7 @@ runs:
           chmod 755 /home/postgres/pgsql-${{ inputs.from_pg_version }}/lib/*.so
         fi
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache pipenv
       with:
         path: ~/.local/share/virtualenvs
@@ -154,7 +154,7 @@ runs:
         fi
 
     - name: Upload postgres test logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: postgres-logs-${{ inputs.pg_version }}-${{ inputs.test_make_target }}${{ inputs.from_pg_version != '' && format('-from{0}', inputs.from_pg_version) || '' }}${{ inputs.worker_id != '' && format('-{0}', inputs.worker_id) || '' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
         with:
           fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
           echo "PATH=/home/postgres/pgsql-${{ inputs.pg_version }}/bin:$PATH" >> $GITHUB_ENV
           echo "PG_REGRESS_DIR=/home/postgres/pgsql-${{ inputs.pg_version }}/regress" >> $GITHUB_ENV
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache_pipenv
         name: Cache pipenv
         with:

--- a/.github/workflows/pytest_all.yml
+++ b/.github/workflows/pytest_all.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ./.github/actions/build-and-push-image
         id: build-and-push
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ./.github/actions/build-and-push-image
         id: build-and-push
@@ -94,7 +94,7 @@ jobs:
         pg_version: [16, 17, 18, 19]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/build-and-install
@@ -119,7 +119,7 @@ jobs:
         pg_version: [16, 17, 18, 19]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/build-and-install
@@ -163,7 +163,7 @@ jobs:
           - 'check-pg_map'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/run-test
@@ -194,7 +194,7 @@ jobs:
         worker_id: [1, 2, 3, 4, 5]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/run-test
@@ -231,7 +231,7 @@ jobs:
           - 'installcheck-pg_map'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/run-test
@@ -261,7 +261,7 @@ jobs:
           - 'installcheck-postgres-with_extensions_created'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/run-test
@@ -275,7 +275,7 @@ jobs:
       
       - name: Upload installcheck-postgres artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: installcheck-postgres-${{ matrix.pg_version }}-debian-logs
           path: ${{ env.PG_REGRESS_DIR }}/regression.diffs
@@ -301,7 +301,7 @@ jobs:
         worker_id: [1, 2, 3, 4, 5]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/run-test
@@ -332,7 +332,7 @@ jobs:
           - 'check-isolation_pg_lake_table'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - uses: ./.github/actions/run-test
@@ -361,7 +361,7 @@ jobs:
           - 'check-pg_lake_table-upgrade'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out repository code
 
       - name: Extract from and to pg versions


### PR DESCRIPTION
GitHub is deprecating the Node 20 runtime for Actions and now forces Node 20 actions onto Node 24, emitting a deprecation warning for every affected step (e.g. `build-image-debian`: `actions/checkout@v4, docker/login-action@v2`).

This bumps each affected action to its first Node 24 major, so the runtime matches and the warnings clear:

| action | before | after |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `docker/login-action` | v2 | v4 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |

Each target is the earliest major that runs on `node24` (a pure runtime bump), avoiding the additional behavioral changes in the newest majors (direct uploads / ESM / digest-mismatch-error defaults).

## ⚠️ Requires an allow-list update before CI can pass

This repo restricts Actions to a pinned allow-list (**Settings → Actions → General → Allowed actions**, `allowed_actions: selected`, `github_owned_allowed: false`). The list currently pins the **old** versions, so the bumped versions are blocked at workflow startup (`startup_failure`, "workflow file issue") until an admin adds them.

An admin needs to add these patterns to the allowed-actions list (the old entries can be dropped once nothing references them):

```
actions/checkout@v5
docker/login-action@v4
actions/cache@v5
actions/upload-artifact@v6
actions/download-artifact@v7
```

Once the allow-list is updated, the workflows will start and run normally.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/