### PR TITLE
Stop recording a sniffed line terminator on CSV foreign tables

### DIFF
--- a/pg_lake_engine/include/pg_lake/pgduck/sniff_csv.h
+++ b/pg_lake_engine/include/pg_lake/pgduck/sniff_csv.h
@@ -21,4 +21,4 @@
 #include "nodes/pg_list.h"
 
 extern PGDLLEXPORT void SniffCSV(char *url, CopyDataCompression compression, List *options,
-								 char **delimiter, char **quote, char **escape, bool *header, char **newLine);
+								 char **delimiter, char **quote, char **escape, bool *header);

--- a/pg_lake_engine/src/pgduck/sniff_csv.c
+++ b/pg_lake_engine/src/pgduck/sniff_csv.c
@@ -30,10 +30,14 @@
 /*
  * SniffCSV calls the DuckDB sniff_csv function to determine the
  * properties of the CSV file.
+ *
+ * The line terminator is deliberately not reported.  We only sniff the first
+ * file of the path, and DuckDB detects the terminator per file, so there is
+ * nothing useful a single answer could say about a multi-file path.
  */
 void
 SniffCSV(char *url, CopyDataCompression compression, List *options,
-		 char **delimiter, char **quote, char **escape, bool *header, char **newLine)
+		 char **delimiter, char **quote, char **escape, bool *header)
 {
 	StringInfoData command;
 
@@ -45,7 +49,7 @@ SniffCSV(char *url, CopyDataCompression compression, List *options,
 		ereport(ERROR, (errmsg("couldn't find files at %s", url)));
 
 	appendStringInfo(&command,
-					 "SELECT Delimiter, Quote, Escape, HasHeader, NewLineDelimiter FROM sniff_csv(%s",
+					 "SELECT Delimiter, Quote, Escape, HasHeader FROM sniff_csv(%s",
 					 quote_literal_cstr((char *) linitial(outputFiles)));
 
 	if (compression != DATA_COMPRESSION_INVALID)
@@ -70,7 +74,7 @@ SniffCSV(char *url, CopyDataCompression compression, List *options,
 	/* make sure we PQclear the result */
 	PG_TRY();
 	{
-		if (PQntuples(result) != 1 && PQnfields(result) != 4)
+		if (PQntuples(result) != 1 || PQnfields(result) != 4)
 		{
 			ereport(ERROR, (errmsg("unexpected CSV detection result")));
 		}
@@ -94,12 +98,6 @@ SniffCSV(char *url, CopyDataCompression compression, List *options,
 		*escape = pstrdup(rawValue);
 
 		*header = strcasecmp(PQgetvalue(result, 0, 3), "t") == 0;
-
-		rawValue = PQgetvalue(result, 0, 4);
-		if (strcmp(rawValue, "") == 0)
-			rawValue = "\\n";
-
-		*newLine = pstrdup(rawValue);
 
 		PQclear(result);
 	}

--- a/pg_lake_table/src/describe/describe.c
+++ b/pg_lake_table/src/describe/describe.c
@@ -454,10 +454,9 @@ SniffCSVOptions(char *url, CopyDataCompression compression, List *options)
 	char	   *quote = NULL;
 	char	   *escape = NULL;
 	bool		header = NULL;
-	char	   *newLine = NULL;
 
 	SniffCSV(url, compression, options,
-			 &delimiter, &quote, &escape, &header, &newLine);
+			 &delimiter, &quote, &escape, &header);
 
 	if (!HasOption((List *) options, "delimiter") && *delimiter != '\0')
 	{
@@ -487,13 +486,14 @@ SniffCSVOptions(char *url, CopyDataCompression compression, List *options)
 											   -1));
 	}
 
-	if (!HasOption((List *) options, "new_line"))
-	{
-		options = lappend(options, makeDefElem("new_line",
-											   (Node *) makeString(newLine),
-											   -1));
-	}
-
+	/*
+	 * We deliberately do not store the sniffed new_line.  DuckDB works the
+	 * line terminator out per file, whereas we only sniff the first file of
+	 * the path, so persisting it would apply one file's terminator to every
+	 * file behind a glob and silently drop the rows of the others.  The other
+	 * sniffed options have to be stored because nothing can recover them once
+	 * auto_detect is off.
+	 */
 
 	return options;
 }
