### PR TITLE
ci: wait for pgduck_server socket before installcheck tests

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -143,6 +143,25 @@ runs:
           psql -U postgres -d regression -h localhost -p 5432 -c "CREATE EXTENSION pg_lake CASCADE;"
           psql -U postgres -d regression -h localhost -p 5432 -c "CREATE EXTENSION pg_lake_spatial CASCADE;"
 
+          # pgduck_server was started in the background above and only binds
+          # its unix socket after DuckDB is initialized (extension install
+          # plus --init_file_path), so the socket appearing is the readiness
+          # signal.  Without this wait the first pytests can outrun that
+          # startup and fail with "could not start query engine: ... No such
+          # file or directory" while every later test passes.
+          for _ in $(seq 1 120); do
+            if [ -S /tmp/.s.PGSQL.5332 ]; then
+              break
+            fi
+            sleep 1
+          done
+
+          if [ ! -S /tmp/.s.PGSQL.5332 ]; then
+            echo "pgduck_server did not create /tmp/.s.PGSQL.5332 within 120s" >&2
+            cat /tmp/pgduck_installcheck_logs >&2 || true
+            exit 1
+          fi
+
           make ${{ inputs.test_make_target }}
         elif [ ${{ inputs.upgrade }} == 'true' ]; then
           TEST_PG_UPGRADE_FROM_BINDIR=/home/postgres/pgsql-${{ inputs.from_pg_version }}/bin make ${{ inputs.test_make_target }}


### PR DESCRIPTION
## Problem
  The installcheck job starts `pgduck_server` in the background and then goes straight into `initdb`, `pg_ctl` and `make`, with nothing that waits for the engine. pgduck_server binds its unix socket only after DuckDB is initialized
  (extension install plus `--init_file_path`), so when that startup is slower than Postgres' the first pytests collected run before the socket exists and fail with:

  ERROR:  could not start query engine: connection to server on socket "/tmp/.s.PGSQL.5332" failed: No such file or directory

  A recent `installcheck-pg_lake_iceberg` run lost the two alphabetically first tests this way and passed the other 269. The engine bound its socket 48 milliseconds after the second failure, so the next test in the same file passed.
  ## Solution
  Poll for `/tmp/.s.PGSQL.5332` after Postgres is up, so pgduck_server startup still overlaps `initdb` and costs nothing in the common case. If the socket never appears within 120 seconds, print the pgduck_server log and fail the step,
  rather than letting every engine-dependent test fail one by one with a connection error.

---

## Checklist

- [x] I have tested my changes and added tests if necessary
- [x] I updated documentation if needed
- [x] **I confirm that all my commits are signed off (DCO)**

---

## DCO Reminder (important)

This project uses the Developer Certificate of Origin (DCO).  
DCO is a simple way for you to confirm that you wrote your code and that you have the right to contribute it.

If the DCO check fails, please sign off your commits.

### How to sign off

For your last commit:
    git commit --amend -s
    git push --force

For multiple commits:
    git rebase --signoff main
    git push --force

More info: https://developercertificate.org/
