### PR TITLE
Restore the .security context bundle

### DIFF
--- a/.security/architecture.md
+++ b/.security/architecture.md
@@ -1,0 +1,246 @@
+# Architecture
+
+> Derived-from: Snowflake-Labs/pg_lake@031d6f58798d · generated 2026-09-03
+> Regenerate when: a scheme is added to `IsSupportedURL`; pgduck_server gains a listener that is not a unix socket, or gains an authentication step; a new extension directory appears at the top level; the set of built-in Iceberg catalog servers changes, or `pg_lake_iceberg.default_catalog` stops defaulting to `postgres`; a lake role starts being checked on a read or write of an existing table; `pg_lake_iceberg.default_location_prefix` changes GUC context; a new background worker or a new path that reaches object storage outside a user query is added; or the two processes stop sharing the PostgreSQL temp-file directory.
+
+pg_lake is a set of PostgreSQL extensions plus one separate process. Reads and
+writes of lake tables are planned in PostgreSQL and executed by DuckDB in that
+other process, and the two halves are joined by a unix socket and a shared
+temp-file directory. Almost every security question about pg_lake is a question
+about one of those two joins, or about which URLs a SQL user is allowed to name.
+
+## The extensions
+
+The top-level directories are the extensions: `pg_lake` (an umbrella that
+requires the others and exposes `lake.version()`), `pg_lake_table`,
+`pg_lake_copy`, `pg_lake_iceberg`, `pg_lake_engine`, `pg_map`,
+`pg_lake_spatial`, `pg_lake_benchmark`, `pg_extension_base` and
+`pg_extension_updater`. They are versioned together; the current
+`default_version` is 3.5 in every control file.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake/pg_lake.control:1-8` @ 031d6f58798d (2026-09-03)
+
+None of them is marked `trusted`, so `CREATE EXTENSION` requires a superuser.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake/pg_lake.control` (no `trusted` in any `.control` file) @ 031d6f58798d (2026-09-03)
+
+`pg_extension_base` is the library that goes in `shared_preload_libraries`. It
+refuses to load any other way, and at postmaster start it reads the control
+files of installed extensions and loads the libraries named on their
+`#!shared_preload_libraries` comment line. `pg_lake.control` carries such a
+line, which is how the `pg_lake` library ends up preloaded without being named
+in `postgresql.conf`.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_extension_base/src/pg_extension_base.c:53-68`, `pg_extension_base/src/library_preloader.c:20-21,233-236`, `pg_lake/pg_lake.control:8` @ 031d6f58798d (2026-09-03)
+
+That mechanism is a loading decision, not a privilege one: what a preloaded
+library may do is decided by the hooks it installs and the role checks it makes,
+which is the subject of `trust-boundaries.md`.
+
+## pgduck_server
+
+`pgduck_server` is a standalone multi-threaded process that speaks the
+PostgreSQL v3 wire protocol and executes statements against an embedded DuckDB
+with the `duckdb_pglake` extension. It listens on a unix socket only, on
+`/tmp` and port 5332 by default, with the socket file chmod'ed to 0770 and no
+group owner unless one is given.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/command_line/command_line.c:45-50`, `pgduck_server/src/pgserver/pgserver.c:67,116,212,222,278,315` @ 031d6f58798d (2026-09-03)
+
+PostgreSQL backends connect to it with libpq, using the conninfo string in the
+`pg_lake_engine.host` GUC. That GUC is `PGC_POSTMASTER` and carries
+`GUC_NO_SHOW_ALL`, so it is fixed at postmaster start and does not appear in
+`SHOW ALL`.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/init.c:82-90`, `pg_lake_engine/include/pg_lake/pgduck/client.h:25`, `pg_lake_engine/src/pgduck/client.c:57,100-200` @ 031d6f58798d (2026-09-03)
+
+**One server serves the whole cluster.** Every database and every user in the
+PostgreSQL instance is served by the same pgduck_server process, so DuckDB's
+secrets, settings and file cache are shared state rather than per-session
+state. The code says so where it matters: the name of a vended secret includes
+`MyDatabaseId` specifically because the namespace is shared.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/vended_secrets.c:53-74` @ 031d6f58798d (2026-09-03)
+
+DuckDB state that is not per-session is the origin of most of `threat-model.md`.
+
+## The two joins between the halves
+
+**The socket.** Statements pg_lake builds as text travel to pgduck_server over
+the unix socket. There is no authentication on that channel at all: see
+`trust-boundaries.md`, boundary 3.
+
+**The temp-file directory.** Data that cannot stream through the protocol goes
+through a file both processes can see. pg_lake generates those paths under the
+PostgreSQL temp-file directory, `$PGDATA/base/pgsql_tmp`, and registers a memory
+context callback to unlink them.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/storage/local_storage.c:35-80` @ 031d6f58798d (2026-09-03)
+
+In the documented container topology that directory is a shared volume mounted
+into both containers, and pgduck_server has full filesystem access to it.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `docker/docker-compose.yml:8-12,33-38` @ 031d6f58798d (2026-09-03)
+
+## Storage
+
+Lake tables live in object storage. The schemes pg_lake accepts are fixed by
+`IsSupportedURL`: `s3://`, `gs://`, the three Azure forms, `http://`,
+`https://`, Hugging Face and `r2://`. There is no `file://` scheme.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/copy/copy_format.c:420-442` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the absence of `file://` does not mean pg_lake never touches the
+local filesystem. `COPY` accepts a bare local path, and the check that gates it
+is a replica of a core PostgreSQL check rather than a scheme rule; see
+`trust-boundaries.md`, boundary 2.
+
+Iceberg tables are addressed through one of three built-in foreign servers on
+the `iceberg_catalog` FDW, created by the extension upgrade script and named
+`pg_lake_postgres_catalog` (the catalog is PostgreSQL itself),
+`pg_lake_object_store_catalog` (the catalog is a file in the object store) and
+`pg_lake_rest_catalog` (an Iceberg REST catalog). `USAGE` on each is granted to
+`lake_write`.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/pg_lake_iceberg--3.3--3.4.sql:85-99` @ 031d6f58798d (2026-09-03)
+
+**PostgreSQL is the default catalog.** `pg_lake_iceberg.default_catalog` defaults
+to `postgres`, so a `CREATE TABLE ... USING iceberg` that names no catalog gets
+the PostgreSQL one. The pointer to each table's current `metadata.json` lives in
+`lake_iceberg.tables_internal`, and `pg_catalog.iceberg_tables` presents it in
+the shape an Iceberg JDBC catalog client expects. No external catalog service is
+in the path, and no credential is needed to reach the catalog, because reaching
+it is a local table read.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/init.c:204-214`, `pg_lake_iceberg/pg_lake_iceberg--3.0.sql:24-72` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** `pg_catalog.iceberg_tables` has `SELECT` granted to `public`, so
+any user in the database can read the storage location of every Iceberg table in
+it, including tables they hold no privilege on. The path is not the data, but a
+user who also holds `lake_read` can then read the files at that path directly and
+so bypass the table's own `GRANT`s. That is the reach of `lake_read` rather than a
+property of the view, but the view is what makes it easy to aim.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/pg_lake_iceberg--3.0.sql:69-72`, `pg_lake_iceberg/pg_lake_iceberg--3.2--3.3.sql:9-11` @ 031d6f58798d (2026-09-03)
+
+Those three server names are reserved: the extension refuses to let anyone else
+create or alter a server under them. The reason is a credential one and is
+covered in `data-and-secrets.md`.
+
+## Paths that reach storage outside a user query
+
+Three things touch object storage or the local cache without a user statement
+driving them, which makes them worth naming separately.
+
+**The cache manager worker.** A background worker started from `_PG_init`,
+connected to shared catalogs only, which calls into the cache-management
+function roughly once a minute and trims the file cache to
+`pg_lake_engine.max_cache_size`. It restarts after 5 seconds if it dies.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/cache_worker.c:81-95,100-176`, `pg_lake_engine/src/init.c:92-125,258` @ 031d6f58798d (2026-09-03)
+
+**The deletion queue.** Files that a table no longer references are recorded in
+`lake_engine.deletion_queue` and deleted later by vacuum, bounded by
+`pg_lake_engine.vacuum_file_remove_max_retries`,
+`vacuum_file_remove_retry_interval` and `orphaned_file_retention_period`. The
+queue is `SELECT`-able by `lake_write`, and `lake_engine.flush_deletion_queue`
+is revoked from public and granted to `lake_write`.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/pg_lake_engine--3.0.sql:112-127`, `pg_lake_engine/src/init.c:152-202` @ 031d6f58798d (2026-09-03)
+
+**The deferred-drop resolver.** With `pg_lake_table.defer_drop_file_cleanup`, a
+dropped Iceberg table leaves its `metadata.json` on the queue and vacuum later
+calls `lake_iceberg.find_all_referenced_files` over SPI to enumerate what to
+delete. That function walks an arbitrary object-store path with the server's
+credentials, and the upgrade script revokes it from public for exactly that
+reason; vacuum reaches it as the extension owner instead.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/pg_lake_iceberg--3.3--3.4.sql:104-113`, `pg_lake_table/src/init.c:353-363` @ 031d6f58798d (2026-09-03)
+
+## The permission model
+
+`pg_lake_engine`'s install script creates three roles: `lake_read`,
+`lake_write`, and `lake_read_write`, which holds the other two. They are group
+roles created with a bare `CREATE ROLE`, so nobody logs in as them.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/pg_lake_engine--3.0.sql:1-20` @ 031d6f58798d (2026-09-03)
+
+The point that decides most questions about pg_lake's permissions is that those
+roles gate **naming a storage location**, not **using a table**. There are two
+layers, and they are checked at different times by different code.
+
+### Using a table: ordinary PostgreSQL privileges, no lake role
+
+A user with no lake role at all can `SELECT`, `INSERT`, `UPDATE` and `DELETE` on
+a lake table backed by S3 or Iceberg, given only `USAGE` on the schema and the
+table-level `GRANT`s. Nothing in the read or write path re-checks for `lake_read`
+or `lake_write`, because the role check ran once, at `CREATE`, on the location the
+creator named. From then on the table is an ordinary PostgreSQL object whose
+privileges are ordinary PostgreSQL privileges, including column-level ones.
+
+A regression test pins the whole sequence: the user is refused all five statements
+with schema `USAGE` only, and each one starts working as the matching table-level
+`GRANT` arrives, all without any lake role.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/tests/pytests/test_permissions.py:728-847`, `pg_lake_table/tests/pytests/test_permissions.py:354-429` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the corollary is that a lake role is much stronger than a table
+privilege, not a smaller version of one. `lake_read` is not "may read lake
+tables"; it is "may read any object the pgduck_server credentials can reach",
+which includes the files behind a table the holder has no `SELECT` on. Grant the
+lake roles to the users who define tables, and use table privileges for everyone
+who only queries them.
+
+### Naming a location: the lake roles
+
+The role check happens when a statement carries a location. `CheckURLReadAccess`
+wants `lake_read` and `CheckURLWriteAccess` wants `lake_write`, and the FDW option
+validators call the write one with `NULL` first, for the role check alone, before
+any option has been inspected. Because all Iceberg tables are writable, the
+`pg_lake_iceberg` validator does that unconditionally: creating an Iceberg table
+requires `lake_write` whatever the location is, while `lake_read` is enough to
+create a read-only `pg_lake` table over an existing file.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/src/fdw/option.c:95,200,212,225,666,742`, `pg_lake_engine/src/permissions/roles.c:79-103,115-133` @ 031d6f58798d (2026-09-03)
+
+A regression test walks the three states for the same user: with no lake role both
+a `pg_lake` and an Iceberg table are refused; with `lake_read` the read-only
+`pg_lake` table is created but the Iceberg table and a writable `pg_lake` table
+are still refused; with `lake_read_write` both succeed.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/tests/pytests/test_permissions.py:110-198` @ 031d6f58798d (2026-09-03)
+
+### The location is not a free choice either
+
+Holding `lake_write` does not make every location acceptable, and omitting the
+location does not let a user pick one implicitly.
+
+- An explicit location goes through the scheme allowlist, the query-parameter
+  allowlist and the Azure host allowlist (`trust-boundaries.md`, boundary 1), and
+  an Iceberg location additionally may not contain a `?` at all, since the value
+  is a prefix that pg_lake appends `/metadata.json` and data-file paths onto.
+- With no location, `CREATE TABLE ... USING iceberg` is rewritten to carry a
+  placeholder, and after the table exists the placeholder is replaced with
+  `pg_lake_iceberg.default_location_prefix` plus
+  `database/schema/table/relation_id`. That GUC is `PGC_SUSET`, so a non-superuser
+  cannot point it anywhere: the administrator chooses the prefix and the user gets
+  a subdirectory of it named after their own table.
+- For the object-store catalog the anchor is stricter still. The table is placed
+  under the catalog's own root rather than the default prefix, because
+  `catalog.json` records absolute metadata locations and a catalog that points
+  outside its own storage is unreadable to anyone authorized for just that root.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/src/fdw/option.c:742-756`, `pg_lake_table/src/ddl/create_table.c:1038-1051,1065-1078`, `pg_lake_iceberg/src/init.c:192-202` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the default prefix is one prefix for the whole cluster, so
+per-table subdirectories separate names, not tenants. Every user who can create a
+table writes under the same root, and any of them who holds `lake_read` can read
+the whole root. There is no per-role prefix authorization anywhere in pg_lake.
+
+### What is callable without any of this
+
+The SQL surface reachable with no lake role and no table grant is deliberately
+small: the `lake` and `lake_struct` schemas, `lake.version()`,
+`is_object_created_by_lake`, and the catalog views described above.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake/pg_lake--3.0.sql:4-16`, `pg_lake_table/pg_lake_table--3.0.sql:20-56,435` @ 031d6f58798d (2026-09-03)

