### PR TITLE
Let DuckDB detect the CSV line terminator

### DIFF
--- a/pg_lake_copy/tests/pytests/test_csv_copy.py
+++ b/pg_lake_copy/tests/pytests/test_csv_copy.py
@@ -2,6 +2,7 @@ import pytest
 import psycopg2
 import time
 import duckdb
+import gzip
 import math
 from utils_pytest import *
 
@@ -1072,5 +1073,35 @@ def test_auto_detect(pg_conn, azure):
 
     # Currently disabled, we do not properly distinguish empty string and NULL with auto_detect
     # assert result_before == result_after
+
+    pg_conn.rollback()
+
+
+def test_line_terminators(pg_conn, s3):
+    """A CRLF or CR file must load every row, not silently report COPY 0"""
+    run_command("CREATE TABLE test_line_terminators (a int, b text)", pg_conn)
+
+    for name, terminator in [("lf", "\n"), ("crlf", "\r\n"), ("cr", "\r")]:
+        lines = ["a,b", "1,one", "2,two", "3,three"]
+        key = f"test_line_terminators/{name}.csv.gz"
+        s3.put_object(
+            Bucket=TEST_BUCKET,
+            Key=key,
+            Body=gzip.compress((terminator.join(lines) + terminator).encode()),
+        )
+
+        run_command("TRUNCATE test_line_terminators", pg_conn)
+        run_command(
+            f"COPY test_line_terminators FROM 's3://{TEST_BUCKET}/{key}' "
+            f"WITH (format csv, header true, compression 'gzip')",
+            pg_conn,
+        )
+
+        result = run_query("SELECT a, b FROM test_line_terminators ORDER BY a", pg_conn)
+        assert [tuple(row) for row in result] == [
+            (1, "one"),
+            (2, "two"),
+            (3, "three"),
+        ], f"{name} line terminator loaded {result}"
 
     pg_conn.rollback()

--- a/pg_lake_engine/src/csv/csv_options.c
+++ b/pg_lake_engine/src/csv/csv_options.c
@@ -117,9 +117,16 @@ NormalizedExternalCSVOptions(List *inputOptions)
 		delimiter = ",";
 		quote = "\"";
 		escape = "\"";
-		newLineStr = "\\n";
 		nullStr = "";
 		forceQuote = NULL;
+
+		/*
+		 * No new_line default: PostgreSQL's COPY has no line-terminator
+		 * option and accepts \n, \r\n and \r alike, and DuckDB detects the
+		 * terminator itself even with auto_detect off. Pinning it to \n made
+		 * a CRLF file parse as one malformed line, which COPY consumed as the
+		 * header row and reported as "COPY 0" with no error.
+		 */
 
 		/* not exposed to user */
 		hasSkip = true;

--- a/pg_lake_table/tests/pytests/test_csv_tables.py
+++ b/pg_lake_table/tests/pytests/test_csv_tables.py
@@ -1019,3 +1019,33 @@ def test_s3_csv_null_padding_with_custom_null_and_padding(pg_conn, s3, extension
     assert null_count[0][0] == 3, "Expected 3 rows with NULL values"
 
     pg_conn.rollback()
+
+
+def test_csv_crlf_newlines_with_explicit_columns(pg_conn, s3, extension, tmp_path):
+    """CRLF line endings are handled without sniffing, which columns skip"""
+    csv_key = "test_csv_crlf_explicit_columns/data.csv"
+    csv_path = f"s3://{TEST_BUCKET}/{csv_key}"
+
+    local_csv_path = tmp_path / "crlf_data.csv"
+    with open(local_csv_path, "wb") as csv_file:
+        csv_file.write(b"id,name,value\r\n")
+        csv_file.write(b"1,alice,100\r\n")
+        csv_file.write(b"2,bob,200\r\n")
+        csv_file.write(b"3,charlie,300\r\n")
+
+    s3.upload_file(local_csv_path, TEST_BUCKET, csv_key)
+
+    # Spelling out the columns skips the sniffer, so nothing tells the engine
+    # what the line terminator is
+    run_command(
+        f"""
+        CREATE FOREIGN TABLE test_crlf_csv_explicit (id int, name text, value int)
+        SERVER pg_lake OPTIONS (path '{csv_path}', format 'csv', header 'true');
+        """,
+        pg_conn,
+    )
+
+    result = run_query("SELECT * FROM test_crlf_csv_explicit ORDER BY id", pg_conn)
+    assert result == [[1, "alice", 100], [2, "bob", 200], [3, "charlie", 300]], result
+
+    pg_conn.rollback()


### PR DESCRIPTION
### Problem

Loading a CRLF-terminated CSV with `COPY .. FROM` silently loads nothing:

```
postgres=> CREATE TABLE staging_client_load ()
  WITH (definition_from = '@STAGE/initial_load_member_master_2M.csv.gz');
postgres=> COPY staging_client_load FROM '@STAGE/initial_load_member_master_2M.csv.gz'
  WITH (FORMAT csv, HEADER true, compression 'gzip');
COPY 0
Time: 4271.939 ms
```

The same file loads fine through `CREATE TABLE .. WITH (load_from = ..)` (2,000,000 rows, 82s).

### Cause

`COPY .. FROM` and a csv foreign table with explicit columns both run `read_csv` with
`auto_detect=false`, and `NormalizedExternalCSVOptions` then substituted PostgreSQL's COPY defaults
for every option the user did not give. PostgreSQL has no line-terminator option — `COPY` accepts
`\n`, `\r\n` and `\r` alike — so there was nothing to substitute, and the hard-coded
`new_line='\n'` made DuckDB read a CRLF file as one long malformed line. With `header true` that
single line was consumed as the header row, so the read returned zero rows **and raised nothing**.

`load_from` escaped it because `ProcessCreateFromFile` appends `auto_detect=true` for CSV.

Measured against the engine, same option set, LF vs CRLF vs CR:

| file | `new_line='\n'` (before) | option omitted (after) |
| --- | --- | --- |
| LF | 3 rows | 3 rows |
| CRLF | **0 rows, no error** | 3 rows |
| CR | **0 rows, no error** | 3 rows |
| CRLF, no trailing terminator | **0 rows, no error** | 3 rows |
| CRLF + newline inside a quoted field | **0 rows, no error** | 2 rows |
| mixed CRLF and LF | **0 rows, no error** | honest parse error |

### Fix

Drop the default and let DuckDB detect the terminator, which it does even with `auto_detect` off.
An explicit `new_line` (a csv foreign-table option) still wins, LF files are unaffected, and
`COPY TO` never read the option.

### Tests

- `pg_lake_copy` `test_line_terminators`: gzipped LF, CRLF and CR files each load all rows through
  `COPY .. FROM .. WITH (format csv, header true, compression 'gzip')`. Fails on `main` with 0 rows
  for CRLF and CR.
- `pg_lake_table` `test_csv_crlf_newlines_with_explicit_columns`: the same file behind a foreign
  table with spelled-out columns, which is the other way to skip the sniffer. The existing
  `test_csv_with_windows_crlf_newlines` only covers `()` inference, where the sniffed `new_line`
  hid the bug.