### PR TITLE
Defer Azure overwrite truncate so files are never published empty

### DIFF
--- a/duckdb_pglake/Makefile
+++ b/duckdb_pglake/Makefile
@@ -148,6 +148,7 @@ patch_duckdb: $(shell find patches -type f -name '*.patch')
 		[ -d "$$extdir" ] || continue ; \
 		ext=$$(basename $$extdir) ; \
 		echo "staging patches for extension $$ext" ; \
+		rm -rf duckdb/.github/patches/extensions/$$ext && \
 		mkdir -p duckdb/.github/patches/extensions/$$ext && \
 		cp $$extdir*.patch duckdb/.github/patches/extensions/$$ext/ ; \
 	done

--- a/duckdb_pglake/extension_config.cmake
+++ b/duckdb_pglake/extension_config.cmake
@@ -17,6 +17,7 @@ duckdb_extension_load(aws
 duckdb_extension_load(azure
     GIT_URL https://github.com/duckdb/duckdb-azure
     GIT_TAG 003214c96d0caa39d5c3e27a9e1976a0692c7d37
+    APPLY_PATCHES
 )
 
 # Extension from this repo

--- a/duckdb_pglake/patches/extensions/azure/defer-overwrite-truncate.patch
+++ b/duckdb_pglake/patches/extensions/azure/defer-overwrite-truncate.patch
@@ -44,6 +44,113 @@ index 0bd6bf4..439a154 100644
  		}
  		// NOTE: honor convention for S3/Azure "foo/" empty file -> "foo" dir marker
  		auto is_dir = StringUtil::EndsWith(afh.GetPath(), "/");