--- a/.security/data-and-secrets.md
+++ b/.security/data-and-secrets.md
@@ -1,0 +1,191 @@
+# Data and secrets
+
+> Derived-from: Snowflake-Labs/pg_lake@031d6f58798d · generated 2026-09-03
+> Regenerate when: a credential option is added to the `iceberg_catalog` option descriptors, or `IsRedactableUserMappingSecret` changes; the handler registration order in `pg_lake_iceberg/src/init.c` changes; the vended secret name or scope changes; a `rest_catalog_*` GUC changes context; the set of built-in catalog server names changes; or a new statement type can carry a credential in its text.
+
+pg_lake holds two kinds of credential: the object-store credentials that live
+inside pgduck_server, and the Iceberg REST catalog credentials that live in the
+PostgreSQL catalog. They have different owners, different lifetimes and different
+exposure, so they are described separately.
+
+## Object-store credentials live in pgduck_server
+
+DuckDB's secrets manager inside pgduck_server holds the credentials that actually
+open an object-store URL. pg_lake in PostgreSQL does not store them and does not
+need to see them: a backend sends SQL over the socket and DuckDB applies whatever
+secret matches the path.
+
+**Consequence.** Those secrets are process-wide, so they are shared by every
+database and every user in the cluster (`architecture.md`). A PostgreSQL user's
+reach into object storage is decided by `lake_read` / `lake_write` plus whatever
+those secrets cover, and not by anything more granular.
+
+**Bounded by:** how the long-lived secrets get into pgduck_server is a deployment
+question this repository does not answer. The container setup here does it with a
+startup SQL file against a local emulator; a real deployment substitutes its own
+mechanism, and the security of the credentials in it is that mechanism's
+responsibility. See `deployment.md`.
+
+## Vended credentials are scoped and temporary
+
+When a catalog vends short-lived credentials for a specific table, pg_lake pushes
+them into the shared pgduck_server. Three properties of that push matter.
+
+**The name is namespaced and deterministic.**
+`pglake_vended_<dbOid>_<serverOid>_<hash(secretId)>`, where the comment states
+the reason for each part: the database OID because one pgduck_server is shared by
+all databases in the cluster, and a 64-bit hash so distinct identities do not
+collide in the shared namespace. Determinism is what makes
+`CREATE OR REPLACE SECRET` idempotent across credential rotation.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/vended_secrets.c:53-74` @ 031d6f58798d (2026-09-03)
+
+**The secret carries a URL `SCOPE`,** so DuckDB only applies it to paths under
+that prefix rather than to every S3 request in the process.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/vended_secrets.c:18-25,292-293` @ 031d6f58798d (2026-09-03)
+
+**It is temporary and in-memory,** so it never lands in the DuckDB database file.
+It is re-pushed when it is new or nearing expiry, and dropped by name when no
+longer needed.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/vended_secrets.c:355-372,383-400` @ 031d6f58798d (2026-09-03)
+
+The credential values are interpolated into the `CREATE SECRET` text, so they go
+through `EscapeSingleQuotes` first; that helper and the rest of the rendering
+path are in `input-rendering.md`.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/vended_secrets.c:78-102,256-262` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** `SCOPE` routes a secret, it does not protect it. Any session on
+the socket can list the secrets manager and use any secret in it, scope or no
+scope (`threat-model.md`, T1 and T5). The naming and scoping keep unrelated
+credentials from being applied to the wrong request; they are not a boundary
+between tenants.
+
+There is also a deliberate gap in the refresh logic, stated in the code: if
+pgduck_server restarts, a backend that believes its pushed secret is still fresh
+will not re-push until the next reconcile that has other work to do.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/vended_secrets.c:363-367` @ 031d6f58798d (2026-09-03)
+
+## Catalog credentials belong on a user mapping
+
+For an Iceberg REST catalog, `client_id` and `client_secret` are per-user
+credentials. The option descriptors mark them as user-mapping options, and the
+validator comment states the rule directly: they "are credentials and therefore
+belong on a user mapping".
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_options.c:114-117,273-283,286-338` @ 031d6f58798d (2026-09-03)
+
+The OAuth token obtained with them is cached per (server, user mapping), so one
+user's token is not reused for another.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c:47-54` @ 031d6f58798d (2026-09-03)
+
+There are superuser-only GUC fallbacks for the same values
+(`pg_lake_iceberg.rest_catalog_client_id` and `_client_secret`, plus host, OAuth
+path, auth type and scope). All are `PGC_SUSET` with `GUC_SUPERUSER_ONLY`,
+`GUC_NO_SHOW_ALL` and `GUC_NOT_IN_SAMPLE`, so an ordinary user can neither set
+nor read them.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/init.c:284-362` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** a GUC fallback is one credential for the whole cluster, which is
+the opposite of the per-user model above. Setting it in `postgresql.conf` means
+every user who can reach the catalog shares one identity there, and
+`GUC_NO_SHOW_ALL` means a review of the running configuration will not show that
+this happened.
+
+## DDL guards around those credentials
+
+Four refusals protect the credentials already stored, all in the same utility
+handler:
+
+- **the endpoint cannot be changed on a server in use.** `ALTER SERVER ... OPTIONS (SET rest_endpoint ...)` or `oauth_endpoint` is refused while the server has user mappings or dependent Iceberg tables, because, as the hint says, it "would redirect catalog credentials of every mapping owner to the new URL". That is a credential-theft primitive available to whoever owns the server.
+
+  **Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_ddl.c:439-503` @ 031d6f58798d (2026-09-03)
+
+- **the three built-in catalog server names are reserved.** `pg_lake_postgres_catalog`, `pg_lake_object_store_catalog` and `pg_lake_rest_catalog` cannot be created, renamed onto, altered, have their owner changed, or have user mappings created on them by anyone. Reserving the names is what lets the other guards trust a name without looking up the FDW behind it.
+
+  **Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_ddl.c:266-302,357-372,391-405,428-437,439-460,504-517` @ 031d6f58798d (2026-09-03)
+
+- **a credential cannot be dropped out from under dependent tables.** `ALTER USER MAPPING ... OPTIONS (DROP client_secret)` is refused while the server has dependent Iceberg tables. `SET` and `ADD` stay allowed, since those are rotation rather than removal.
+
+  **Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_ddl.c:518-573` @ 031d6f58798d (2026-09-03)
+
+- **the built-in servers cannot be detached from the extension.** `ALTER EXTENSION ... DROP SERVER` is refused for them, because detaching the dependency edge would let the object be dropped freely afterwards.
+
+  **Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_ddl.c:574-621` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** these are utility-statement guards, so they hold for SQL that
+goes through `ProcessUtility` in a session where the extension is loaded. They
+are not catalog constraints. They also do not fire while `creating_extension` is
+set, which is how the extension creates the reserved servers in the first place.
+
+## Keeping credentials out of statement text
+
+A `CREATE USER MAPPING ... OPTIONS (client_secret '...')` statement contains a
+credential in its text, and that text is reported in error contexts and in
+`pg_stat_statements`. `RedactRestCatalogUserMappingSecrets` scrubs the backing
+query-string buffer in place when the statement carries a credential option.
+
+Two design decisions in it are worth repeating:
+
+- **the whole statement is redacted,** not the literal, which the comment
+  explains as trading some observability for a much smaller surface than a
+  hand-rolled string-literal parser. A user-mapping statement with no credential
+  option is left visible.
+- **when the server cannot be proven to belong to another FDW, it is treated as
+  possibly Iceberg** so the statement is scrubbed anyway.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_ddl.c:657-690,691-719,720-757,758-816,817-859` @ 031d6f58798d (2026-09-03)
+
+The registration order carries the security property. Handlers are prepended, so
+the redaction is registered *after* the validator in order to run *before* it,
+which is what stops a validator `ereport(ERROR)` from surfacing an unredacted
+statement in its error context. The comment at the registration says so.
+
+```c
+	/*
+	 * Register last so it runs first: RegisterUtilityStatementHandler
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/init.c:379-387`, `pg_lake_iceberg/src/rest_catalog/rest_catalog_ddl.c:800-815` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** this covers the query string pg_lake's own handler chain sees. It
+is not a general claim that the credential appears nowhere: it is still in
+`pg_user_mappings` for those entitled to read it, and if the statement was typed
+interactively it is in the client's history. Most concretely, pgduck_server's
+`--debug` flag logs full query text, which includes the `CREATE SECRET`
+statements pg_lake sends with credential values in them.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/pgsession/pgsession.c:383,557`, `pgduck_server/src/duckdb/duckdb.c:638` @ 031d6f58798d (2026-09-03)
+
+The OAuth failure path is the other place a credential could leak outward: it
+reports that the token request failed without echoing the response body.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c:301-322` @ 031d6f58798d (2026-09-03)
+
+## Table data
+
+Table data is in object storage, in Parquet, with Iceberg metadata alongside it
+when the table is an Iceberg table. pg_lake does not encrypt it: confidentiality
+at rest is the object store's, under whatever bucket policy and key the
+deployment configures.
+
+Two local copies of data exist and are worth knowing about:
+
+- **the file cache**, a local directory of remote file contents, trimmed by the
+  cache-manager worker to `pg_lake_engine.max_cache_size`. It is keyed by path
+  and has no tenant dimension, so a cached object is available to any query that
+  names the same path.
+- **the temp-file directory**, `$PGDATA/base/pgsql_tmp`, used to move data
+  between the two processes. pg_lake registers a memory-context callback to
+  unlink what it creates.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/cache_worker.c:100-176`, `pg_lake_engine/src/init.c:92-125`, `pg_lake_engine/src/storage/local_storage.c:35-80` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** both are plaintext on local disk, and both are readable by the
+processes that share them. Cleanup of a temp file is tied to the memory context,
+so a crash can leave one behind. Neither is a place to rely on for isolation.

--- a/.security/deployment.md
+++ b/.security/deployment.md
@@ -1,0 +1,158 @@
+# Deployment
+
+> Derived-from: Snowflake-Labs/pg_lake@031d6f58798d · generated 2026-09-03
+> Regenerate when: a pgduck_server command-line flag is added or its default changes; the DuckDB configuration in `duckdb_global_init` changes; `install.sh` changes what it writes to `postgresql.conf` or what it downloads; the docker compose topology changes which volumes the two containers share; or the startup umask changes.
+
+pg_lake is two processes that have to be deployed together, and the security of
+the result depends more on how they are placed than on anything in the SQL layer.
+This document covers what the repository actually configures, and which choices
+it leaves to the operator.
+
+## The two processes
+
+PostgreSQL loads `pg_extension_base` from `shared_preload_libraries`, which then
+loads the pg_lake libraries named on the installed control files.
+`install.sh` writes that line when it initialises a cluster, and prints it as a
+manual step when using an existing one.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `install.sh:566-568,812,825` @ 031d6f58798d (2026-09-03)
+
+pgduck_server runs separately and must be started before pg_lake is usable.
+`install.sh` prints the minimal invocation, which uses the default socket
+directory:
+
+```
+pgduck_server --cache_dir /tmp/pg_lake_cache/
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `install.sh:830-831` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** that default puts both the socket and the cache in `/tmp`, which
+is world-writable and shared with every other user on the machine. The socket
+itself is protected (0770, no group, so user-only) and the DuckDB database file
+is checked for symlinks and foreign ownership before opening, but the cache
+directory gets no such check. A single-user development box is the case this
+default fits; it is not a deployment posture. Give pgduck_server its own user and
+its own directories, per `threat-model.md` T1.
+
+One thing does work in the operator's favour by default: pgduck_server sets a
+umask of `0077` before it does anything else, so files it creates are not
+group- or world-readable.
+
+```c
+	umask(S_IRWXG | S_IRWXO);
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/main.c:60` @ 031d6f58798d (2026-09-03)
+
+## The flags that carry security weight
+
+| Flag | Default | Why it matters |
+| --- | --- | --- |
+| `--unix_socket_directory` | `/tmp` | The whole of boundary 3. A `@`-prefixed value makes it an abstract socket with no permissions at all. |
+| `--unix_socket_group` | empty | Empty means user-only. Naming a group widens access to that group. |
+| `--unix_socket_permissions` | `0770` | Widening this widens the only control on the socket. |
+| `--no_extension_install` | off | Selects the extension posture below. |
+| `--extensions_dir` | unset | Where extensions load from. Must not be writable by anyone but the server. |
+| `--init_file_path` | unset | Arbitrary SQL executed at startup as the server's own session. |
+| `--duckdb_database_file_path` | `~/.pglake/pgduck_server.db` | Ownership-checked before opening. |
+| `--cache_dir` | unset | Local plaintext copies of remote files. Not ownership-checked. |
+| `--debug` | off | Logs full query text, including `CREATE SECRET` statements. |
+| `--memory_limit` | 80% of system memory | Availability for the whole cluster. |
+| `--max_clients` | 10000 | Availability for the whole cluster. |
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/command_line/command_line.c:40-50,107-124,135-172` @ 031d6f58798d (2026-09-03)
+
+## The startup SQL file
+
+`--init_file_path` names a file whose statements are executed on startup, before
+any client connects. It runs with the server's full DuckDB privilege, so it is a
+trusted input in the strict sense: whoever can write that file can run anything
+in the process.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/main.c:67-74`, `pgduck_server/src/command_line/command_line.c:117` @ 031d6f58798d (2026-09-03)
+
+Its intended use is exactly what the shipped example does: create the long-lived
+object-store secrets. The example points at a local emulator with dummy
+credentials.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `docker/scripts/init-pgduck-server.sql:1-11` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** a real deployment puts real credentials in that file or supplies
+them another way, and this repository provides nothing for either. Protecting the
+file, and keeping the credentials in it as narrow as the deployment allows, is
+entirely on the operator. Note the consequence from `data-and-secrets.md`: a
+secret created here is cluster-wide, so its reach is the reach of every
+`lake_read` holder in every database.
+
+## The DuckDB extension posture
+
+`duckdb_global_init` sets two coherent configurations, selected by whether
+extension installation is allowed.
+
+With installs allowed (the default):
+
+- `allow_unsigned_extensions = false`
+- `autoinstall_known_extensions = true`
+
+With `--no_extension_install`:
+
+- `autoinstall_known_extensions = false`
+- `custom_extension_repository = disabled`, which the comment explains is there to
+  make a manual `INSTALL` fail as well
+- `allow_unsigned_extensions = true`, permitted in this mode on the reasoning that
+  the operator builds the extensions themselves
+
+`autoload_known_extensions` is `true` in both, and `enable_external_file_cache`
+is `false` because pg_lake has its own cache.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/duckdb/duckdb.c:248-289`, `pgduck_server/src/main.c:67-74` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the second posture trades signature checking for a closed
+install path, so it is only sound while the extension directory is not writable
+by anyone who could otherwise connect. Combined with a writable
+`--extensions_dir` it is strictly worse than the default. And because
+`autoload_known_extensions` stays on in both, an extension present in that
+directory loads on first use without anyone issuing a `LOAD`.
+
+## The container topology
+
+The shipped compose file runs PostgreSQL and pgduck_server as separate containers
+and joins them with two named volumes: one for the socket directory and one for
+the PostgreSQL temp-file directory. Both are mounted at the same path in both
+containers, and the pgduck_server entrypoint chowns them to `postgres` and
+chmods them to 700 before starting the server. pgduck_server listens on a unix
+socket only, and the compose comments say so twice.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `docker/docker-compose.yml:8-12,30-38,66-68`, `docker/scripts/entrypoint-pgduck-server.sh:13-29` @ 031d6f58798d (2026-09-03)
+
+This is the topology the security model assumes: no TCP listener anywhere near
+pgduck_server, and the socket reachable only through a shared volume rather than
+the network.
+
+**Bounded by:** separate containers give process and filesystem separation, not
+isolation of what pgduck_server can do once reached. Both containers also run
+with `SYS_PTRACE` added, which is a debugging convenience in this compose file
+and should not be carried into a real deployment. The third service is
+localstack, an S3 emulator with dummy credentials, which exists for local
+development only.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `docker/docker-compose.yml:21-22,47-48,52-64` @ 031d6f58798d (2026-09-03)
+
+## What install.sh pulls in
+
+`install.sh` installs build and runtime dependencies through the platform package
+manager with `sudo`, which is the normal arrangement for a build script but does
+mean it is a privileged script.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `install.sh:228-229,272-275,633-636` @ 031d6f58798d (2026-09-03)
+
+With `--with-test-deps` it also downloads the PostgreSQL JDBC driver over HTTPS
+by version number.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `install.sh:757-762` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** that download is not checksum-verified or signature-verified in
+the script, so it trusts HTTPS and the upstream host. It only happens on the
+test-dependency path, so it does not affect a production install, but a CI image
+built with `--with-test-deps` inherits the trust.

--- a/.security/input-rendering.md
+++ b/.security/input-rendering.md
@@ -1,0 +1,125 @@
+# Rendering values into SQL
+
+> Derived-from: Snowflake-Labs/pg_lake@031d6f58798d · generated 2026-09-03
+> Regenerate when: a new helper renders a value into SQL text bound for DuckDB or for SPI; `duckdb_kwlist.h` stops being generated from the vendored keyword list; a call site starts interpolating a value into a query given to `run_attached`; or the FDW deparser starts binding parameters instead of interpolating constants.
+
+pg_lake builds SQL as text in two directions, and both are injection surfaces:
+
+- **outward to DuckDB**, over the socket, where the statement runs with the
+  server's full privilege (`threat-model.md`, T1);
+- **inward to PostgreSQL through SPI**, where several paths run as the extension
+  owner, which is typically a superuser.
+
+Neither direction uses bound parameters end to end, so the correctness of the
+quoting helpers is what stands in for it. This document lists them.
+
+## Outward: text sent to DuckDB
+
+### Identifiers
+
+`duckdb_quote_identifier` is pg_lake's replacement for core's
+`quote_identifier`. It exists because DuckDB's parser is a fork of PostgreSQL's
+with extra reserved words (`PIVOT`, `LAMBDA`, `QUALIFY`), so core's keyword list
+under-quotes: an identifier that needs quoting in DuckDB and not in PostgreSQL
+comes out bare.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/keywords.c:74-134`, `tools/generate_duckdb_kwlist.py:1-21` @ 031d6f58798d (2026-09-03)
+
+The keyword table is generated from the vendored DuckDB `kwlist.hpp` and
+committed, with `make check-duckdb-kwlist` verifying it is not stale.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `Makefile:229-238`, `.github/workflows/lint.yml:57-59` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the check proves the table matches the pinned DuckDB, not that
+every call site uses it. An identifier rendered with core's `quote_identifier`
+somewhere in the DuckDB-bound path would pass every gate in this repository.
+
+### String literals
+
+Three helpers, for three destinations:
+
+- `deparseStringLiteral` for constants in deparsed FDW queries;
+- `EscapeSingleQuotes` for values interpolated into `CREATE SECRET`, which is how
+  vended credentials reach DuckDB (`data-and-secrets.md`);
+- `QuoteDuckDBStructKey` for struct keys, which additionally escapes backslashes
+  because the value has to survive a round trip through CSV.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/src/fdw/deparse.c:2520-2542`, `pg_lake_engine/src/pgduck/vended_secrets.c:78-102`, `pg_lake_engine/src/pgduck/struct_conversion.c:49-60,157` @ 031d6f58798d (2026-09-03)
+
+### The deparser interpolates rather than binds
+
+`deparseConst` renders constants into the query text instead of sending them as
+parameters. That is a deliberate design choice for a pushdown deparser, and it
+means every type's output function is part of the injection surface rather than
+just the string case.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/src/fdw/deparse.c:2706-2790` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** correctness here rests on each rendered constant being
+re-parseable by DuckDB as the same value, which is a per-type property with no
+single check behind it. A type whose output form DuckDB parses differently is a
+correctness bug first and potentially an injection one second.
+
+## Inward: text executed through SPI as the extension owner
+
+Several bookkeeping paths run SQL as the `pg_lake_engine` extension owner via
+`SPI_START_EXTENSION_OWNER`, because the caller has already had its permissions
+checked and the internal tables are not user-writable. That makes those paths
+the highest-value injection targets in the repository: the owner is usually a
+superuser.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/cleanup/in_progress_files.c:281,357,426,530,755` @ 031d6f58798d (2026-09-03)
+
+The in-progress-file insert shows the pattern that keeps this safe. The inner
+statement is built as text with `quote_literal_cstr` around the path, and then
+that whole statement is passed as a bound `$1` text parameter to
+`extension_base.run_attached`:
+
+```c
+	DECLARE_SPI_ARGS(1);
+	SPI_ARG_VALUE(1, TEXTOID, query->data, false);
+
+	bool		readOnly = false;
+
+	SPI_EXECUTE("select * from extension_base.run_attached($1)", readOnly);
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/cleanup/in_progress_files.c:519-537`, `pg_extension_base/include/pg_extension_base/spi_helpers.h:54-90` @ 031d6f58798d (2026-09-03)
+
+The reason the parameter matters is recorded in a regression test rather than in
+the code: this call previously wrapped the inner query in `$$...$$`, and a `$$`
+inside a user-supplied table `location` closed that quoting early. Since the
+statement ran as the extension owner with `readOnly = false`, a `lake_write`
+holder could append `ALTER ROLE ... SUPERUSER`. The test asserts the escalation
+does not happen, and names the fix so a future change cannot quietly undo it.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/tests/pytests/test_security.py:79-155` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the structural lesson is that dollar-quoting a generated
+statement is not safe when any part of it is user-influenced, and `location` is
+user-influenced because `IsSupportedURL` only checks the scheme. Nothing
+mechanically prevents a new `$$`-wrapped query from being introduced: the
+protection is the convention of passing generated SQL through
+`DECLARE_SPI_ARGS` / `SPI_ARG_VALUE`, plus the tests that cover the paths already
+found. A new call site is not covered until someone writes the test.
+
+Two more paths in the same class have their own regression tests, because the
+user-influenced value arrives from further away in each:
+
+- **the benchmark data generators.** `lake_tpch.gen` and `lake_tpcds.gen` take a
+  `location`, and the tests cover both that the functions require `lake_write`
+  and that a SQL-injection payload in `location` is blocked.
+
+  **Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_benchmark/tests/pytests/test_security.py:1-4,40-207` @ 031d6f58798d (2026-09-03)
+
+- **`catalog.json` for an object-store catalog.** The file is read from object
+  storage, so its contents are attacker-influenced wherever a user can write to
+  the catalog prefix (`threat-model.md`, T7). Three tests cover a dollar-quote
+  payload in it: that it is blocked, that a value containing a `$` sequence still
+  parses, and that it survives a round trip through the writer.
+
+  **Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/tests/pytests/test_security.py:194-427` @ 031d6f58798d (2026-09-03)
+
+The pairing in those tests is the part worth copying: a rejection test alone
+passes just as well against code that rejects everything, so each is paired with
+a test that the legitimate value still works.