@@ -507,7 +507,6 @@ static bool
 HasAllSniffCSVOptions(List *options)
 {
 	return HasOption(options, "delimiter") &&
-		HasOption(options, "new_line") &&
 		HasOption(options, "quote") &&
 		HasOption(options, "escape") &&
 		HasOption(options, "header");

--- a/pg_lake_table/tests/pytests/test_csv_tables.py
+++ b/pg_lake_table/tests/pytests/test_csv_tables.py
@@ -1049,3 +1049,42 @@ def test_csv_crlf_newlines_with_explicit_columns(pg_conn, s3, extension, tmp_pat
     assert result == [[1, "alice", 100], [2, "bob", 200], [3, "charlie", 300]], result
 
     pg_conn.rollback()
+
+
+def test_csv_mixed_line_terminators_across_glob(pg_conn, s3, extension, tmp_path):
+    """Files behind one glob may disagree on the line terminator
+
+    Column inference sniffs the first file only, so a terminator recorded
+    from it would be applied to every other file and silently drop rows.
+    """
+    prefix = "test_csv_mixed_line_terminators"
+
+    for name, terminator, rows in [
+        ("a_crlf", "\r\n", ["1,one", "2,two"]),
+        ("b_lf", "\n", ["3,three", "4,four"]),
+    ]:
+        lines = ["id,name"] + rows
+        local_csv_path = tmp_path / f"{name}.csv"
+        with open(local_csv_path, "wb") as csv_file:
+            csv_file.write((terminator.join(lines) + terminator).encode())
+
+        s3.upload_file(local_csv_path, TEST_BUCKET, f"{prefix}/{name}.csv")
+
+    run_command(
+        f"""
+        CREATE FOREIGN TABLE test_mixed_terminators ()
+        SERVER pg_lake OPTIONS (path 's3://{TEST_BUCKET}/{prefix}/*.csv',
+                                format 'csv', header 'true');
+        """,
+        pg_conn,
+    )
+
+    result = run_query("SELECT * FROM test_mixed_terminators ORDER BY id", pg_conn)
+    assert result == [
+        [1, "one"],
+        [2, "two"],
+        [3, "three"],
+        [4, "four"],
+    ], result
+
+    pg_conn.rollback()


### PR DESCRIPTION
Builds on #617.

#617 stops pinning `new_line` to `\n` when `auto_detect` is off. The same
pinning still happens through a second door, so the silent row loss it fixes
is still reachable.

`CREATE FOREIGN TABLE` with inferred columns calls `SniffCSVOptions()`, which
sniffs the CSV to recover the options that cannot be detected once
`auto_detect` is off, and stores the line terminator among them. Only the
first file of the path is sniffed, so a glob whose files disagree gets one
file's terminator applied to all of them.

## Repro

`a1.csv` is CRLF, `a2.csv` is LF, two rows each:

```sql
CREATE FOREIGN TABLE t ()
SERVER pg_lake OPTIONS (path 's3://bucket/mix/*.csv', format 'csv', header 'true');

SELECT ftoptions FROM pg_foreign_table WHERE ftrelid = 't'::regclass;
-- {...,"new_line=\\r\\n"}

SELECT * FROM t;   -- 2 rows
```

The LF file's rows are gone. No error, no warning. Spelling the columns out
skips the sniffer entirely and returns all 4 after #617, which is the
inconsistency this closes.

## Fix

DuckDB detects the terminator per file, so there is nothing to recover and
nothing to store. Drop it from the sniffed options, and from `SniffCSV()`
altogether since it has no other caller. The remaining sniffed options stay,
because nothing else can supply them once `auto_detect` is off.

An explicit `new_line` foreign-table option is untouched and still wins.

## Note

One drive-by on a line I was already deleting around: the result guard read
`PQntuples(result) != 1 && PQnfields(result) != 4`, which could essentially
never fire. Changed to `||`. Happy to split it out if you'd rather.

## Tests

`test_csv_mixed_line_terminators_across_glob` puts a CRLF file and an LF file
behind one glob and expects all four rows.

Verified failing before the fix (2 of 4 rows) and passing after. Full
`pg_lake_copy` (272 passed) and `pg_lake_table` (2738 passed) are clean; the
15 remaining failures are identical to the ones on the base branch.

Made with [Cursor](https://cursor.com)