+diff --git a/src/azure_dfs_filesystem.cpp b/src/azure_dfs_filesystem.cpp
+index 838abac..96bedd6 100644
+--- a/src/azure_dfs_filesystem.cpp
++++ b/src/azure_dfs_filesystem.cpp
+@@ -8,6 +8,7 @@
+ #include "duckdb/common/shared_ptr.hpp"
+ #include "duckdb/common/string_util.hpp"
+ #include "duckdb/common/types/timestamp.hpp"
++#include "duckdb/common/types/uuid.hpp"
+ #include "duckdb/function/scalar/string_common.hpp"
+ #include "duckdb/logging/file_system_logger.hpp"
+ 
+@@ -102,8 +103,12 @@ AzureDfsContextState::GetDfsFileSystemClient(const std::string &file_system_name
+ //////// AzureDfsContextState ////////
+ AzureDfsStorageFileHandle::AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &fs, const OpenFileInfo &info,
+                                                      FileOpenFlags flags, const AzureOptions &options,
+-                                                     Azure::Storage::Files::DataLake::DataLakeFileClient client)
+-    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, options), file_client(std::move(client)) {
++                                                     Azure::Storage::Files::DataLake::DataLakeFileSystemClient fs_client,
++                                                     Azure::Storage::Files::DataLake::DataLakeFileClient client,
++                                                     string destination_path)
++    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, options),
++      file_system_client(std::move(fs_client)), file_client(std::move(client)),
++      destination_file_path(std::move(destination_path)) {
+ }
+ 
+ void AzureDfsStorageFileHandle::StageWriteBuffer() {
+@@ -138,8 +143,45 @@ void AzureDfsStorageFileHandle::Sync(bool close) {
+ }
+ 
+ void AzureDfsStorageFileHandle::Close() {
+-	Sync(true);
+-	DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
++	if (closed) {
++		return;
++	}
++	try {
++		Sync(true);
++		if (replacement_pending) {
++			auto renamed = file_system_client.RenameFile(temporary_file_path, destination_file_path);
++			replacement_pending = false;
++			file_client = std::move(renamed.Value);
++		}
++		closed = true;
++		DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
++	} catch (...) {
++		CleanupPendingReplacement();
++		throw;
++	}
++}
++
++void AzureDfsStorageFileHandle::CleanupPendingReplacement() {
++	if (!replacement_pending) {
++		return;
++	}
++	try {
++		file_client.DeleteIfExists();
++	} catch (...) { // NOLINT
++	}
++	replacement_pending = false;
++}
++
++AzureDfsStorageFileHandle::~AzureDfsStorageFileHandle() {
++	if (Exception::UncaughtException()) {
++		CleanupPendingReplacement();
++		return;
++	}
++	try {
++		Close();
++	} catch (...) { // NOLINT
++		CleanupPendingReplacement();
++	}
+ }
+ 
+ //////// AzureDfsStorageFileSystem ////////
+@@ -170,7 +212,8 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
+ 	}
+ 
+ 	auto handle = make_uniq<AzureDfsStorageFileHandle>(*this, info, flags, storage_context->options,
+-	                                                   file_system_client.GetFileClient(file_path));
++	                                                   file_system_client, file_system_client.GetFileClient(file_path),
++	                                                   file_path);
+ 	if (!handle->PostConstruct()) {
+ 		return nullptr;
+ 	}
+@@ -333,7 +376,6 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+ 		auto res_create = afh.file_client.Create();
+ 		set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
+ 	};
+-	auto truncate_file = create_file;
+ 
+ 	try {
+ 		auto res_props = afh.file_client.GetProperties();
+@@ -341,7 +383,12 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+ 			throw IOException("AzureDfsStorageFileSystem will not open file: '%s', ExclusiveCreate specified "
+ 			                  "while file already exists.");
+ 		} else if (afh.flags.OpenForWriting() && afh.flags.OverwriteExistingFile()) {
+-			return truncate_file();
++			afh.temporary_file_path =
++			    afh.destination_file_path + ".tmp-" + UUID::ToString(UUID::GenerateRandomUUID());
++			afh.file_client = afh.file_system_client.GetFileClient(afh.temporary_file_path);
++			auto res_create = afh.file_client.Create();
++			afh.replacement_pending = true;
++			return set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
+ 		}
+ 		// NOTE: honor convention for S3/Azure "foo/" empty file -> "foo" dir marker
+ 		auto is_dir = StringUtil::EndsWith(afh.GetPath(), "/") || res_props.Value.IsDirectory;
 diff --git a/src/include/azure_blob_filesystem.hpp b/src/include/azure_blob_filesystem.hpp
 index 67bfebd..1ada92a 100644
 --- a/src/include/azure_blob_filesystem.hpp
@@ -56,3 +163,34 @@ index 67bfebd..1ada92a 100644
  	duckdb::unique_ptr<data_t[]> write_buffer;
  	idx_t write_buffer_offset = 0;
  };
+diff --git a/src/include/azure_dfs_filesystem.hpp b/src/include/azure_dfs_filesystem.hpp
+index c28417d..2feedac 100644
+--- a/src/include/azure_dfs_filesystem.hpp
++++ b/src/include/azure_dfs_filesystem.hpp
+@@ -28,15 +28,24 @@ class AzureDfsStorageFileSystem;
+ class AzureDfsStorageFileHandle : public AzureFileHandle {
+ public:
+ 	AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
+-	                          const AzureOptions &options, Azure::Storage::Files::DataLake::DataLakeFileClient client);
+-	~AzureDfsStorageFileHandle() override = default;
++	                          const AzureOptions &options,
++	                          Azure::Storage::Files::DataLake::DataLakeFileSystemClient file_system_client,
++	                          Azure::Storage::Files::DataLake::DataLakeFileClient client,
++	                          string destination_file_path);
++	~AzureDfsStorageFileHandle() override;
+ 
+ 	void StageWriteBuffer();
+ 	void Sync(bool close = false);
+ 	void Close() override;
++	void CleanupPendingReplacement();
+ 
+ public:
++	Azure::Storage::Files::DataLake::DataLakeFileSystemClient file_system_client;
+ 	Azure::Storage::Files::DataLake::DataLakeFileClient file_client;
++	string destination_file_path;
++	string temporary_file_path;
++	bool replacement_pending = false;
++	bool closed = false;
+ 	duckdb::unique_ptr<data_t[]> write_buffer;
+ 	idx_t write_buffer_offset = 0;
+ 	// Bytes sent to Append (staged on server, committed or not): always <= file_offset,