--- a/.security/secure-coding.md
+++ b/.security/secure-coding.md
@@ -1,0 +1,142 @@
+# Secure coding practices
+
+> Derived-from: Snowflake-Labs/pg_lake@031d6f58798d · generated 2026-09-03
+> Regenerate when: a `test_security.py` suite is added or removed; a suite stops running in CI, or the `pg_version` matrices change; the `check-indent` or `check-duckdb-kwlist` gate is removed; or a new URL gate ships without a test in one of these suites.
+
+The controls in `trust-boundaries.md` are single `if` statements in a large tree,
+so what keeps them alive is the test suites that fail when one is removed. This
+document says which those are, what CI runs them on, and where the coverage runs
+out.
+
+## The security regression suites
+
+Four suites, one per extension that has a boundary to defend. Each one opens by
+naming the vulnerability class it exists for.
+
+| Suite | Tests | Class |
+| --- | --- | --- |
+| `pg_lake_copy/tests/pytests/test_security.py` | 21 | privilege-check bypass and SSRF |
+| `pg_lake_iceberg/tests/pytests/test_security.py` | 15 | Avro parsing, nested metadata paths, credential redaction |
+| `pg_lake_table/tests/pytests/test_security.py` | 5 | privilege escalation and SQL injection |
+| `pg_lake_benchmark/tests/pytests/test_security.py` | 4 | SQL injection through a `location` argument |
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/tests/pytests/test_security.py:1-4`, `pg_lake_iceberg/tests/pytests/test_security.py:1-3`, `pg_lake_table/tests/pytests/test_security.py:1-4`, `pg_lake_benchmark/tests/pytests/test_security.py:1-4` @ 031d6f58798d (2026-09-03)
+
+Three properties of how they are written are worth keeping.
+
+**They test through the product surface, as an unprivileged user.** The `COPY`
+tests connect as a role with no lake privileges and try to read `/etc/passwd`,
+`/tmp/test.json` and `/home/postgres/.pgpass`. They assert on the behaviour, not
+on the presence of a check in the source.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/tests/pytests/test_security.py:38-130` @ 031d6f58798d (2026-09-03)
+
+**Every rejection is paired with an acceptance.** `test_clean_s3_url_still_works`
+sits next to the query-string rejections, `test_s3_url_with_safe_query_param_is_accepted`
+next to the allowlist, `test_azure_container_url_still_works` next to the Azure
+host rejections. A rejection test on its own would keep passing against code that
+rejects everything, which is a real way for a gate to rot into a denial of
+service.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/tests/pytests/test_security.py:265-288,338-360,518-561` @ 031d6f58798d (2026-09-03)
+
+**The nested cases are covered, not just the top-level one.** For Iceberg the
+attacker-controlled value can arrive inside a manifest list, a manifest, or a
+data-file entry, and each of those is a separate test. One of them,
+`test_manifest_url_check_does_not_require_lake_read`, pins the deliberate
+asymmetry that the scheme check on a metadata-derived path is not also a role
+check.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/tests/pytests/test_security.py:272-429` @ 031d6f58798d (2026-09-03)
+
+The escalation tests in `pg_lake_table` go further and assert on the outcome
+rather than the error: they check `rolsuper` on the test user afterwards, so the
+test fails if the payload succeeds even when the statement also raises.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_table/tests/pytests/test_security.py:142-152` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** these suites cover the gates that exist. They cannot fail for a
+new entry point that never got a gate, because nothing enumerates the entry
+points. The call-site list in `trust-boundaries.md` is the closest thing to that
+enumeration, and it is a snapshot, which is why the `Regenerate when:` line on
+that document leads with a new call site appearing.
+
+## What CI runs
+
+Every suite runs on PostgreSQL 17 and 18 on AlmaLinux, as separate make targets.
+Builds cover 16, 17 and 18.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `.github/workflows/pytest_all.yml:93-94,118-119,149-163` @ 031d6f58798d (2026-09-03)
+
+`check-pg_lake_table` is split across five parallel workers because it is slow;
+the other targets run whole. The SQL regression suites run separately, on a
+Debian image, so both distributions are exercised.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `.github/workflows/pytest_all.yml:188-194,206-207,209-243` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the pytest matrices are 17 and 18 only, so none of the four
+security suites ever runs on PostgreSQL 16 even though 16 is built and its SQL
+regression suites do run. A version-specific behaviour difference in a gate on 16
+would not be caught. `install.sh` is not exercised by CI at all either, which
+matters because it is the script that writes `shared_preload_libraries` and
+prints the pgduck_server invocation (`deployment.md`).
+
+## The two static gates
+
+**Formatting.** `make check-indent` runs `pgindent` against a typedefs list
+downloaded for a pinned PostgreSQL version, and CI runs the same target, so local
+and CI formatting agree.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `Makefile:52-55,70-85`, `.github/workflows/lint.yml:53-55` @ 031d6f58798d (2026-09-03)
+
+**The DuckDB keyword table.** `make check-duckdb-kwlist` fails when the
+committed keyword table no longer matches the vendored DuckDB's `kwlist.hpp`.
+This is the only gate in the repository that catches a *dependency bump*
+invalidating a security-relevant table: a new DuckDB reserved word that is not in
+the committed list means `duckdb_quote_identifier` under-quotes it
+(`input-rendering.md`).
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `Makefile:229-238`, `.github/workflows/lint.yml:57-59`, `tools/generate_duckdb_kwlist.py:1-21` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** the generator can fetch `kwlist.hpp` over the network from GitHub
+at the pinned submodule SHA when the submodule is not checked out, so in that mode
+the check trusts the fetch. There is no linting for the pattern that caused the
+escalation in `input-rendering.md` either: nothing flags a new `$$`-wrapped
+generated statement, or a new call site that skips a URL gate.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `tools/generate_duckdb_kwlist.py:28,39-41` @ 031d6f58798d (2026-09-03)
+
+## Conventions worth following
+
+Drawn from the code that already exists, so a change that departs from them is
+worth a second look:
+
+- **A gate goes at the entry point, and every entry point gets one.** Adding a
+  function that takes a path or a URL means adding a `CheckURLReadAccess` or
+  `CheckURLWriteAccess` call, and the FDW pattern of calling the gate with `NULL`
+  first for the role check and again with the value once it is known is the
+  worked example.
+- **Allowlist, never denylist.** All four URL controls are allowlists, and the
+  comment on the query-parameter one gives the reason: the set of settings DuckDB
+  honours grows, so a denylist rots into a bypass.
+- **State the bypass in the comment.** The comments on the local-path check, the
+  http(s) write refusal and the Azure container-part check each name the concrete
+  attack. That is what let this bundle cite an intent rather than guess one.
+- **Generated SQL is a bound parameter, not an interpolation.** Use
+  `DECLARE_SPI_ARGS` / `SPI_ARG_VALUE`; do not wrap a generated statement in
+  `$$...$$`.
+- **A new gate ships with a paired test.** One that the payload is rejected, one
+  that the legitimate value still works.
+- **Credentials go on user mappings.** A GUC fallback is a cluster-wide identity;
+  see `data-and-secrets.md`.
+- **A privilege-relevant GUC is `PGC_SUSET` at least,** and
+  `GUC_SUPERUSER_ONLY` if it carries a credential.
+
+## Reporting
+
+Security issues in pg_lake should be reported privately to the maintainers rather
+than in a public issue. At this commit the repository has no `SECURITY.md`, so
+there is no documented reporting address in-tree; `.github/CODEOWNERS` names the
+maintaining team.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `.github/CODEOWNERS:8-14` (no `SECURITY.md` in the repository root or in `.github/`) @ 031d6f58798d (2026-09-03)

--- a/.security/security.yaml
+++ b/.security/security.yaml
@@ -1,0 +1,65 @@
+apiVersion: snowflake.com/security/v1alpha1
+kind: SecurityContext
+metadata:
+  name: pg_lake
+  labels:
+    products: pg_lake
+spec:
+  # Controls this repository actually implements.  Each one is described, with a
+  # file:line citation, in the document named next to it.
+  control_ids:
+    - lake-read-write-roles                  # architecture.md
+    - table-privileges-govern-dml            # architecture.md
+    - suset-default-location-prefix          # architecture.md
+    - url-scheme-allowlist                   # trust-boundaries.md
+    - url-query-parameter-allowlist          # trust-boundaries.md
+    - azure-host-suffix-allowlist            # trust-boundaries.md
+    - http-write-target-refusal              # trust-boundaries.md
+    - copy-local-path-server-files-check     # trust-boundaries.md
+    - pgduck-socket-filesystem-permissions   # trust-boundaries.md
+    - duckdb-database-file-ownership-check   # deployment.md
+    - spi-parameter-binding                  # input-rendering.md
+    - superuser-only-credential-gucs         # data-and-secrets.md
+    - user-mapping-credential-placement      # data-and-secrets.md
+    - user-mapping-secret-redaction          # data-and-secrets.md
+    - reserved-catalog-server-names          # data-and-secrets.md
+    - oauth-error-body-not-echoed            # data-and-secrets.md
+    - vended-secret-scoping                  # data-and-secrets.md
+    - duckdb-extension-install-posture       # deployment.md
+    - duckdb-identifier-quoting              # input-rendering.md
+    - duckdb-keyword-list-drift-check        # secure-coding.md
+    - url-gate-regression-suite              # secure-coding.md
+
+  documents:
+    - path: architecture.md
+      kind: context
+      description: "What pg_lake is made of: the extension set inside PostgreSQL, pgduck_server as a separate DuckDB process reached over a unix socket, the temp-file directory the two share, object storage as the actual table storage, the three built-in Iceberg catalog servers with PostgreSQL itself as the default catalog, and the file cache, deletion queue and cache-manager worker that touch storage outside a user query.  Also the permission model in full: the lake roles gate naming a storage location, ordinary table privileges govern every read and write afterwards, and the default location prefix is a superuser-set GUC so a user cannot choose where their table lands."
+    - path: trust-boundaries.md
+      kind: threat-model
+      description: "Every place untrusted input reaches privileged code: a SQL user naming a URL, the roles and allowlists that gate it, the COPY path that reaches the local filesystem, and the Postgres-to-pgduck_server boundary, which has no authentication and is held only by filesystem permissions on the socket."
+    - path: threat-model.md
+      kind: threat-model
+      description: "Ranked threats for a pg_lake deployment: SSRF into an internal or metadata endpoint, exfiltration through a write target, arbitrary local file access through the DuckDB process, secret and cache visibility across databases inside the one shared pgduck_server, and denial of service against that single process. Each with the control that addresses it and what stays uncovered."
+    - path: data-and-secrets.md
+      kind: context
+      description: "Where object-store credentials live and how they move: DuckDB secrets inside pgduck_server, per-user Iceberg REST catalog credentials on foreign user mappings, the superuser-only GUC fallbacks, the statement redaction that keeps those credentials out of query text, and the vended STS credential pg_lake pushes into pgduck_server under a scoped name."
+    - path: deployment.md
+      kind: context
+      description: "How pg_lake is installed and run: two processes, the socket directory and its permissions, install.sh and the docker compose topology, the DuckDB extension install posture with and without --no_extension_install, and the operator-supplied startup SQL file."
+    - path: secure-coding.md
+      kind: secure-coding
+      description: "The gates that keep the above honest: the security regression suite that pins every URL gate, the generated DuckDB keyword list drift check, the formatting gate, and the PostgreSQL version matrix the suites run on."
+    - path: input-rendering.md
+      kind: secure-coding
+      description: "Every helper that turns values into SQL text, in both directions.  Outward to DuckDB: duckdb_quote_identifier and the generated keyword list behind it, EscapeSingleQuotes for secret values, QuoteDuckDBStructKey for struct literals that travel through CSV, and the FDW deparser, which interpolates constants rather than binding them.  Inward through SPI as the extension owner, which is usually a superuser, where generated SQL is passed as a bound parameter after a dollar-quoted version of the same call was found to allow privilege escalation."
+
+  related_repositories:
+    - repo: duckdb/duckdb
+      relationship: dependency
+      description: "Submodule at duckdb_pglake/duckdb.  pgduck_server embeds DuckDB, so DuckDB's filesystem, httpfs and azure implementations are the code that actually opens a URL or a local path.  The URL gates in this repository exist because those implementations read connection settings off the URL and place no restriction on local paths."
+    - repo: duckdb/duckdb-postgres
+      relationship: dependency
+      description: "Submodule at duckdb_pglake/duckdb-postgres, patched in-tree via duckdb_pglake/duckdb-postgres.patch.  Used for the postgres_scan path."
+    - repo: apache/avro
+      relationship: dependency
+      description: "Submodule at avro/, patched in-tree via avro.patch.  Parses Iceberg manifest files, which are attacker-influenced input whenever a user can write to the table's storage location."

--- a/.security/threat-model.md
+++ b/.security/threat-model.md
@@ -1,0 +1,223 @@
+# Threat model
+
+> Derived-from: Snowflake-Labs/pg_lake@031d6f58798d · generated 2026-09-03
+> Regenerate when: a URL gate is added, removed or moved; a new statement type is routed through the `ProcessUtility` hook; pgduck_server gains per-session state, an authentication step or a query timeout; the DuckDB extension posture in `duckdb.c` changes; or a new SQL-callable function reaches object storage or the local filesystem.
+
+The threats below are ordered by how much they cost when they land, not by how
+likely they are. Each one names the control that addresses it and what the
+control does not reach. The controls themselves are described in
+`trust-boundaries.md` and `data-and-secrets.md`; this document is about what
+they are for and where the gaps are.
+
+The assumed attacker is a PostgreSQL user who holds `lake_read` or `lake_write`
+and nothing more, unless a threat says otherwise. A user without either role
+cannot name a URL at all, though they can still query and modify any lake table
+their ordinary table privileges cover (`architecture.md`). A superuser is not an
+attacker in this model because a PostgreSQL superuser can run arbitrary code by
+design.
+
+Holding a lake role is worth more than any table privilege, and that is the first
+thing to get right when granting one. `lake_read` reads any object the
+pgduck_server credentials can reach, which includes the files behind tables its
+holder has no `SELECT` on, and `pg_catalog.iceberg_tables` is world-readable and
+gives the paths. Treat the lake roles as a property of the person who defines
+tables, not as the way to let someone query them.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/permissions/roles.c:79-103`, `pg_lake_iceberg/pg_lake_iceberg--3.0.sql:69-72` @ 031d6f58798d (2026-09-03)
+
+## T1: a local process connects to pgduck_server directly
+
+**What it gets.** Everything. The socket has no authentication
+(`trust-boundaries.md`, boundary 3), so a connection is a DuckDB session with the
+server's full privilege: read and write any file the pgduck_server user can
+reach, use or dump every secret in the shared secrets manager, and reach every
+object those credentials cover. PostgreSQL's role checks are not in the path
+because the attacker never went through PostgreSQL.
+
+**Control.** Filesystem permissions on the socket, and nothing else. Default
+0770 with an empty group is user-only.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/command_line/command_line.c:40-47`, `pgduck_server/src/pgserver/pgserver.c:212-214,272-300` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** A shared socket directory that other users can write to, a
+`--unix_socket_group` or `--unix_socket_permissions` wider than the deployment
+needs, and an abstract socket, which has no permissions at all. This threat is
+why running pgduck_server as its own user, in its own namespace, or in its own
+container is the deployment recommendation rather than an optimisation.
+
+## T2: SSRF into an internal or cloud metadata endpoint
+
+**What it gets.** A URL is not just a name: DuckDB's S3 filesystem takes
+connection settings from the query string, and the Azure filesystems take the
+endpoint from the host. A `lake_read` user who can steer either one can make the
+server issue a request to an address of their choosing inside the network, and
+read the response body back as query rows. The classic target is the instance
+metadata service, whose response is a set of credentials.
+
+**Controls.** The query-parameter allowlist (two keys), the Azure host-suffix
+allowlist with its label-boundary and container-part checks, and the scheme
+allowlist applied to manifest-derived paths as well as user-named ones.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/permissions/roles.c:196-269,285-339,374-425,164-172` @ 031d6f58798d (2026-09-03)
+
+Regression tests cover the metadata-endpoint form specifically, on `COPY` in
+both directions, on a foreign table, and on the Iceberg metadata functions.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/tests/pytests/test_security.py:198-264,289-337,361-386` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** `http://` and `https://` reads are not gated beyond the
+`lake_read` role, because on those schemes the URL is the request target and the
+query string is ordinary. Granting `lake_read` therefore includes the ability to
+make the server fetch an arbitrary http(s) URL and return the body. If that
+matters in a deployment, it has to be handled by network policy around the
+pgduck_server process, not by pg_lake. Nothing in this repository restricts
+which hosts the DuckDB HTTP client may reach.
+
+## T3: exfiltration through a write target
+
+**What it gets.** A `lake_write` user who can name an outbound target moves any
+data they can query out of the deployment in one statement.
+
+**Control.** Writes to `http(s)://` are refused for everyone including
+superusers, with exfiltration named as the reason. `pg_lake.stage_location` is
+validated the same way when it is set.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/permissions/roles.c:115-155`, `pg_lake_engine/src/init.c:266-300` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** Object-store write targets are only checked for scheme, query
+string and (on Azure) host. A `lake_write` user may write to any bucket the
+server's credentials can write to, including one that is not theirs, and to a
+public bucket belonging to someone else if the credentials permit anonymous
+writes. pg_lake has no per-prefix write authorisation.
+
+## T4: arbitrary local file access through the DuckDB process
+
+**What it gets.** DuckDB's `LocalFileSystem` has no restrictions, so a path that
+reaches it reads or writes as the pgduck_server user: `~/.pgpass`, key material,
+`postgresql.conf`.
+
+**Controls.** There is no `file://` scheme in `IsSupportedURL`, and the one place
+that accepts a bare local path, `COPY`, replicates core's
+`pg_read_server_files` / `pg_write_server_files` check because pg_lake's
+`ProcessUtility` hook runs ahead of core's own check
+(`trust-boundaries.md`, boundary 2).
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/copy/copy_format.c:420-442`, `pg_lake_copy/src/copy/copy.c:415-434,823-841` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** The replicated check can drift from the core check it copies,
+and it only covers `COPY`. Completeness depends on every other path rejecting a
+non-URL argument on the scheme allowlist, which is a property of the current call
+sites rather than something enforced centrally. A new entry point that takes a
+path and forgets the gate reopens this, which is what the regression suite in
+`secure-coding.md` exists to catch.
+
+Two files that are read by design belong here as well: the pgduck_server startup
+SQL file, executed as the server's own session at boot, and the DuckDB database
+file, which is checked for symlinks and foreign ownership before it is opened.
+Both are operator-supplied; see `deployment.md`.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/main.c:74`, `pgduck_server/src/duckdb/duckdb.c:179-219` @ 031d6f58798d (2026-09-03)
+
+## T5: one user reaching another user's credentials or cached data
+
+**What it gets.** One pgduck_server serves every database and every user in the
+cluster, so its DuckDB secrets, settings and file cache are cluster-wide state.
+A user in database A can potentially use a credential pushed on behalf of a user
+in database B, or read a cached file belonging to a query they could not have run.
+
+**Controls.** Vended credentials are pushed under a name that includes the
+database OID, the server OID and a hash, and with a URL `SCOPE`, so DuckDB will
+only apply a secret to a matching path. They are created as temporary
+in-memory secrets, so they do not persist in the database file. Iceberg REST
+catalog credentials live on per-user foreign user mappings, and the token cache
+is keyed by (server, user mapping).
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/pgduck/vended_secrets.c:53-74,245-301,355-367`, `pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c:47-54` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** Scoping is a routing rule, not an access control. Any session on
+the socket can enumerate the secrets manager, and a broader long-lived secret
+configured by the operator applies to every database in the cluster by design.
+The file cache has no tenant dimension at all. Where hard separation between
+tenants is required, it needs separate pgduck_server processes, which is a
+deployment choice this repository does not make.
+
+## T6: credential disclosure in query text, errors or logs
+
+**What it gets.** Catalog credentials, and with them whatever the catalog
+protects.
+
+**Controls.** All `rest_catalog_*` GUCs are `PGC_SUSET` and
+`GUC_SUPERUSER_ONLY`, so they are not readable by an ordinary user.
+`client_id` and `client_secret` are documented as belonging on a user mapping
+rather than a server. Statements that carry those options are blanked out of the
+reported query string before any validator can raise an error containing them,
+and the redaction hook is deliberately registered after the validator so the
+ordering holds. The OAuth failure path does not echo the response body.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/init.c:284-362`, `pg_lake_iceberg/src/rest_catalog/rest_catalog_options.c:273-283`, `pg_lake_iceberg/src/rest_catalog/rest_catalog_ddl.c:783-820`, `pg_lake_iceberg/src/rest_catalog/rest_catalog_auth.c:301-322` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** The redaction covers the statement text pg_lake reports; it is
+not a claim about every place PostgreSQL might record a statement. And
+pgduck_server's `--debug` flag logs full query text, which includes the
+`CREATE SECRET` statements pg_lake sends. `--debug` is not a debugging
+convenience on a deployment holding real credentials.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/pgsession/pgsession.c:383,557`, `pgduck_server/src/duckdb/duckdb.c:638` @ 031d6f58798d (2026-09-03)
+
+## T7: hostile table metadata
+
+**What it gets.** Iceberg manifests are Avro, data files are Parquet, and both
+are parsed by vendored C and C++ code. Anyone who can write to a table's storage
+location controls that input, and a storage location is not always as private as
+the table's PostgreSQL privileges suggest.
+
+**Control.** Paths taken from metadata go through `ValidateStorageURL`, so a
+manifest cannot change the scheme or smuggle a query string into the next read.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_iceberg/src/iceberg/read_manifest.c:88,138,261` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** That is a check on the path, not on the bytes. Memory safety in
+the Avro and Parquet readers belongs to the vendored dependencies listed in
+`security.yaml`, and both carry in-tree patches, so a fix upstream is not
+automatically a fix here. Treat write access to a table's storage location as
+equivalent to influence over the parsers.
+
+## T8: denial of service against the single process
+
+**What it gets.** pgduck_server is one process for the whole cluster, so a query
+that exhausts its memory or a client that occupies it degrades or stops lake
+access for every database at once, including administrative paths like the
+deletion queue.
+
+**Controls.** `--memory_limit` (default 80 percent of system memory),
+`--max_clients` (default 10000), `--cache_on_write_max_size` (default 1GB), and
+`--continue_on_oom` to keep serving after an out-of-memory error rather than
+stopping. The cache-manager background worker trims the file cache to
+`pg_lake_engine.max_cache_size`, and restarts 5 seconds after a crash.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/command_line/command_line.c:48-49,112-114`, `pg_lake_engine/src/pgduck/cache_worker.c:81-95` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** There is no per-user or per-database resource accounting inside
+pgduck_server and no statement timeout of its own, so the limits are global.
+Availability isolation between tenants needs separate processes, as in T5.
+
+## T9: supply chain through DuckDB extensions
+
+**What it gets.** Code execution inside pgduck_server, which by T1 is
+everything.
+
+**Control.** Two coherent postures, described in `deployment.md`. With installs
+allowed, unsigned extensions are refused and only known extensions autoinstall.
+With `--no_extension_install`, autoinstall is off and
+`custom_extension_repository` is set to `disabled` so that manual `INSTALL`
+fails too; unsigned extensions are permitted in that mode because the operator
+built them.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/duckdb/duckdb.c:248-283` @ 031d6f58798d (2026-09-03)
+
+**Not covered.** `autoload_known_extensions` is on in both postures, so an
+extension already present in the extension directory loads on first use without
+an explicit `LOAD`. The two postures are also only as separate as the flag: a
+deployment that passes `--no_extension_install` and also ships a writable
+extension directory has combined "unsigned extensions permitted" with "attacker
+can place a file there". Keep the extension directory read-only to the server.