--- a/duckdb_pglake/patches/extensions/azure/defer-overwrite-truncate.patch
+++ b/duckdb_pglake/patches/extensions/azure/defer-overwrite-truncate.patch
@@ -1,10 +1,21 @@
 diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
-index 0bd6bf4..439a154 100644
+index 0bd6bf4..f512f15 100644
 --- a/src/azure_blob_filesystem.cpp
 +++ b/src/azure_blob_filesystem.cpp
-@@ -96,6 +96,12 @@ void AzureBlobStorageFileHandle::Sync() {
+@@ -89,13 +89,22 @@ void AzureBlobStorageFileHandle::StageWriteBuffer() {
+ 	write_buffer_offset = 0;
+ }
+ 
+-void AzureBlobStorageFileHandle::Sync() {
++void AzureBlobStorageFileHandle::Sync(bool close) {
+ 	if (!(flags.OpenForWriting() || flags.OpenForAppending())) {
+ 		return;
+ 	}
  	try {
  		StageWriteBuffer();
++		if (truncate_pending && !close) {
++			return;
++		}
  		if (staged_block_count == 0) {
 +			if (!truncate_pending) {
 +				return;
@@ -15,7 +26,7 @@ index 0bd6bf4..439a154 100644
  			return;
  		}
  		std::vector<std::string> all_ids;
-@@ -108,6 +114,7 @@ void AzureBlobStorageFileHandle::Sync() {
+@@ -108,6 +117,7 @@ void AzureBlobStorageFileHandle::Sync() {
  		last_modified = AzureBlobStorageFileSystem::ToTimestamp(res.Value.LastModified);
  		committed_block_count += staged_block_count;
  		staged_block_count = 0;
@@ -23,7 +34,16 @@ index 0bd6bf4..439a154 100644
  	} catch (const Azure::Storage::StorageException &e) {
  		throw IOException("AzureBlobStorageFileSystem FileSync of '%s' failed with %s Reason Phrase: %s", GetPath(),
  		                  e.ErrorCode, e.ReasonPhrase);
-@@ -307,7 +314,6 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+@@ -115,7 +125,7 @@ void AzureBlobStorageFileHandle::Sync() {
+ }
+ 
+ void AzureBlobStorageFileHandle::Close() {
+-	Sync();
++	Sync(true);
+ 	DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
+ }
+ 
+@@ -307,7 +317,6 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
  		auto res_create = afh.blob_client.CommitBlockList({});
  		set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
  	};
@@ -31,7 +51,7 @@ index 0bd6bf4..439a154 100644
  
  	try {
  		auto res_props = afh.blob_client.GetProperties();
-@@ -315,7 +321,11 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+@@ -315,7 +324,11 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
  			throw IOException("AzureBlobStorageFileSystem will not open file: '%s', ExclusiveCreate specified "
  			                  "while file already exists.");
  		} else if (afh.flags.OpenForWriting() && afh.flags.OverwriteExistingFile()) {
@@ -45,7 +65,7 @@ index 0bd6bf4..439a154 100644
  		// NOTE: honor convention for S3/Azure "foo/" empty file -> "foo" dir marker
  		auto is_dir = StringUtil::EndsWith(afh.GetPath(), "/");
 diff --git a/src/azure_dfs_filesystem.cpp b/src/azure_dfs_filesystem.cpp
-index 838abac..96bedd6 100644
+index 838abac..cd7282e 100644
 --- a/src/azure_dfs_filesystem.cpp
 +++ b/src/azure_dfs_filesystem.cpp
 @@ -8,6 +8,7 @@
@@ -71,7 +91,7 @@ index 838abac..96bedd6 100644
  }
  
  void AzureDfsStorageFileHandle::StageWriteBuffer() {
-@@ -138,8 +143,45 @@ void AzureDfsStorageFileHandle::Sync(bool close) {
+@@ -138,8 +143,37 @@ void AzureDfsStorageFileHandle::Sync(bool close) {
  }
  
  void AzureDfsStorageFileHandle::Close() {
@@ -84,8 +104,8 @@ index 838abac..96bedd6 100644
 +		Sync(true);
 +		if (replacement_pending) {
 +			auto renamed = file_system_client.RenameFile(temporary_file_path, destination_file_path);
-+			replacement_pending = false;
 +			file_client = std::move(renamed.Value);
++			replacement_pending = false;
 +		}
 +		closed = true;
 +		DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
@@ -107,19 +127,11 @@ index 838abac..96bedd6 100644
 +}
 +
 +AzureDfsStorageFileHandle::~AzureDfsStorageFileHandle() {
-+	if (Exception::UncaughtException()) {
-+		CleanupPendingReplacement();
-+		return;
-+	}
-+	try {
-+		Close();
-+	} catch (...) { // NOLINT
-+		CleanupPendingReplacement();
-+	}
++	CleanupPendingReplacement();
  }
  
  //////// AzureDfsStorageFileSystem ////////
-@@ -170,7 +212,8 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
+@@ -170,7 +204,8 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
  	}
  
  	auto handle = make_uniq<AzureDfsStorageFileHandle>(*this, info, flags, storage_context->options,
@@ -129,7 +141,7 @@ index 838abac..96bedd6 100644
  	if (!handle->PostConstruct()) {
  		return nullptr;
  	}
-@@ -333,7 +376,6 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+@@ -333,7 +368,6 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
  		auto res_create = afh.file_client.Create();
  		set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
  	};
@@ -137,7 +149,7 @@ index 838abac..96bedd6 100644
  
  	try {
  		auto res_props = afh.file_client.GetProperties();
-@@ -341,7 +383,12 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+@@ -341,7 +375,12 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
  			throw IOException("AzureDfsStorageFileSystem will not open file: '%s', ExclusiveCreate specified "
  			                  "while file already exists.");
  		} else if (afh.flags.OpenForWriting() && afh.flags.OverwriteExistingFile()) {
@@ -152,10 +164,18 @@ index 838abac..96bedd6 100644
  		// NOTE: honor convention for S3/Azure "foo/" empty file -> "foo" dir marker
  		auto is_dir = StringUtil::EndsWith(afh.GetPath(), "/") || res_props.Value.IsDirectory;
 diff --git a/src/include/azure_blob_filesystem.hpp b/src/include/azure_blob_filesystem.hpp
-index 67bfebd..1ada92a 100644
+index 67bfebd..beb6028 100644
 --- a/src/include/azure_blob_filesystem.hpp
 +++ b/src/include/azure_blob_filesystem.hpp
-@@ -39,6 +39,7 @@ public:
+@@ -32,13 +32,14 @@ public:
+ 	~AzureBlobStorageFileHandle() override = default;
+ 
+ 	void StageWriteBuffer();
+-	void Sync();
++	void Sync(bool close = false);
+ 	void Close() override;
+ 
+ public:
  	Azure::Storage::Blobs::BlockBlobClient blob_client;
  	size_t committed_block_count = 0; // maintain position while open; only used if Sync() called before Close()
  	uint32_t staged_block_count = 0;

--- a/duckdb_pglake/patches/extensions/azure/defer-overwrite-truncate.patch
+++ b/duckdb_pglake/patches/extensions/azure/defer-overwrite-truncate.patch
@@ -1,0 +1,58 @@
+diff --git a/src/azure_blob_filesystem.cpp b/src/azure_blob_filesystem.cpp
+index 0bd6bf4..439a154 100644
+--- a/src/azure_blob_filesystem.cpp
++++ b/src/azure_blob_filesystem.cpp
+@@ -96,6 +96,12 @@ void AzureBlobStorageFileHandle::Sync() {
+ 	try {
+ 		StageWriteBuffer();
+ 		if (staged_block_count == 0) {
++			if (!truncate_pending) {
++				return;
++			}
++			auto res = blob_client.CommitBlockList({});
++			last_modified = AzureBlobStorageFileSystem::ToTimestamp(res.Value.LastModified);
++			truncate_pending = false;
+ 			return;
+ 		}
+ 		std::vector<std::string> all_ids;
+@@ -108,6 +114,7 @@ void AzureBlobStorageFileHandle::Sync() {
+ 		last_modified = AzureBlobStorageFileSystem::ToTimestamp(res.Value.LastModified);
+ 		committed_block_count += staged_block_count;
+ 		staged_block_count = 0;
++		truncate_pending = false;
+ 	} catch (const Azure::Storage::StorageException &e) {
+ 		throw IOException("AzureBlobStorageFileSystem FileSync of '%s' failed with %s Reason Phrase: %s", GetPath(),
+ 		                  e.ErrorCode, e.ReasonPhrase);
+@@ -307,7 +314,6 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+ 		auto res_create = afh.blob_client.CommitBlockList({});
+ 		set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
+ 	};
+-	auto truncate_file = create_file;
+ 
+ 	try {
+ 		auto res_props = afh.blob_client.GetProperties();
+@@ -315,7 +321,11 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
+ 			throw IOException("AzureBlobStorageFileSystem will not open file: '%s', ExclusiveCreate specified "
+ 			                  "while file already exists.");
+ 		} else if (afh.flags.OpenForWriting() && afh.flags.OverwriteExistingFile()) {
+-			return truncate_file();
++			// Defer the truncate until close. CommitBlockList({}) here would publish a
++			// zero-length blob while the new content is still being staged.
++			afh.committed_block_count = 0;
++			afh.truncate_pending = true;
++			return set_props(false, 0, ToTimestamp(res_props.Value.LastModified));
+ 		}
+ 		// NOTE: honor convention for S3/Azure "foo/" empty file -> "foo" dir marker
+ 		auto is_dir = StringUtil::EndsWith(afh.GetPath(), "/");
+diff --git a/src/include/azure_blob_filesystem.hpp b/src/include/azure_blob_filesystem.hpp
+index 67bfebd..1ada92a 100644
+--- a/src/include/azure_blob_filesystem.hpp
++++ b/src/include/azure_blob_filesystem.hpp
+@@ -39,6 +39,7 @@ public:
+ 	Azure::Storage::Blobs::BlockBlobClient blob_client;
+ 	size_t committed_block_count = 0; // maintain position while open; only used if Sync() called before Close()
+ 	uint32_t staged_block_count = 0;
++	bool truncate_pending = false;
+ 	duckdb::unique_ptr<data_t[]> write_buffer;
+ 	idx_t write_buffer_offset = 0;
+ };

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1697,7 +1697,12 @@ def test_object_store_catalog_periodic_rewrite_azure_no_zero_byte_reads(
     run_command("SELECT pg_sleep(0.2)", superuser_conn)
 
     try:
-        run_command(f"SET pg_lake_iceberg.default_location_prefix TO '{location}'", pg_conn)
+        run_command(
+            "DROP SCHEMA IF EXISTS test_periodic_rewrite_azure CASCADE", pg_conn
+        )
+        run_command(
+            f"SET pg_lake_iceberg.default_location_prefix TO '{location}'", pg_conn
+        )
         pg_conn.commit()
 
         run_command("CREATE SCHEMA test_periodic_rewrite_azure", pg_conn)
@@ -1713,20 +1718,28 @@ def test_object_store_catalog_periodic_rewrite_azure_no_zero_byte_reads(
         dbname = run_query("SELECT current_database()", pg_conn)[0][0]
         key = f"{catalog_prefix}/catalog/{dbname}/catalog.json"
 
+        first_body = json.loads(azure.download_blob(key).readall())
+        first_snapshot_time = first_body["catalog-snapshot-time"]
+        saw_new_snapshot = False
         deadline = time.monotonic() + 8
         while time.monotonic() < deadline:
             body = azure.download_blob(key).readall()
-            assert len(body) > 0, (
-                f"catalog.json at {key} was observed as zero bytes during a rewrite"
-            )
+            assert (
+                len(body) > 0
+            ), f"catalog.json at {key} was observed as zero bytes during a rewrite"
             parsed = json.loads(body)
             assert "catalog-snapshot-time" in parsed
             assert "tables" in parsed
+            saw_new_snapshot |= parsed["catalog-snapshot-time"] > first_snapshot_time
             time.sleep(0.01)
 
-        run_command("DROP SCHEMA test_periodic_rewrite_azure CASCADE", pg_conn)
-        pg_conn.commit()
+        assert (
+            saw_new_snapshot
+        ), "catalog.json was not rewritten during the polling window"
     finally:
+        run_command(
+            "DROP SCHEMA IF EXISTS test_periodic_rewrite_azure CASCADE", pg_conn
+        )
         run_command("RESET pg_lake_iceberg.default_location_prefix", pg_conn)
         pg_conn.commit()
 
@@ -1747,6 +1760,7 @@ def test_object_store_catalog_periodic_rewrite_azure_no_zero_byte_reads(
             superuser_conn,
         )
         run_command("SELECT pg_reload_conf()", superuser_conn)
+        run_command("SELECT pg_sleep(0.2)", superuser_conn)
         superuser_conn.autocommit = False
 
 

--- a/pg_lake_table/tests/pytests/test_object_store_catalog.py
+++ b/pg_lake_table/tests/pytests/test_object_store_catalog.py
@@ -1665,6 +1665,91 @@ def test_object_store_catalog_periodic_rewrite(
         superuser_conn.autocommit = False
 
 
+# Periodic catalog rewrites on Azure must not publish catalog.json as a zero-length
+# blob while the new content is still being uploaded.
+def test_object_store_catalog_periodic_rewrite_azure_no_zero_byte_reads(
+    pg_conn,
+    superuser_conn,
+    azure,
+    extension,
+):
+    location = f"azure://{TEST_BUCKET}"
+    catalog_prefix = "tmp_az_rewrite"
+
+    superuser_conn.autocommit = True
+    run_command(
+        f"ALTER SYSTEM SET pg_lake_iceberg.object_store_catalog_location_prefix = '{location}'",
+        superuser_conn,
+    )
+    run_command(
+        f"ALTER SYSTEM SET pg_lake_iceberg.internal_object_store_catalog_prefix = '{catalog_prefix}'",
+        superuser_conn,
+    )
+    run_command(
+        f"ALTER SYSTEM SET pg_lake_iceberg.external_object_store_catalog_prefix = '{catalog_prefix}'",
+        superuser_conn,
+    )
+    run_command(
+        "ALTER SYSTEM SET pg_lake_iceberg.object_store_catalog_max_age = '1s'",
+        superuser_conn,
+    )
+    run_command("SELECT pg_reload_conf()", superuser_conn)
+    run_command("SELECT pg_sleep(0.2)", superuser_conn)
+
+    try:
+        run_command(f"SET pg_lake_iceberg.default_location_prefix TO '{location}'", pg_conn)
+        pg_conn.commit()
+
+        run_command("CREATE SCHEMA test_periodic_rewrite_azure", pg_conn)
+        run_command(
+            "CREATE TABLE test_periodic_rewrite_azure.tbl(a int) USING iceberg WITH (catalog='object_store')",
+            pg_conn,
+        )
+        pg_conn.commit()
+        wait_until_object_store_writable_table_pushed(
+            pg_conn, "test_periodic_rewrite_azure", "tbl"
+        )
+
+        dbname = run_query("SELECT current_database()", pg_conn)[0][0]
+        key = f"{catalog_prefix}/catalog/{dbname}/catalog.json"
+
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            body = azure.download_blob(key).readall()
+            assert len(body) > 0, (
+                f"catalog.json at {key} was observed as zero bytes during a rewrite"
+            )
+            parsed = json.loads(body)
+            assert "catalog-snapshot-time" in parsed
+            assert "tables" in parsed
+            time.sleep(0.01)
+
+        run_command("DROP SCHEMA test_periodic_rewrite_azure CASCADE", pg_conn)
+        pg_conn.commit()
+    finally:
+        run_command("RESET pg_lake_iceberg.default_location_prefix", pg_conn)
+        pg_conn.commit()
+
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.object_store_catalog_location_prefix",
+            superuser_conn,
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.internal_object_store_catalog_prefix",
+            superuser_conn,
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.external_object_store_catalog_prefix",
+            superuser_conn,
+        )
+        run_command(
+            "ALTER SYSTEM RESET pg_lake_iceberg.object_store_catalog_max_age",
+            superuser_conn,
+        )
+        run_command("SELECT pg_reload_conf()", superuser_conn)
+        superuser_conn.autocommit = False
+
+
 CACHE_FILE_PREFIX = "pgl-cache."
 
 


### PR DESCRIPTION
## Description

On Azure, rewriting an existing object used DuckDB's truncate-on-open path. For block blobs that meant `CommitBlockList({})` at open, which published a durable zero-length blob before the new bytes were staged and committed at close.

That is visible to any reader of a fixed-path file that we overwrite in place, including `catalog.json`. pg_lake never serializes an empty catalog (even an empty database is `{"catalog-snapshot-time":...,"tables":[]}`), so a 0-byte object is always an in-flight write, not a valid snapshot. S3 already replaces at close, so this is Azure-specific.

This PR patches the pinned duckdb-azure extension (`APPLY_PATCHES`) on the Blob path only (`azure://`, `az://`), in 37 lines over two files:

- Nothing happens to the destination at open. A reader keeps seeing the previous object, or a 404 on a first write, until the replacement lands.
- At `Close()`, if everything written still fits in the write buffer (`azure_write_block_size`, 8 MiB by default), the blob is replaced with a single Put Blob. That is the `catalog.json` case, and the same branch truncates an overwrite that wrote no bytes at all.
- Anything larger stages blocks as before and lands as one `CommitBlockList` at close. `azure_write_staged_blocks_per_commit` defaults to 0, which upstream documents as committing the full block list only on close, and pg_lake does not set it, so no partial file becomes visible either.

`abfs[s]://` is deliberately left on upstream behaviour and still truncates at open through `Create()`. Getting the same guarantee there needs a different mechanism (a temp file plus a rename over the destination, which in turn needs credentials permitted to rename, and leaves the temp file behind if a writer dies), so it is out of scope here.

The extension patch staging step now removes stale generated patches before copying the current set, making repeated local builds deterministic.

Two regression tests write more than one block to `azure://` on Azurite, once over an existing object and once as a first write, while a thread samples the destination every 5 ms. They assert the old size is what readers see throughout the overwrite, that a first write stays absent rather than empty, and that the write actually spanned several blocks so the window was wide enough to sample. The single Put Blob branch is what every small write to `azure://` now takes, including the `catalog.json` rewrites in `test_object_store_catalog_periodic_rewrite`.

---
## Checklist

- [x] I have tested my changes and added tests if necessary
- [ ] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