--- a/.security/trust-boundaries.md
+++ b/.security/trust-boundaries.md
@@ -1,0 +1,256 @@
+# Trust boundaries
+
+> Derived-from: Snowflake-Labs/pg_lake@031d6f58798d · generated 2026-09-03
+> Regenerate when: a new call site of `CheckURLReadAccess` / `CheckURLWriteAccess` / `ValidateStorageURL` appears, or an existing one is removed; the query-parameter allowlist in `IsAllowedQueryParamKey` changes; `IsSupportedURL` gains a scheme; the Azure host check changes shape; a second place accepts a bare local path; pgduck_server gains an authentication step or a non-unix listener; or a new SQL-callable function is granted to `lake_read` or `lake_write`.
+
+pg_lake has three boundaries worth naming. Two of them are ordinary
+PostgreSQL privilege checks in front of a powerful primitive. The third,
+PostgreSQL to pgduck_server, has no authentication and is worth understanding
+before deploying pg_lake anywhere the socket is not private.
+
+## Boundary 1: a SQL user naming a URL
+
+Naming a URL is the central privileged act in pg_lake. DuckDB will open it with
+whatever credentials pgduck_server holds, and return the bytes as query rows.
+Four controls sit in front of that.
+
+### The role check
+
+`CheckURLReadAccess` requires `lake_read` (or superuser); `CheckURLWriteAccess`
+requires `lake_write`. When the role does not exist, only a superuser can name a
+URL at all.
+
+```c
+	if (!superuser() &&
+		(readRoleId == InvalidOid || !has_privs_of_role(userId, readRoleId)))
+		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						errmsg("permission denied to read from URL"),
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/permissions/roles.c:79-103,115-133` @ 031d6f58798d (2026-09-03)
+
+The gates are called from every entry point that takes a path from the user:
+`COPY` in both directions, `CREATE TABLE ... LOAD FROM`, the FDW option
+validator for `path` and `location` and the `writable` option, the Iceberg
+metadata functions, the `lake_file` utility functions, and the manifest reader.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/src/copy/copy.c:417,823`, `pg_lake_copy/src/ddl/create_table.c:228`, `pg_lake_table/src/fdw/option.c:95,200,212,225,666,742`, `pg_lake_iceberg/src/iceberg/iceberg_functions.c:55,77,150`, `pg_lake_iceberg/src/iceberg/read_manifest.c:88,138,261`, `pg_lake_table/src/util/s3_file_utils.c:68,100,167,225,276`, `pg_lake_benchmark/src/tpch.c:77,113`, `pg_lake_benchmark/src/tpcds.c:80` @ 031d6f58798d (2026-09-03)
+
+That list is the whole set: at this commit there is no other caller of the three
+gate functions anywhere in the tree.
+
+The check is on the statement that names the location, which in practice means
+`CREATE`. Querying and modifying an existing lake table afterwards needs only
+ordinary PostgreSQL table privileges, and no lake role at all; the permission
+model is set out in `architecture.md`.
+
+**Bounded by:** this is a per-URL check, not a per-object one. `lake_read` is
+all-or-nothing: a user who holds it may read every object the pgduck_server
+credentials can reach, in any bucket, for any tenant those credentials cover.
+pg_lake has no notion of which prefixes a given PostgreSQL role may touch. The
+blast radius of `lake_read` is therefore exactly the reach of the credentials
+configured in pgduck_server, which is an operator decision made outside this
+repository. It follows that `lake_read` outranks any table `GRANT`: its holder can
+read the files behind a table they cannot `SELECT`, and
+`pg_catalog.iceberg_tables` tells them where those files are.
+
+### The scheme allowlist
+
+`IsSupportedURL` is an allowlist, and `ValidateStorageURL` applies it to paths
+pg_lake reads out of table data (a manifest entry, a data-file path) where the
+role check already ran on the URL the user named.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/copy/copy_format.c:420-442`, `pg_lake_engine/src/permissions/roles.c:164-172` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** applying the scheme check to manifest-derived paths is what stops
+a table's own metadata from redirecting a scan, but it is a scheme and
+query-string check, not a location check. A manifest may still point at a
+different bucket that the server's credentials happen to reach.
+
+### The query-parameter allowlist
+
+DuckDB's S3 filesystem reads connection settings off the URL query string, so a
+URL is a configuration channel and not just a name. The allowlist is two
+entries:
+
+```c
+	static const char *const allowlist[] = {
+		"s3_region=",
+		"s3_requester_pays=",
+		NULL,
+	};
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/permissions/roles.c:196-269` @ 031d6f58798d (2026-09-03)
+
+The vector this closes is named in the code: `s3_endpoint=` lets any `lake_read`
+user point the request at an internal host and read the response back as query
+rows, and the parameter set DuckDB honours grows over time, so a denylist would
+be bypass-prone.
+
+**Bounded by:** `http://` and `https://` URLs are exempt from the check, because
+`?` is an ordinary query separator there. On those two schemes the URL is the
+request target already, which is why writes to them are refused outright below,
+and why reads on them are only as safe as the decision to grant `lake_read`.
+
+### The Azure host allowlist
+
+Azure URLs carry the endpoint in the host rather than the query string, so they
+get their own check. `az://<account>.<endpoint>/...` and
+`abfss://<container>@<account>.<endpoint>/...` both send the request to
+`https://<account>.<endpoint>`, and the host must end in a suffix from
+`pg_lake.allowed_azure_host_suffixes`. The default list is the six public and
+sovereign-cloud blob and dfs suffixes; an empty list rejects every URL that names
+a host.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/permissions/roles.c:285-339,374-425`, `pg_lake_engine/include/pg_lake/extensions/pg_lake_engine.h:33-36`, `pg_lake_engine/src/init.c:227-240` @ 031d6f58798d (2026-09-03)
+
+Three details in that check are each closing a bypass rather than being
+defensive in general:
+
+- the suffix match must land on a label boundary and leave at least one
+  character of account name, so neither `evilblob.core.windows.net` nor the bare
+  suffix itself passes;
+- a container part containing `.` or `@` is rejected, because DuckDB's URL parser
+  splits the authority elsewhere when it does, which would otherwise reach a host
+  this check rejects;
+- a host with no dot is allowed, since DuckDB then takes the endpoint from the
+  configured secret, but a bracketed IPv6 literal is explicitly not given that
+  exit.
+
+**Bounded by:** the setting is `PGC_SUSET`, so widening it is an admin action,
+but it is a host allowlist and nothing more. Any account under an allowed suffix
+is reachable, including one belonging to someone else, if the server's
+credentials or a public container permit it.
+
+### The http(s) write refusal
+
+Writes to `http://` and `https://` are refused for everyone, superusers
+included:
+
+```c
+	/*
+	 * Bare http(s):// URLs have no legitimate write target in pg_lake.  The
+	 * only realistic use is exfiltrating data through DuckDB's HTTP client to
+	 * an internal service.  Hard reject for everyone, including superusers.
+	 */
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/permissions/roles.c:142-152` @ 031d6f58798d (2026-09-03)
+
+`pg_lake.stage_location` is validated the same way at GUC-set time: it must be a
+cloud-storage URL, must not be `http(s)://`, and must not contain a query
+string.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/init.c:266-300` @ 031d6f58798d (2026-09-03)
+
+## Boundary 2: a SQL user naming a local path
+
+`COPY` accepts a bare local path, and pg_lake routes `COPY` through its
+`ProcessUtility` hook, which runs before core's `DoCopy()` and therefore before
+core's `pg_read_server_files` check. pg_lake replicates that check on the
+local-path branch:
+
+```c
+		/*
+		 * Local file paths bypass PostgreSQL's standard DoCopy() because
+		 * pg_lake routes them through its ProcessUtility hook before the core
+		 * pg_read_server_files check fires.  Replicate that check here so a
+		 * non-privileged user cannot read arbitrary server files via DuckDB's
+		 * unrestricted LocalFileSystem.
+		 */
+```
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/src/copy/copy.c:415-434` (read), `pg_lake_copy/src/copy/copy.c:823-841` (write, `pg_write_server_files`) @ 031d6f58798d (2026-09-03)
+
+This is the boundary with the shortest history: the regression tests name the
+bypass they were written for, including the glob form and the combination with a
+duplicate format option.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/tests/pytests/test_security.py:38-197` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** a replica of a core check is a copy, and a copy can drift. If
+core changes what `pg_read_server_files` means, or pg_lake starts routing
+another statement type through its hook ahead of a core check, nothing here
+notices. The control is also specific to `COPY`: every other entry point rejects
+a non-URL path on the scheme allowlist instead, so the two mechanisms have to
+stay complete between them.
+
+## Boundary 3: PostgreSQL to pgduck_server
+
+**There is no authentication on this boundary.** pgduck_server reads a v3
+startup packet, refuses SSL and GSSAPI requests (it only listens on a unix
+socket, where SSL does not apply) and refuses other protocol versions, and then
+proceeds to serve queries. No authentication exchange happens at any point.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/pgsession/pgsession_io.c:199-293` @ 031d6f58798d (2026-09-03)
+
+What holds the boundary is filesystem permissions on the socket: the socket
+directory, its group, and the socket mode (0770 by default, group empty unless
+`--unix_socket_group` is given).
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/command_line/command_line.c:45-47,107`, `pgduck_server/src/pgserver/pgserver.c:212-214,272-300` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** those permissions are skipped entirely for an abstract socket.
+`--unix_socket_directory` accepts a path starting with `@`, which puts the socket
+in the Linux abstract namespace, and both the permission-setting function and the
+lock-file function return early on that leading character:
+
+```c
+	/* no file system permissions for abstract sockets */
+	if (unixSocketPath[0] == '@')
+		return STATUS_OK;
+```
+
+An abstract socket has no filesystem entry and no mode, so it is reachable by
+every process in the network namespace. Since filesystem permissions are the
+only thing holding this boundary, an abstract socket removes the boundary. Do not
+configure one outside a namespace that contains nothing else.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/pgserver/pgserver.c:241-245,278-283`, `pgduck_server/src/command_line/command_line.c:107,158,191` @ 031d6f58798d (2026-09-03)
+
+Anyone who can connect to that socket has the full DuckDB surface: reading and
+writing any local file the pgduck_server user can reach, listing and using every
+secret in the shared secrets manager, and running `INSTALL`/`LOAD` subject only
+to the extension posture in `deployment.md`. There is no per-database or
+per-user separation inside the process, because there is no notion of a
+PostgreSQL user there at all.
+
+**Bounded by:** the default socket directory is `/tmp`, which is world-writable
+and shared. The 0770 mode with an empty group leaves the socket reachable by the
+owning user only, which is the safe end of the range, but the deployment decides
+this: `--unix_socket_group postgres` in the documented container setup widens it
+to that group, and a wider `--unix_socket_permissions` widens it further. pg_lake
+cannot detect a bad choice here, and there is no second control behind it.
+
+One related check does exist for the on-disk database file. Before opening it,
+pgduck_server refuses a symlink and refuses a file owned by a different uid, with
+the reason stated as `/tmp` squatting.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pgduck_server/src/duckdb/duckdb.c:179-219` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** that check covers the database file specifically. The socket
+directory, the cache directory and the shared temp-file directory get no
+equivalent ownership check, and the temp-file directory is writable by both
+processes by design.
+
+## What is not a boundary
+
+**GUCs are admin surface, not user surface.** The security-relevant settings are
+`PGC_SUSET`, and the credential-bearing ones additionally
+`GUC_SUPERUSER_ONLY`: `pg_lake.allowed_azure_host_suffixes`,
+`pg_lake.stage_location`, `pg_lake_table.enable_delete_file_function`,
+`pg_lake_table.skip_drop_access_hook`, and the whole
+`pg_lake_iceberg.rest_catalog_*` family.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_engine/src/init.c:216-240`, `pg_lake_table/src/init.c:331-350`, `pg_lake_iceberg/src/init.c:284-362` @ 031d6f58798d (2026-09-03)
+
+A regression test pins the Azure setting as not user-settable.
+
+**Basis:** code-verified Snowflake-Labs/pg_lake `pg_lake_copy/tests/pytests/test_security.py:562-585` @ 031d6f58798d (2026-09-03)
+
+**Bounded by:** `pg_lake_table.skip_drop_access_hook` and
+`enable_delete_file_function` both turn off a restriction rather than tighten
+one, so an admin who sets them in `postgresql.conf` has changed the model for
+every user in the cluster. Neither is reported in `SHOW ALL`, so a review of the
+running configuration will not show them.


### PR DESCRIPTION
## Problem

#606 added the `.security/` context bundle. #483 (Split CODEOWNERS into per-area owners) was branched from a main that predated #606, so when it merged it deleted the entire directory as a side effect — none of the eight files were intended to change.

## Solution

Restore the eight `.security/` files exactly as they landed in #606.

## Test plan

- [x] `git diff` against #606's version of the bundle is empty